### PR TITLE
Fix Bot's name case-sensitive Issue

### DIFF
--- a/Composer/packages/client/src/CreationFlow/index.js
+++ b/Composer/packages/client/src/CreationFlow/index.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useContext } from 'react';
+import { toLower } from 'lodash';
 
 import { CreationFlowStatus } from '../constants';
 
@@ -109,7 +110,7 @@ export function CreationFlow(props) {
   const getErrorMessage = name => {
     if (
       bots.findIndex(bot => {
-        return bot.name === name;
+        return toLower(bot.name) === toLower(name);
       }) >= 0
     ) {
       return 'duplication of name';


### PR DESCRIPTION
## Description

This PR is to fix Bot's name case-sensitive issue. 
**Root cause**
Not compared bot name ignore case.
**Solution**
Compare bot name in lower case.

## Task Item

Fix https://github.com/microsoft/BotFramework-Composer/issues/1023

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have functionally tested my change

## Screenshots 

Please include screenshots or gifs if your PR include UX changes.
