### PR TITLE
fix: Create bot from scratch may create a non-empty bot

### DIFF
--- a/Composer/packages/client/src/CreationFlow/CreateOptions/index.js
+++ b/Composer/packages/client/src/CreationFlow/CreateOptions/index.js
@@ -72,10 +72,10 @@ export function CreateOptions(props) {
 
   const handleJumpToNext = () => {
     if (option === 'Create from template') {
-      if (template === null) onNext(templates[0]);
+      if (template === null) onNext(templates[1].key);
       else onNext(template.key);
     } else {
-      onNext(null);
+      onNext(templates[1].key);
     }
   };
 

--- a/Composer/packages/client/src/CreationFlow/CreateOptions/index.js
+++ b/Composer/packages/client/src/CreationFlow/CreateOptions/index.js
@@ -14,9 +14,9 @@ import { choiceGroup, templateItem, optionRoot, optionIcon, placeholder } from '
 
 export function CreateOptions(props) {
   const [option, setOption] = useState('create');
-  const [template, setTemplate] = useState(null);
   const { templates, onDismiss, onNext } = props;
-
+  const emptyBotKey = templates[1].id;
+  const [template, setTemplate] = useState(emptyBotKey);
   function SelectOption(props) {
     const { checked, text, key } = props;
     return (
@@ -72,10 +72,9 @@ export function CreateOptions(props) {
 
   const handleJumpToNext = () => {
     if (option === 'Create from template') {
-      if (template === null) onNext(templates[1].key);
-      else onNext(template.key);
+      onNext(template.key);
     } else {
-      onNext(templates[1].key);
+      onNext(emptyBotKey);
     }
   };
 

--- a/Composer/packages/client/src/CreationFlow/CreateOptions/index.js
+++ b/Composer/packages/client/src/CreationFlow/CreateOptions/index.js
@@ -67,12 +67,12 @@ export function CreateOptions(props) {
   };
 
   const handleItemChange = (event, option) => {
-    setTemplate(option);
+    setTemplate(option.key);
   };
 
   const handleJumpToNext = () => {
     if (option === 'Create from template') {
-      onNext(template.key);
+      onNext(template);
     } else {
       onNext(emptyBotKey);
     }


### PR DESCRIPTION
## Description
when the state templateId is set. Create a bot from scratch will use that templateId. But it should be emptyBot.

## Task Item

Closes #1814 
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have functionally tested my change

## Screenshots

Please include screenshots or gifs if your PR include UX changes.
