### PR TITLE
fix missing LG resource link

### DIFF
--- a/Composer/packages/server/src/models/bot/indexers/dialogIndexers.ts
+++ b/Composer/packages/server/src/models/bot/indexers/dialogIndexers.ts
@@ -29,21 +29,26 @@ export class DialogIndexer {
     const visitor: VisitorFunc = (path: string, value: any): boolean => {
       // it's a valid schema dialog node.
       if (has(value, '$type')) {
-        let target;
+        const targets: string[] = [];
+        // look for prompt field
+        if (has(value, 'prompt')) {
+          targets.push(value.prompt);
+        }
+        // look for unrecognizedPrompt field
+        if (has(value, 'unrecognizedPrompt')) {
+          targets.push(value.unrecognizedPrompt);
+        }
+        // look for other $type
         switch (value.$type) {
           case 'Microsoft.SendActivity':
-            target = value.activity;
+            targets.push(value.activity);
             break;
-          case 'Microsoft.TextInput':
-            target = value.prompt;
-            break;
-
           // if we want stop at some $type, do here
           case 'location':
             return true;
         }
 
-        if (target && typeof target === 'string') {
+        targets.forEach(target => {
           // match a template name
           // match a temlate func  e.g. `showDate()`
           // eslint-disable-next-line security/detect-unsafe-regex
@@ -53,7 +58,7 @@ export class DialogIndexer {
             const templateName = matchResult[1];
             templates.push(templateName);
           }
-        }
+        });
       }
       return false;
     };


### PR DESCRIPTION
## Description

lg template look cover `prompt` & `unrecognizedPrompt`

hard-coded field  that we look for lgTemplate in dialog is 

- SendActivity.Activity
- *.prompt
- *.unrecognizedPrompt

## Task Item

https://github.com/microsoft/BotFramework-Composer/issues/915

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have functionally tested my change

## Screenshots

![image](https://user-images.githubusercontent.com/49866537/67065337-7d413e80-f1a0-11e9-8a4d-c784a3697f68.png)

