### PR TITLE
feat: display 6 actions as contentless node

### DIFF
--- a/Composer/packages/extensions/visual-designer/__tests__/layouters/measureJsonBoundary.test.ts
+++ b/Composer/packages/extensions/visual-designer/__tests__/layouters/measureJsonBoundary.test.ts
@@ -11,6 +11,7 @@ import {
   ChoiceInputSize,
   ChoiceInputMarginTop,
   ChoiceInputMarginBottom,
+  StandardNodeWidth,
 } from '../../src/constants/ElementSizes';
 
 describe('measureJsonBoundary', () => {
@@ -31,7 +32,7 @@ describe('measureJsonBoundary', () => {
       new Boundary(LoopIconSize.width, LoopIconSize.height)
     );
     expect(measureJsonBoundary({ $type: ObiTypes.LogAction })).toEqual(
-      new Boundary(InitNodeSize.width, InitNodeSize.height)
+      new Boundary(StandardNodeWidth, InitNodeSize.height)
     );
   });
   it("should return boundary whose size is determined by the data's choices when json.$type is choiceInput", () => {

--- a/Composer/packages/extensions/visual-designer/__tests__/layouters/measureJsonBoundary.test.ts
+++ b/Composer/packages/extensions/visual-designer/__tests__/layouters/measureJsonBoundary.test.ts
@@ -12,6 +12,7 @@ import {
   ChoiceInputMarginTop,
   ChoiceInputMarginBottom,
   StandardNodeWidth,
+  HeaderHeight,
 } from '../../src/constants/ElementSizes';
 
 describe('measureJsonBoundary', () => {
@@ -31,9 +32,7 @@ describe('measureJsonBoundary', () => {
     expect(measureJsonBoundary({ $type: ObiTypes.LoopIndicator })).toEqual(
       new Boundary(LoopIconSize.width, LoopIconSize.height)
     );
-    expect(measureJsonBoundary({ $type: ObiTypes.LogAction })).toEqual(
-      new Boundary(StandardNodeWidth, InitNodeSize.height)
-    );
+    expect(measureJsonBoundary({ $type: ObiTypes.LogAction })).toEqual(new Boundary(StandardNodeWidth, HeaderHeight));
   });
   it("should return boundary whose size is determined by the data's choices when json.$type is choiceInput", () => {
     const data1: { [key: string]: any } = {

--- a/Composer/packages/extensions/visual-designer/src/constants/ElementColors.ts
+++ b/Composer/packages/extensions/visual-designer/src/constants/ElementColors.ts
@@ -8,7 +8,7 @@ const Colors = {
   Black: '#000000',
   AzureGray: '#3C3C41',
   AzureGray2: '#656565',
-  AzureGray3: '#EBEBEB',
+  AzureGray3: '#D7D7D7',
   Gray80: '#B3B0AD',
   Gray60: '#C8C6C4',
 

--- a/Composer/packages/extensions/visual-designer/src/constants/ElementSizes.ts
+++ b/Composer/packages/extensions/visual-designer/src/constants/ElementSizes.ts
@@ -1,8 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+export const StandardNodeWidth = 200;
+export const HeaderHeight = 24;
+
 export const InitNodeSize = {
-  width: 200,
+  width: StandardNodeWidth,
   height: 48,
 };
 

--- a/Composer/packages/extensions/visual-designer/src/layouters/measureJsonBoundary.ts
+++ b/Composer/packages/extensions/visual-designer/src/layouters/measureJsonBoundary.ts
@@ -4,6 +4,8 @@
 import { ObiTypes } from '../constants/ObiTypes';
 import { Boundary } from '../models/Boundary';
 import {
+  StandardNodeWidth,
+  HeaderHeight,
   DiamondSize,
   InitNodeSize,
   LoopIconSize,
@@ -123,6 +125,14 @@ export function measureJsonBoundary(json): Boundary {
       break;
     case ObiTypes.InvalidPromptBrick:
       boundary = new Boundary(IconBrickSize.width, IconBrickSize.height);
+      break;
+    case ObiTypes.EndDialog:
+    case ObiTypes.EndTurn:
+    case ObiTypes.RepeatDialog:
+    case ObiTypes.CancelAllDialogs:
+    case ObiTypes.LogAction:
+    case ObiTypes.TraceActivity:
+      boundary = new Boundary(StandardNodeWidth, HeaderHeight);
       break;
     default:
       boundary = new Boundary(InitNodeSize.width, InitNodeSize.height);

--- a/Composer/packages/extensions/visual-designer/src/schema/uischema.tsx
+++ b/Composer/packages/extensions/visual-designer/src/schema/uischema.tsx
@@ -14,6 +14,7 @@ import { IfConditionWidget } from '../widgets/IfConditionWidget';
 import { SwitchConditionWidget } from '../widgets/SwitchConditionWidget';
 import { ForeachWidget } from '../widgets/ForeachWidget';
 import { ChoiceInputChoices } from '../widgets/ChoiceInput';
+import { ActionHeader } from '../widgets/ActionHeader';
 import { ElementIcon } from '../utils/obiPropertyResolver';
 import { ObiColors } from '../constants/ElementColors';
 
@@ -136,16 +137,16 @@ export const uiSchema: UISchema = {
     content: data => `Delete ${Array.isArray(data.properties) ? data.properties.length : 0} properties`,
   },
   [SDKTypes.EndDialog]: {
-    'ui:widget': ActionCard,
-    content: 'End this dialog',
+    'ui:widget': ActionHeader,
+  },
+  [SDKTypes.RepeatDialog]: {
+    'ui:widget': ActionHeader,
   },
   [SDKTypes.CancelAllDialogs]: {
-    'ui:widget': ActionCard,
-    content: 'Cancel all active dialogs',
+    'ui:widget': ActionHeader,
   },
   [SDKTypes.EndTurn]: {
-    'ui:widget': ActionCard,
-    content: 'Wait for another message',
+    'ui:widget': ActionHeader,
   },
   [SDKTypes.EmitEvent]: {
     'ui:widget': ActionCard,
@@ -156,12 +157,10 @@ export const uiSchema: UISchema = {
     content: data => data.url,
   },
   [SDKTypes.TraceActivity]: {
-    'ui:widget': ActionCard,
-    content: data => data.name,
+    'ui:widget': ActionHeader,
   },
   [SDKTypes.LogAction]: {
-    'ui:widget': ActionCard,
-    content: data => data.text,
+    'ui:widget': ActionHeader,
   },
   [SDKTypes.EditActions]: {
     'ui:widget': ActionCard,

--- a/Composer/packages/extensions/visual-designer/src/widgets/ActionHeader.tsx
+++ b/Composer/packages/extensions/visual-designer/src/widgets/ActionHeader.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /** @jsx jsx */
 import { jsx, css } from '@emotion/core';
 import { generateSDKTitle } from '@bfc/shared';
@@ -6,9 +9,6 @@ import { WidgetComponent, WidgetContainerProps } from '../schema/uischema.types'
 import { StandardNodeWidth, HeaderHeight } from '../constants/ElementSizes';
 import { ObiColors } from '../constants/ElementColors';
 import { NodeMenu } from '../components/menus/NodeMenu';
-
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
 
 export interface ActionHeaderProps extends WidgetContainerProps {
   title: string;

--- a/Composer/packages/extensions/visual-designer/src/widgets/ActionHeader.tsx
+++ b/Composer/packages/extensions/visual-designer/src/widgets/ActionHeader.tsx
@@ -1,0 +1,79 @@
+/** @jsx jsx */
+import { jsx, css } from '@emotion/core';
+import { generateSDKTitle } from '@bfc/shared';
+
+import { WidgetComponent, WidgetContainerProps } from '../schema/uischema.types';
+import { StandardNodeWidth, HeaderHeight } from '../constants/ElementSizes';
+import { ObiColors } from '../constants/ElementColors';
+import { NodeMenu } from '../components/menus/NodeMenu';
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export interface ActionHeaderProps extends WidgetContainerProps {
+  title: string;
+  disableSDKTitle?: boolean;
+  menu?: JSX.Element | 'none';
+  colors: {
+    theme: string;
+    icon: string;
+  };
+}
+
+const DefaultColors = {
+  theme: ObiColors.AzureGray3,
+  icon: ObiColors.AzureGray2,
+};
+
+const container = css`
+  cursor: pointer;
+  font-family: Segoe UI;
+  font-size: 12px;
+  line-height: 14px;
+  color: black;
+`;
+
+const header = css`
+  font-size: 12px;
+  font-family: Segoe UI;
+  line-height: 14px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  whitespace: pre;
+`;
+
+export const ActionHeader: WidgetComponent<ActionHeaderProps> = ({
+  id,
+  data,
+  onEvent,
+  title,
+  disableSDKTitle,
+  menu,
+  colors = DefaultColors,
+}) => {
+  const headerContent = disableSDKTitle ? title : generateSDKTitle(data, title);
+
+  return (
+    <div
+      css={css`
+        ${container};
+        width: ${StandardNodeWidth}px;
+        height: ${HeaderHeight}px;
+        background-color: ${colors.theme};
+      `}
+    >
+      <div
+        css={css`
+          ${header};
+          width: calc(100% - 40px);
+          padding: 4px 8px;
+        `}
+      >
+        {headerContent}
+      </div>
+      <div css={{ position: 'absolute', top: 4, right: 0 }}>
+        {menu === 'none' ? null : menu || <NodeMenu id={id} onEvent={onEvent} />}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Description

Follows new design, implement a new widget `<ActionHeader />` to draw contentless node and apply it to 6 types:
1. EndDialog
2. EndTurn
3. RepeatDialog
4. CancelAllDialogs
5. LogAction
6. TraceActivity

**Preview the changes in UISchema** (2 types out of 6):
![image](https://user-images.githubusercontent.com/8528761/75446027-8be70000-59a1-11ea-9bfa-dc639bffe2d4.png)



### Design
According to new design, we want to show some types as contentless node.

![image](https://user-images.githubusercontent.com/8528761/75440790-5c32fa80-5997-11ea-8cf1-d720625c0a71.png)

### What's changed?
1. Created a new widget `<ActionHeader />`
2. Consumed the new widget in 6 types' definition to make them borderless.
3. Adjusted element size constants.
4. Color

### Why created a new widget?
   I plan to retire the `FormCard` component in next few PRs because it can't meet our customization requirements under the new widget-based structure.
   Therefore, this PR copied out a part of its code as `ActionHeader`; the new widget will be applied to more actions as a nested field. For example:

   ```
   [SDKTypes.SendActivity]: {
       "ui:widget": Card,
       "header": {
           "ui:widget": ActionHeader,
       },
        "body": {
           "ui:widget": LGActivity,
           "text": data => data.activity,
       }
   }
   ```

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
fixes #1701 
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
![image](https://user-images.githubusercontent.com/8528761/75447393-3bbd6d00-59a4-11ea-9c10-c06ed46ce945.png)
![image](https://user-images.githubusercontent.com/8528761/75447416-44ae3e80-59a4-11ea-821d-419997f810f3.png)

