### PR TITLE
fix: adding auto closing pairs in LG editor

### DIFF
--- a/Composer/packages/lib/code-editor/src/languages/lg.ts
+++ b/Composer/packages/lib/code-editor/src/languages/lg.ts
@@ -89,6 +89,14 @@ export function registerLGLanguage(monaco: typeof monacoEditor) {
     mimetypes: ['application/lg'],
   });
 
+  monaco.languages.setLanguageConfiguration('botbuilderlg', {
+    autoClosingPairs: [
+      { open: '{', close: '}' },
+      { open: '[', close: ']' },
+      { open: '(', close: ')' },
+    ],
+  });
+
   monaco.editor.defineTheme('lgtheme', {
     base: 'vs',
     inherit: false,


### PR DESCRIPTION
In LG editor, when user enter ' (', '[', '{' in template, it will auto close the pair with ')', ']', '}'. 

closes #1679 