### PR TITLE
Update LU placeholder text + aka.ms link

### DIFF
--- a/Composer/packages/lib/code-editor/src/LuEditor.tsx
+++ b/Composer/packages/lib/code-editor/src/LuEditor.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { RichEditor, RichEditorProps } from './RichEditor';
 
-const LU_HELP = 'http://aka.ms/lu-file-format';
+const LU_HELP = 'https://aka.ms/lu-file-format';
 const placeholder = `> See ${LU_HELP} to learn about supported LU concepts.`;
 
 export function LuEditor(props: RichEditorProps) {

--- a/SampleBots/Interrupt/GetProfile/GetProfile.lu
+++ b/SampleBots/Interrupt/GetProfile/GetProfile.lu
@@ -1,4 +1,4 @@
-> See http://aka.ms/lu-file-format to learn about supported LU concepts.
+> See https://aka.ms/lu-file-format to learn about supported LU concepts.
 
 # Why
 - Why do you ask?

--- a/SampleBots/Interrupt/Main/Main.lu
+++ b/SampleBots/Interrupt/Main/Main.lu
@@ -1,4 +1,4 @@
-> See http://aka.ms/lu-file-format to learn about supported LU concepts.
+> See https://aka.ms/lu-file-format to learn about supported LU concepts.
 
 ## GetStarted
 - Get started


### PR DESCRIPTION
## Description

Updating the current placeholder/ description text for inline LU editor. 
Replacing the long link with an aka.ms link.

## Type of change

Please delete options that are not relevant.
- [x] Doc update (document update)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have functionally tested my change

## Screenshots 

![Screen Shot 2019-10-02 at 6 48 27 PM](https://user-images.githubusercontent.com/20918136/66094237-1db02580-e548-11e9-8919-a1a7a6ef4ff6.png)
