### PR TITLE
chore: add startup script to check for oudated versions

### DIFF
--- a/Composer/package.json
+++ b/Composer/package.json
@@ -19,7 +19,7 @@
     "packages/tools/language-servers/*"
   ],
   "scripts": {
-    "build": "node scripts/begin.js && node scripts/update.js && yarn build:prod",
+    "build": "node scripts/update.js && node scripts/begin.js && yarn build:prod",
     "build:prod": "yarn build:dev && yarn build:server && yarn build:client",
     "build:dev": "yarn build:tools && yarn build:lib && yarn build:extensions",
     "build:lib": "yarn workspace @bfc/libs build:all",

--- a/Composer/package.json
+++ b/Composer/package.json
@@ -19,7 +19,7 @@
     "packages/tools/language-servers/*"
   ],
   "scripts": {
-    "build": "node scripts/begin.js && yarn build:prod",
+    "build": "node scripts/begin.js && node scripts/update.js && yarn build:prod",
     "build:prod": "yarn build:dev && yarn build:server && yarn build:client",
     "build:dev": "yarn build:tools && yarn build:lib && yarn build:extensions",
     "build:lib": "yarn workspace @bfc/libs build:all",
@@ -28,7 +28,7 @@
     "build:client": "yarn workspace @bfc/client build",
     "build:tools": "yarn workspace @bfc/tools build:all",
     "start": "cross-env NODE_ENV=production PORT=3000 yarn start:server",
-    "startall": "concurrently --kill-others-on-fail \"npm:runtime\" \"npm:start\"",
+    "startall": "node scripts/update.js && concurrently --kill-others-on-fail \"npm:runtime\" \"npm:start\"",
     "start:dev": "concurrently  \"npm:start:client\" \"npm:start:server:dev\"",
     "start:client": "yarn workspace @bfc/client start",
     "start:server": "yarn workspace @bfc/server start",

--- a/Composer/scripts/update.js
+++ b/Composer/scripts/update.js
@@ -1,7 +1,7 @@
 const chalk = require('react-dev-utils/chalk');
 const { execSync } = require('child_process');
 
-const RELEASE_BRANCH = 'cwhitten/stable';
+const RELEASE_BRANCH = 'stable';
 const branch = execSync("git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* (.*)/ \1/'");
 const trimmedBranch = branch
   .toString()

--- a/Composer/scripts/update.js
+++ b/Composer/scripts/update.js
@@ -1,0 +1,20 @@
+const chalk = require('react-dev-utils/chalk');
+const { execSync } = require('child_process');
+
+console.log(chalk.yellow('Checking for updates...\n'));
+try {
+  const sha = execSync('git rev-parse --short');
+  const originSha = execSync('git rev-parse --short origin/stable');
+  if (sha.toString() !== originSha.toString()) {
+    console.log(
+      chalk.yellow(
+        `An update to Composer is available.\n\nRun 'git pull origin stable' or fetch from origin/stable using another git-based tool.\n\nSee the CHANGELOG for more details.\nhttps://github.com/microsoft/BotFramework-Composer/blob/stable/CHANGELOG.md#releases\n`
+      )
+    );
+  } else {
+    console.log(chalk.green('You are using the most up to date version of Composer.'));
+  }
+} catch (e) {
+  console.log('e', e);
+  return;
+}

--- a/Composer/scripts/update.js
+++ b/Composer/scripts/update.js
@@ -1,23 +1,29 @@
 const chalk = require('react-dev-utils/chalk');
 const { execSync } = require('child_process');
 
-console.log(chalk.yellow('Checking for updates...\n'));
-try {
-  const branch = execSync("git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/ \1/'");
-  const trimmedBranch = branch.toString().replace(' * ', '')
-  console.log('tb', trimmedBranch)
-  const sha = execSync(`git rev-parse --short ${trimmedBranch.toString()}`);
-  const originSha = execSync(`git rev-parse --short origin/${trimmedBranch.toString()}`);
-  if (sha.toString() !== originSha.toString()) {
-    console.log(
-      chalk.yellow(
-        `An update to Composer is available.\n\nRun 'git pull origin stable' or fetch from origin/stable using another git-based tool.\n\nSee the CHANGELOG for more details.\nhttps://github.com/microsoft/BotFramework-Composer/blob/stable/CHANGELOG.md#releases\n`
-      )
-    );
-  } else {
-    console.log(chalk.green('You are using the most up to date version of Composer.'));
+const RELEASE_BRANCH = 'cwhitten/stable';
+const branch = execSync("git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* (.*)/ \1/'");
+const trimmedBranch = branch
+  .toString()
+  .trim()
+  .replace(/\*\s?/, '');
+
+if (trimmedBranch === RELEASE_BRANCH) {
+  console.log(chalk.yellow('Checking for updates...\n'));
+  try {
+    const sha = execSync(`git rev-parse --short ${RELEASE_BRANCH}`).toString();
+    const originSha = execSync(`git rev-parse --short origin/${RELEASE_BRANCH}`).toString();
+    if (sha !== originSha) {
+      console.log(
+        chalk.yellow(
+          `An update to Composer is available.\n\nRun 'git pull origin stable' or fetch from origin/stable using another git-based tool.\n\nSee the CHANGELOG for more details.\nhttps://github.com/microsoft/BotFramework-Composer/blob/stable/CHANGELOG.md#releases\n`
+        )
+      );
+    } else {
+      console.log(chalk.green('You are using the most up to date version of Composer.'));
+    }
+  } catch (e) {
+    console.log('e', e);
+    return;
   }
-} catch (e) {
-  console.log('e', e);
-  return;
 }

--- a/Composer/scripts/update.js
+++ b/Composer/scripts/update.js
@@ -4,9 +4,10 @@ const { execSync } = require('child_process');
 console.log(chalk.yellow('Checking for updates...\n'));
 try {
   const branch = execSync("git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/ \1/'");
-  console.log('b', branch.toString())
-  const sha = execSync(`git rev-parse --short ${branch.toString()}`);
-  const originSha = execSync(`git rev-parse --short origin/${branch.toString()}`);
+  const trimmedBranch = branch.toString().replace(' * ', '')
+  console.log('tb', trimmedBranch)
+  const sha = execSync(`git rev-parse --short ${trimmedBranch.toString()}`);
+  const originSha = execSync(`git rev-parse --short origin/${trimmedBranch.toString()}`);
   if (sha.toString() !== originSha.toString()) {
     console.log(
       chalk.yellow(

--- a/Composer/scripts/update.js
+++ b/Composer/scripts/update.js
@@ -3,8 +3,10 @@ const { execSync } = require('child_process');
 
 console.log(chalk.yellow('Checking for updates...\n'));
 try {
-  const sha = execSync('git rev-parse --short');
-  const originSha = execSync('git rev-parse --short origin/stable');
+  const branch = execSync("git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/ \1/'");
+  console.log('b', branch.toString())
+  const sha = execSync(`git rev-parse --short ${branch.toString()}`);
+  const originSha = execSync(`git rev-parse --short origin/${branch.toString()}`);
   if (sha.toString() !== originSha.toString()) {
     console.log(
       chalk.yellow(

--- a/Composer/scripts/update.js
+++ b/Composer/scripts/update.js
@@ -23,7 +23,6 @@ if (trimmedBranch === RELEASE_BRANCH) {
       console.log(chalk.green('You are using the most up to date version of Composer.'));
     }
   } catch (e) {
-    console.log('e', e);
-    return;
+    console.log(chalk.yellow('Unable to compare applications versions.. continuing'));
   }
 }

--- a/Composer/scripts/update.js
+++ b/Composer/scripts/update.js
@@ -1,7 +1,7 @@
 const chalk = require('react-dev-utils/chalk');
 const { execSync } = require('child_process');
 
-const RELEASE_BRANCH = 'cwhitten/update';
+const RELEASE_BRANCH = 'stable';
 const branch = execSync("git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* (.*)/ \1/'");
 const trimmedBranch = branch
   .toString()

--- a/Composer/scripts/update.js
+++ b/Composer/scripts/update.js
@@ -1,7 +1,7 @@
 const chalk = require('react-dev-utils/chalk');
 const { execSync } = require('child_process');
 
-const RELEASE_BRANCH = 'stable';
+const RELEASE_BRANCH = 'cwhitten/update';
 const branch = execSync("git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* (.*)/ \1/'");
 const trimmedBranch = branch
   .toString()
@@ -11,6 +11,7 @@ const trimmedBranch = branch
 if (trimmedBranch === RELEASE_BRANCH) {
   console.log(chalk.yellow('Checking for updates...\n'));
   try {
+    execSync('git fetch');
     const sha = execSync(`git rev-parse --short ${RELEASE_BRANCH}`).toString();
     const originSha = execSync(`git rev-parse --short origin/${RELEASE_BRANCH}`).toString();
     if (sha !== originSha) {


### PR DESCRIPTION
refs #1674

This change introduces a script to parse the local git branch and use it to do sha inspection of the corresponding remote branch. I've added a `RELEASE_BRANCH` guard to avoid unnecessary checks in development mode. This seems appropriate for now.

I've added execution of the script inside both `build` and `startall`.

<img width="606" alt="Screen Shot 2019-11-29 at 12 54 09 PM" src="https://user-images.githubusercontent.com/1156704/69889852-ffe11180-12a7-11ea-967d-e151e0504041.png">

<img width="603" alt="Screen Shot 2019-11-29 at 12 53 48 PM" src="https://user-images.githubusercontent.com/1156704/69889887-3585fa80-12a8-11ea-8c24-a0923233f92d.png">
