### PR TITLE
adjust id numbers in dialog samples

### DIFF
--- a/Composer/packages/server/assets/projects/ActionsSample/ComposerDialogs/Actions/Actions.dialog
+++ b/Composer/packages/server/assets/projects/ActionsSample/ComposerDialogs/Actions/Actions.dialog
@@ -16,7 +16,7 @@
         {
           "$type": "Microsoft.SendActivity",
           "$designer": {
-            "id": "166131"
+            "id": "522200"
           },
           "activity": "${bfdactivity-522200()}"
         },
@@ -45,7 +45,7 @@
         {
           "$type": "Microsoft.SendActivity",
           "$designer": {
-            "id": "643043"
+            "id": "797905"
           },
           "activity": "${bfdactivity-797905()}"
         },

--- a/Composer/packages/server/assets/projects/ActionsSample/ComposerDialogs/EditActions/EditActions.dialog
+++ b/Composer/packages/server/assets/projects/ActionsSample/ComposerDialogs/EditActions/EditActions.dialog
@@ -15,7 +15,7 @@
         {
           "$type": "Microsoft.EditActions",
           "$designer": {
-            "id": "250234"
+            "id": "250235"
           },
           "changeType": "insertActions",
           "actions": [

--- a/Composer/packages/server/assets/projects/TodoRecognizerSetSample/ComposerDialogs/ClearToDos/ClearToDos.dialog
+++ b/Composer/packages/server/assets/projects/TodoRecognizerSetSample/ComposerDialogs/ClearToDos/ClearToDos.dialog
@@ -31,7 +31,7 @@
             {
               "$type": "Microsoft.SendActivity",
               "$designer": {
-                "id": "832307"
+                "id": "832300"
               },
               "activity": "${bfdactivity-832307()}"
             }
@@ -40,7 +40,7 @@
             {
               "$type": "Microsoft.SendActivity",
               "$designer": {
-                "id": "983761"
+                "id": "983760"
               },
               "activity": "${bfdactivity-983761()}"
             }

--- a/Composer/packages/server/assets/projects/TodoRecognizerSetSample/ComposerDialogs/DeleteToDo/DeleteToDo.dialog
+++ b/Composer/packages/server/assets/projects/TodoRecognizerSetSample/ComposerDialogs/DeleteToDo/DeleteToDo.dialog
@@ -53,7 +53,7 @@
             {
               "$type": "Microsoft.SendActivity",
               "$designer": {
-                "id": "549615"
+                "id": "549610"
               },
               "activity": "${bfdactivity-549615()}"
             }

--- a/Composer/packages/server/assets/projects/TodoRecognizerSetSample/ComposerDialogs/ShowToDos/ShowToDos.dialog
+++ b/Composer/packages/server/assets/projects/TodoRecognizerSetSample/ComposerDialogs/ShowToDos/ShowToDos.dialog
@@ -32,7 +32,7 @@
             {
               "$type": "Microsoft.SendActivity",
               "$designer": {
-                "id": "662084",
+                "id": "662004",
                 "name": "Send an Activity"
               },
               "activity": "${bfdactivity-662084()}"

--- a/Composer/packages/server/assets/projects/TodoSample/ComposerDialogs/ClearToDos/ClearToDos.dialog
+++ b/Composer/packages/server/assets/projects/TodoSample/ComposerDialogs/ClearToDos/ClearToDos.dialog
@@ -40,7 +40,7 @@
             {
               "$type": "Microsoft.SendActivity",
               "$designer": {
-                "id": "983761"
+                "id": "983766"
               },
               "activity": "${bfdactivity-983761()}"
             }

--- a/Composer/packages/server/assets/projects/TodoSample/ComposerDialogs/DeleteToDo/DeleteToDo.dialog
+++ b/Composer/packages/server/assets/projects/TodoSample/ComposerDialogs/DeleteToDo/DeleteToDo.dialog
@@ -53,7 +53,7 @@
             {
               "$type": "Microsoft.SendActivity",
               "$designer": {
-                "id": "549615"
+                "id": "549616"
               },
               "activity": "${bfdactivity-549615()}"
             }


### PR DESCRIPTION
Some of the dialog files in the Sample files had duplicate ID fields. This change should eliminate these duplicates, letting the "duplicate-id" a11y test past.

## Description

Since the ID fields on the dialogs are populated using the "id" field on the dialogs read from the files, they all need to be unique within each file in order to make sure the IDs don't collide when rendered.

## Task Item

Closes #2142 
