### PR TITLE
Fix docs link

### DIFF
--- a/Composer/README.md
+++ b/Composer/README.md
@@ -29,7 +29,7 @@ then go to http://localhost:3000/, best experienced in Chrome
 If you run into the issue of `There appears to be trouble with your network connection. Retrying...` when running `yarn install`, plese run `yarn install --network-timeout 1000000` instead to bypass the issue.
 
 ## Documentation
-The documentation for Composer [can be found here](/blob/master/docs/).
+The documentation for Composer [can be found here](/toc.md).
 
 ## Extension Framework
 Composer is built on top of an extension framework, which allows anyone to provide an extension as the editor of certain type of bot assets.


### PR DESCRIPTION
I submitted the following pull request to stable branch.
So, I resubmit to master branch as @a-b-r-o-w-n said.
[Fix docs link #1549](https://github.com/microsoft/BotFramework-Composer/pull/1549)

## Description
I found the following link is the below 404.
So, I guess the correct link is "https://github.com/microsoft/BotFramework-Composer/blob/stable/toc.md".

