### PR TITLE
use custom widget for dialog dropdown

### DIFF
--- a/Composer/packages/extensions/obieditortest/src/Form/widgets/DialogSelectWidget.tsx
+++ b/Composer/packages/extensions/obieditortest/src/Form/widgets/DialogSelectWidget.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { WidgetProps } from 'react-jsonschema-form';
+
+import { SelectWidget } from './SelectWidget';
+
+export const DialogSelectWidget: React.FC<WidgetProps> = props => {
+  const { formContext } = props;
+
+  return (
+    <SelectWidget
+      {...props}
+      options={{ enumOptions: (formContext.dialogOptions || []).map(d => ({ value: d, label: d })) }}
+    />
+  );
+};

--- a/Composer/packages/extensions/obieditortest/src/Form/widgets/index.ts
+++ b/Composer/packages/extensions/obieditortest/src/Form/widgets/index.ts
@@ -1,10 +1,11 @@
 import { ToggleWidget } from './ToggleWidget';
 
-export * from './DateTimeWidget';
-export * from './TextWidget';
-export * from './SelectWidget';
 export * from './CheckboxWidget';
-export * from './TextareaWidget';
+export * from './DateTimeWidget';
+export * from './DialogSelectWidget';
 export * from './RadioWidget';
+export * from './SelectWidget';
+export * from './TextareaWidget';
+export * from './TextWidget';
 
 export const toggle = ToggleWidget;

--- a/Composer/packages/extensions/obieditortest/src/FormEditor.tsx
+++ b/Composer/packages/extensions/obieditortest/src/FormEditor.tsx
@@ -74,6 +74,8 @@ export const FormEditor: React.FunctionComponent<FormEditorProps> = props => {
     ...uiSchema[type],
   };
 
+  const dialogOptions = dialogs.map(f => f.name);
+
   const onChange = newValue => {
     if (!isEqual(newValue.formData, data)) {
       props.onChange(updateDesigner(newValue.formData));
@@ -109,6 +111,7 @@ export const FormEditor: React.FunctionComponent<FormEditorProps> = props => {
           uiSchema={dialogUiSchema}
           formContext={{
             shellApi,
+            dialogOptions,
             editorSchema: schemas.editor,
             rootId: props.focusPath,
           }}

--- a/Composer/packages/extensions/obieditortest/src/schema/uischema.ts
+++ b/Composer/packages/extensions/obieditortest/src/schema/uischema.ts
@@ -1,12 +1,13 @@
 import {
   CasesField,
-  RulesField,
-  StepsField,
-  SelectorField,
-  RecognizerField,
-  JsonField,
   CodeField,
+  JsonField,
+  RecognizerField,
+  RulesField,
+  SelectorField,
+  StepsField,
 } from '../Form/fields';
+import { DialogSelectWidget } from '../Form/widgets';
 
 export const uiSchema = {
   'Microsoft.AdaptiveDialog': {
@@ -23,6 +24,11 @@ export const uiSchema = {
       'ui:field': StepsField,
     },
     'ui:order': ['*', 'recognizer', 'selector'],
+  },
+  'Microsoft.BeginDialog': {
+    dialog: {
+      'ui:widget': DialogSelectWidget,
+    },
   },
   'Microsoft.CodeStep': {
     codeHandler: {
@@ -75,6 +81,11 @@ export const uiSchema = {
   'Microsoft.MostSpecificSelector': {
     selector: {
       'ui:field': SelectorField,
+    },
+  },
+  'Microsoft.ReplaceDialog': {
+    dialog: {
+      'ui:widget': DialogSelectWidget,
     },
   },
   'Microsoft.Rule': {


### PR DESCRIPTION
custom widget allows us to use form context to get dialog options and sets us up to get the app schema from the bot project