### PR TITLE
Fix toolbar button `disabled` state in desgin page (fix #1393, #1418)

### DIFF
--- a/Composer/packages/client/src/pages/design/index.tsx
+++ b/Composer/packages/client/src/pages/design/index.tsx
@@ -206,61 +206,61 @@ function DesignPage(props) {
       type: 'action',
       text: formatMessage('Undo'),
       buttonProps: {
-        disabled: !undoHistory.canUndo(),
         iconProps: {
           iconName: 'Undo',
         },
         onClick: () => actions.undo(),
       },
       align: 'left',
+      disabled: !undoHistory.canUndo(),
     },
     {
       type: 'action',
       text: formatMessage('Redo'),
       buttonProps: {
-        disabled: !undoHistory.canRedo(),
         iconProps: {
           iconName: 'Redo',
         },
         onClick: () => actions.redo(),
       },
       align: 'left',
+      disabled: !undoHistory.canRedo(),
     },
     {
       type: 'action',
       text: formatMessage('Cut'),
       buttonProps: {
-        disabled: !nodeOperationAvailable,
         iconProps: {
           iconName: 'Cut',
         },
         onClick: () => VisualEditorAPI.cutSelection(),
       },
       align: 'left',
+      disabled: !nodeOperationAvailable,
     },
     {
       type: 'action',
       text: formatMessage('Copy'),
       buttonProps: {
-        disabled: !nodeOperationAvailable,
         iconProps: {
           iconName: 'Copy',
         },
         onClick: () => VisualEditorAPI.copySelection(),
       },
       align: 'left',
+      disabled: !nodeOperationAvailable,
     },
     {
       type: 'action',
       text: formatMessage('Delete'),
       buttonProps: {
-        disabled: !nodeOperationAvailable,
         iconProps: {
           iconName: 'Delete',
         },
         onClick: () => VisualEditorAPI.deleteSelection(),
       },
       align: 'left',
+      disabled: !nodeOperationAvailable,
     },
     {
       type: 'element',


### PR DESCRIPTION
## Description

Because of this change
![image](https://user-images.githubusercontent.com/8528761/67914808-28ec8480-fbcc-11e9-8b20-2e0452d1a0b9.png)

We need to update the position of the `disabled` property
![image](https://user-images.githubusercontent.com/8528761/67914856-4cafca80-fbcc-11e9-8cf2-29dc98f564c0.png)

## Task Item

Follows #1338 
Closes #1393 
Fixes #1418 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change which improve code quality, clean up, add tests, etc)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Doc update (document update)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have functionally tested my change

## Screenshots

Please include screenshots or gifs if your PR include UX changes.
