### PR TITLE
Ignore some generated file when using docker build

### DIFF
--- a/Composer/.dockerignore
+++ b/Composer/.dockerignore
@@ -3,6 +3,8 @@
 **/dist
 **/build
 **/es
+**/server/data.json
+**/server/tmp.zip
 # not ignore all lib folder because packages/lib, so probably we should rename that to libs
 packages/lib/*/lib
 packages/extensions/*/lib


### PR DESCRIPTION
## Description

The data.json is generated when starting the server. Use docker build will copy it to the docker image. This may cause the recent bot can't be opened for the absolute path. 

## Task Item

https://github.com/microsoft/BotFramework-Composer/issues/824

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change which improve code quality, clean up, add tests, etc)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Doc update (document update)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have functionally tested my change
