### PR TITLE
[WIP][visual editor]bugfix: cursor move left or right to wrong node

### DIFF
--- a/Composer/packages/extensions/visual-designer/demo/src/stories/VisualEditorDemo.js
+++ b/Composer/packages/extensions/visual-designer/demo/src/stories/VisualEditorDemo.js
@@ -83,7 +83,7 @@ export class VisualEditorDemo extends Component {
               data={obiJson}
               dialogId={selectedFile}
               focusedEvent={focusedEvent}
-              focusedSteps={focusedSteps}
+              focusedActions={focusedSteps}
               focusedTab={focusedTab}
               clipboardActions={clipboardActions}
               shellApi={{

--- a/Composer/packages/extensions/visual-designer/src/utils/cursorTracker.ts
+++ b/Composer/packages/extensions/visual-designer/src/utils/cursorTracker.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { element } from 'prop-types';
+
 import { KeyboardCommandTypes } from '../constants/KeyboardCommandTypes';
 import { InitNodeSize, LoopEdgeMarginLeft, IconBrickSize, ElementInterval } from '../constants/ElementSizes';
 import { AttrNames } from '../constants/ElementAttributes';
@@ -17,6 +19,94 @@ enum Axle {
   Y,
 }
 
+interface ElementVector {
+  distance: number;
+  assistDistance: number;
+  selectedId: string;
+}
+
+// calculate vector between element and currentElement
+function calculateElementVector(
+  currentElement: HTMLElement,
+  element: HTMLElement,
+  boundRectKey: BoundRect,
+  assistAxle: Axle
+): ElementVector {
+  const currentElementBounds = currentElement.getBoundingClientRect();
+  const bounds: ClientRect = element.getBoundingClientRect();
+  let distance;
+  let assistDistance;
+
+  if (assistAxle === Axle.X) {
+    if (boundRectKey === BoundRect.Top) {
+      distance = bounds[boundRectKey] - currentElementBounds[boundRectKey];
+    } else {
+      distance = currentElementBounds[boundRectKey] - bounds[boundRectKey];
+    }
+    assistDistance = Math.abs(
+      currentElementBounds.left + currentElementBounds.width / 2 - (bounds.left + bounds.width / 2)
+    );
+  } else {
+    if (boundRectKey === BoundRect.Left) {
+      distance =
+        bounds[boundRectKey] + bounds.width / 2 - (currentElementBounds[boundRectKey] + currentElementBounds.width / 2);
+    } else {
+      distance =
+        currentElementBounds[boundRectKey] - currentElementBounds.width / 2 - (bounds[boundRectKey] - bounds.width / 2);
+    }
+    assistDistance = Math.abs(
+      currentElementBounds.top + currentElementBounds.height / 2 - (bounds.top + bounds.height / 2)
+    );
+  }
+  return {
+    distance,
+    assistDistance,
+    selectedId: element.getAttribute(AttrNames.SelectedId),
+  } as ElementVector;
+}
+
+// get the neareast element by caculating the venctor.
+function localeElementByVenctor(elements: ElementVector[], assistAxle: Axle): ElementVector {
+  let minElement: ElementVector = {
+    distance: 1000,
+    assistDistance: 1000,
+    selectedId: '',
+  };
+
+  // x is the length of the botAsk node and the exception node on x-axis
+  // y is the length of the botAsk node and the exception node on y-axis
+  // minCot is the cot angle of x and y
+  const x = (IconBrickSize.width + InitNodeSize.width) / 2 + LoopEdgeMarginLeft;
+  const y = ElementInterval.y + InitNodeSize.height;
+  const minCot = x / y;
+
+  elements.forEach(element => {
+    if (assistAxle === Axle.X) {
+      if (
+        element.assistDistance < InitNodeSize.width / 2 &&
+        element.distance > 0 &&
+        element.distance < minElement.distance
+      ) {
+        minElement = element;
+      }
+    } else {
+      // Only when the neareast node and the current node's cot angle must bigger than minCot can we avoid move left or right to the wrong exception node
+      if (
+        element.distance > 0 &&
+        (element.distance / element.assistDistance > minCot || element.distance > x) &&
+        element.distance <= minElement.distance
+      ) {
+        if (element.assistDistance > minElement.assistDistance && element.distance < minElement.distance) {
+          minElement = element;
+        } else if (element.assistDistance <= minElement.assistDistance && element.distance <= minElement.distance) {
+          minElement = element;
+        }
+      }
+    }
+  });
+  return minElement;
+}
+
 /**
  *
  * @param currentElement current element
@@ -27,79 +117,27 @@ enum Axle {
  */
 function localeNearestElement(
   currentElement: HTMLElement,
-  elements: NodeListOf<HTMLElement>,
+  elements: HTMLElement[],
   boundRectKey: BoundRect,
   assistAxle: Axle,
   filterAttrs?: AttrNames[]
 ): HTMLElement {
   let neareastElement: HTMLElement = currentElement;
-  let minDistance = 10000;
-  let distance = minDistance;
-  const elementArr = Array.from(elements).filter(
+  const elementArr = elements.filter(
     element => !filterAttrs || (filterAttrs && filterAttrs.find(key => !!element.getAttribute(key)))
   );
-  const currentElementBounds = currentElement.getBoundingClientRect();
-  let bounds: ClientRect;
-  let assistDistance;
-
-  // x is the length of the botAsk node and the exception node on x-axis
-  // y is the length of the botAsk node and the exception node on y-axis
-  // minCot is the cot angle of x and y
-  const x = (IconBrickSize.width + InitNodeSize.width) / 2 + LoopEdgeMarginLeft;
-  const y = ElementInterval.y + InitNodeSize.height;
-  const minCot = x / y;
-  let minAssistDistance = 10000;
-
-  elementArr.forEach(element => {
-    bounds = element.getBoundingClientRect();
-
-    if (assistAxle === Axle.X) {
-      if (boundRectKey === BoundRect.Top) {
-        distance = bounds[boundRectKey] - currentElementBounds[boundRectKey];
-      } else {
-        distance = currentElementBounds[boundRectKey] - bounds[boundRectKey];
-      }
-      assistDistance = Math.abs(
-        currentElementBounds.left + currentElementBounds.width / 2 - (bounds.left + bounds.width / 2)
-      );
-      if (assistDistance < InitNodeSize.width / 2 && distance > 0 && distance < minDistance) {
-        neareastElement = element;
-        minDistance = distance;
-      }
-    } else {
-      if (boundRectKey === BoundRect.Left) {
-        distance =
-          bounds[boundRectKey] +
-          bounds.width / 2 -
-          (currentElementBounds[boundRectKey] + currentElementBounds.width / 2);
-      } else {
-        distance =
-          currentElementBounds[boundRectKey] -
-          currentElementBounds.width / 2 -
-          (bounds[boundRectKey] - bounds.width / 2);
-      }
-      assistDistance = Math.abs(
-        currentElementBounds.top + currentElementBounds.height / 2 - (bounds.top + bounds.height / 2)
-      );
-
-      // Only when the neareast node and the current node's cot angle must bigger than minCot can we avoid move left or right to the wrong exception node
-      if (distance > 0 && (distance / assistDistance > minCot || distance > x) && distance <= minDistance) {
-        if (assistDistance > minAssistDistance && distance < minDistance) {
-          neareastElement = element;
-          minDistance = distance;
-        } else if (assistDistance <= minAssistDistance && distance <= minDistance) {
-          neareastElement = element;
-          minDistance = distance;
-          minAssistDistance = assistDistance;
-        }
-      }
-    }
-  });
+  const elementVectors = elementArr.map(element =>
+    calculateElementVector(currentElement, element, boundRectKey, assistAxle)
+  );
+  neareastElement = elementArr.find(
+    element =>
+      element.getAttribute(AttrNames.SelectedId) === localeElementByVenctor(elementVectors, assistAxle).selectedId
+  ) as HTMLElement;
   return neareastElement;
 }
 
-function localeElementByTab(currentElement: HTMLElement, elements: NodeListOf<HTMLElement>, command: string) {
-  const elementArr = Array.from(elements);
+function localeElementByTab(currentElement: HTMLElement, elements: HTMLElement[], command: string) {
+  let elementArr = elements;
   const currentElementBounds = currentElement.getBoundingClientRect();
   let bounds: ClientRect;
   let selectedElement: HTMLElement = currentElement;
@@ -122,7 +160,8 @@ function localeElementByTab(currentElement: HTMLElement, elements: NodeListOf<HT
       }
     });
     if (!isInvolved) {
-      selectedElement = localeNearestElement(currentElement, elements, BoundRect.Top, Axle.X, [
+      elementArr = elements.filter(ele => !judgeElementRelation(ele.getBoundingClientRect(), currentElementBounds));
+      selectedElement = localeNearestElement(currentElement, elementArr, BoundRect.Top, Axle.X, [
         AttrNames.NodeElement,
         AttrNames.EdgeMenuElement,
       ]);
@@ -136,7 +175,8 @@ function localeElementByTab(currentElement: HTMLElement, elements: NodeListOf<HT
       }
     });
     if (!isInvolved) {
-      selectedElement = localeNearestElement(currentElement, elements, BoundRect.Bottom, Axle.X, [
+      elementArr = elements.filter(ele => !judgeElementRelation(ele.getBoundingClientRect(), currentElementBounds));
+      selectedElement = localeNearestElement(currentElement, elementArr, BoundRect.Bottom, Axle.X, [
         AttrNames.NodeElement,
         AttrNames.EdgeMenuElement,
       ]);
@@ -156,6 +196,7 @@ export function moveCursor(
   id: string,
   command: string
 ): { [key: string]: string | undefined } {
+  const elements = Array.from(selectedElements);
   const currentElement = Array.from(selectedElements).find(
     element => element.dataset.selectedId === id || element.dataset.focusedId === id
   );
@@ -163,50 +204,46 @@ export function moveCursor(
   let element: HTMLElement = currentElement;
   switch (command) {
     case KeyboardCommandTypes.Cursor.MoveDown:
-      element = localeNearestElement(currentElement, selectedElements, BoundRect.Top, Axle.X, [AttrNames.NodeElement]);
+      element = localeNearestElement(currentElement, elements, BoundRect.Top, Axle.X, [AttrNames.NodeElement]);
       break;
     case KeyboardCommandTypes.Cursor.MoveUp:
-      element = localeNearestElement(currentElement, selectedElements, BoundRect.Bottom, Axle.X, [
-        AttrNames.NodeElement,
-      ]);
+      element = localeNearestElement(currentElement, elements, BoundRect.Bottom, Axle.X, [AttrNames.NodeElement]);
       break;
     case KeyboardCommandTypes.Cursor.MoveLeft:
-      element = localeNearestElement(currentElement, selectedElements, BoundRect.Right, Axle.Y, [
-        AttrNames.NodeElement,
-      ]);
+      element = localeNearestElement(currentElement, elements, BoundRect.Right, Axle.Y, [AttrNames.NodeElement]);
       break;
     case KeyboardCommandTypes.Cursor.MoveRight:
-      element = localeNearestElement(currentElement, selectedElements, BoundRect.Left, Axle.Y, [AttrNames.NodeElement]);
+      element = localeNearestElement(currentElement, elements, BoundRect.Left, Axle.Y, [AttrNames.NodeElement]);
       break;
     case KeyboardCommandTypes.Cursor.ShortMoveDown:
-      element = localeNearestElement(currentElement, selectedElements, BoundRect.Top, Axle.X, [
+      element = localeNearestElement(currentElement, elements, BoundRect.Top, Axle.X, [
         AttrNames.NodeElement,
         AttrNames.EdgeMenuElement,
       ]);
       break;
     case KeyboardCommandTypes.Cursor.ShortMoveUp:
-      element = localeNearestElement(currentElement, selectedElements, BoundRect.Bottom, Axle.X, [
+      element = localeNearestElement(currentElement, elements, BoundRect.Bottom, Axle.X, [
         AttrNames.NodeElement,
         AttrNames.EdgeMenuElement,
       ]);
       break;
     case KeyboardCommandTypes.Cursor.ShortMoveLeft:
-      element = localeNearestElement(currentElement, selectedElements, BoundRect.Right, Axle.Y, [
+      element = localeNearestElement(currentElement, elements, BoundRect.Right, Axle.Y, [
         AttrNames.NodeElement,
         AttrNames.EdgeMenuElement,
       ]);
       break;
     case KeyboardCommandTypes.Cursor.ShortMoveRight:
-      element = localeNearestElement(currentElement, selectedElements, BoundRect.Left, Axle.Y, [
+      element = localeNearestElement(currentElement, elements, BoundRect.Left, Axle.Y, [
         AttrNames.NodeElement,
         AttrNames.EdgeMenuElement,
       ]);
       break;
     case KeyboardCommandTypes.Cursor.MovePrevious:
-      element = localeElementByTab(currentElement, selectedElements, KeyboardCommandTypes.Cursor.MovePrevious);
+      element = localeElementByTab(currentElement, elements, KeyboardCommandTypes.Cursor.MovePrevious);
       break;
     case KeyboardCommandTypes.Cursor.MoveNext:
-      element = localeElementByTab(currentElement, selectedElements, KeyboardCommandTypes.Cursor.MoveNext);
+      element = localeElementByTab(currentElement, elements, KeyboardCommandTypes.Cursor.MoveNext);
       break;
   }
   element.scrollIntoView(true);

--- a/Composer/packages/extensions/visual-designer/src/utils/cursorTracker.ts
+++ b/Composer/packages/extensions/visual-designer/src/utils/cursorTracker.ts
@@ -48,21 +48,16 @@ function localeNearestElement(
   const x = (IconBrickSize.width + InitNodeSize.width) / 2 + LoopEdgeMarginLeft;
   const y = ElementInterval.y + InitNodeSize.height;
   const minCot = x / y;
+  let minAssistDistance = 10000;
 
   elementArr.forEach(element => {
     bounds = element.getBoundingClientRect();
 
     if (assistAxle === Axle.X) {
       if (boundRectKey === BoundRect.Top) {
-        distance =
-          bounds[boundRectKey] +
-          bounds.height / 2 -
-          (currentElementBounds[boundRectKey] + currentElementBounds.height / 2);
+        distance = bounds[boundRectKey] - currentElementBounds[boundRectKey];
       } else {
-        distance =
-          currentElementBounds[boundRectKey] -
-          currentElementBounds.height / 2 -
-          (bounds[boundRectKey] - bounds.height / 2);
+        distance = currentElementBounds[boundRectKey] - bounds[boundRectKey];
       }
       assistDistance = Math.abs(
         currentElementBounds.left + currentElementBounds.width / 2 - (bounds.left + bounds.width / 2)
@@ -88,9 +83,15 @@ function localeNearestElement(
       );
 
       // Only when the neareast node and the current node's cot angle must bigger than minCot can we avoid move left or right to the wrong exception node
-      if (distance > 0 && distance / assistDistance > minCot && distance <= minDistance) {
-        neareastElement = element;
-        minDistance = distance;
+      if (distance > 0 && (distance / assistDistance > minCot || distance > x) && distance <= minDistance) {
+        if (assistDistance > minAssistDistance && distance < minDistance) {
+          neareastElement = element;
+          minDistance = distance;
+        } else if (assistDistance <= minAssistDistance && distance <= minDistance) {
+          neareastElement = element;
+          minDistance = distance;
+          minAssistDistance = assistDistance;
+        }
       }
     }
   });

--- a/Composer/packages/extensions/visual-designer/src/utils/cursorTracker.ts
+++ b/Composer/packages/extensions/visual-designer/src/utils/cursorTracker.ts
@@ -66,7 +66,7 @@ function calculateElementVector(
 }
 
 // get the neareast element by caculating the venctor.
-function localeElementByVenctor(elements: ElementVector[], assistAxle: Axle): ElementVector {
+function locateElementByVenctor(elements: ElementVector[], assistAxle: Axle): ElementVector {
   let minElement: ElementVector = {
     distance: 1000,
     assistDistance: 1000,
@@ -115,7 +115,7 @@ function localeElementByVenctor(elements: ElementVector[], assistAxle: Axle): El
  * @param assistAxle assist axle for calculating.
  * @param filterAttrs filtering elements
  */
-function localeNearestElement(
+function locateNearestElement(
   currentElement: HTMLElement,
   elements: HTMLElement[],
   boundRectKey: BoundRect,
@@ -131,12 +131,12 @@ function localeNearestElement(
   );
   neareastElement = elementArr.find(
     element =>
-      element.getAttribute(AttrNames.SelectedId) === localeElementByVenctor(elementVectors, assistAxle).selectedId
+      element.getAttribute(AttrNames.SelectedId) === locateElementByVenctor(elementVectors, assistAxle).selectedId
   ) as HTMLElement;
   return neareastElement;
 }
 
-function localeElementByTab(currentElement: HTMLElement, elements: HTMLElement[], command: string) {
+function locateElementByTab(currentElement: HTMLElement, elements: HTMLElement[], command: string) {
   let elementArr = elements;
   const currentElementBounds = currentElement.getBoundingClientRect();
   let bounds: ClientRect;
@@ -161,7 +161,7 @@ function localeElementByTab(currentElement: HTMLElement, elements: HTMLElement[]
     });
     if (!isInvolved) {
       elementArr = elements.filter(ele => !judgeElementRelation(ele.getBoundingClientRect(), currentElementBounds));
-      selectedElement = localeNearestElement(currentElement, elementArr, BoundRect.Top, Axle.X, [
+      selectedElement = locateNearestElement(currentElement, elementArr, BoundRect.Top, Axle.X, [
         AttrNames.NodeElement,
         AttrNames.EdgeMenuElement,
       ]);
@@ -176,7 +176,7 @@ function localeElementByTab(currentElement: HTMLElement, elements: HTMLElement[]
     });
     if (!isInvolved) {
       elementArr = elements.filter(ele => !judgeElementRelation(ele.getBoundingClientRect(), currentElementBounds));
-      selectedElement = localeNearestElement(currentElement, elementArr, BoundRect.Bottom, Axle.X, [
+      selectedElement = locateNearestElement(currentElement, elementArr, BoundRect.Bottom, Axle.X, [
         AttrNames.NodeElement,
         AttrNames.EdgeMenuElement,
       ]);
@@ -204,46 +204,46 @@ export function moveCursor(
   let element: HTMLElement = currentElement;
   switch (command) {
     case KeyboardCommandTypes.Cursor.MoveDown:
-      element = localeNearestElement(currentElement, elements, BoundRect.Top, Axle.X, [AttrNames.NodeElement]);
+      element = locateNearestElement(currentElement, elements, BoundRect.Top, Axle.X, [AttrNames.NodeElement]);
       break;
     case KeyboardCommandTypes.Cursor.MoveUp:
-      element = localeNearestElement(currentElement, elements, BoundRect.Bottom, Axle.X, [AttrNames.NodeElement]);
+      element = locateNearestElement(currentElement, elements, BoundRect.Bottom, Axle.X, [AttrNames.NodeElement]);
       break;
     case KeyboardCommandTypes.Cursor.MoveLeft:
-      element = localeNearestElement(currentElement, elements, BoundRect.Right, Axle.Y, [AttrNames.NodeElement]);
+      element = locateNearestElement(currentElement, elements, BoundRect.Right, Axle.Y, [AttrNames.NodeElement]);
       break;
     case KeyboardCommandTypes.Cursor.MoveRight:
-      element = localeNearestElement(currentElement, elements, BoundRect.Left, Axle.Y, [AttrNames.NodeElement]);
+      element = locateNearestElement(currentElement, elements, BoundRect.Left, Axle.Y, [AttrNames.NodeElement]);
       break;
     case KeyboardCommandTypes.Cursor.ShortMoveDown:
-      element = localeNearestElement(currentElement, elements, BoundRect.Top, Axle.X, [
+      element = locateNearestElement(currentElement, elements, BoundRect.Top, Axle.X, [
         AttrNames.NodeElement,
         AttrNames.EdgeMenuElement,
       ]);
       break;
     case KeyboardCommandTypes.Cursor.ShortMoveUp:
-      element = localeNearestElement(currentElement, elements, BoundRect.Bottom, Axle.X, [
+      element = locateNearestElement(currentElement, elements, BoundRect.Bottom, Axle.X, [
         AttrNames.NodeElement,
         AttrNames.EdgeMenuElement,
       ]);
       break;
     case KeyboardCommandTypes.Cursor.ShortMoveLeft:
-      element = localeNearestElement(currentElement, elements, BoundRect.Right, Axle.Y, [
+      element = locateNearestElement(currentElement, elements, BoundRect.Right, Axle.Y, [
         AttrNames.NodeElement,
         AttrNames.EdgeMenuElement,
       ]);
       break;
     case KeyboardCommandTypes.Cursor.ShortMoveRight:
-      element = localeNearestElement(currentElement, elements, BoundRect.Left, Axle.Y, [
+      element = locateNearestElement(currentElement, elements, BoundRect.Left, Axle.Y, [
         AttrNames.NodeElement,
         AttrNames.EdgeMenuElement,
       ]);
       break;
     case KeyboardCommandTypes.Cursor.MovePrevious:
-      element = localeElementByTab(currentElement, elements, KeyboardCommandTypes.Cursor.MovePrevious);
+      element = locateElementByTab(currentElement, elements, KeyboardCommandTypes.Cursor.MovePrevious);
       break;
     case KeyboardCommandTypes.Cursor.MoveNext:
-      element = localeElementByTab(currentElement, elements, KeyboardCommandTypes.Cursor.MoveNext);
+      element = locateElementByTab(currentElement, elements, KeyboardCommandTypes.Cursor.MoveNext);
       break;
   }
   element.scrollIntoView(true);

--- a/Composer/packages/extensions/visual-designer/src/utils/cursorTracker.ts
+++ b/Composer/packages/extensions/visual-designer/src/utils/cursorTracker.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { KeyboardCommandTypes } from '../constants/KeyboardCommandTypes';
-import { InitNodeSize } from '../constants/ElementSizes';
+import { InitNodeSize, LoopEdgeMarginLeft, IconBrickSize, ElementInterval } from '../constants/ElementSizes';
 import { AttrNames } from '../constants/ElementAttributes';
 
 enum BoundRect {
@@ -40,18 +40,30 @@ function localeNearestElement(
   );
   const currentElementBounds = currentElement.getBoundingClientRect();
   let bounds: ClientRect;
-  let assistMinDistance = 10000;
   let assistDistance;
+
+  // x is the length of the botAsk node and the exception node on x-axis
+  // y is the length of the botAsk node and the exception node on y-axis
+  // minCot is the cot angle of x and y
+  const x = (IconBrickSize.width + InitNodeSize.width) / 2 + LoopEdgeMarginLeft;
+  const y = ElementInterval.y + InitNodeSize.height;
+  const minCot = x / y;
 
   elementArr.forEach(element => {
     bounds = element.getBoundingClientRect();
-    if (boundRectKey === BoundRect.Top || boundRectKey === BoundRect.Left) {
-      distance = bounds[boundRectKey] - currentElementBounds[boundRectKey];
-    } else {
-      distance = currentElementBounds[boundRectKey] - bounds[boundRectKey];
-    }
 
     if (assistAxle === Axle.X) {
+      if (boundRectKey === BoundRect.Top) {
+        distance =
+          bounds[boundRectKey] +
+          bounds.height / 2 -
+          (currentElementBounds[boundRectKey] + currentElementBounds.height / 2);
+      } else {
+        distance =
+          currentElementBounds[boundRectKey] -
+          currentElementBounds.height / 2 -
+          (bounds[boundRectKey] - bounds.height / 2);
+      }
       assistDistance = Math.abs(
         currentElementBounds.left + currentElementBounds.width / 2 - (bounds.left + bounds.width / 2)
       );
@@ -60,13 +72,25 @@ function localeNearestElement(
         minDistance = distance;
       }
     } else {
+      if (boundRectKey === BoundRect.Left) {
+        distance =
+          bounds[boundRectKey] +
+          bounds.width / 2 -
+          (currentElementBounds[boundRectKey] + currentElementBounds.width / 2);
+      } else {
+        distance =
+          currentElementBounds[boundRectKey] -
+          currentElementBounds.width / 2 -
+          (bounds[boundRectKey] - bounds.width / 2);
+      }
       assistDistance = Math.abs(
         currentElementBounds.top + currentElementBounds.height / 2 - (bounds.top + bounds.height / 2)
       );
-      if (distance > 0 && distance <= minDistance && assistMinDistance >= assistDistance) {
+
+      // Only when the neareast node and the current node's cot angle must bigger than minCot can we avoid move left or right to the wrong exception node
+      if (distance > 0 && distance / assistDistance > minCot && distance <= minDistance) {
         neareastElement = element;
         minDistance = distance;
-        assistMinDistance = assistDistance;
       }
     }
   });


### PR DESCRIPTION
## Description

bugfix: cursor move left or right to wrong node
-before
It will jump to the previous promt's exception node when moving right.
![beforeCursor](https://user-images.githubusercontent.com/5860999/67759061-c08d8e00-fa79-11e9-92e0-3d233640e7a8.gif)


- after
![afterCursor](https://user-images.githubusercontent.com/5860999/67758473-b3bc6a80-fa78-11e9-9e49-663f53b6a7ec.gif)

## Task Item

#1082 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change which improve code quality, clean up, add tests, etc)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Doc update (document update)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have functionally tested my change

## Screenshots

Please include screenshots or gifs if your PR include UX changes.
