### PR TITLE
fix: support copy actions across dilaogs

### DIFF
--- a/Composer/packages/extensions/visual-designer/src/index.tsx
+++ b/Composer/packages/extensions/visual-designer/src/index.tsx
@@ -76,7 +76,7 @@ const VisualDesigner: React.FC<VisualDesignerProps> = ({
     clipboardActions: clipboardActions || [],
     updateLgTemplate,
     getLgTemplates,
-    copyLgTemplate,
+    copyLgTemplate: (id: string, from: string, to?: string) => copyLgTemplate(id, from, to).catch(() => ''),
     removeLgTemplate,
     removeLgTemplates,
     removeLuIntent,


### PR DESCRIPTION
## Description
**Problem:**
Users can't copy actions across different dialog files. If they copied some actions and pasted to another dialog file, nothing would happen. 

**Solution:**
This PR fixes that issue by handling errors when the copy lg api invocation failed.

**Context:**
This bug is related to recent lg file structure changes. Previously, we only have one lg file 'common.lg', but for now, each dialog file has a default lg file, makes our `copyLgTemplate` api won't work if user wants to copy a template from 'Main.lg' to 'Todo.lg'.

As I discussed with Zhixiang, it's quite complicated to deal with cross-file lg template copying problem because LG template could be nested. In this PR, visual editor only defenses potential LG copy failures to make sure the functionality 'copy selection' always work even no lg content will be copied. Compared to 'nothing will be copied', 'copy actions without lg' sounds an acceptable quick fix.

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
fixes #2199 
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
