### PR TITLE
fix: lg all-up view editing ctrl-z bug

### DIFF
--- a/Composer/packages/client/src/pages/language-generation/code-editor.tsx
+++ b/Composer/packages/client/src/pages/language-generation/code-editor.tsx
@@ -29,7 +29,6 @@ const CodeEditor: React.FC<CodeEditorProps> = props => {
   const { fileId } = props;
   const file = lgFiles?.find(({ id }) => id === 'common');
   const [diagnostics, setDiagnostics] = useState(get(file, 'diagnostics', []));
-  const [content, setContent] = useState('');
   const [errorMsg, setErrorMsg] = useState('');
   const [lgEditor, setLgEditor] = useState<editor.IStandaloneCodeEditor | null>(null);
 
@@ -47,6 +46,7 @@ const CodeEditor: React.FC<CodeEditorProps> = props => {
   const line = Array.isArray(hashLine) ? +hashLine[0] : typeof hashLine === 'string' ? +hashLine : undefined;
 
   const inlineMode = !!template;
+  const [content, setContent] = useState(template?.body || file?.content);
 
   useEffect(() => {
     // reset content with file.content's initial state


### PR DESCRIPTION
## Description

The initial state, content is empty, so keep ctrl-z will hit this. fixed by set initial content as expected.

## Task Item

fix #1803 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change which improve code quality, clean up, add tests, etc)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Doc update (document update)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have functionally tested my change

## Screenshots

Please include screenshots or gifs if your PR include UX changes.
