### PR TITLE
[Shell & Visual Editor]sync customer action for visual & form edior

### DIFF
--- a/Composer/packages/client/src/extension-container/ExtensionContainer.js
+++ b/Composer/packages/client/src/extension-container/ExtensionContainer.js
@@ -55,7 +55,6 @@ function ExtensionContainer() {
     },
 
     saveData: newData => {
-      setShellData(Object.assign({}, shellData, { data: newData }));
       return apiClient.apiCall('saveData', newData);
     },
 


### PR DESCRIPTION
Related issue: https://fuselabs.visualstudio.com/Composer/_workitems/edit/29700/
### Changes
1. sync customer action for visual & form edior
2. new item be selected when created in Visual Editor

### Preview
before
![before](https://user-images.githubusercontent.com/5860999/59591119-07f52c80-9120-11e9-8b40-b660f56427c8.gif)

after
![after](https://user-images.githubusercontent.com/5860999/59591142-104d6780-9120-11e9-9bcb-45a880b245f5.gif)
