### PR TITLE
fix: Updated replace dialog's dialog property title

### DIFF
--- a/Composer/packages/lib/shared/src/appschema.ts
+++ b/Composer/packages/lib/shared/src/appschema.ts
@@ -2732,7 +2732,7 @@ export const appschema: OBISchema = {
         ...$properties(SDKTypes.ReplaceDialog),
         dialog: {
           $type: 'Microsoft.IDialog',
-          title: 'Dialog',
+          title: 'Dialog name',
           description: 'Current dialog will be replaced by this dialog.',
           type: 'string',
         },


### PR DESCRIPTION
## Description
Updated the dialog property title in `Microsoft.ReplaceDialog`'s app schema to match the title in the SDK schema.

## Task Item
Closes #1697 

## Screenshots
![image](https://user-images.githubusercontent.com/17039790/73988072-73318000-48f6-11ea-9eaa-580690fb6517.png)

