### PR TITLE
fix: ability to view storages when in local dev on mac

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,7 @@
     { "language": "typescript", "autoFix": true },
     { "language": "typescriptreact", "autoFix": true }
   ],
+  "eslint.workingDirectories": ["./Composer"],
   "editor.formatOnSave": true,
   "typescript.tsdk": "./Composer/node_modules/typescript/lib"
 }

--- a/Composer/packages/client/__tests__/components/DialogWrapper/index.test.tsx
+++ b/Composer/packages/client/__tests__/components/DialogWrapper/index.test.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import { render } from 'react-testing-library';
-import { DialogWrapper } from '@app/components/DialogWrapper';
+import { DialogWrapper } from '@src/components/DialogWrapper';
 
 describe('<DialogWrapper />', () => {
   const props = {

--- a/Composer/packages/client/__tests__/jest.d.ts
+++ b/Composer/packages/client/__tests__/jest.d.ts
@@ -1,0 +1,9 @@
+import { ActionTypes } from '@src/constants';
+
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toBeDispatchedWith(type: ActionTypes, payload?: any, error?: any);
+    }
+  }
+}

--- a/Composer/packages/client/__tests__/jest.d.ts
+++ b/Composer/packages/client/__tests__/jest.d.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { ActionTypes } from '@src/constants';
 
 declare global {

--- a/Composer/packages/client/__tests__/setupTests.ts
+++ b/Composer/packages/client/__tests__/setupTests.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import formatMessage from 'format-message';
 import { setIconOptions } from 'office-ui-fabric-react/lib/Styling';
 import 'jest-dom/extend-expect';

--- a/Composer/packages/client/__tests__/store/actions/storage.test.ts
+++ b/Composer/packages/client/__tests__/store/actions/storage.test.ts
@@ -1,0 +1,61 @@
+import httpClient from '@src/utils/httpUtil';
+import { ActionTypes } from '@src/constants';
+import { fetchFolderItemsByPath } from '@src/store/action/storage';
+import { Store } from '@src/store/types';
+
+jest.mock('@src/utils/httpUtil');
+
+const dispatch = jest.fn();
+
+const store = ({ dispatch, getState: () => ({}) } as unknown) as Store;
+
+describe('fetchFolderItemsByPath', () => {
+  const id = 'default';
+  const path = '/some/path';
+
+  it('dispatches SET_STORAGEFILE_FETCHING_STATUS', async () => {
+    await fetchFolderItemsByPath(store, id, path);
+
+    expect(dispatch).toBeDispatchedWith(ActionTypes.SET_STORAGEFILE_FETCHING_STATUS, {
+      status: 'pending',
+    });
+  });
+
+  it('fetches folder items from api', async () => {
+    await fetchFolderItemsByPath(store, id, path);
+
+    expect(httpClient.get).toHaveBeenCalledWith(`/storages/${id}/blobs`, { params: { path } });
+  });
+
+  describe('when api call is successful', () => {
+    beforeEach(() => {
+      (httpClient.get as jest.Mock).mockResolvedValue({ some: 'response' });
+    });
+
+    it('dispatches GET_STORAGEFILE_SUCCESS', async () => {
+      await fetchFolderItemsByPath(store, id, path);
+
+      expect(dispatch).toBeDispatchedWith(ActionTypes.GET_STORAGEFILE_SUCCESS, {
+        response: { some: 'response' },
+      });
+    });
+  });
+
+  describe('when api call fails', () => {
+    beforeEach(() => {
+      (httpClient.get as jest.Mock).mockRejectedValue('some error');
+    });
+
+    it('dispatches SET_STORAGEFILE_FETCHING_STATUS', async () => {
+      await fetchFolderItemsByPath(store, id, path);
+
+      expect(dispatch).toBeDispatchedWith(
+        ActionTypes.SET_STORAGEFILE_FETCHING_STATUS,
+        {
+          status: 'failure',
+        },
+        'some error'
+      );
+    });
+  });
+});

--- a/Composer/packages/client/__tests__/store/actions/storage.test.ts
+++ b/Composer/packages/client/__tests__/store/actions/storage.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import httpClient from '@src/utils/httpUtil';
 import { ActionTypes } from '@src/constants';
 import { fetchFolderItemsByPath } from '@src/store/action/storage';

--- a/Composer/packages/client/jest.config.js
+++ b/Composer/packages/client/jest.config.js
@@ -17,7 +17,7 @@ module.exports = {
     'office-ui-fabric-react/lib/(.*)$': 'office-ui-fabric-react/lib-commonjs/$1',
     '@uifabric/fluent-theme/lib/(.*)$': '@uifabric/fluent-theme/lib-commonjs/$1',
 
-    '^@app/(.*)$': '<rootDir>/src/$1',
+    '^@src/(.*)$': '<rootDir>/src/$1',
   },
   testPathIgnorePatterns: ['/node_modules/', '/jestMocks/', '/testUtils/'],
   // Some node modules are packaged and distributed in a non-transpiled form

--- a/Composer/packages/client/jest.config.js
+++ b/Composer/packages/client/jest.config.js
@@ -19,14 +19,14 @@ module.exports = {
 
     '^@src/(.*)$': '<rootDir>/src/$1',
   },
-  testPathIgnorePatterns: ['/node_modules/', '/jestMocks/', '/testUtils/'],
+  testPathIgnorePatterns: ['/node_modules/', '/jestMocks/', '/testUtils/', '__tests__/setupTests.ts', '.*\\.d\\.ts'],
   // Some node modules are packaged and distributed in a non-transpiled form
   // (ex. contain import & export statements); and Jest won't be able to
   // understand them because node_modules aren't transformed by default. So
   // we can specify that they need to be transformed here.
   transformIgnorePatterns: ['/node_modules/'],
 
-  setupFilesAfterEnv: [path.resolve(__dirname, './setupTests.ts')],
+  setupFilesAfterEnv: [path.resolve(__dirname, './__tests__/setupTests.ts')],
   globals: {
     'ts-jest': {
       tsConfig: path.resolve(__dirname, './tsconfig.json'),

--- a/Composer/packages/client/jest.config.js
+++ b/Composer/packages/client/jest.config.js
@@ -26,7 +26,7 @@ module.exports = {
   // we can specify that they need to be transformed here.
   transformIgnorePatterns: ['/node_modules/'],
 
-  setupFilesAfterEnv: [path.resolve(__dirname, './setupTests.js')],
+  setupFilesAfterEnv: [path.resolve(__dirname, './setupTests.ts')],
   globals: {
     'ts-jest': {
       tsConfig: path.resolve(__dirname, './tsconfig.json'),

--- a/Composer/packages/client/setupTests.ts
+++ b/Composer/packages/client/setupTests.ts
@@ -1,0 +1,38 @@
+import formatMessage from 'format-message';
+import { setIconOptions } from 'office-ui-fabric-react/lib/Styling';
+import 'jest-dom/extend-expect';
+import { cleanup } from 'react-testing-library';
+
+// Suppress icon warnings.
+setIconOptions({
+  disableWarnings: true,
+});
+
+formatMessage.setup({
+  missingTranslation: 'ignore',
+});
+
+expect.extend({
+  toBeDispatchedWith(dispatch: jest.Mock, type: string, payload: any, error?: any) {
+    if (this.isNot) {
+      expect(dispatch).not.toHaveBeenCalledWith({
+        type,
+        payload,
+        error,
+      });
+    } else {
+      expect(dispatch).toHaveBeenCalledWith({
+        type,
+        payload,
+        error,
+      });
+    }
+
+    return {
+      pass: !this.isNot,
+      message: () => 'dispatch called with correct type and payload',
+    };
+  },
+});
+
+afterEach(cleanup);

--- a/Composer/packages/client/src/store/action/storage.ts
+++ b/Composer/packages/client/src/store/action/storage.ts
@@ -76,7 +76,7 @@ export const fetchFolderItemsByPath: ActionCreator = async ({ dispatch }, id, pa
         status: 'pending',
       },
     });
-    const response = await httpClient.get(`/storages/${id}/blobs/${path}`);
+    const response = await httpClient.get(`/storages/${id}/blobs`, { params: { path } });
     dispatch({
       type: ActionTypes.GET_STORAGEFILE_SUCCESS,
       payload: {

--- a/Composer/packages/client/src/utils/__mocks__/httpUtil.ts
+++ b/Composer/packages/client/src/utils/__mocks__/httpUtil.ts
@@ -1,0 +1,9 @@
+const defaultResponse = { data: {} };
+
+export default {
+  get: jest.fn().mockResolvedValue(defaultResponse),
+  post: jest.fn().mockResolvedValue(defaultResponse),
+  put: jest.fn().mockResolvedValue(defaultResponse),
+  patch: jest.fn().mockResolvedValue(defaultResponse),
+  delete: jest.fn().mockResolvedValue(defaultResponse),
+};

--- a/Composer/packages/client/src/utils/__mocks__/httpUtil.ts
+++ b/Composer/packages/client/src/utils/__mocks__/httpUtil.ts
@@ -1,3 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/// <reference types="jest" />
+
 const defaultResponse = { data: {} };
 
 export default {

--- a/Composer/packages/client/tsconfig.json
+++ b/Composer/packages/client/tsconfig.json
@@ -6,7 +6,7 @@
     "module": "esnext",
     "baseUrl": ".",
     "paths": {
-      "@app/*": ["src/*"]
+      "@src/*": ["src/*"]
     }
   },
   "include": ["./src/**/*", "./__tests__/**/*"],

--- a/Composer/packages/client/tsconfig.json
+++ b/Composer/packages/client/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "outDir": "build",
     "allowJs": true,
     "declaration": false,
     "module": "esnext",
@@ -9,5 +10,5 @@
       "@src/*": ["src/*"]
     }
   },
-  "include": ["./src/**/*", "./__tests__/**/*"],
+  "include": ["./src/**/*", "./__tests__/**/*"]
 }

--- a/Composer/packages/server/README.md
+++ b/Composer/packages/server/README.md
@@ -4,16 +4,16 @@ API server for composer app
 ## API spec
 
 ### FileSystem API
-FileSystem api allows you to management multiple storages and perform file-based on top of them.  
+FileSystem api allows you to management multiple storages and perform file-based on top of them.
 
 
 #### storage
 
-`storage` is a top-level resource which follows the common pattern of a REST api. 
+`storage` is a top-level resource which follows the common pattern of a REST api.
 
 `GET api/storages` list storages
 
-by default return 
+by default return
 ```
 {
     id: "default"
@@ -39,20 +39,20 @@ by default return
 
 
 #### blob
-blobs is a sub-resouce of storage, but it's not refered by ID, it's refer by path, because we are building a unified file api interface, not targeting a specific clound storage (which always have id for any item).  
+blobs is a sub-resouce of storage, but it's not refered by ID, it's refer by path, because we are building a unified file api interface, not targeting a specific clound storage (which always have id for any item).
 
-`GET api/storages/{storageId}/blobs/{path}` list dir or get file
+`GET api/storages/{storageId}/blobs?path={path}` list dir or get file
 
 this `path` is an absolute path for now
 
-Sample 
+Sample
 ```
 GET api/storage/default/c:/bots
 
 {
     name: "bots",
     parent: "c:/",
-    children: 
+    children:
     {
         {
             name: "config",
@@ -69,7 +69,7 @@ GET api/storage/default/c:/bots
     }
 }
 
-GET api/storage/default/c:/bots/a.bot 
+GET api/storage/default/c:/bots/a.bot
 
 {
    entry: "main.dialog"
@@ -81,12 +81,12 @@ GET api/storage/default/c:/bots/a.bot
 
 ### ProjectManagement API
 
-ProjectManagement api allows you to controlled current project status. open\close project, get project related resources etc. 
+ProjectManagement api allows you to controlled current project status. open\close project, get project related resources etc.
 
 `GET api/projects/opened`
 
 check if there is a opened projects, return path and storage if any, resolved all files inside this project, sample response
-``` 
+```
 {
     storageId: "default"
     path: "C:/bots/bot1.bot",

--- a/Composer/packages/server/__tests__/controllers/storage.test.ts
+++ b/Composer/packages/server/__tests__/controllers/storage.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { Request, Response } from 'express';
 import StorageService from '@src/services/storage';
 import { StorageController } from '@src/controllers/storage';

--- a/Composer/packages/server/__tests__/controllers/storage.test.ts
+++ b/Composer/packages/server/__tests__/controllers/storage.test.ts
@@ -1,0 +1,53 @@
+import { Request, Response } from 'express';
+import StorageService from '@src/services/storage';
+import { StorageController } from '@src/controllers/storage';
+
+jest.mock('@src/services/storage', () => ({
+  getBlob: jest.fn(),
+}));
+
+let mockReq: Request;
+let mockRes: Response;
+
+beforeEach(() => {
+  mockReq = {
+    params: {},
+    query: {},
+    body: {},
+  } as Request;
+
+  mockRes = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  } as any;
+});
+
+describe('getBlob', () => {
+  beforeEach(() => {
+    mockReq.params.storageId = 'default';
+  });
+
+  it('returns 400 when path query not present', async () => {
+    await StorageController.getBlob(mockReq, mockRes);
+
+    expect(mockRes.status).toHaveBeenCalledWith(400);
+    expect(mockRes.json).toHaveBeenCalledWith({ message: 'path missing from query' });
+  });
+
+  it('returns 400 when path is not absolute', async () => {
+    mockReq.query.path = 'some/path';
+    await StorageController.getBlob(mockReq, mockRes);
+
+    expect(mockRes.status).toHaveBeenCalledWith(400);
+    expect(mockRes.json).toHaveBeenCalledWith({ message: 'path must be absolute' });
+  });
+
+  it('returns blob for absolute path', async () => {
+    mockReq.query.path = '/some/path';
+    (StorageService.getBlob as jest.Mock).mockResolvedValue('some blob');
+    await StorageController.getBlob(mockReq, mockRes);
+
+    expect(mockRes.status).toHaveBeenCalledWith(200);
+    expect(mockRes.json).toHaveBeenCalledWith('some blob');
+  });
+});

--- a/Composer/packages/server/__tests__/models/bot/botProject.test.ts
+++ b/Composer/packages/server/__tests__/models/bot/botProject.test.ts
@@ -3,6 +3,7 @@
 
 import fs from 'fs';
 
+import rimraf from 'rimraf';
 import { seedNewDialog, DialogInfo } from '@bfc/shared';
 
 import { Path } from '../../../src/utility/path';
@@ -20,9 +21,10 @@ const mockLocationRef: LocationRef = {
   path: Path.join(__dirname, `${botDir}`),
 };
 
-const proj = new BotProject(mockLocationRef);
+let proj: BotProject;
 
 beforeEach(async () => {
+  proj = new BotProject(mockLocationRef);
   await proj.index();
 });
 
@@ -66,7 +68,7 @@ describe('createFromTemplate', () => {
     try {
       fs.unlinkSync(Path.resolve(__dirname, `${botDir}/ComposerDialogs/${dialogName}/${dialogName}.dialog`));
     } catch (err) {
-      throw new Error(err);
+      // ignore
     }
   });
 
@@ -104,7 +106,7 @@ describe('copyTo', () => {
               fs.unlinkSync(curPath);
             }
           });
-          fs.rmdirSync(path);
+          rimraf.sync(path);
         }
       };
       deleteFolder(copyDir);
@@ -133,11 +135,11 @@ describe('modify non exist files', () => {
 });
 
 describe('lg operation', () => {
-  afterAll(() => {
+  afterEach(() => {
     try {
-      fs.rmdirSync(Path.resolve(__dirname, `${botDir}/ComposerDialogs/root`));
+      rimraf.sync(Path.resolve(__dirname, `${botDir}/ComposerDialogs/root`));
     } catch (err) {
-      throw new Error(err);
+      // ignore
     }
   });
 
@@ -159,7 +161,10 @@ describe('lg operation', () => {
 
   it('should update lg file and update index', async () => {
     const id = 'root';
-    const content = '# hello \n - hello2';
+    let content = '# hello \n - hello';
+    await proj.createLgFile(id, content);
+
+    content = '# hello \n - hello2';
     const lgFiles = await proj.updateLgFile(id, content);
     const result = lgFiles.find(f => f.id === id);
 
@@ -175,6 +180,9 @@ describe('lg operation', () => {
 
   it('should delete lg file and update index', async () => {
     const id = 'root';
+    const content = '# hello \n - hello';
+    await proj.createLgFile(id, content);
+
     const lgFiles = await proj.removeLgFile(id);
     const result = lgFiles.find(f => f.id === id);
 
@@ -186,13 +194,12 @@ describe('lg operation', () => {
 });
 
 describe('lu operation', () => {
-  afterAll(() => {
+  afterEach(() => {
     try {
-      fs.rmdirSync(Path.resolve(__dirname, `${botDir}/ComposerDialogs/root`));
-      fs.unlinkSync(Path.resolve(__dirname, `${botDir}/ComposerDialogs/generated/luis.status.json`));
-      fs.rmdirSync(Path.resolve(__dirname, `${botDir}/ComposerDialogs/generated`));
+      rimraf.sync(Path.resolve(__dirname, `${botDir}/ComposerDialogs/root`));
+      rimraf.sync(Path.resolve(__dirname, `${botDir}/ComposerDialogs/generated`));
     } catch (err) {
-      throw new Error(err);
+      // ignore
     }
   });
 
@@ -214,7 +221,10 @@ describe('lu operation', () => {
 
   it('should update lu file and update index', async () => {
     const id = 'root';
-    const content = '## hello \n - hello2';
+    let content = '## hello \n - hello';
+    await proj.createLuFile(id, content);
+    content = '## hello \n - hello2';
+
     const luFiles = await proj.updateLuFile(id, content);
     const result = luFiles.find(f => f.id === id);
 
@@ -222,21 +232,24 @@ describe('lu operation', () => {
     expect(luFiles.length).toEqual(4);
 
     expect(result).not.toBeUndefined();
-    if (result !== undefined) {
-      expect(result.relativePath).toEqual('ComposerDialogs/root/root.lu');
-      expect(result.content).toEqual(content);
-    }
+    expect(result?.relativePath).toEqual('ComposerDialogs/root/root.lu');
+    expect(result?.content).toEqual(content);
   });
 
   it('should throw error when lu content is invalid', async () => {
     const id = 'root';
-    const content = 'hello \n hello3';
+    let content = '## hello \n - hello';
+    await proj.createLuFile(id, content);
+
+    content = 'hello \n hello3';
 
     await expect(proj.updateLuFile(id, content)).rejects.toThrow();
   });
 
   it('should delete lu file and update index', async () => {
     const id = 'root';
+    const content = '## hello \n - hello2';
+    await proj.createLuFile(id, content);
     const luFiles = await proj.removeLuFile(id);
     const result = luFiles.find(f => f.id === id);
 

--- a/Composer/packages/server/__tests__/services/project.test.ts
+++ b/Composer/packages/server/__tests__/services/project.test.ts
@@ -27,7 +27,7 @@ jest.mock('../../src/store/store', () => {
         return data[key];
       },
       set: (key: string, value: any) => {
-        console.log(`set ${value} in store`);
+        // console.log(`set ${value} in store`);
       },
     },
   };

--- a/Composer/packages/server/jest.config.js
+++ b/Composer/packages/server/jest.config.js
@@ -4,6 +4,12 @@ module.exports = {
   preset: 'ts-jest/presets/js-with-babel',
   testPathIgnorePatterns: ['/node_modules/'],
   watchPathIgnorePatterns: ['<rootDir>/__tests__/mocks'],
+
+  moduleNameMapper: {
+    // allow tests to import src code from '@src'
+    '^@src/(.*)$': '<rootDir>/src/$1',
+  },
+
   globals: {
     'ts-jest': {
       tsConfig: path.resolve(__dirname, './tsconfig.json'),

--- a/Composer/packages/server/package.json
+++ b/Composer/packages/server/package.json
@@ -11,7 +11,7 @@
     "build": "tsc -p tsconfig.build.json",
     "start": "node build/server.js",
     "start:dev": "nodemon",
-    "test": "yarn typecheck && jest",
+    "test": "jest",
     "test:watch": "jest --watch",
     "typecheck": "tsc --noEmit",
     "lint": "eslint --quiet --ext .js,.jsx,.ts,.tsx ./src ./__tests__",

--- a/Composer/packages/server/src/controllers/storage.ts
+++ b/Composer/packages/server/src/controllers/storage.ts
@@ -22,8 +22,11 @@ function updateCurrentPath(req: Request, res: Response) {
 
 async function getBlob(req: Request, res: Response) {
   const storageId = req.params.storageId;
-  const reqpath = decodeURI(req.params.path);
   try {
+    if (!req.query.path) {
+      throw new Error('path missing from query');
+    }
+    const reqpath = decodeURI(req.query.path);
     if (!Path.isAbsolute(reqpath)) {
       throw new Error('path must be absolute');
     }

--- a/Composer/packages/server/src/models/bot/botProject.ts
+++ b/Composer/packages/server/src/models/bot/botProject.ts
@@ -306,7 +306,7 @@ export class BotProject {
     await this._removeFile(luFile.relativePath);
 
     await this.luPublisher.onFileChange(luFile.relativePath, FileUpdateType.DELETE);
-    this._cleanUp(luFile.relativePath);
+    await this._cleanUp(luFile.relativePath);
     return this.mergeLuStatus(this.luFiles, this.luPublisher.status);
   };
 
@@ -367,16 +367,16 @@ export class BotProject {
     return (await this.fileStorage.exists(this.dir)) && (await this.fileStorage.stat(this.dir)).isDir;
   }
 
-  private _cleanUp = (relativePath: string) => {
+  private _cleanUp = async (relativePath: string) => {
     const absolutePath = `${this.dir}/${relativePath}`;
     const dirPath = Path.dirname(absolutePath);
-    this._removeEmptyFolder(dirPath);
+    await this._removeEmptyFolder(dirPath);
   };
 
   private _removeEmptyFolder = async (folderPath: string) => {
     const files = await this.fileStorage.readDir(folderPath);
     if (files.length === 0) {
-      this.fileStorage.rmDir(folderPath);
+      await this.fileStorage.rmDir(folderPath);
     }
   };
 

--- a/Composer/packages/server/src/router/api.ts
+++ b/Composer/packages/server/src/router/api.ts
@@ -35,7 +35,7 @@ router.get('/projects/recent', ProjectController.getRecentProjects);
 router.put('/storages/currentPath', StorageController.updateCurrentPath);
 router.get('/storages', StorageController.getStorageConnections);
 router.post('/storages', StorageController.createStorageConnection);
-router.get('/storages/:storageId/blobs/:path(*)', StorageController.getBlob);
+router.get('/storages/:storageId/blobs', StorageController.getBlob);
 
 // connector
 router.get('/launcher/connect', BotConnectorController.connect);

--- a/Composer/packages/server/tsconfig.json
+++ b/Composer/packages/server/tsconfig.json
@@ -4,7 +4,11 @@
     "declaration": false,
     "outDir": "./build/",
     "sourceMap": true,
-    "target": "es6"
+    "target": "es6",
+    "baseUrl": ".",
+    "paths": {
+      "@src/*": ["src/*"]
+    }
   },
   "include": ["src/**/*.ts", "__tests__/**/*.test.ts"]
 }


### PR DESCRIPTION
## Description

The root cause of this was not url encoding the path when loading storage folders and the webpack-dev-server not properly proxying the request to the api server (which is why it was working when running in production mode). 

I went ahead and refactored a bit, making the path a query string param instead of a route parameter. As well as some jest updates.

## Task Item

closes #1612