### PR TITLE
fix: Remove the unused lufiles in notifications

### DIFF
--- a/Composer/packages/client/src/pages/notifications/useNotifications.tsx
+++ b/Composer/packages/client/src/pages/notifications/useNotifications.tsx
@@ -8,6 +8,7 @@ import { StoreContext } from '../../store';
 import { replaceDialogDiagnosticLabel } from '../../utils';
 
 import { INotification, DiagnosticSeverity } from './types';
+import { getReferredFiles } from './../../utils/luUtil';
 
 export default function useNotifications(filter?: string) {
   const { state } = useContext(StoreContext);
@@ -28,7 +29,7 @@ export default function useNotifications(filter?: string) {
         });
       });
     });
-    luFiles.forEach(lufile => {
+    getReferredFiles(luFiles, dialogs).forEach(lufile => {
       lufile.diagnostics.map(diagnostic => {
         const location = `${lufile.id}.lu`;
         notifactions.push({


### PR DESCRIPTION
## Description

filter the luFiles that are used by dialogs.

## Task Item

closes #1744 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change which improve code quality, clean up, add tests, etc)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Doc update (document update)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have functionally tested my change

## Screenshots

![luis](https://user-images.githubusercontent.com/39758135/70627347-0d5fa980-1c61-11ea-90a2-6ee9f3ea1707.gif)

