### PR TITLE
fix: RepeatDialog not shown

### DIFF
--- a/Composer/packages/extensions/visual-designer/src/schema/uischema.ts
+++ b/Composer/packages/extensions/visual-designer/src/schema/uischema.ts
@@ -8,6 +8,9 @@ import { ActionCard } from '../widgets/ActionCard';
 import { UISchema } from './uischema.types';
 
 export const uiSchema: UISchema = {
+  default: {
+    'ui:widget': ActionCard,
+  },
   [SDKTypes.EditArray]: {
     'ui:widget': ActionCard,
     content: data => `${data.changeType} {${data.itemsProperty || '?'}}`,

--- a/Composer/packages/extensions/visual-designer/src/schema/uischema.types.ts
+++ b/Composer/packages/extensions/visual-designer/src/schema/uischema.types.ts
@@ -4,9 +4,13 @@
 import { FC, ComponentClass } from 'react';
 import { BaseSchema, SDKTypes } from '@bfc/shared';
 
+export enum UISchemaBuiltinKeys {
+  default = 'default',
+}
+
 /** schema */
 export type UISchema = {
-  [key in SDKTypes]?: UIWidget;
+  [key in SDKTypes | UISchemaBuiltinKeys]?: UIWidget;
 };
 
 /** widget */

--- a/Composer/packages/extensions/visual-designer/src/schema/uischemaRenderer.tsx
+++ b/Composer/packages/extensions/visual-designer/src/schema/uischemaRenderer.tsx
@@ -2,10 +2,8 @@
 // Licensed under the MIT License.
 
 import React from 'react';
-import { BaseSchema, generateSDKTitle } from '@bfc/shared';
+import { BaseSchema } from '@bfc/shared';
 import get from 'lodash/get';
-
-import { ActionCard } from '../widgets/ActionCard';
 
 import { uiSchema } from './uischema';
 import { UIWidget, UI_WIDGET_KEY, UIWidgetProp } from './uischema.types';
@@ -42,14 +40,9 @@ const renderWidget = (inputData, schema: UIWidget, contextProps = {}): JSX.Eleme
   return <Widget data={inputData} {...contextProps} {...props} />;
 };
 
-const renderFallbackElement = (data: BaseSchema, context) => {
-  return <ActionCard data={data} title={generateSDKTitle(data)} menu={context.menu} onClick={context.onClick} />;
-};
-
 export const renderSDKType = (data: BaseSchema, context?: { menu: JSX.Element; onClick }): JSX.Element => {
   const $type = get(data, '$type');
-  const schema: UIWidget = get(uiSchema, $type);
-  if (!schema) return renderFallbackElement(data, context);
+  const schema = get(uiSchema, $type, uiSchema.default);
 
   return renderWidget(data, schema, context);
 };

--- a/Composer/packages/extensions/visual-designer/src/schema/uischemaRenderer.tsx
+++ b/Composer/packages/extensions/visual-designer/src/schema/uischemaRenderer.tsx
@@ -2,8 +2,10 @@
 // Licensed under the MIT License.
 
 import React from 'react';
-import { BaseSchema } from '@bfc/shared';
+import { BaseSchema, generateSDKTitle } from '@bfc/shared';
 import get from 'lodash/get';
+
+import { ActionCard } from '../widgets/ActionCard';
 
 import { uiSchema } from './uischema';
 import { UIWidget, UI_WIDGET_KEY, UIWidgetProp } from './uischema.types';
@@ -40,12 +42,14 @@ const renderWidget = (inputData, schema: UIWidget, contextProps = {}): JSX.Eleme
   return <Widget data={inputData} {...contextProps} {...props} />;
 };
 
-const renderFallbackElement = (data: BaseSchema) => <></>;
+const renderFallbackElement = (data: BaseSchema, context) => {
+  return <ActionCard data={data} title={generateSDKTitle(data)} menu={context.menu} onClick={context.onClick} />;
+};
 
 export const renderSDKType = (data: BaseSchema, context?: { menu: JSX.Element; onClick }): JSX.Element => {
   const $type = get(data, '$type');
   const schema: UIWidget = get(uiSchema, $type);
-  if (!schema) return renderFallbackElement(data);
+  if (!schema) return renderFallbackElement(data, context);
 
   return renderWidget(data, schema, context);
 };

--- a/Composer/packages/extensions/visual-designer/src/widgets/ActionCard.tsx
+++ b/Composer/packages/extensions/visual-designer/src/widgets/ActionCard.tsx
@@ -10,8 +10,8 @@ import { ObiColors } from '../constants/ElementColors';
 
 export interface ActionCardProps extends WidgetContainerProps {
   title: string;
-  icon?: string;
-  content?: string | number | JSX.Element;
+  icon: string;
+  content: string | number | JSX.Element;
   menu: JSX.Element;
   colors?: {
     theme: string;

--- a/Composer/packages/extensions/visual-designer/src/widgets/ActionCard.tsx
+++ b/Composer/packages/extensions/visual-designer/src/widgets/ActionCard.tsx
@@ -10,8 +10,8 @@ import { ObiColors } from '../constants/ElementColors';
 
 export interface ActionCardProps extends WidgetContainerProps {
   title: string;
-  icon: string;
-  content: string | number | JSX.Element;
+  icon?: string;
+  content?: string | number | JSX.Element;
   menu: JSX.Element;
   colors?: {
     theme: string;


### PR DESCRIPTION
fixes #1831 

## Description
If a $type is not covered by uischema, it should fallback to a default element. However, the default elelement was set to `<></>` which is a blank node (it should show something).

Now the fallback renderer was set to a grey box
![image](https://user-images.githubusercontent.com/8528761/71953272-a6f88780-321c-11ea-92d2-ebbc4b3a6758.png)

changes on uischema:
![image](https://user-images.githubusercontent.com/8528761/71953781-3b171e80-321e-11ea-865d-d266d2f0529f.png)
