### PR TITLE
Organize lg template parsing logic in Composer

### DIFF
--- a/Composer/packages/extensions/visual-designer/src/editors/ObiEditor.tsx
+++ b/Composer/packages/extensions/visual-designer/src/editors/ObiEditor.tsx
@@ -6,6 +6,7 @@ import { jsx } from '@emotion/core';
 import { useContext, FC, useEffect, useState, useRef } from 'react';
 import { MarqueeSelection, Selection } from 'office-ui-fabric-react/lib/MarqueeSelection';
 import { has, get } from 'lodash';
+import { parseLgTemplateString } from 'shared';
 
 import { NodeEventTypes } from '../constants/NodeEventTypes';
 import { KeyboardCommandTypes, KeyboardPrimaryTypes } from '../constants/KeyboardCommandTypes';
@@ -85,13 +86,8 @@ export const ObiEditor: FC<ObiEditorProps> = ({
 
             const templates: string[] = [];
             targets.forEach(target => {
-              // only match auto generated lg temapte name
-              const reg = /\[(bfd((?:activity)|(?:prompt)|(?:unrecognizedPrompt)|(?:defaultValueResponse)|(?:invalidPrompt))-\d{6})\]/g;
-              let matchResult;
-              while ((matchResult = reg.exec(target)) !== null) {
-                const templateName = matchResult[1];
-                templates.push(templateName);
-              }
+              const lg = parseLgTemplateString(target);
+              lg && templates.push(lg.lgId);
             });
 
             return templates;

--- a/Composer/packages/extensions/visual-designer/src/utils/hooks.ts
+++ b/Composer/packages/extensions/visual-designer/src/utils/hooks.ts
@@ -2,25 +2,9 @@
 // Licensed under the MIT License.
 
 import { useContext, useState, useEffect } from 'react';
+import { parseLgTemplateString } from 'shared';
 
 import { NodeRendererContext } from '../store/NodeRendererContext';
-
-// matches [bfd<someName>-123456]
-const TEMPLATE_PATTERN = /^\[(bfd.+-\d{6})\]$/;
-
-const getTemplateId = (str?: string): string | null => {
-  if (!str) {
-    return null;
-  }
-
-  const match = TEMPLATE_PATTERN.exec(str);
-
-  if (!match || !match[1]) {
-    return null;
-  }
-
-  return match[1];
-};
 
 export const useLgTemplate = (str?: string, dialogId?: string) => {
   const { getLgTemplates } = useContext(NodeRendererContext);
@@ -28,7 +12,8 @@ export const useLgTemplate = (str?: string, dialogId?: string) => {
   let cancelled = false;
 
   const updateTemplateText = async () => {
-    const templateId = getTemplateId(str);
+    const lg = parseLgTemplateString(str || '');
+    const templateId = lg ? lg.lgId : '';
 
     if (templateId && dialogId) {
       // this is an LG template, go get it's content

--- a/Composer/packages/lib/shared/src/copyUtils.ts
+++ b/Composer/packages/lib/shared/src/copyUtils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { isLgTemplateString, parseLgTemplateString } from './lgUtils';
+import { isLgTemplateString, parseLgTemplateString, buildLgId, toLgTemplateString } from './lgUtils';
 
 const NestedFieldNames = {
   Actions: 'actions',
@@ -65,10 +65,10 @@ async function copyLgActivity(activity: string, designerId: string, lgApi: any):
   if (currentLg) {
     // Create new lg activity.
     const newLgContent = currentLg.Body;
-    const newLgId = `bfd${templateType}-${designerId}`;
+    const newLgId = buildLgId(designerId, templateType);
     try {
       await updateLgTemplate('common', newLgId, newLgContent);
-      return `[${newLgId}]`;
+      return toLgTemplateString(newLgId);
     } catch (e) {
       return newLgContent;
     }

--- a/Composer/packages/lib/shared/src/copyUtils.ts
+++ b/Composer/packages/lib/shared/src/copyUtils.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { isLgTemplate, parseLgTemplate } from './lgUtils';
+
 const NestedFieldNames = {
   Actions: 'actions',
   ElseActions: 'elseActions',
@@ -38,22 +40,6 @@ async function walkAdaptiveAction(input: any, visitor: (data: any) => Promise<an
       Promise.all(children.map(async x => await walkAdaptiveAction(x, visitor)));
     }
   }
-}
-
-const TEMPLATE_PATTERN = /^\[bfd(.+)-(\d+)\]$/;
-function isLgTemplate(template: string): boolean {
-  return TEMPLATE_PATTERN.test(template);
-}
-
-function parseLgTemplate(template: string) {
-  const result = TEMPLATE_PATTERN.exec(template);
-  if (result && result.length === 3) {
-    return {
-      templateType: result[1],
-      templateId: result[2],
-    };
-  }
-  return null;
 }
 
 async function copyLgActivity(activity: string, designerId: string, lgApi: any): Promise<string> {

--- a/Composer/packages/lib/shared/src/copyUtils.ts
+++ b/Composer/packages/lib/shared/src/copyUtils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { isLgTemplate, parseLgTemplateString } from './lgUtils';
+import { isLgTemplateString, parseLgTemplateString } from './lgUtils';
 
 const NestedFieldNames = {
   Actions: 'actions',
@@ -83,7 +83,7 @@ const overrideLgActivity = async (data, { lgApi }) => {
 const overrideLgPrompt = async (data, { lgApi }) => {
   const promptFields = ['prompt', 'unrecognizedPrompt', 'defaultValueResponse', 'invalidPrompt'];
   for (const field of promptFields) {
-    if (isLgTemplate(data[field])) {
+    if (isLgTemplateString(data[field])) {
       data[field] = await copyLgActivity(data[field], data.$designer.id, lgApi);
     }
   }

--- a/Composer/packages/lib/shared/src/copyUtils.ts
+++ b/Composer/packages/lib/shared/src/copyUtils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { isLgTemplate, parseLgTemplate } from './lgUtils';
+import { isLgTemplate, parseLgTemplateString } from './lgUtils';
 
 const NestedFieldNames = {
   Actions: 'actions',
@@ -46,7 +46,7 @@ async function copyLgActivity(activity: string, designerId: string, lgApi: any):
   if (!activity) return '';
   if (!lgApi) return activity;
 
-  const lgTemplate = parseLgTemplate(activity);
+  const lgTemplate = parseLgTemplateString(activity);
   if (!lgTemplate) return activity;
 
   const { templateType } = lgTemplate;

--- a/Composer/packages/lib/shared/src/index.ts
+++ b/Composer/packages/lib/shared/src/index.ts
@@ -11,3 +11,4 @@ export * from './dialogFactory';
 export * from './promptTabs';
 export * from './appschema';
 export * from './types';
+export * from './lgUtils';

--- a/Composer/packages/lib/shared/src/lgUtils.ts
+++ b/Composer/packages/lib/shared/src/lgUtils.ts
@@ -17,3 +17,12 @@ export function parseLgTemplateString(templateStr: string) {
   }
   return null;
 }
+
+export function buildLgId(templateId: string, templateType = 'activity'): string {
+  const lgId = `bfd${templateType}-${templateId}`;
+  return lgId;
+}
+
+export function toLgTemplateString(lgId: string): string {
+  return `[${lgId}]`;
+}

--- a/Composer/packages/lib/shared/src/lgUtils.ts
+++ b/Composer/packages/lib/shared/src/lgUtils.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 const TEMPLATE_PATTERN = /^\[(bfd(.+)-(\d+))\]$/;
-export function isLgTemplate(template: string): boolean {
+export function isLgTemplateString(template: string): boolean {
   return TEMPLATE_PATTERN.test(template);
 }
 

--- a/Composer/packages/lib/shared/src/lgUtils.ts
+++ b/Composer/packages/lib/shared/src/lgUtils.ts
@@ -1,17 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-const TEMPLATE_PATTERN = /^\[bfd(.+)-(\d+)\]$/;
+const TEMPLATE_PATTERN = /^\[(bfd(.+)-(\d+))\]$/;
 export function isLgTemplate(template: string): boolean {
   return TEMPLATE_PATTERN.test(template);
 }
 
-export function parseLgTemplate(template: string) {
-  const result = TEMPLATE_PATTERN.exec(template);
-  if (result && result.length === 3) {
+export function parseLgTemplateString(templateStr: string) {
+  const result = TEMPLATE_PATTERN.exec(templateStr);
+  if (result && result.length === 4) {
     return {
-      templateType: result[1],
-      templateId: result[2],
+      lgId: result[1],
+      templateType: result[2],
+      templateId: result[3],
     };
   }
   return null;

--- a/Composer/packages/lib/shared/src/lgUtils.ts
+++ b/Composer/packages/lib/shared/src/lgUtils.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+const TEMPLATE_PATTERN = /^\[bfd(.+)-(\d+)\]$/;
+export function isLgTemplate(template: string): boolean {
+  return TEMPLATE_PATTERN.test(template);
+}
+
+export function parseLgTemplate(template: string) {
+  const result = TEMPLATE_PATTERN.exec(template);
+  if (result && result.length === 3) {
+    return {
+      templateType: result[1],
+      templateId: result[2],
+    };
+  }
+  return null;
+}


### PR DESCRIPTION
**Motivation**: A refactoring PR for preparing future migration of lg template format.
```
[bfdactivity-123456] -> @{bfdactivity-123456}
```

**Description**
Ideally, we should implement a pair of methods to build the content in a node / the id sent to API:
```ts
// '[bfdactivity-1234]' -> ['bfdactivity-1234', 'activity', '1234']
const parseLgTemplateString: (rawString: string)=> string;

// 'bfdactivity-1234' -> '[bfdactivity-1234]'
const toLgTemplateString: (lgId: string) => string
```
**Todo**
- UT

## Task Item

Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change which improve code quality, clean up, add tests, etc)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Doc update (document update)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have functionally tested my change

## Screenshots

Please include screenshots or gifs if your PR include UX changes.
