### PR TITLE
fix: Switch to actions/checkout@v2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Set Node Version
         uses: actions/setup-node@v1
         with:
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Set Dotnet Version
         uses: actions/setup-dotnet@v1
         with:
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: docker-compose build
         run: docker-compose build
       - name: Health check

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Cache Node Modules
         uses: actions/cache@preview
         with:


### PR DESCRIPTION
attempting to address:

```
git checkout --progress --force b679ac13b2c48def229f873545fa1258bbf0decd 
359##[error]fatal: reference is not a tree: b679ac13b2c48def229f873545fa1258bbf0decd 
360Removed matchers: 'checkout-git' 
361##[error]Git checkout failed with exit code: 128 
362##[error]Exit code 1 returned from process: file name '/home/runner/runners/2.165.2/bin/Runner.PluginHost', arguments 'action "GitHub.Runner.Plugins.Repository.v1_0.CheckoutTask, Runner.Plugins"'.
```

fixes #2221