### PR TITLE
Pass the auth token properly to the build command

### DIFF
--- a/Composer/packages/server/src/models/connector/interface.ts
+++ b/Composer/packages/server/src/models/connector/interface.ts
@@ -8,6 +8,11 @@ export enum BotStatus {
 
 export type BotEnvironments = 'production' | 'integration' | 'editing';
 
+export interface AuthenticatedToken {
+  accessToken: string;
+  deocdedToken?: AuthenticatedUser;
+}
+
 export interface AuthenticatedUser {
   [ClaimNames.name]: string;
   [ClaimNames.upn]: string;
@@ -18,7 +23,7 @@ export interface BotConfig {
   MicrosoftAppPassword: string;
   luis: ILuisConfig;
   targetEnvironment?: BotEnvironments;
-  user?: AuthenticatedUser;
+  user?: AuthenticatedToken;
 }
 
 export interface IBotConnector {

--- a/Composer/packages/server/src/models/connector/selfHostConnector.ts
+++ b/Composer/packages/server/src/models/connector/selfHostConnector.ts
@@ -24,14 +24,17 @@ export class SelfHostBotConnector implements IBotConnector {
 
   public sync = async (config: BotConfig) => {
     const { targetEnvironment: env } = config;
-    const user = config.user ? config.user[ClaimNames.name] : 'unknown_user';
-    const userEmail = config.user ? config.user[ClaimNames.upn] : undefined;
+    const user = config.user && config.user.deocdedToken ? config.user.deocdedToken[ClaimNames.name] : 'unknown_user';
+    const userEmail = config.user && config.user.deocdedToken ? config.user.deocdedToken[ClaimNames.upn] : undefined;
+    const accessToken = config.user ? config.user.accessToken : undefined;
     await this.buildAsync({
       user,
       userEmail,
       //eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       dest: resolve(process.env.HOME!, 'site/artifacts/bot'),
       env: env && env !== 'editing' ? env : 'integration',
+      botId: undefined,
+      accessToken,
     });
   };
 }

--- a/Composer/packages/server/src/router/absh.ts
+++ b/Composer/packages/server/src/router/absh.ts
@@ -126,7 +126,10 @@ const absh: AuthProviderInit = {
             return;
           }
 
-          req.user = token;
+          req.user = {
+            decodedToken: token,
+            accessToken: bearer,
+          };
           next();
         });
       } catch (err) {

--- a/Composer/packages/server/types/selfHostCommands.d.ts
+++ b/Composer/packages/server/types/selfHostCommands.d.ts
@@ -4,6 +4,8 @@ declare namespace SelfHostCommands {
     userEmail?: string;
     env: 'production' | 'integration';
     dest: string;
+    accessToken: string | undefined;
+    botId: string | undefined;
   }
   export interface Build {
     (argv: ARGV): Promise<string>;


### PR DESCRIPTION
The selfHost build command needs both the decoded JWT token and the undecoded token passed in, as now accessToken is a required parameter for build. This PR changes how the token is passed into the BotConnector (both decoded and full token are passed), and updates to how the build command uses these.