### PR TITLE
fix: update LG Editor with new theme

### DIFF
--- a/Composer/packages/lib/code-editor/src/languages/lg.ts
+++ b/Composer/packages/lib/code-editor/src/languages/lg.ts
@@ -38,9 +38,7 @@ export function registerLGLanguage(monaco: typeof monacoEditor) {
         // structure_lg
         [/^\s*\[/, { token: 'structure-lg-identifier', goBack: 1, next: '@structure_lg' }],
         //parameter in template name
-        [/([a-zA-Z0-9_.'-]+)(,|\))/, ['parameter', 'delimeter']],
-        //expression
-        [/@\{/, { token: 'expression', next: '@expression' }],
+        [/([a-zA-Z0-9_][a-zA-Z0-9_-]*)(,|\))/, ['parameter', 'delimeter']],
         // other
         [/[^\()]/, 'template-name'],
       ],
@@ -58,30 +56,28 @@ export function registerLGLanguage(monaco: typeof monacoEditor) {
         //expression
         [/@\{/, { token: 'expression', next: '@expression' }],
       ],
-
       fence_block: [
-        // There are only expression and normal text in multi-line mode
-        [/`{3}\s*$/, 'fence-block', '@pop'],
+        [/`{3}\s*/, { token: 'fence-block', next: '@pop' }],
         [/@\{/, { token: 'expression', next: '@expression' }],
-        [/./, 'fence-block.content'],
+        [/./, 'fence-block'],
       ],
       expression: [
         [/\}/, 'expression', '@pop'],
-        [/([a-zA-Z][a-zA-Z0-9_.-]*)(\s*\()/, [{ token: 'function-name' }, { token: 'param_identifier' }]],
-        [/'[\s\S]*?'/, 'string'],
-        [/([a-zA-Z][a-zA-Z0-9_.-]*)(,|\))/, ['parameter', 'delimeter']],
-        [/([a-zA-Z][a-zA-Z0-9_.-]*)/, 'parameter'],
-        [/[0-9.]+/, 'number'],
-        [/.*$/, 'expression.content', '@pop'],
+        [/(\s*[a-zA-Z_][a-zA-Z0-9_-]*)(\s*\()/, [{ token: 'function-name' }, { token: 'param_identifier' }]],
+        [/(\s*[a-zA-Z_][a-zA-Z0-9_.-]*\s*)(,|\))/, ['parameter', 'delimeter']],
+        [/\s*[0-9.]+\s*/, 'number'],
+        [/(\s*'[^']*?'\s*)(,|\))/, ['string', 'delimeter']],
+        [/(\s*"[^"]*?"\s*)(,|\))/, ['string', 'delimeter']],
+        [/(\s*[^},'"(]*\s*)(,|\))/, ['other-expression', 'delimeter']],
+        [/[^@}]*$/, { token: 'expression.content', next: '@pop' }],
       ],
       structure_lg: [
         [/^\s*\]\s*$/, 'structure-lg', '@pop'],
         [/\]\s*$/, 'imports', '@pop'],
         [/(\s*\[\s*)([a-zA-Z0-9_-]+\s*$)/, ['stucture-lg-identifier', 'structure-name']],
         [/^\s*>[\s\S]*$/, 'comments'],
+        [/\|/, { token: 'alternative' }],
         [/@\{/, { token: 'expression', next: '@expression' }],
-        [/.*=/, { token: 'structure-property' }],
-        [/./, 'structure-lg.content'],
       ],
     },
   });
@@ -98,11 +94,12 @@ export function registerLGLanguage(monaco: typeof monacoEditor) {
     inherit: false,
     colors: {},
     rules: [
-      { token: 'template-name', foreground: '0000FF' },
-      { token: 'function-name', foreground: '79571E' },
-      { token: 'keywords', foreground: '0000FF' },
+      { token: 'template-name', foreground: 'CA5010' },
+      { token: 'function-name', foreground: 'CA5010' },
+      { token: 'keywords', foreground: '0078D7' },
       { token: 'comments', foreground: '7A7574' },
-      { token: 'number', foreground: '00A32B' },
+      { token: 'parameter', foreground: '004E8C' },
+      { token: 'fence-block', foreground: '038387' },
       { token: 'string', foreground: 'DF2C2C' },
       { token: 'structure-name', foreground: '00B7C3' },
     ],


### PR DESCRIPTION
Closes #776 

update LG editor with new theme.
![image](https://user-images.githubusercontent.com/17074777/70227950-77261200-178e-11ea-831e-183c6695a550.png)

Examples for current LG theme:
1. template _name and keywords:
![keywords1](https://user-images.githubusercontent.com/17074777/70228028-9886fe00-178e-11ea-9f71-3646389e774e.PNG)

2. Multiline 
![multiLine1](https://user-images.githubusercontent.com/17074777/70228046-a2106600-178e-11ea-9d75-beb5d9a69499.PNG)

3. Nested function calls in expression
![nestedExpression1](https://user-images.githubusercontent.com/17074777/70228051-a472c000-178e-11ea-89fb-b4cb20f48e60.PNG)

4. Structure-lg
![structure1](https://user-images.githubusercontent.com/17074777/70228054-a63c8380-178e-11ea-855e-8c4a7d2d06bd.PNG)
![structure2](https://user-images.githubusercontent.com/17074777/70228058-a76db080-178e-11ea-8685-ae39123373f7.PNG)