### PR TITLE
chore: remove `OAuth` action from 'External Resource' group in the dialog menu

### DIFF
--- a/Composer/packages/lib/shared/src/viewUtils.ts
+++ b/Composer/packages/lib/shared/src/viewUtils.ts
@@ -91,7 +91,6 @@ export const dialogGroups: DialogGroupsMap = {
     types: [
       SDKTypes.HttpRequest,
       SDKTypes.EmitEvent,
-      SDKTypes.OAuthInput,
       SDKTypes.QnAMakerDialog,
       //  SDKTypes.CodeStep
     ],


### PR DESCRIPTION
## Description
Closes #2064 

We have two entries for the `OauthInput` type.
As we discussed in the issue, it might be cleaner to just be in ask a question section.
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
#2064 
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots
![image](https://user-images.githubusercontent.com/8528761/75128670-36d88f00-5700-11ea-9d27-98f1701da5a1.png)
<!---
Please include screenshots or gifs if your PR include UX changes.
--->
