### PR TITLE
change widget to field

### DIFF
--- a/Composer/packages/extensions/obiformeditor/src/schema/uischema.ts
+++ b/Composer/packages/extensions/obiformeditor/src/schema/uischema.ts
@@ -21,7 +21,7 @@ const activityFields = {
     'ui:widget': 'TextareaWidget',
   },
   value: {
-    'ui:widget': 'NullField',
+    'ui:field': 'NullField',
   },
 };
 


### PR DESCRIPTION
widgets can either be a string which exists in the form's widget map or a component function. they cannot be a string for a custom widget component.