### PR TITLE
Ignore artifacts in docker copy

### DIFF
--- a/Composer/.dockerignore
+++ b/Composer/.dockerignore
@@ -2,3 +2,7 @@
 **/package-lock.json
 **/dist
 **/build
+**/es
+# not ignore all lib folder because packages/lib, so probably we should rename that to libs
+packages/lib/**/lib
+packages/extensions/**/lib


### PR DESCRIPTION
Some packages were producing es/ folder and stop producing that after switching to ts. 

The problem is we still copy the old es folder to docker, which affects the latest update to take effect. 

A clean fix in docker would be stop copy build artifacts，which this PR does. 

But locally, if you are seeing the same issue, you should manually remove es folder from 'VisualEditor'. 