### PR TITLE
Fix potentially unsafe 'title' field visit

### DIFF
--- a/Composer/packages/extensions/visual-designer/src/components/nodes/Trigger.tsx
+++ b/Composer/packages/extensions/visual-designer/src/components/nodes/Trigger.tsx
@@ -18,7 +18,7 @@ function getLabel(data: any): string {
 
   const labelOverrides = ConceptLabels[data.$type];
 
-  if (labelOverrides.title) {
+  if (labelOverrides && labelOverrides.title) {
     return labelOverrides.title;
   }
 

--- a/Composer/packages/extensions/visual-designer/src/components/nodes/templates/RuleCard.tsx
+++ b/Composer/packages/extensions/visual-designer/src/components/nodes/templates/RuleCard.tsx
@@ -90,7 +90,7 @@ export const RuleCard: React.FC<CardProps> = ({ id, data, label, onEvent }): JSX
     const step = normalizeObiStep(data[StepsKey][0]);
     if (step.$type === ObiTypes.BeginDialog) {
       dialog = step.dialog;
-      summary = ConceptLabels[step.$type].title || step.$type;
+      summary = ConceptLabels[step.$type] ? ConceptLabels[step.$type].title : step.$type;
     } else {
       summary = formatMessage('1 action: {step}', { step: (ConceptLabels[step.$type] || {}).title || step.$type });
     }

--- a/Composer/packages/extensions/visual-designer/src/components/nodes/templates/RuleCard.tsx
+++ b/Composer/packages/extensions/visual-designer/src/components/nodes/templates/RuleCard.tsx
@@ -90,7 +90,7 @@ export const RuleCard: React.FC<CardProps> = ({ id, data, label, onEvent }): JSX
     const step = normalizeObiStep(data[StepsKey][0]);
     if (step.$type === ObiTypes.BeginDialog) {
       dialog = step.dialog;
-      summary = ConceptLabels[step.$type] ? ConceptLabels[step.$type].title : step.$type;
+      summary = ConceptLabels[step.$type].title || step.$type;
     } else {
       summary = formatMessage('1 action: {step}', { step: (ConceptLabels[step.$type] || {}).title || step.$type });
     }


### PR DESCRIPTION
## Description

As reported by Hongyang, there might be console errors about null reference exception on '.title' field (cannot repro is stably). This PR defends this issue.

## Task Item

Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change which improve code quality, clean up, add tests, etc)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Doc update (document update)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have functionally tested my change

## Screenshots

Please include screenshots or gifs if your PR include UX changes.
