### PR TITLE
ci: update validate-pr action trigger

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -1,8 +1,6 @@
 name: Pull Request Validation
 
-on:
-  pull_request:
-    types: [opened, reopened, edited]
+on: pull_request
 
 jobs:
   conventional-pr:


### PR DESCRIPTION
The `edited` event creates a new check instead of re-using the failed on. This creates more noise that necessary. Instead, use the `re-run` check in the Github UI.

refs #1564