### PR TITLE
[Visual Editor] Remove duplicated 'Delete' key event listener to fix #1250

### DIFF
--- a/Composer/packages/extensions/visual-designer/src/editors/ObiEditor.tsx
+++ b/Composer/packages/extensions/visual-designer/src/editors/ObiEditor.tsx
@@ -320,12 +320,6 @@ export const ObiEditor: FC<ObiEditorProps> = ({
                 '&:focus': { outline: 'none' },
               }}
               ref={el => (divRef = el)}
-              onKeyUp={e => {
-                const keyString = e.key;
-                if (keyString === 'Delete' && focusedId) {
-                  dispatchEvent(NodeEventTypes.Delete, { id: focusedId });
-                }
-              }}
               onClick={e => {
                 e.stopPropagation();
                 dispatchEvent(NodeEventTypes.Focus, { id: '' });


### PR DESCRIPTION
## Description

The `onKeyUp` listener in `ObiEditor` was duplicated with our new `KeyboardZone` component. We forgot to clean up this event handler when merging the new shortcut layer. It should be outdated now.

In this PR, this isolated key event listener was removed and won't influence the 'Delete' shortcut because it's already covered in `<KeyboardZone />`.
(Check our shortcut bindings here: https://github.com/microsoft/BotFramework-Composer/blob/stable/Composer/packages/extensions/visual-designer/src/constants/KeyboardCommandTypes.ts)

## Task Item

Fixes #1250 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change which improve code quality, clean up, add tests, etc)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Doc update (document update)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have functionally tested my change

## Screenshots

Please include screenshots or gifs if your PR include UX changes.
