### PR TITLE
Fire up form editor for non leaf dialog node

### DIFF
--- a/Composer/packages/client/src/store/reducer/index.js
+++ b/Composer/packages/client/src/store/reducer/index.js
@@ -75,9 +75,11 @@ const getStorageFileSuccess = (state, { response }) => {
 const navigateTo = (state, { path }) => {
   if (state.navPath !== path) {
     state.navPath = path;
-    state.focusPath = '';
+    state.focusPath = state.navPath; // fire up form editor on non-leaf node
+
     state.navPathHistory.push(path);
-    //check if navto dialog
+
+    // update file index if we are switching to new dialog
     const lastDialogIndex = findLastIndex(state.navPathHistory, path => {
       return getBaseName(path) === path;
     });
@@ -91,6 +93,7 @@ const navigateTo = (state, { path }) => {
 
 const navigateDown = (state, { subPath }) => {
   state.navPath = state.navPath + subPath;
+  state.focusPath = state.navPath; // fire up form editor on non-leaf node
   state.navPathHistory.push(state.navPath);
   return state;
 };


### PR DESCRIPTION
Fire up form editor for non leaf node is as simple as when navigation path changed, also updated the focus path. 

Some minor issues i found in the result,
* The main dialog looks not good when showing up, leave @yeze322  to group intent to take less space
* Form editor is pretty slow at first load, @a-b-r-o-w-n  do you get any idea?

![image](https://user-images.githubusercontent.com/3829387/55743130-16f69900-5a64-11e9-8ac8-6814c7f886ba.png)
![image](https://user-images.githubusercontent.com/3829387/55743156-2544b500-5a64-11e9-8ef4-f38ead760cee.png)

