### PR TITLE
Fix some issues causing a broken experience in MS Edge

### DIFF
--- a/Composer/packages/client/package.json
+++ b/Composer/packages/client/package.json
@@ -19,7 +19,6 @@
     "codemirror": "^5.45.0",
     "composer-extensions": "*",
     "css-loader": "1.0.0",
-    "cssesc": "^3.0.0",
     "dotenv": "6.0.0",
     "dotenv-expand": "4.2.0",
     "eslint": "5.12.0",

--- a/Composer/packages/client/src/store/action/lg.js
+++ b/Composer/packages/client/src/store/action/lg.js
@@ -113,14 +113,14 @@ export async function updateLgTemplate(dispatch, { file, templateName, template 
   const oldTemplates = lgUtil.parse(file.content);
   if (Array.isArray(oldTemplates) === false) throw new Error('origin lg file is not valid');
 
-  const orignialTemplate = oldTemplates.find(x => x.Name === templateName);
+  const originalTemplate = oldTemplates.find(x => x.Name === templateName);
   let content = file.content.replace(/\s+$/, '');
 
-  if (orignialTemplate === undefined) {
+  if (originalTemplate === undefined) {
     content = `${content}${content ? '\n\n' : ''}${textFromTemplates([template])}\n`;
   } else {
-    const startLineNumber = orignialTemplate.ParseTree._start.line;
-    const endLineNumber = orignialTemplate.ParseTree._stop.line;
+    const startLineNumber = originalTemplate.ParseTree._start.line;
+    const endLineNumber = originalTemplate.ParseTree._stop.line;
 
     const lines = content.split('\n');
     const contentBefore = lines.slice(0, startLineNumber - 1).join('\n');

--- a/Composer/packages/extensions/obiformeditor/src/Form/fields/BaseField.tsx
+++ b/Composer/packages/extensions/obiformeditor/src/Form/fields/BaseField.tsx
@@ -5,7 +5,6 @@ import { JSONSchema6 } from 'json-schema';
 import { IdSchema, UiSchema } from '@bfcomposer/react-jsonschema-form';
 import get from 'lodash.get';
 import classnames from 'classnames';
-import * as cssesc from 'cssesc';
 
 import { FormContext } from '../types';
 import SectionSeparator from '../SectionSeparator';
@@ -66,13 +65,12 @@ export function BaseField<T = any>(props: BaseFieldProps<T>): JSX.Element {
 
     return descriptionOverride || description || uiSchema['ui:description'] || schema.description;
   };
-
   return isRootBaseField ? (
-    <RootField {...props} key={key} id={cssesc(key)}>
+    <RootField {...props} key={key} id={key.replace(/\.|#/g, '')}>
       {children}
     </RootField>
   ) : (
-    <div className={classnames('BaseField', className)} key={key} id={cssesc(key)}>
+    <div className={classnames('BaseField', className)} key={key} id={key.replace(/\.|#/g, '')}>
       <SectionSeparator label={getTitle()}>
         {descriptionOverride !== false && (descriptionOverride || description || schema.description) && (
           <p

--- a/Composer/packages/extensions/obiformeditor/src/Form/widgets/IntentWidget.tsx
+++ b/Composer/packages/extensions/obiformeditor/src/Form/widgets/IntentWidget.tsx
@@ -3,7 +3,6 @@ import { Dropdown, ResponsiveMode, IDropdownOption } from 'office-ui-fabric-reac
 import get from 'lodash.get';
 import { NeutralColors } from '@uifabric/fluent-theme';
 import formatMessage from 'format-message';
-import * as cssesc from 'cssesc';
 
 import { LuFile, DialogInfo } from '../../types';
 import { BFDWidgetProps, FormContext } from '../types';
@@ -90,7 +89,7 @@ export const IntentWidget: React.FC<BFDWidgetProps> = props => {
     <>
       <Dropdown
         {...rest}
-        id={cssesc(id)}
+        id={id.replace(/\.|#/g, '')}
         label={label}
         onBlur={() => onBlur(id, value)}
         onChange={handleChange}


### PR DESCRIPTION
## Description

CSS.escape and String.prototype.trimEnd are APIs that do no exist in Microsoft Edge (non-Chromium) 

## Task Item

https://github.com/microsoft/BotFramework-Composer/issues/504

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change which improve code quality, clean up, add tests, etc)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Doc update (document update)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have functionally tested my change

## Screenshots 

Please include screenshots or gifs if your PR include UX changes.
