### PR TITLE
[Form Editor] Fix outdated IfCondition schema in Form Editor

### DIFF
--- a/Composer/packages/extensions/obieditortest/src/schema/appschema.ts
+++ b/Composer/packages/extensions/obieditortest/src/schema/appschema.ts
@@ -643,11 +643,11 @@ export function getMergedSchema(dialogFiles: DialogInfo[] = []): JSONSchema6 {
             type: 'string',
             description: 'String must contain an expression.',
           },
-          ifTrue: {
+          steps: {
             $type: 'Microsoft.IRuleSelector',
             $ref: '#/definitions/Microsoft.IRuleSelector',
           },
-          ifFalse: {
+          elseSteps: {
             $type: 'Microsoft.IRuleSelector',
             $ref: '#/definitions/Microsoft.IRuleSelector',
           },


### PR DESCRIPTION
`ifTrue` -> `steps`
`ifFalse` -> `elseSteps`

ref: https://github.com/microsoft/botbuilder-dotnet/blob/4.next/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Steps/IfCondition.cs