### PR TITLE
fix: Aligned elements in prompt settings

### DIFF
--- a/Composer/packages/extensions/obiformeditor/src/Form/fields/PromptField/styles.ts
+++ b/Composer/packages/extensions/obiformeditor/src/Form/fields/PromptField/styles.ts
@@ -58,12 +58,12 @@ export const settingsFields = css`
   display: flex;
   flex-wrap: wrap;
   position: relative;
+  align-items: flex-end;
 `;
 
 export const settingsFieldFull = css`
   flex-basis: 100%;
   overflow: hidden;
-  align-items: flex-end;
 `;
 
 export const settingsFieldHalf = css`

--- a/Composer/packages/extensions/obiformeditor/src/Form/fields/PromptField/styles.ts
+++ b/Composer/packages/extensions/obiformeditor/src/Form/fields/PromptField/styles.ts
@@ -63,6 +63,7 @@ export const settingsFields = css`
 export const settingsFieldFull = css`
   flex-basis: 100%;
   overflow: hidden;
+  align-items: flex-end;
 `;
 
 export const settingsFieldHalf = css`


### PR DESCRIPTION
## Description
Set `align-items` to `flex-end` in `settingsFields` to align the prompt settings text inputs.

## Task Item
Closes #1673 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have functionally tested my change

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/17039790/72938607-1cd21800-3d20-11ea-904f-3331f2f00938.png)

### After
![image](https://user-images.githubusercontent.com/17039790/72938601-1a6fbe00-3d20-11ea-9f95-f658d8ce8b86.png)
