### PR TITLE
fix: add fault tolerance for syntax highlighting

### DIFF
--- a/Composer/packages/lib/code-editor/src/languages/lg.ts
+++ b/Composer/packages/lib/code-editor/src/languages/lg.ts
@@ -72,7 +72,7 @@ export function registerLGLanguage(monaco: typeof monacoEditor) {
         [/([a-zA-Z][a-zA-Z0-9_.-]*)(,|\))/, ['parameter', 'delimeter']],
         [/([a-zA-Z][a-zA-Z0-9_.-]*)/, 'parameter'],
         [/[0-9.]+/, 'number'],
-        [/./, 'expression.content'],
+        [/.*$/, 'expression.content', '@pop'],
       ],
       structure_lg: [
         [/^\s*\]\s*$/, 'structure-lg', '@pop'],


### PR DESCRIPTION
fix mistakes in syntax highlighting when user enter an unpaired expression.


For example:
![image](https://user-images.githubusercontent.com/17074777/70031267-d137a380-15e5-11ea-8399-d7e7c86c928c.png)

closes #1689