### PR TITLE
fix docker build

### DIFF
--- a/Composer/.dockerignore
+++ b/Composer/.dockerignore
@@ -4,5 +4,5 @@
 **/build
 **/es
 # not ignore all lib folder because packages/lib, so probably we should rename that to libs
-packages/lib/**/lib
-packages/extensions/**/lib
+packages/lib/*/lib
+packages/extensions/*/lib


### PR DESCRIPTION
## Description

Fix docker build fail.

Root cause is in docker ignore, we ignore **/lib, causing the new folder "lib" inside src in VisualEditor not copied into docker. 

Fix: not aggressively ignore lib, only ignore one-level. 

## Task Item

Please include the link to the related work item, like fix [Something is not working](http://url.here)

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change which improve code quality, clean up, add tests, etc)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Doc update (document update)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have functionally tested my change

## Screenshots 

Please include screenshots or gifs if your PR include UX changes.
