### PR TITLE
a11y: fix duplicate ids in .dialog files

### DIFF
--- a/BotProject/Templates/CSharp/Scripts/deploy.ps1
+++ b/BotProject/Templates/CSharp/Scripts/deploy.ps1
@@ -117,7 +117,13 @@ if ($luisAuthoringKey -and $luisAuthoringRegion) {
 	if (Get-Command bf -errorAction SilentlyContinue) {
 		$customizedSettings = Get-Content $(Join-Path $remoteBotPath settings appsettings.json) | ConvertFrom-Json
 		$customizedEnv = $customizedSettings.luis.environment
-		bf luis:build --in .\ --botName $name --authoringKey $luisAuthoringKey --dialog --out .\generated --suffix $customizedEnv -f
+		
+		# create generated folder if not exists
+		if (!(Test-Path generated)) {
+			New-Item -ItemType Directory -Force -Path generated
+		}
+		
+		bf luis:build --in .\ --botName $name --authoringKey $luisAuthoringKey --dialog --out .\generated --suffix $customizedEnv -f --region $luisAuthoringRegion
 	}
 	else {
 		Write-Host "bf luis:build does not exist, use the following command to install:"

--- a/Composer/packages/client/src/pages/setting/deployment/deployWizard.js
+++ b/Composer/packages/client/src/pages/setting/deployment/deployWizard.js
@@ -57,9 +57,9 @@ export const DeployWizard = props => {
       children: <DeployWizardStep2 botValues={botValues} nextStep={completeStep2} closeModal={resetModal} />,
     },
     {
-      title: formatMessage('Deploy your Bot'),
+      title: formatMessage('Publish your Bot'),
       subText:
-        'Deploy your bot code and Composer assets to Azure using the command below. Run this any time you want to update your bot on Azure.',
+        'Publish your bot code and Composer assets to Azure using the command below. Run this any time you want to update your bot on Azure.',
       children: <DeployWizardStep3 botValues={botValues} closeModal={resetModal} />,
     },
   ];

--- a/Composer/packages/client/src/pages/setting/deployment/deployWizardStep-getDeploy.js
+++ b/Composer/packages/client/src/pages/setting/deployment/deployWizardStep-getDeploy.js
@@ -28,7 +28,7 @@ export const DeployWizardStep3 = props => {
       <Stack horizontal gap="2rem" styles={styles.stackinput}>
         <StackItem grow={1} styles={styles.halfstack}>
           <TextField
-            label={formatMessage('Deploy Bot Script')}
+            label={formatMessage('Publish Bot Script')}
             styles={styles.textarea}
             value={scriptValue}
             readOnly={true}
@@ -44,7 +44,7 @@ export const DeployWizardStep3 = props => {
         <StackItem grow={1}>
           <p>
             {formatMessage(
-              'Copy the commands above, and paste them into your terminal.  The output will look like the screenshot below. Note that it may take several minutes for the deploy to complete.'
+              'Copy the commands above, and paste them into your terminal.  The output will look like the screenshot below. Note that it may take several minutes for the publish to complete.'
             )}
           </p>
           <img

--- a/Composer/packages/client/src/pages/setting/deployment/index.js
+++ b/Composer/packages/client/src/pages/setting/deployment/index.js
@@ -11,12 +11,12 @@ import { DeployWizard } from './deployWizard.js';
 import { styles } from './styles';
 
 const instructions = {
-  title: formatMessage('Deploy your bot to Azure'),
+  title: formatMessage('Publish your bot to Azure'),
   description: formatMessage(
-    'For team members or customers to interact with this bot, your bot needs to be deployed. In this version of Composer, this step is not yet automated, however, Composer can configure Azure Resources and generate a script to deploy your bot. You can use this script whenever you want to deploy an updated version of your bot.'
+    'For team members or customers to interact with this bot, your bot needs to be published. In this version of Composer, this step is not yet automated, however, Composer can configure Azure Resources and generate a script to publish your bot. You can use this script whenever you want to publish an updated version of your bot.'
   ),
   button1: formatMessage('Create Azure Resources'),
-  button2: formatMessage('Deploy Bot to Azure'),
+  button2: formatMessage('Publish Bot to Azure'),
   helpLink: 'https://aka.ms/bfc-publishing-your-bot',
 };
 

--- a/Composer/packages/server/assets/projects/ActionsSample/ComposerDialogs/Actions/Actions.dialog
+++ b/Composer/packages/server/assets/projects/ActionsSample/ComposerDialogs/Actions/Actions.dialog
@@ -16,7 +16,7 @@
         {
           "$type": "Microsoft.SendActivity",
           "$designer": {
-            "id": "166131"
+            "id": "522200"
           },
           "activity": "${bfdactivity-522200()}"
         },
@@ -45,7 +45,7 @@
         {
           "$type": "Microsoft.SendActivity",
           "$designer": {
-            "id": "643043"
+            "id": "797905"
           },
           "activity": "${bfdactivity-797905()}"
         },

--- a/Composer/packages/server/assets/projects/ActionsSample/ComposerDialogs/EditActions/EditActions.dialog
+++ b/Composer/packages/server/assets/projects/ActionsSample/ComposerDialogs/EditActions/EditActions.dialog
@@ -15,7 +15,7 @@
         {
           "$type": "Microsoft.EditActions",
           "$designer": {
-            "id": "250234"
+            "id": "250235"
           },
           "changeType": "insertActions",
           "actions": [

--- a/Composer/packages/server/assets/projects/TodoRecognizerSetSample/ComposerDialogs/ClearToDos/ClearToDos.dialog
+++ b/Composer/packages/server/assets/projects/TodoRecognizerSetSample/ComposerDialogs/ClearToDos/ClearToDos.dialog
@@ -31,7 +31,7 @@
             {
               "$type": "Microsoft.SendActivity",
               "$designer": {
-                "id": "832307"
+                "id": "832300"
               },
               "activity": "${bfdactivity-832307()}"
             }
@@ -40,7 +40,7 @@
             {
               "$type": "Microsoft.SendActivity",
               "$designer": {
-                "id": "983761"
+                "id": "983760"
               },
               "activity": "${bfdactivity-983761()}"
             }

--- a/Composer/packages/server/assets/projects/TodoRecognizerSetSample/ComposerDialogs/DeleteToDo/DeleteToDo.dialog
+++ b/Composer/packages/server/assets/projects/TodoRecognizerSetSample/ComposerDialogs/DeleteToDo/DeleteToDo.dialog
@@ -53,7 +53,7 @@
             {
               "$type": "Microsoft.SendActivity",
               "$designer": {
-                "id": "549615"
+                "id": "549610"
               },
               "activity": "${bfdactivity-549615()}"
             }

--- a/Composer/packages/server/assets/projects/TodoRecognizerSetSample/ComposerDialogs/ShowToDos/ShowToDos.dialog
+++ b/Composer/packages/server/assets/projects/TodoRecognizerSetSample/ComposerDialogs/ShowToDos/ShowToDos.dialog
@@ -32,7 +32,7 @@
             {
               "$type": "Microsoft.SendActivity",
               "$designer": {
-                "id": "662084",
+                "id": "662004",
                 "name": "Send an Activity"
               },
               "activity": "${bfdactivity-662084()}"

--- a/Composer/packages/server/assets/projects/TodoSample/ComposerDialogs/ClearToDos/ClearToDos.dialog
+++ b/Composer/packages/server/assets/projects/TodoSample/ComposerDialogs/ClearToDos/ClearToDos.dialog
@@ -40,7 +40,7 @@
             {
               "$type": "Microsoft.SendActivity",
               "$designer": {
-                "id": "983761"
+                "id": "983766"
               },
               "activity": "${bfdactivity-983761()}"
             }

--- a/Composer/packages/server/assets/projects/TodoSample/ComposerDialogs/DeleteToDo/DeleteToDo.dialog
+++ b/Composer/packages/server/assets/projects/TodoSample/ComposerDialogs/DeleteToDo/DeleteToDo.dialog
@@ -53,7 +53,7 @@
             {
               "$type": "Microsoft.SendActivity",
               "$designer": {
-                "id": "549615"
+                "id": "549616"
               },
               "activity": "${bfdactivity-549615()}"
             }


### PR DESCRIPTION
## Description

Dialogs get created from the .dialog files and populate their components' "id" tags from the ids given in the file. If the files have duplicate ids in them, the output HTML will as well, and this is an a11y problem.

## Task Item

Closes #2142 
