### PR TITLE
fix: QnA Maker EndpointKey is null Issue

### DIFF
--- a/Composer/packages/lib/shared/src/constant.ts
+++ b/Composer/packages/lib/shared/src/constant.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export const SensitiveProperties = ['MicrosoftAppPassword', 'luis.authoringKey', 'luis.endpointKey', 'qna.endpointkey'];
+export const SensitiveProperties = ['MicrosoftAppPassword', 'luis.authoringKey', 'luis.endpointKey'];


### PR DESCRIPTION
## Description

This PR is to fix this [Issue](https://github.com/microsoft/BotFramework-Composer/issues/1538)
[Ref](https://github.com/microsoft/BotFramework-Composer/pull/1558)

**Root Cause** 
This Issue is because the botproject(runtime) read qna.endpointkey from disk before, and we omit it as a fixed sensitive property. But It's more like a self-defined property and no need to omit. 

## Task Item
closes #1538

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change which improve code quality, clean up, add tests, etc)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Doc update (document update)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have functionally tested my change

## Screenshots
During the QnaMaker trace, it won't show "Object not set to instance of an object" anymore.
![image](https://user-images.githubusercontent.com/21174180/68727909-af5b8a00-0600-11ea-998e-8e3b46d8c663.png)