### PR TITLE
Default to the LUIS sample on empty homepage

### DIFF
--- a/Composer/packages/client/src/pages/home/index.tsx
+++ b/Composer/packages/client/src/pages/home/index.tsx
@@ -147,7 +147,7 @@ export const Home = props => {
                 title={''}
                 content={'ToDoBotWithLuis'}
                 styles={home.lastestBotItem}
-                onClick={async () => {
+                onClick={() => {
                   onClickTemplate('ToDoBotWithLuisSample');
                 }}
               />


### PR DESCRIPTION
<img width="1677" alt="Screen Shot 2019-10-29 at 4 28 52 PM" src="https://user-images.githubusercontent.com/1156704/67817038-405f2c80-fa69-11e9-9997-4aa8762b35a2.png">
