### PR TITLE
add login.microsoftonline.com and *.botframework.com to CSP frame-src

### DIFF
--- a/Composer/packages/server/src/server.ts
+++ b/Composer/packages/server/src/server.ts
@@ -25,7 +25,7 @@ const CS_POLICIES = [
   "img-src 'self' data:;",
   "base-uri 'none';",
   "connect-src 'self';",
-  "frame-src 'self' bfemulator:;",
+  "frame-src 'self' bfemulator: https://login.microsoftonline.com https://*.botframework.com;",
   "worker-src 'self';",
   "form-action 'none';",
   "frame-ancestors 'self';",


### PR DESCRIPTION
## Description

Adding https://login.microsoftonline.com and https://*.botframework.com to the composer server side content security policy to allow login refresh to work

Without it, the hosted composer session can not refresh the login token.

For release build the initial token is valid for 2 hours. 
For scratch devportal, the token is only valid for 20 minutes.

Notice, since the token is saved in the local store and **NOT** refreshed when composer refreshes, the user may encounter the failure to refresh login less predictable from session to session.

1. users opens composer at 10am, works on it, close it, goto lunch
1. user comes back at 11:45, reopen the composer, works for 15 minutes, then hit the 'cant refresh login' bug.

User can workaround this by refresh the composer after the token expires.

If this is a bug fix, please describe the root cause and analysis of this problem.

## Task Item

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change which improve code quality, clean up, add tests, etc)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Doc update (document update)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have functionally tested my change

## Screenshots

Please include screenshots or gifs if your PR include UX changes.
