### PR TITLE
fix ToDoLuisBot.main.dialog

### DIFF
--- a/SampleBots/ToDoLuisBot/ToDoLuisBot.main.dialog
+++ b/SampleBots/ToDoLuisBot/ToDoLuisBot.main.dialog
@@ -3,7 +3,12 @@
     "$type": "Microsoft.AdaptiveDialog",
     "$id": "root",
     "autoEndDialog": false,
-    "recognizer": "ToDoLuis.lu",
+    "recognizer": {
+    	"$type": "Microsoft.LuisRecognizer",
+    	"applicationId": "e4b3cf81-d69c-4323-9374-707655ba9703",
+    	"endpointKey": "95140545afd44a1997e2eaf47007fa7b",
+    	"endpoint": "https://westus.api.cognitive.microsoft.com/luis/v2.0/apps/e4b3cf81-d69c-4323-9374-707655ba9703?verbose=true&timezoneOffset=-360&subscription-key=95140545afd44a1997e2eaf47007fa7b&q="
+    },
     "steps": [
         {
             "$type": "Microsoft.SendActivity",
@@ -15,21 +20,30 @@
             "$type": "Microsoft.IntentRule",
             "intent": "AddToDo",
             "steps": [
-                "ToDoLuisBot.AddItem"
+                {
+                    "$type": "Microsoft.BeginDialog",
+                    "dialog": "ToDoLuisBot.AddItem"
+                }               
             ]
         },
         {
             "$type": "Microsoft.IntentRule",
             "intent": "DeleteToDo",
             "steps": [
-                "ToDoLuisBot.DeleteItem"
+                {
+                    "$type": "Microsoft.BeginDialog",
+                    "dialog": "ToDoLuisBot.DeleteItem"
+                }             
             ]
         },
         {
             "$type": "Microsoft.IntentRule",
             "intent": "ShowToDo",
             "steps": [
-                "ToDoLuisBot.ShowItems"
+                {
+                    "$type": "Microsoft.BeginDialog",
+                    "dialog": "ToDoLuisBot.ShowItems"
+                }                
             ]
         },
         {


### PR DESCRIPTION
Composer doesn't know how to handle implicit begin dialog steps or `lu.dialog` file references.

ex:
```
steps: ['AddToDo'],
recognizer: 'ToDoBot.lu'
```

Let's make sure that when updating sample bots they can render correctly in Composer.