### PR TITLE
fix: minor styling and labeling for linting ux 

### DIFF
--- a/Composer/packages/client/src/TestController.tsx
+++ b/Composer/packages/client/src/TestController.tsx
@@ -182,16 +182,10 @@ export const TestController: React.FC = () => {
         )}
         <div ref={addRef}>
           {showError && (
-            <Fragment>
+            <div style={{ float: 'left' }} onClick={handleErrorButtonClick}>
               <span css={errorCount}>{errorLength}</span>
-              <IconButton
-                iconProps={{ iconName: 'ErrorBadge' }}
-                css={errorButton}
-                title="Error"
-                ariaLabel="Error"
-                onClick={handleErrorButtonClick}
-              />
-            </Fragment>
+              <IconButton iconProps={{ iconName: 'ErrorBadge' }} css={errorButton} title="Error" ariaLabel="Error" />
+            </div>
           )}
           <PrimaryButton
             css={botButton}

--- a/Composer/packages/lib/shared/src/labelMap.ts
+++ b/Composer/packages/lib/shared/src/labelMap.ts
@@ -29,7 +29,7 @@ export const ConceptLabels: { [key in ConceptLabelKey]?: LabelOverride } = {
     title: formatMessage('Language Generation'),
   },
   [SDKTypes.AdaptiveDialog]: {
-    title: formatMessage('AdaptiveDialog'),
+    title: formatMessage('Adaptive dialog'),
   },
   [SDKTypes.AttachmentInput]: {
     title: formatMessage('File or attachment'),

--- a/Composer/packages/server/schemas/editor.schema
+++ b/Composer/packages/server/schemas/editor.schema
@@ -15,7 +15,7 @@
     },
     "Microsoft.AdaptiveDialog": {
       "description": "This configures a data driven dialog via a collection of events and actions.",
-      "title": "AdaptiveDialog",
+      "title": "Adaptive dialog",
       "helpLink": "https://aka.ms/botframework",
       "helpLinkText": "Learn more"
     },


### PR DESCRIPTION
refs #1667

- makes the error/warning number clickable to the Navigaiton page
- changes subtitle label to Adaptive dialog, from AdaptiveDialog