### PR TITLE
fix: add luis authoring region for lubuild 

### DIFF
--- a/BotProject/Templates/CSharp/Scripts/deploy.ps1
+++ b/BotProject/Templates/CSharp/Scripts/deploy.ps1
@@ -117,7 +117,13 @@ if ($luisAuthoringKey -and $luisAuthoringRegion) {
 	if (Get-Command bf -errorAction SilentlyContinue) {
 		$customizedSettings = Get-Content $(Join-Path $remoteBotPath settings appsettings.json) | ConvertFrom-Json
 		$customizedEnv = $customizedSettings.luis.environment
-		bf luis:build --in .\ --botName $name --authoringKey $luisAuthoringKey --dialog --out .\generated --suffix $customizedEnv -f
+		
+		# create generated folder if not exists
+		if (!(Test-Path generated)) {
+			New-Item -ItemType Directory -Force -Path generated
+		}
+		
+		bf luis:build --in .\ --botName $name --authoringKey $luisAuthoringKey --dialog --out .\generated --suffix $customizedEnv -f --region $luisAuthoringRegion
 	}
 	else {
 		Write-Host "bf luis:build does not exist, use the following command to install:"


### PR DESCRIPTION
## Description

fixes #2218

1. Create generated if not exists ( if user doesn't debug locally, the 'generated' folder would not be created and luis build would fail)
2. Add luis authoring region in deploy.ps1.
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
