### PR TITLE
refactor: use composition instead of inheritance in ElementRenderer

### DIFF
--- a/Composer/packages/extensions/visual-designer/src/components/nodes/layout-steps/BaseInput.tsx
+++ b/Composer/packages/extensions/visual-designer/src/components/nodes/layout-steps/BaseInput.tsx
@@ -12,7 +12,10 @@ import { OffsetContainer } from '../../lib/OffsetContainer';
 import { Edge } from '../../lib/EdgeComponents';
 import { GraphNode } from '../../../models/GraphNode';
 import { transformBaseInput } from '../../../transformers/transformBaseInput';
-import { ElementRenderer } from '../../renderers/ElementRenderer';
+import { ElementWrapper } from '../../renderers/ElementWrapper';
+import { BotAsks } from '../steps/BotAsks';
+import { UserInput } from '../steps/UserInput';
+import { InvalidPromptBrick } from '../steps/InvalidPromptBrick';
 
 const calculateNodes = (data, jsonpath: string) => {
   const { botAsks, userAnswers, invalidPrompt } = transformBaseInput(data, jsonpath);
@@ -33,31 +36,19 @@ export const BaseInput: FC<NodeProps> = ({ id, data, onEvent, onResize }): JSX.E
   return (
     <div className="Action-BaseInput" css={{ width: boundary.width, height: boundary.height }}>
       <OffsetContainer offset={botAsksNode.offset}>
-        <ElementRenderer
-          id={botAsksNode.id}
-          tab={PromptTab.BOT_ASKS}
-          data={botAsksNode.data}
-          onEvent={onEvent}
-          onResize={onResize}
-        />
+        <ElementWrapper id={botAsksNode.id} tab={PromptTab.BOT_ASKS}>
+          <BotAsks id={botAsksNode.id} data={botAsksNode.data} onEvent={onEvent} onResize={onResize} />
+        </ElementWrapper>
       </OffsetContainer>
       <OffsetContainer offset={userAnswersNode.offset}>
-        <ElementRenderer
-          id={userAnswersNode.id}
-          tab={PromptTab.USER_INPUT}
-          data={userAnswersNode.data}
-          onEvent={onEvent}
-          onResize={onResize}
-        />
+        <ElementWrapper id={userAnswersNode.id} tab={PromptTab.USER_INPUT}>
+          <UserInput id={userAnswersNode.id} data={userAnswersNode.data} onEvent={onEvent} onResize={onResize} />
+        </ElementWrapper>
       </OffsetContainer>
       <OffsetContainer offset={brickNode.offset}>
-        <ElementRenderer
-          id={brickNode.id}
-          tab={PromptTab.OTHER}
-          data={brickNode.data}
-          onEvent={onEvent}
-          onResize={onResize}
-        />
+        <ElementWrapper id={brickNode.id} tab={PromptTab.OTHER}>
+          <InvalidPromptBrick id={brickNode.id} data={brickNode.data} onEvent={onEvent} onResize={onResize} />
+        </ElementWrapper>
       </OffsetContainer>
       {edges ? edges.map(x => <Edge key={x.id} {...x} />) : null}
     </div>

--- a/Composer/packages/extensions/visual-designer/src/components/nodes/layout-steps/Foreach.tsx
+++ b/Composer/packages/extensions/visual-designer/src/components/nodes/layout-steps/Foreach.tsx
@@ -13,9 +13,12 @@ import { NodeEventTypes } from '../../../constants/NodeEventTypes';
 import { OffsetContainer } from '../../lib/OffsetContainer';
 import { Edge } from '../../lib/EdgeComponents';
 import { LoopIndicator } from '../../decorations/LoopIndicator';
-import { ElementRenderer } from '../../renderers/ElementRenderer';
 import { StepGroup } from '../../groups';
 import { NodeProps, defaultNodeProps } from '../nodeProps';
+import { ForeachDetail } from '../steps/ForeachDetail';
+import { ElementWrapper } from '../../renderers/ElementWrapper';
+import { ObiTypes } from '../../../constants/ObiTypes';
+import { ForeachPageDetail } from '../steps/ForeachPageDetail';
 
 import { NodeMap, BoundaryMap } from './types';
 
@@ -68,16 +71,19 @@ export const Foreach: FunctionComponent<NodeProps> = ({ id, data, onEvent, onRes
   }
 
   const { foreachNode, stepsNode, loopBeginNode, loopEndNode } = nodeMap;
+  const ForeachHeader = data.$type === ObiTypes.Foreach ? ForeachDetail : ForeachPageDetail;
   return (
     <div css={{ width: boundary.width, height: boundary.height, position: 'relative' }}>
       <OffsetContainer offset={foreachNode.offset}>
-        <ElementRenderer
-          key={foreachNode.id}
-          id={foreachNode.id}
-          data={foreachNode.data}
-          onEvent={onEvent}
-          onResize={onResize}
-        />
+        <ElementWrapper id={id}>
+          <ForeachHeader
+            key={foreachNode.id}
+            id={foreachNode.id}
+            data={foreachNode.data}
+            onEvent={onEvent}
+            onResize={onResize}
+          />
+        </ElementWrapper>
       </OffsetContainer>
       <OffsetContainer offset={stepsNode.offset}>
         <StepGroup

--- a/Composer/packages/extensions/visual-designer/src/components/nodes/layout-steps/IfCondition.tsx
+++ b/Composer/packages/extensions/visual-designer/src/components/nodes/layout-steps/IfCondition.tsx
@@ -14,8 +14,9 @@ import { OffsetContainer } from '../../lib/OffsetContainer';
 import { Edge } from '../../lib/EdgeComponents';
 import { StepGroup } from '../../groups';
 import { Diamond } from '../templates/Diamond';
-import { ElementRenderer } from '../../renderers/ElementRenderer';
+import { ElementWrapper } from '../../renderers/ElementWrapper';
 import { NodeProps, defaultNodeProps } from '../nodeProps';
+import { ConditionNode } from '../steps/ConditionNode';
 
 import { NodeMap, BoundaryMap } from './types';
 
@@ -67,13 +68,15 @@ export const IfCondition: FunctionComponent<NodeProps> = ({ id, data, onEvent, o
   return (
     <div css={{ width: boundary.width, height: boundary.height, position: 'relative' }}>
       <OffsetContainer offset={condition.offset}>
-        <ElementRenderer
-          key={condition.id}
-          id={condition.id}
-          data={condition.data}
-          onEvent={onEvent}
-          onResize={onResize}
-        />
+        <ElementWrapper id={condition.id}>
+          <ConditionNode
+            key={condition.id}
+            id={condition.id}
+            data={condition.data}
+            onEvent={onEvent}
+            onResize={onResize}
+          />
+        </ElementWrapper>
       </OffsetContainer>
       <OffsetContainer offset={choice.offset}>
         <Diamond

--- a/Composer/packages/extensions/visual-designer/src/components/nodes/layout-steps/SwitchCondition.tsx
+++ b/Composer/packages/extensions/visual-designer/src/components/nodes/layout-steps/SwitchCondition.tsx
@@ -14,8 +14,9 @@ import { OffsetContainer } from '../../lib/OffsetContainer';
 import { Edge } from '../../lib/EdgeComponents';
 import { StepGroup } from '../../groups';
 import { Diamond } from '../templates/Diamond';
-import { ElementRenderer } from '../../renderers/ElementRenderer';
 import { NodeProps, defaultNodeProps } from '../nodeProps';
+import { ElementWrapper } from '../../renderers/ElementWrapper';
+import { ConditionNode } from '../steps/ConditionNode';
 
 const calculateNodeMap = (path, data) => {
   const result = transformSwitchCondition(data, path);
@@ -65,13 +66,15 @@ export const SwitchCondition: FunctionComponent<NodeProps> = ({ id, data, onEven
   return (
     <div css={{ width: boundary.width, height: boundary.height, position: 'relative' }}>
       <OffsetContainer offset={nodeMap && nodeMap.conditionNode.offset}>
-        <ElementRenderer
-          key={conditionNode.id}
-          id={conditionNode.id}
-          data={conditionNode.data}
-          onEvent={onEvent}
-          onResize={onResize}
-        />
+        <ElementWrapper id={conditionNode.id}>
+          <ConditionNode
+            key={conditionNode.id}
+            id={conditionNode.id}
+            data={conditionNode.data}
+            onEvent={onEvent}
+            onResize={onResize}
+          />
+        </ElementWrapper>
       </OffsetContainer>
       <OffsetContainer offset={choiceNode.offset} css={{ zIndex: 100 }}>
         <Diamond

--- a/Composer/packages/extensions/visual-designer/src/components/renderers/ElementWrapper.tsx
+++ b/Composer/packages/extensions/visual-designer/src/components/renderers/ElementWrapper.tsx
@@ -3,38 +3,12 @@
 
 /** @jsx jsx */
 import { jsx, css } from '@emotion/core';
-import { FC, ComponentClass, useContext } from 'react';
+import { FC, useContext } from 'react';
 import classnames from 'classnames';
 
-import { ObiTypes } from '../../constants/ObiTypes';
 import { AttrNames } from '../../constants/ElementAttributes';
 import { NodeRendererContext } from '../../store/NodeRendererContext';
 import { SelectionContext } from '../../store/SelectionContext';
-import { ChoiceInput, BotAsks, UserInput, InvalidPromptBrick } from '../nodes/index';
-import { ConditionNode } from '../nodes/steps/ConditionNode';
-import { ForeachDetail } from '../nodes/steps/ForeachDetail';
-import { ForeachPageDetail } from '../nodes/steps/ForeachPageDetail';
-import { NodeProps, defaultNodeProps } from '../nodes/nodeProps';
-import { UISchemaRenderer } from '../../schema/uischemaRenderer';
-
-const rendererByObiType = {
-  [ObiTypes.ConditionNode]: ConditionNode,
-  [ObiTypes.ForeachDetail]: ForeachDetail,
-  [ObiTypes.ForeachPageDetail]: ForeachPageDetail,
-  [ObiTypes.BeginDialog]: UISchemaRenderer,
-  [ObiTypes.ReplaceDialog]: UISchemaRenderer,
-  [ObiTypes.SendActivity]: UISchemaRenderer,
-  [ObiTypes.ChoiceInputDetail]: ChoiceInput,
-  [ObiTypes.BotAsks]: BotAsks,
-  [ObiTypes.UserAnswers]: UserInput,
-  [ObiTypes.InvalidPromptBrick]: InvalidPromptBrick,
-};
-const DEFAULT_RENDERER = UISchemaRenderer;
-
-function chooseRendererByType($type): FC<NodeProps> | ComponentClass<NodeProps> {
-  const renderer = rendererByObiType[$type] || DEFAULT_RENDERER;
-  return renderer;
-}
 
 const nodeBorderHoveredStyle = css`
   box-shadow: 0px 0px 0px 1px #323130;
@@ -49,9 +23,12 @@ const nodeBorderDoubleSelectedStyle = css`
   outline: 2px solid #0078d4;
   box-shadow: 0px 0px 0px 6px rgba(0, 120, 212, 0.3);
 `;
+export interface ElementWrapperProps {
+  id: string;
+  tab?: string;
+}
 
-export const ElementRenderer: FC<NodeProps> = ({ id, data, onEvent, onResize, tab }): JSX.Element => {
-  const ChosenRenderer = chooseRendererByType(data.$type);
+export const ElementWrapper: FC<ElementWrapperProps> = ({ id, tab, children }): JSX.Element => {
   const selectableId = tab ? `${id}${tab}` : id;
   const { focusedId, focusedEvent, focusedTab } = useContext(NodeRendererContext);
   const { selectedIds, getNodeIndex } = useContext(SelectionContext);
@@ -86,16 +63,7 @@ export const ElementRenderer: FC<NodeProps> = ({ id, data, onEvent, onResize, ta
       `}
       {...declareElementAttributes(selectableId, id)}
     >
-      <ChosenRenderer
-        id={id}
-        data={data}
-        onEvent={onEvent}
-        onResize={size => {
-          onResize(size, 'element');
-        }}
-      />
+      {children}
     </div>
   );
 };
-
-ElementRenderer.defaultProps = defaultNodeProps;


### PR DESCRIPTION
## Description
fixes #1770 
Refactor the component `ElementRenderer` -> `ElementWrapper` to prepare for schema-driven.
```tsx
// This is the usage of 'ElementRenderer' (inheritance)
<ElementRender
  id={'trigggers[0].actions[0]'}
  data={json}
/>

// This is the usage of 'ElementWrapper' (composition)
<ElementWrapper id={xxx}>
  <UiSchemaRenderere id={xxx} data={json} />
</ElementWrapper>
```
![image](https://user-images.githubusercontent.com/8528761/72674571-6538ce00-3ab3-11ea-9395-cff7b991cde6.png)

(In my next PR, I will migrate those remaining $types to uischema)
## Task Item

#1770 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code refactor (non-breaking change which improve code quality, clean up, add tests, etc)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Doc update (document update)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have functionally tested my change

## Screenshots

Please include screenshots or gifs if your PR include UX changes.
