### PR TITLE
show bot name when creating bot

### DIFF
--- a/Composer/packages/client/src/CreationFlow/DefineConversation/index.js
+++ b/Composer/packages/client/src/CreationFlow/DefineConversation/index.js
@@ -107,7 +107,7 @@ export function DefineConversation(props) {
             />
           </StackItem>
         </Stack>
-        {enableLocationBrowse && <LocationSelectContent onChange={updateLocation} />}
+        {enableLocationBrowse && <LocationSelectContent onChange={updateLocation} allowOpeningBot={false} />}
 
         <DialogFooter>
           <DefaultButton onClick={onDismiss} text={formatMessage('Cancel')} />

--- a/Composer/packages/client/src/CreationFlow/DefineConversation/index.js
+++ b/Composer/packages/client/src/CreationFlow/DefineConversation/index.js
@@ -1,14 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import React, { useState, useContext, useEffect, useRef, Fragment } from 'react';
+import React, { useState, Fragment } from 'react';
 import formatMessage from 'format-message';
 import { DialogFooter, PrimaryButton, DefaultButton, Stack, StackItem, TextField } from 'office-ui-fabric-react';
 
 import { LocationSelectContent } from '../LocationBrowser/LocationSelectContent';
 import { styles as wizardStyles } from '../StepWizard/styles';
 
-import { StoreContext } from './../../store';
 import { name, description } from './styles';
 
 const nameRegex = /^[a-zA-Z0-9-_.]+$/;

--- a/Composer/packages/client/src/CreationFlow/LocationBrowser/FileSelector.tsx
+++ b/Composer/packages/client/src/CreationFlow/LocationBrowser/FileSelector.tsx
@@ -157,7 +157,6 @@ export const FileSelector: React.FC<FileSelectorProps> = props => {
     });
     return files;
   }, [focusedStorageFolder]);
-
   function onRenderDetailsHeader(props, defaultRender) {
     return (
       <Sticky stickyPosition={StickyPositionType.Header} isScrollSynced={true}>

--- a/Composer/packages/client/src/CreationFlow/LocationBrowser/LocationSelectContent.tsx
+++ b/Composer/packages/client/src/CreationFlow/LocationBrowser/LocationSelectContent.tsx
@@ -18,7 +18,7 @@ const NEW_BOT_LOCATION_KEY = 'newBotLocation';
 export function LocationSelectContent(props) {
   const { state, actions } = useContext(StoreContext);
   const { storages, focusedStorageFolder, storageFileLoadingStatus } = state;
-  const { onOpen, onChange } = props;
+  const { onOpen, onChange, allowOpeningBot = true } = props;
 
   const { fetchFolderItemsByPath } = actions;
   const currentStorageIndex = useRef(0);
@@ -68,22 +68,17 @@ export function LocationSelectContent(props) {
       const path = item.filePath;
       if (type === FileTypes.FOLDER) {
         updateCurrentPath(path, storageId);
-      } else if (type === FileTypes.BOT) {
+      } else if (type === FileTypes.BOT && allowOpeningBot) {
         onOpen(path, storageId);
       }
     }
   };
 
   const checkShowItem = item => {
-    // this is a file->open browser
-    if (onOpen) {
-      if (item.type === 'bot' || item.type === 'folder') {
-        return true;
-      }
-      return false;
-    } else {
-      return item.type === 'folder';
+    if (item.type === 'bot' || item.type === 'folder') {
+      return true;
     }
+    return false;
   };
 
   return (

--- a/Composer/packages/client/src/CreationFlow/index.js
+++ b/Composer/packages/client/src/CreationFlow/index.js
@@ -40,15 +40,9 @@ export function CreationFlow(props) {
     init();
   }, [creationFlowStatus]);
 
-  // const getAllBots = async () => {
-  //   const data = await getAllProjects();
-  //   setBots(data);
-  // };
-
   const init = () => {
     if (creationFlowStatus !== CreationFlowStatus.CLOSE) {
       fetchTemplates();
-      //await getAllBots();
     }
 
     // load storage system list

--- a/Composer/packages/client/src/CreationFlow/index.js
+++ b/Composer/packages/client/src/CreationFlow/index.js
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import Path from 'path';
+
 import React, { useState, useEffect, useContext } from 'react';
-import { toLower, get } from 'lodash';
+import get from 'lodash.get';
 
 import { CreationFlowStatus, DialogCreationCopy, Steps, FileTypes } from '../constants';
 
@@ -19,15 +21,7 @@ export function CreationFlow(props) {
   const [step, setStep] = useState();
   // eslint-disable-next-line react/prop-types
   const { creationFlowStatus, setCreationFlowStatus } = props;
-  const {
-    fetchTemplates,
-    getAllProjects,
-    openBotProject,
-    createProject,
-    saveProjectAs,
-    saveTemplateId,
-    fetchStorages,
-  } = actions;
+  const { fetchTemplates, openBotProject, createProject, saveProjectAs, saveTemplateId, fetchStorages } = actions;
   const { templateId, templateProjects, focusedStorageFolder } = state;
 
   useEffect(() => {
@@ -123,8 +117,7 @@ export function CreationFlow(props) {
   const getErrorMessage = name => {
     if (
       bots.findIndex(bot => {
-        const path = `${focusedStorageFolder.parent}/${focusedStorageFolder.name}/${name}`;
-        console.log(bot.path, path);
+        const path = Path.join(focusedStorageFolder.parent, focusedStorageFolder.name, name);
         return bot.path === path;
       }) >= 0
     ) {


### PR DESCRIPTION
## Description
1. When creating a new bot, we should compare the name with the bots existing in current folder.
2. For user's convenience, we should show up all bots existing in current folder.

## Task Item

Closes #1445 #1372 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have functionally tested my change

## Screenshots


![aaaa](https://user-images.githubusercontent.com/24380525/68101647-a9332280-ff09-11e9-8421-5b0e8d8a48e7.gif)
