### PR TITLE
[WIP] Implement file explorer for open

### DIFF
--- a/Composer/packages/client/src/components/TreeView/folder.js
+++ b/Composer/packages/client/src/components/TreeView/folder.js
@@ -1,0 +1,25 @@
+/** @jsx jsx */
+import { jsx } from "@emotion/core";
+import { Icon } from "office-ui-fabric-react/lib/Icon";
+import { folder } from "./styles";
+
+export const Folder = props => {
+
+  let iconName = props.opened? 'FabricOpenFolderHorizontal':'FabricFolder';
+
+  if(props.folder.scheme === "file") {
+    iconName = 'TextDocument'
+  }
+
+  return (
+    <div css={folder}>
+      <Icon iconName={iconName} className="ms-IconExample" />
+      <span 
+        data-id={props.folder.webid} 
+        onClick={()=>props.onFolderClick(props.folder)} 
+        onContextMenu={props.onFolderRightClick}>
+        {props.folder.name}
+      </span>
+    </div>
+  );
+}

--- a/Composer/packages/client/src/components/TreeView/index.js
+++ b/Composer/packages/client/src/components/TreeView/index.js
@@ -1,0 +1,21 @@
+/** @jsx jsx */
+import { jsx } from "@emotion/core";
+import { } from "./styles";
+import { Node } from "./node";
+
+export const FolderTree = props => {
+
+    const tree = props.tree;
+
+    function buildFolderTree () {
+        return tree.map((node, key) => {
+            return <Node key={key} node={node} activeNode={props.activeNode} onSelect={props.onSelect}/>
+        })
+    }
+    
+    return (
+        <ul>
+            { tree && tree.length ? buildFolderTree() : 'loading...'}
+        </ul>
+    );
+}

--- a/Composer/packages/client/src/components/TreeView/node.js
+++ b/Composer/packages/client/src/components/TreeView/node.js
@@ -1,0 +1,30 @@
+/** @jsx jsx */
+import { jsx } from "@emotion/core";
+import { Folder }from './folder'
+import { useState } from 'react';
+import { openul, closeul, node } from "./styles";
+
+export const Node = props => {
+
+    const [opened, setOpened] = useState(false)
+
+    function handleRightClick (e) {
+        e.preventDefault()
+        console.log('Handle Right-click.')
+    }
+
+    return (
+      <li css={node}>
+        <Folder 
+            folder={props.node} 
+            opened={opened} 
+            onFolderClick={(node)=>{setOpened(!opened); props.onSelect(node)}} 
+            onFolderRightClick={handleRightClick}/>
+        <ul css={opened? openul:closeul}>
+          {props.node.children.map((child, key) => {
+            return <Node key={key} node={child} activeNode={props.activeNode} onSelect={props.onSelect}/>
+          })}
+        </ul>
+      </li>
+    )
+}

--- a/Composer/packages/client/src/components/TreeView/styles.js
+++ b/Composer/packages/client/src/components/TreeView/styles.js
@@ -1,0 +1,17 @@
+import { css } from "@emotion/core";
+
+export const openul = css`
+    display: inherit;
+`;
+
+export const closeul = css`
+    display: none;
+`;
+
+export const folder = css`
+    cursor: default;
+`;
+
+export const node = css`
+    padding-left:15px;
+`;


### PR DESCRIPTION
The reason we need a file explorer to open .bot file is that,  browser don's allow you to get the specific file path of selected file through the default file selection window.

Our temporary workaround is in https://github.com/Microsoft/BotFramework-Composer/pull/29 which we guess the path, based on one setting in setting.json (pickWorkingDir). 

I vision this would be a file explorer will support both local and remote, this is not a high-priority task, so  @youyu16  and @VanyLaw , please help on this, as your ramp up task.