### PR TITLE
fix: yarn start:dev can't work in windows

### DIFF
--- a/Composer/packages/server/package.json
+++ b/Composer/packages/server/package.json
@@ -62,7 +62,6 @@
     "azure-storage": "^2.10.3",
     "body-parser": "^1.18.3",
     "cookie-parser": "^1.4.4",
-    "cross-env": "^6.0.3",
     "debug": "^4.1.1",
     "dotenv": "^8.1.0",
     "ejs": "^2.7.1",

--- a/Composer/packages/server/package.json
+++ b/Composer/packages/server/package.json
@@ -16,7 +16,7 @@
   "author": "",
   "license": "ISC",
   "nodemonConfig": {
-    "exec": "TS_NODE_FILES=true node --inspect=9229 -r ts-node/register src/server.ts",
+    "exec": "cross-env TS_NODE_FILES=true node --inspect=9229 -r ts-node/register src/server.ts",
     "watch": [
       "src"
     ],
@@ -62,6 +62,7 @@
     "azure-storage": "^2.10.3",
     "body-parser": "^1.18.3",
     "cookie-parser": "^1.4.4",
+    "cross-env": "^6.0.3",
     "debug": "^4.1.1",
     "dotenv": "^8.1.0",
     "ejs": "^2.7.1",

--- a/Composer/packages/server/src/models/environment/interface.ts
+++ b/Composer/packages/server/src/models/environment/interface.ts
@@ -4,7 +4,7 @@
 import { ISettingManager } from '../settings';
 import { IBotConnector } from '../connector';
 import { absHosted } from '../../settings/env';
-import settings from '../../settings/settings';
+import settings from '../../settings';
 
 export interface IEnvironmentConfig {
   name: string;

--- a/Composer/packages/server/src/services/asset.ts
+++ b/Composer/packages/server/src/services/asset.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import settings from '../settings/settings';
+import settings from '../settings';
 import { AssetManager } from '../models/asset/assetManager';
 
 class AssetService {

--- a/Composer/packages/server/src/settings/index.ts
+++ b/Composer/packages/server/src/settings/index.ts
@@ -6,14 +6,12 @@ import merge from 'lodash.merge';
 import settings from './settings.json';
 
 // overall the guidance in settings.json is to list every item in "development"
-// section with a default value, and override the value for different environment
-// in later sections
+// section with a default value, and override the value for different
+// environment in later sections
 
 const defaultSettings = settings.development;
 const environment = process.env.NODE_ENV || 'development';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const environmentSettings = (settings as any)[environment];
-
 const finalSettings = merge(defaultSettings, environmentSettings);
-
 export default finalSettings;

--- a/Composer/packages/server/src/settings/index.ts
+++ b/Composer/packages/server/src/settings/index.ts
@@ -6,12 +6,14 @@ import merge from 'lodash.merge';
 import settings from './settings.json';
 
 // overall the guidance in settings.json is to list every item in "development"
-// section with a default value, and override the value for different
-// environment in later sections
+// section with a default value, and override the value for different environment
+// in later sections
 
 const defaultSettings = settings.development;
 const environment = process.env.NODE_ENV || 'development';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const environmentSettings = (settings as any)[environment];
+
 const finalSettings = merge(defaultSettings, environmentSettings);
+
 export default finalSettings;

--- a/Composer/yarn.lock
+++ b/Composer/yarn.lock
@@ -5158,8 +5158,8 @@ create-react-context@^0.2.1:
 
 cross-env@^6.0.3:
   version "6.0.3"
-  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-6.0.3.tgz#4256b71e49b3a40637a0ce70768a6ef5c72ae941"
-  integrity sha512-+KqxF6LCvfhWvADcDPqo64yVIB31gv/jQulX2NGzKS/g3GEVz6/pt4wjHFtFWsHMddebWD/sDthJemzM4MaAag==
+  resolved "https://botbuilder.myget.org/F/botbuilder-declarative/npm/cross-env/-/cross-env-6.0.3.tgz#4256b71e49b3a40637a0ce70768a6ef5c72ae941"
+  integrity sha1-Qla3HkmzpAY3oM5wdopu9ccq6UE=
   dependencies:
     cross-spawn "^7.0.0"
 

--- a/Composer/yarn.lock
+++ b/Composer/yarn.lock
@@ -5158,8 +5158,8 @@ create-react-context@^0.2.1:
 
 cross-env@^6.0.3:
   version "6.0.3"
-  resolved "https://botbuilder.myget.org/F/botbuilder-declarative/npm/cross-env/-/cross-env-6.0.3.tgz#4256b71e49b3a40637a0ce70768a6ef5c72ae941"
-  integrity sha1-Qla3HkmzpAY3oM5wdopu9ccq6UE=
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-6.0.3.tgz#4256b71e49b3a40637a0ce70768a6ef5c72ae941"
+  integrity sha512-+KqxF6LCvfhWvADcDPqo64yVIB31gv/jQulX2NGzKS/g3GEVz6/pt4wjHFtFWsHMddebWD/sDthJemzM4MaAag==
   dependencies:
     cross-spawn "^7.0.0"
 


### PR DESCRIPTION
## Description

1. Add [cross-env](https://www.npmjs.com/package/cross-env) to set environment variables for different platforms.

![image](https://user-images.githubusercontent.com/39758135/68185152-cfc18e00-ffdb-11e9-836e-c79086f770ba.png)

2. In development "import settings from '../settings/settings';" will import setting.json. This will make some path can't be found. so I renamed the setting.ts to index.ts.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change which improve code quality, clean up, add tests, etc)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Doc update (document update)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have functionally tested my change

## Screenshots

Please include screenshots or gifs if your PR include UX changes.
