### PR TITLE
fix: botproject build script powershell version limit 

### DIFF
--- a/BotProject/Templates/CSharp/Scripts/build_runtime.ps1
+++ b/BotProject/Templates/CSharp/Scripts/build_runtime.ps1
@@ -1,21 +1,5 @@
-Param(
-	[object] $config,
-	[string] $customSettingFolder,
-  [string] $luisAuthroingKey,
-  [SecureString] $appPassword,
-  [string] $projFolder = $(Join-Path $(Get-Location) BotProject CSharp)
-)
-
-if ($PSVersionTable.PSVersion.Major -lt 6){
-	Write-Host "! Powershell 6 is required, current version is $($PSVersionTable.PSVersion.Major), please refer following documents for help."
-	Write-Host "For Windows - https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-windows?view=powershell-6"
-	Write-Host "For Mac - https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-macos?view=powershell-6"
-	Break
-}
-
 if ((dotnet --version) -lt 3) {
-	Write-Host "! dotnet core 3.0 is required, please refer following documents for help."
-	Write-Host "https://dotnet.microsoft.com/download/dotnet-core/3.0"
+	throw "! dotnet core 3.0 is required, please refer following documents for help. https://dotnet.microsoft.com/download/dotnet-core/3.0"
 	Break
 }
 

--- a/Composer/packages/client/src/store/action/bot.ts
+++ b/Composer/packages/client/src/store/action/bot.ts
@@ -28,7 +28,7 @@ export const connectBot: ActionCreator = async (store, settings) => {
         status: 'unConnected',
       },
     });
-    throw new Error(err.response.data.message);
+    throw new Error(err.response?.data?.message || err.message);
   }
 };
 

--- a/Composer/packages/server/src/models/connector/csharpBotConnector.ts
+++ b/Composer/packages/server/src/models/connector/csharpBotConnector.ts
@@ -64,7 +64,7 @@ export class CSharpBotConnector implements IBotConnector {
       let script = ['./Scripts/build_runtime.sh'];
       if (process.platform === 'win32') {
         shell = 'powershell';
-        script = ['./Scripts/build_runtime.ps1', '-executionpolicy', 'bypass'];
+        script = ['-executionpolicy', 'bypass', '-file', './Scripts/build_runtime.ps1'];
       }
       const build = spawn(`${shell}`, script, {
         cwd: dir,

--- a/Composer/packages/server/src/models/connector/csharpBotConnector.ts
+++ b/Composer/packages/server/src/models/connector/csharpBotConnector.ts
@@ -167,6 +167,7 @@ export class CSharpBotConnector implements IBotConnector {
   connect = async (_: BotEnvironments, __: string) => {
     const originPort = urlParse(this.endpoint).port;
     const port = await getPort({ host: 'localhost', port: parseInt(originPort || '3979') });
+    this.endpoint = `http://localhost:${port}`;
     return `http://localhost:${port}/api/messages`;
   };
 

--- a/Composer/packages/server/src/models/connector/csharpBotConnector.ts
+++ b/Composer/packages/server/src/models/connector/csharpBotConnector.ts
@@ -70,6 +70,7 @@ export class CSharpBotConnector implements IBotConnector {
         cwd: dir,
         stdio: ['pipe', 'pipe', 'pipe'],
       });
+      let errorMsg = '';
       buildDebug('building bot runtime: %d', build.pid);
       build.stdout &&
         build.stdout.on('data', function(str) {
@@ -77,10 +78,14 @@ export class CSharpBotConnector implements IBotConnector {
         });
       build.stderr &&
         build.stderr.on('data', function(err) {
-          reject(err.toString());
+          errorMsg = errorMsg + err.toString();
         });
       build.on('exit', function(code) {
-        resolve(code);
+        if (code !== 0) {
+          reject(errorMsg);
+        } else {
+          resolve(code);
+        }
       });
     });
   };

--- a/Composer/packages/server/src/models/connector/csharpBotConnector.ts
+++ b/Composer/packages/server/src/models/connector/csharpBotConnector.ts
@@ -61,12 +61,12 @@ export class CSharpBotConnector implements IBotConnector {
     // build bot runtime
     return new Promise((resolve, reject) => {
       let shell = 'sh';
-      let script = './Scripts/build_runtime.sh';
+      let script = ['./Scripts/build_runtime.sh'];
       if (process.platform === 'win32') {
         shell = 'powershell';
-        script = './Scripts/build_runtime.ps1';
+        script = ['./Scripts/build_runtime.ps1', '-executionpolicy', 'bypass'];
       }
-      const build = spawn(`${shell}`, [`${script}`], {
+      const build = spawn(`${shell}`, script, {
         cwd: dir,
         stdio: ['pipe', 'pipe', 'pipe'],
       });

--- a/Composer/packages/server/src/models/connector/csharpBotConnector.ts
+++ b/Composer/packages/server/src/models/connector/csharpBotConnector.ts
@@ -63,7 +63,7 @@ export class CSharpBotConnector implements IBotConnector {
       let shell = 'sh';
       let script = './Scripts/build_runtime.sh';
       if (process.platform === 'win32') {
-        shell = 'pwsh';
+        shell = 'powershell';
         script = './Scripts/build_runtime.ps1';
       }
       const build = spawn(`${shell}`, [`${script}`], {
@@ -177,7 +177,7 @@ export class CSharpBotConnector implements IBotConnector {
     } catch (err) {
       this.stop();
       this.status = BotStatus.NotConnected;
-      throw new Error('Error while syncing bot runtime.');
+      throw err;
     }
   };
 


### PR DESCRIPTION
## Description
**Cause** Using pwsh command to run a powershell script need its version larger than 6. So when powershell version small than 6, composer crashed in running build script.
**Solution** Remove the powershell version limit in build script, and change the pwsh command into powershell.

## Task Item
Close #1855

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change which improve code quality, clean up, add tests, etc)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Doc update (document update)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have functionally tested my change

## Screenshots

Please include screenshots or gifs if your PR include UX changes.
