### PR TITLE
fix: the path format generated by notification page is wrong

### DIFF
--- a/Composer/packages/client/src/utils/convertUtils/parsePathToFocused.ts
+++ b/Composer/packages/client/src/utils/convertUtils/parsePathToFocused.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { FieldNames } from '@bfc/shared';
+import values from 'lodash/values';
 
 import { parsePathToSelected } from './parsePathToSelected';
 
@@ -12,7 +13,15 @@ export function parsePathToFocused(path: string): string {
 
   const list = path.split('.');
 
-  const matchActions = list.filter(x => x.startsWith(FieldNames.Actions) || x.startsWith(FieldNames.ElseActions));
+  const matchActions = list.filter(x => {
+    if (/\[|\]/.test(x)) {
+      const reg = /\[.*\]/;
+      x = x.replace(reg, '');
+      return x !== FieldNames.Events && values(FieldNames).indexOf(x) > -1;
+    }
+
+    return false;
+  });
 
   if (matchActions.length > 0) {
     return `${trigger}.${matchActions.join('.')}`;


### PR DESCRIPTION
## Description

The 'cases' was ignored when creating the focused path. 

## Task Item

closes #1972

## Screenshots

![path](https://user-images.githubusercontent.com/39758135/74352182-1a308300-4df3-11ea-91bd-cc21dde7245c.gif)

