### PR TITLE
fix: sort action ids correctly

### DIFF
--- a/Composer/packages/extensions/visual-designer/__tests__/utils/normalizeSelection.test.ts
+++ b/Composer/packages/extensions/visual-designer/__tests__/utils/normalizeSelection.test.ts
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { normalizeSelection, sortActionIds } from '../../src/utils/normalizeSelection';
+
+describe('normalizeSelection', () => {
+  it('can filter out child ids', () => {
+    const selectedIds1 = ['actions[0]', 'actions[0].a', 'actions[0].b'];
+    expect(normalizeSelection(selectedIds1)).toEqual(['actions[0]']);
+
+    const selectedIds2 = ['actions[0]', 'actions[0].a', 'actions[0].b', 'actions[1]', 'actions[1].a'];
+    expect(normalizeSelection(selectedIds2)).toEqual(['actions[0]', 'actions[1]']);
+
+    const selectedIds3 = ['actions[0]', 'actions[0].a', 'actions[0].b', 'actions[1]', 'actions[1].a', 'actions[2].a'];
+    expect(normalizeSelection(selectedIds3)).toEqual(['actions[0]', 'actions[1]', 'actions[2].a']);
+  });
+});
+
+describe('sortActionIds', () => {
+  it('can sort input ids at same level', () => {
+    const actionIds = ['actions[10]', 'actions[1]', 'actions[3]', 'actions[2]'];
+    expect(sortActionIds(actionIds)).toEqual(['actions[1]', 'actions[2]', 'actions[3]', 'actions[10]']);
+  });
+
+  it('can sort input ids with children', () => {
+    const actionIds = ['actions[3]', 'actions[2]', 'actions[1].actions[0]', 'actions[1].elseActions[0]', 'actions[1]'];
+    expect(sortActionIds(actionIds)).toEqual([
+      'actions[1]',
+      'actions[1].actions[0]',
+      'actions[1].elseActions[0]',
+      'actions[2]',
+      'actions[3]',
+    ]);
+  });
+
+  it('can sort ids with orphan children', () => {
+    const actionIds = ['actions[3]', 'actions[2]', 'actions[1].actions[0]', 'actions[1].elseActions[0]'];
+    expect(sortActionIds(actionIds)).toEqual([
+      'actions[1].actions[0]',
+      'actions[1].elseActions[0]',
+      'actions[2]',
+      'actions[3]',
+    ]);
+  });
+});

