### PR TITLE
fix: regEx trigger creation bug

### DIFF
--- a/Composer/packages/client/src/components/ProjectTree/TriggerCreationModal.tsx
+++ b/Composer/packages/client/src/components/ProjectTree/TriggerCreationModal.tsx
@@ -95,26 +95,25 @@ interface TriggerCreationModalProps {
   onSubmit: (dialog: DialogInfo, luFilePayload?: LuFilePayload) => void;
 }
 
-const initialFormData: TriggerFormData = {
-  errors: {},
-  $type: intentTypeKey,
-  specifiedType: '',
-  intent: '',
-  triggerPhrases: '',
-  regexEx: '',
-};
-
-const triggerTypeOptions: IDropdownOption[] = getTriggerTypes();
-
 export const TriggerCreationModal: React.FC<TriggerCreationModalProps> = props => {
   const { isOpen, onDismiss, onSubmit, dialogId } = props;
-  const [formData, setFormData] = useState(initialFormData);
   const { state } = useContext(StoreContext);
   const { dialogs, luFiles } = state;
   const luFile = luFiles.find(lu => lu.id === dialogId);
   const dialogFile = dialogs.find(dialog => dialog.id === dialogId);
   const isRegEx = get(dialogFile, 'content.recognizer.$type', '') === regexRecognizerKey;
   const regexIntents = get(dialogFile, 'content.recognizer.intents', []);
+  const isNone = !get(dialogFile, 'content.recognizer');
+  const initialFormData: TriggerFormData = {
+    errors: {},
+    $type: isNone ? '' : intentTypeKey,
+    specifiedType: '',
+    intent: '',
+    triggerPhrases: '',
+    regexEx: '',
+  };
+  const [formData, setFormData] = useState(initialFormData);
+
   const onClickSubmitButton = e => {
     e.preventDefault();
     const errors = validateForm(formData, isRegEx, regexIntents);
@@ -169,7 +168,10 @@ export const TriggerCreationModal: React.FC<TriggerCreationModalProps> = props =
   const eventTypes: IDropdownOption[] = getEventTypes();
   const activityTypes: IDropdownOption[] = getActivityTypes();
   const messageTypes: IDropdownOption[] = getMessageTypes();
-
+  let triggerTypeOptions: IDropdownOption[] = getTriggerTypes();
+  if (isNone) {
+    triggerTypeOptions = triggerTypeOptions.filter(t => t.key !== intentTypeKey);
+  }
   const showIntentName = formData.$type === intentTypeKey;
   const showRegExDropDown = formData.$type === intentTypeKey && isRegEx;
   const showTriggerPhrase = formData.$type === intentTypeKey && !isRegEx;
@@ -200,7 +202,7 @@ export const TriggerCreationModal: React.FC<TriggerCreationModalProps> = props =
             onChange={onSelectTriggerType}
             errorMessage={formData.errors.$type}
             data-testid={'triggerTypeDropDown'}
-            defaultSelectedKey={intentTypeKey}
+            defaultSelectedKey={formData.$type}
           />
           {showEventDropDown && (
             <Dropdown

--- a/Composer/packages/client/src/utils/dialogUtil.ts
+++ b/Composer/packages/client/src/utils/dialogUtil.ts
@@ -89,7 +89,7 @@ export function generateRegexExpression(intent: string, pattern: string) {
   return { intent, pattern };
 }
 
-export function createNewTrigger(dialog: DialogInfo, data: TriggerFormData): DialogInfo {
+export function createTrigger(dialog: DialogInfo, data: TriggerFormData): DialogInfo {
   const dialogCopy = cloneDeep(dialog);
   const trigger = generateNewTrigger(data);
   insert(dialogCopy.content, 'triggers', undefined, trigger);
@@ -115,11 +115,23 @@ export function updateRegExIntent(dialog: DialogInfo, intent: string, pattern: s
   return dialogCopy;
 }
 
+//it is possible that we cannot find a RegEx. Because it will clear all regEx when we
+//switch to another recognizer type
+export function deleteRegExIntent(dialog: DialogInfo, intent: string): DialogInfo {
+  const dialogCopy = cloneDeep(dialog);
+  const regexIntents = get(dialogCopy, 'content.recognizer.intents', []);
+  const index = regexIntents.findIndex(ri => ri.intent === intent);
+  if (index > -1) {
+    regexIntents.splice(index, 1);
+  }
+  return dialogCopy;
+}
+
 export function generateNewDialog(dialogs: DialogInfo[], dialogId: string, data: TriggerFormData): DialogInfo {
   //add new trigger
   const dialog = dialogs.find(dialog => dialog.id === dialogId);
   if (!dialog) throw new Error(`dialog ${dialogId} does not exist`);
-  let updatedDialog = createNewTrigger(dialog, data);
+  let updatedDialog = createTrigger(dialog, data);
 
   //add regex expression
   if (data.regexEx) {
@@ -137,11 +149,16 @@ export function createFocusedPath(selected: number, focused: number) {
 }
 
 export function deleteTrigger(dialogs: DialogInfo[], dialogId: string, index: number) {
-  const dialogCopy = getDialog(dialogs, dialogId);
+  let dialogCopy = getDialog(dialogs, dialogId);
   if (!dialogCopy) return null;
-  const content = dialogCopy.content;
-  content.triggers.splice(index, 1);
-  return content;
+  const isRegEx = get(dialogCopy, 'content.recognizer.$type', '') === regexRecognizerKey;
+  if (isRegEx) {
+    const regExIntent = get(dialogCopy, `content.triggers[${index}].intent`, '');
+    dialogCopy = deleteRegExIntent(dialogCopy, regExIntent);
+  }
+  const triggers = get(dialogCopy, 'content.triggers');
+  triggers.splice(index, 1);
+  return dialogCopy.content;
 }
 
 export function getTriggerTypes(): IDropdownOption[] {


### PR DESCRIPTION
## Description
1. Delete the regEx pattern when we delete the trigger which triggers it.
2. Do not allow user to create an onIntent trigger when the recognizer type is None.
## Task Item
closes #2215
## Screenshots
![aaaaa](https://user-images.githubusercontent.com/24380525/76304467-6988a700-62fe-11ea-858d-e78b300187de.gif)
![aaaaa1](https://user-images.githubusercontent.com/24380525/76304472-6b526a80-62fe-11ea-98cb-f75fec8034c9.gif)



