### PR TITLE
[visual editor]cursor move bugfix

### DIFF
--- a/Composer/packages/extensions/visual-designer/src/components/renderers/ElementRenderer.tsx
+++ b/Composer/packages/extensions/visual-designer/src/components/renderers/ElementRenderer.tsx
@@ -105,9 +105,7 @@ export const ElementRenderer: FC<NodeProps> = ({ id, data, onEvent, onResize }):
       <ChosenRenderer
         id={id}
         data={data}
-        onEvent={(action, id) => {
-          onEvent(action, id, selectedId);
-        }}
+        onEvent={onEvent}
         onResize={size => {
           onResize(size, 'element');
         }}

--- a/Composer/packages/extensions/visual-designer/src/editors/ObiEditor.tsx
+++ b/Composer/packages/extensions/visual-designer/src/editors/ObiEditor.tsx
@@ -143,7 +143,7 @@ export const ObiEditor: FC<ObiEditorProps> = ({
   const [selectedElements, setSelectedElements] = useState<NodeListOf<HTMLElement>>(querySelectedElements());
 
   const handleKeyboardCommand = ({ primaryType, command }) => {
-    const currentSelectedId = selectionContext.selectedIds[0];
+    const currentSelectedId = selectionContext.selectedIds[0] || focusedId;
     switch (primaryType) {
       case KeyboardPrimaryTypes.Node:
         if (command === KeyboardCommandTypes.Node.Delete) {


### PR DESCRIPTION
## Description

- bug: insert new node, use cursor move keyboard shortcut, it goes to wrong place.
- root cause: insert new node will cause data change, so it will reset `selectedIds = []`, we should set `currentSelectedId=selectedIds[0] || focusId` when data reset.  


## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change which improve code quality, clean up, add tests, etc)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Doc update (document update)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have functionally tested my change

## Screenshots 

- before
![bugfix](https://user-images.githubusercontent.com/5860999/65329451-0a699580-dbeb-11e9-9586-acca77642c19.gif)

- after
![bugfix1](https://user-images.githubusercontent.com/5860999/65329467-13f2fd80-dbeb-11e9-86d3-3269cb9f7428.gif)