--- a/Composer/packages/extensions/visual-designer/__tests__/utils/normalizeSelection.test.ts
+++ b/Composer/packages/extensions/visual-designer/__tests__/utils/normalizeSelection.test.ts
@@ -4,15 +4,22 @@
 import { normalizeSelection, sortActionIds } from '../../src/utils/normalizeSelection';
 
 describe('normalizeSelection', () => {
-  it('can filter out child ids', () => {
-    const selectedIds1 = ['actions[0]', 'actions[0].a', 'actions[0].b'];
+  it('should filter out child ids', () => {
+    const selectedIds1 = ['actions[0]', 'actions[0].actions[0]', 'actions[0].actions[1]'];
     expect(normalizeSelection(selectedIds1)).toEqual(['actions[0]']);
 
-    const selectedIds2 = ['actions[0]', 'actions[0].a', 'actions[0].b', 'actions[1]', 'actions[1].a'];
+    const selectedIds2 = ['actions[0]', 'actions[0].actions[0]', 'actions[0].actions[1]', 'actions[1]', 'actions[1].a'];
     expect(normalizeSelection(selectedIds2)).toEqual(['actions[0]', 'actions[1]']);
+  });
 
-    const selectedIds3 = ['actions[0]', 'actions[0].a', 'actions[0].b', 'actions[1]', 'actions[1].a', 'actions[2].a'];
-    expect(normalizeSelection(selectedIds3)).toEqual(['actions[0]', 'actions[1]', 'actions[2].a']);
+  it('should keep orphan child ids', () => {
+    const selectedIds = ['actions[0]', 'actions[0].actions[0]', 'actions[1].actions[0]'];
+    expect(normalizeSelection(selectedIds)).toEqual(['actions[0]', 'actions[1].actions[0]']);
+  });
+
+  it('should throw invalid ids', () => {
+    const selectedIds = ['action[0].a', 'actions[0].diamond', 'actions', 'actions[0].ifelse'];
+    expect(normalizeSelection(selectedIds)).toEqual([]);
   });
 });
 

--- a/Composer/packages/extensions/visual-designer/src/utils/normalizeSelection.ts
+++ b/Composer/packages/extensions/visual-designer/src/utils/normalizeSelection.ts
@@ -3,8 +3,11 @@
 
 export const normalizeSelection = (selectedIds: string[]): string[] => {
   if (!Array.isArray(selectedIds)) return [];
+
+  // filter invalid ids such as 'actions[0].diamond'
+  const validIds = selectedIds.filter(id => id.match(/.*\w+\[\d+\]$/));
   // events[0] < events[0].actions[0] < events[1] < events[1].actions[0]
-  const ascendingIds = sortActionIds(selectedIds);
+  const ascendingIds = sortActionIds(validIds);
 
   for (let i = 0; i < ascendingIds.length; i++) {
     const parentId = ascendingIds[i];

--- a/Composer/packages/extensions/visual-designer/src/utils/normalizeSelection.ts
+++ b/Composer/packages/extensions/visual-designer/src/utils/normalizeSelection.ts
@@ -4,10 +4,11 @@
 export const normalizeSelection = (selectedIds: string[]): string[] => {
   if (!Array.isArray(selectedIds)) return [];
   // events[0] < events[0].actions[0] < events[1] < events[1].actions[0]
-  const ascendingIds = [...selectedIds].sort();
+  const ascendingIds = sortActionIds(selectedIds);
 
   for (let i = 0; i < ascendingIds.length; i++) {
     const parentId = ascendingIds[i];
+    if (!parentId) continue;
     for (let j = i + 1; j < ascendingIds.length; j++) {
       if (ascendingIds[j].startsWith(parentId)) {
         ascendingIds[j] = '';
@@ -16,4 +17,41 @@ export const normalizeSelection = (selectedIds: string[]): string[] => {
   }
 
   return ascendingIds.filter(id => id);
+};
+
+export const sortActionIds = (actionIds: string[]): string[] => {
+  const parsedActionIds = actionIds.map(id => ({
+    id,
+    paths: id
+      .split('.')
+      .map(x => x.replace(/\w+\[(\d+)\]/, '$1'))
+      .map(x => parseInt(x) || 0),
+  }));
+  const sorted = parsedActionIds.sort((a, b) => {
+    const aPaths = a.paths;
+    const bPaths = b.paths;
+
+    let diffIndex = 0;
+    while (diffIndex < aPaths.length && diffIndex < bPaths.length && aPaths[diffIndex] === bPaths[diffIndex]) {
+      diffIndex++;
+    }
+
+    const flag = (aPaths[diffIndex] === undefined ? '0' : '1') + (bPaths[diffIndex] === undefined ? '0' : '1');
+    switch (flag) {
+      case '00':
+        // a equal b ('actions[0]', 'actions[0]')
+        return 0;
+      case '01':
+        // a is b's parent, a < b ('actions[0]', 'actions[0].actions[0]')
+        return -1;
+      case '10':
+        // a is b's child, a > b ('actions[0].actions[0]', 'actions[0]')
+        return 1;
+      case '11':
+        return aPaths[diffIndex] - bPaths[diffIndex];
+      default:
+        return 0;
+    }
+  });
+  return sorted.map(x => x.id);
 };


### PR DESCRIPTION
## Description
1. Solve a bug in previous sort. Now the 
```
// before
['actions[10]', 'actions[2]'] => 'actions[10]' < 'actions[2]'

// after
['actions[10]', 'actions[2]'] => 'actions[2]' < 'actions[10]'
```
2. Filter invalid action ids such as 'actions[0].else', 'actions[0].diamond'
3. Define the exact sort order of orphan actions
```
['actions[0].actions[0]', 'actions[0].actions[1]', 'actions[0].elseActions[0]', 'actions[1]']
  => 'actions[0].actions[0]' <'actions[0].elseActions[0]' < 'actions[0].actions[1]' < 'actions[1]'
```

**TODO**: use a trie-tree to manage action path order
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
