### PR TITLE
fix: E2E test Onboarding and LgPage

### DIFF
--- a/Composer/cypress/integration/LGPage.spec.js
+++ b/Composer/cypress/integration/LGPage.spec.js
@@ -24,7 +24,7 @@ context('check language generation page', () => {
     cy.get('@switchButton').click();
 
     // nav to Main dialog
-    cy.get('.dialogNavTree button[title="__TestTodoSample.Main"]').click();
+    cy.get('.dialogNavTree a[title="__TestTodoSample.Main"]').click();
     cy.wait(300);
 
     // dialog filter, edit mode button is disabled.

--- a/Composer/cypress/integration/Onboarding.spec.js
+++ b/Composer/cypress/integration/Onboarding.spec.js
@@ -18,6 +18,15 @@ context('onboarding', () => {
     cy.get('input[data-testid="NewDialogName"]').type('__TestOnboarding');
     cy.get('input[data-testid="NewDialogName"]').type('{enter}');
     cy.wait(2000);
+
+    //enable onboarding setting
+    cy.visitPage("Settings");
+    cy.wait(2000);
+    cy.get('[data-testid="ProjectTree"]').within(() => {
+      cy.get('[title="Onboarding"]').click();
+    });
+    cy.get('button[data-testid="onboardingToggle"]').click();
+    cy.visitPage("Design Flow");
   });
 
   it('walk through product tour teaching bubbles', () => {

--- a/Composer/cypress/support/commands.js
+++ b/Composer/cypress/support/commands.js
@@ -101,3 +101,7 @@ Cypress.Commands.add('addEventHandler', handler => {
   }
   cy.get(`[data-testid="triggerFormSubmit"]`).click();
 });
+
+Cypress.Commands.add('visitPage', (page) => {
+  cy.get(`[data-testid="LeftNav-CommandBarButton${page}"]`).click();
+});


### PR DESCRIPTION
## Description

1. Onboarding is set disabled by default. Make it enable before testing.
2. LgPage can't find the button.

closes #1592 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change which improve code quality, clean up, add tests, etc)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Doc update (document update)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have functionally tested my change

## Screenshots

Please include screenshots or gifs if your PR include UX changes.
