### PR TITLE
chore: sync new schema in form editor

### DIFF
--- a/Composer/packages/lib/shared/src/appschema.ts
+++ b/Composer/packages/lib/shared/src/appschema.ts
@@ -259,12 +259,13 @@ export const appschema: OBISchema = {
           description: 'One or more options that are passed to the dialog that is called.',
           additionalProperties: true,
         },
-        includeActivity: {
-          type: 'boolean',
-          title: 'Include Activity',
-          description: 'When set to true, dialog that is called can process the current activity.',
-          default: false,
-          examples: [false],
+        activityProcessed: {
+          $role: 'expression',
+          type: 'string',
+          title: 'Activity Processed',
+          description: 'When set to false, the dialog that is called can process the current activity.',
+          default: 'true',
+          examples: ['true'],
         },
         resultProperty: {
           $role: 'expression',


### PR DESCRIPTION
## Description

Replace `includeActivity` with `activityProcessed` for `beginDialog` in form editor depend on new schema.
- Before
![image](https://user-images.githubusercontent.com/5860999/74624645-3d0cbf80-5184-11ea-9f01-726fe949bc8f.png)

- After
![image](https://user-images.githubusercontent.com/5860999/74624698-747b6c00-5184-11ea-8b64-f29dda3a27ef.png)

## Task Item
fixed #1838 

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
