### PR TITLE
chore: change title 'User Answers' to 'User Input'

### DIFF
--- a/Composer/packages/extensions/visual-designer/src/schema/uischema.tsx
+++ b/Composer/packages/extensions/visual-designer/src/schema/uischema.tsx
@@ -33,7 +33,7 @@ const BaseInputSchema: UIWidget = {
   },
   userInput: {
     'ui:widget': ActionCard,
-    title: data => `User Answers (${getInputType(data.$type)})`,
+    title: data => `User Input (${getInputType(data.$type)})`,
     disableSDKTitle: true,
     icon: ElementIcon.User,
     menu: 'none',


### PR DESCRIPTION
## Description
Closes #1915 
In Visual Editor, `User Answers` -> `User Input`.

`User Input` should be the correct title, to make two titles consistent, change the title of visual editor nodes from `User Answers` to `User Input`
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
closes #1915 
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
![image](https://user-images.githubusercontent.com/8528761/73731143-ed38fc00-4772-11ea-97bb-bc94ea8c1fba.png)
