### PR TITLE
Fix can't create bot in Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       # - "9229:9229"
     volumes:
       - ./SampleBots:/SampleBots
+      - ./BotProject:/BotProject
     environment:
       - NODE_ENV=container
     # command:


### PR DESCRIPTION
## Description

We now copy bot runtime into newly created bot, so we need to make sure composer have access to the bot template to be copied.  So expose the botProject folder to docker container. 

## Task Item

https://github.com/microsoft/BotFramework-Composer/issues/1143

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change which improve code quality, clean up, add tests, etc)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Doc update (document update)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have functionally tested my change

## Screenshots

Please include screenshots or gifs if your PR include UX changes.
