### PR TITLE
ci: add a11y title prefix for accessibility prs

### DIFF
--- a/.github/actions/conventional-pr/src/utils.ts
+++ b/.github/actions/conventional-pr/src/utils.ts
@@ -20,6 +20,7 @@ const validTypes = [
   'chore',
   'revert',
   'release',
+  'a11y',
 ];
 
 const typeList = validTypes.map(t => `  - ${t}`).join('\n');


### PR DESCRIPTION
Fix #2172 

## Description

Add 'a11y' prefix to PR titles. This is to help distinguish category for accessibility PRs. 

Please use this prefix for the PRs for issues with the Accessibility label: 
![image](https://user-images.githubusercontent.com/14900841/75913652-29aa5700-5e08-11ea-865c-68536dc30907.png)

Thank you!

