### PR TITLE
fix: [draft]Add ComposerDeployDialogs and ComposerDebugDialogs for different environment.

### DIFF
--- a/BotProject/Templates/CSharp/Scripts/deploy.ps1
+++ b/BotProject/Templates/CSharp/Scripts/deploy.ps1
@@ -56,13 +56,13 @@ if (Test-Path $zipPath) {
 dotnet user-secrets init
 
 # Perform dotnet publish step ahead of zipping up
-$publishFolder = $(Join-Path $projFolder 'bin\Release\netcoreapp2.2')
+$publishFolder = $(Join-Path $projFolder 'bin\Release\netcoreapp3.1')
 dotnet publish -c release -o $publishFolder -v q > $logFile
 
 
 # Copy bot files to running folder
-$remoteBotPath = $(Join-Path $publishFolder "ComposerDialogs")
-$localBotPath = $(Join-Path $projFolder "ComposerDialogs")
+$remoteBotPath = $(Join-Path $publishFolder "ComposerDeployDialogs")
+$localBotPath = $(Join-Path $projFolder "ComposerDeployDialogs")
 Remove-Item $remoteBotPath -Recurse -ErrorAction Ignore
 
 if ($botPath) {
@@ -72,6 +72,9 @@ if ($botPath) {
 else {
 	Copy-Item -Path $localBotPath -Recurse -Destination $publishFolder -Container -Force
 }
+
+# We use ComposerDeployDialogs for deployment
+dotnet user-secrets set "bot" "ComposerDeployDialogs"
 
 # Merge from custom config files
 $customConfigFiles = Get-ChildItem -Path $remoteBotPath -Include "appsettings.json" -Recurse -Force

--- a/BotProject/Templates/CSharp/appsettings.json
+++ b/BotProject/Templates/CSharp/appsettings.json
@@ -1,6 +1,5 @@
 {
   "microsoftAppId": "",
-  "bot": "ComposerDialogs",
   "cosmosDb": {
     "authKey": "",
     "collectionId": "botstate-collection",


### PR DESCRIPTION
## Description

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->
Fix #2007 
Previously botproject have two different runtimes for local debugging and remote deployment, which are Csharp and Templates/Csharp. 
But now there is only one runtime for both things, so the different configuration may be mixed up in the same project, for luis settings there will be two different configuration.
So we need to split the different environment into two different folders, ComposerDebugDialogs and ComposerDeployDialogs. Use 'dotnet user-secrets set' to change the 'bot' config section thus determine which bot we should use.

Previously:
![image](https://user-images.githubusercontent.com/9328933/75318743-15b1a300-58a6-11ea-9d38-b82cad998494.png)


Now:
![image](https://user-images.githubusercontent.com/9328933/75318617-c8353600-58a5-11ea-9376-1bc6075517fc.png)




## Task Item

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
