### PR TITLE
fix: fix 'sort()' function of steps and cases in visual editor

### DIFF
--- a/Composer/packages/extensions/visual-designer/src/components/groups/StepGroup.tsx
+++ b/Composer/packages/extensions/visual-designer/src/components/groups/StepGroup.tsx
@@ -25,6 +25,7 @@ const StepInterval = ElementInterval.y;
 type StepNodeKey = string;
 
 const getStepKey = (stepOrder: number): StepNodeKey => `steps[${stepOrder}]`;
+const parseStepIndex = (stepKey: string): number => parseInt(stepKey.replace(/steps\[(\d+)\]/, '$1'));
 
 const calculateNodes = (groupId: string, data): GraphNodeMap<StepNodeKey> => {
   const steps = transformStepGroup(data, groupId);
@@ -37,7 +38,7 @@ const calculateNodes = (groupId: string, data): GraphNodeMap<StepNodeKey> => {
 
 const calculateLayout = (nodeMap: GraphNodeMap<StepNodeKey>): GraphLayout => {
   const nodes = Object.keys(nodeMap)
-    .sort()
+    .sort((a, b) => parseStepIndex(a) - parseStepIndex(b))
     .map(stepName => nodeMap[stepName]);
   return sequentialLayouter(nodes);
 };

--- a/Composer/packages/extensions/visual-designer/src/widgets/SwitchConditionWidget.tsx
+++ b/Composer/packages/extensions/visual-designer/src/widgets/SwitchConditionWidget.tsx
@@ -28,6 +28,7 @@ enum SwitchNodes {
 type CaseNodeKey = string;
 
 const getCaseKey = (caseIndex: number): CaseNodeKey => `cases[${caseIndex}]`;
+const parseCaseIndex = (caseKey: CaseNodeKey): number => parseInt(caseKey.replace(/cases\[(\d+)\]/, '$1'));
 
 const calculateNodeMap = (path: string, data): GraphNodeMap<SwitchNodes | CaseNodeKey> => {
   const result = transformSwitchCondition(data, path);
@@ -55,7 +56,7 @@ const calculateNodeMap = (path: string, data): GraphNodeMap<SwitchNodes | CaseNo
 const calculateLayout = (nodeMap: GraphNodeMap<SwitchNodes | CaseNodeKey>) => {
   const { switchNode, choiceNode, ...cases } = nodeMap as GraphNodeMap<SwitchNodes>;
   const casesNodes = Object.keys(cases)
-    .sort()
+    .sort((a, b) => parseCaseIndex(a) - parseCaseIndex(b))
     .map(caseName => nodeMap[caseName]);
   return switchCaseLayouter(switchNode, choiceNode, casesNodes);
 };


### PR DESCRIPTION
## Description
As #2165 described, visual editor invoke `sort()` incorrectly, causes a series of 10+ steps have wrong order.
This PR fixes that issue by parsing string to int.

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
closes #2165 
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
![image](https://user-images.githubusercontent.com/8528761/75900232-927ce800-5e77-11ea-81c8-82bf377ad5c4.png)
