### PR TITLE
a11y: adjust id numbers in dialog samples

### DIFF
--- a/Composer/packages/server/assets/projects/ActionsSample/ComposerDialogs/Actions/Actions.dialog
+++ b/Composer/packages/server/assets/projects/ActionsSample/ComposerDialogs/Actions/Actions.dialog
@@ -16,7 +16,7 @@
         {
           "$type": "Microsoft.SendActivity",
           "$designer": {
-            "id": "166131"
+            "id": "522200"
           },
           "activity": "${bfdactivity-522200()}"
         },
@@ -45,7 +45,7 @@
         {
           "$type": "Microsoft.SendActivity",
           "$designer": {
-            "id": "643043"
+            "id": "797905"
           },
           "activity": "${bfdactivity-797905()}"
         },

--- a/Composer/packages/server/assets/projects/ActionsSample/ComposerDialogs/EditActions/EditActions.dialog
+++ b/Composer/packages/server/assets/projects/ActionsSample/ComposerDialogs/EditActions/EditActions.dialog
@@ -15,7 +15,7 @@
         {
           "$type": "Microsoft.EditActions",
           "$designer": {
-            "id": "250234"
+            "id": "250235"
           },
           "changeType": "insertActions",
           "actions": [

--- a/Composer/packages/server/assets/projects/ActionsSample/ComposerDialogs/IfCondition/IfCondition.dialog
+++ b/Composer/packages/server/assets/projects/ActionsSample/ComposerDialogs/IfCondition/IfCondition.dialog
@@ -15,7 +15,7 @@
         {
           "$type": "Microsoft.IfCondition",
           "$designer": {
-            "id": "719594"
+            "id": "719500"
           },
           "condition": "user.name == null",
           "actions": [

--- a/Composer/packages/server/assets/projects/ActionsSample/ComposerDialogs/Main/Main.dialog
+++ b/Composer/packages/server/assets/projects/ActionsSample/ComposerDialogs/Main/Main.dialog
@@ -248,7 +248,7 @@
         {
           "$type": "Microsoft.SendActivity",
           "$designer": {
-            "id": "347762"
+            "id": "640616"
           },
           "activity": "${bfdactivity-640616()}"
         }
@@ -280,10 +280,10 @@
                 {
                   "$type": "Microsoft.SendActivity",
                   "$designer": {
-                    "id": "640616",
+                    "id": "640617",
                     "name": "Send a response"
                   },
-                  "activity": "${bfdactivity-640616()}"
+                  "activity": "${bfdactivity-640617()}"
                 }
               ]
             }

--- a/Composer/packages/server/assets/projects/ActionsSample/ComposerDialogs/Main/Main.lg
+++ b/Composer/packages/server/assets/projects/ActionsSample/ComposerDialogs/Main/Main.lg
@@ -2,3 +2,6 @@
 
 # bfdactivity-640616
 -${help()}
+
+# bfdactivity-640617
+-${help()}

--- a/Composer/packages/server/assets/projects/TodoRecognizerSetSample/ComposerDialogs/ClearToDos/ClearToDos.dialog
+++ b/Composer/packages/server/assets/projects/TodoRecognizerSetSample/ComposerDialogs/ClearToDos/ClearToDos.dialog
@@ -33,16 +33,16 @@
               "$designer": {
                 "id": "832300"
               },
-              "activity": "${bfdactivity-832307()}"
+              "activity": "${bfdactivity-832300()}"
             }
           ],
           "elseActions": [
             {
               "$type": "Microsoft.SendActivity",
               "$designer": {
-                "id": "983760"
+                "id": "983700"
               },
-              "activity": "${bfdactivity-983761()}"
+              "activity": "${bfdactivity-983700()}"
             }
           ]
         }

--- a/Composer/packages/server/assets/projects/TodoRecognizerSetSample/ComposerDialogs/ClearToDos/ClearToDos.dialog
+++ b/Composer/packages/server/assets/projects/TodoRecognizerSetSample/ComposerDialogs/ClearToDos/ClearToDos.dialog
@@ -31,7 +31,7 @@
             {
               "$type": "Microsoft.SendActivity",
               "$designer": {
-                "id": "832307"
+                "id": "832300"
               },
               "activity": "${bfdactivity-832307()}"
             }
@@ -40,7 +40,7 @@
             {
               "$type": "Microsoft.SendActivity",
               "$designer": {
-                "id": "983761"
+                "id": "983760"
               },
               "activity": "${bfdactivity-983761()}"
             }

--- a/Composer/packages/server/assets/projects/TodoRecognizerSetSample/ComposerDialogs/ClearToDos/ClearToDos.lg
+++ b/Composer/packages/server/assets/projects/TodoRecognizerSetSample/ComposerDialogs/ClearToDos/ClearToDos.lg
@@ -1,7 +1,7 @@
 [import](common.lg)
 
-# bfdactivity-832307
+# bfdactivity-832300
 -Successfully cleared items in the Todo List.
 
-# bfdactivity-983761
+# bfdactivity-983700
 -You don't have any items in the Todo List.

--- a/Composer/packages/server/assets/projects/TodoRecognizerSetSample/ComposerDialogs/DeleteToDo/DeleteToDo.dialog
+++ b/Composer/packages/server/assets/projects/TodoRecognizerSetSample/ComposerDialogs/DeleteToDo/DeleteToDo.dialog
@@ -53,7 +53,7 @@
             {
               "$type": "Microsoft.SendActivity",
               "$designer": {
-                "id": "549615"
+                "id": "549610"
               },
               "activity": "${bfdactivity-549615()}"
             }

--- a/Composer/packages/server/assets/projects/TodoRecognizerSetSample/ComposerDialogs/ShowToDos/ShowToDos.dialog
+++ b/Composer/packages/server/assets/projects/TodoRecognizerSetSample/ComposerDialogs/ShowToDos/ShowToDos.dialog
@@ -35,7 +35,7 @@
                 "id": "662004",
                 "name": "Send an Activity"
               },
-              "activity": "${bfdactivity-662084()}"
+              "activity": "${bfdactivity-662004()}"
             }
           ]
         }

--- a/Composer/packages/server/assets/projects/TodoRecognizerSetSample/ComposerDialogs/ShowToDos/ShowToDos.dialog
+++ b/Composer/packages/server/assets/projects/TodoRecognizerSetSample/ComposerDialogs/ShowToDos/ShowToDos.dialog
@@ -32,7 +32,7 @@
             {
               "$type": "Microsoft.SendActivity",
               "$designer": {
-                "id": "662084",
+                "id": "662004",
                 "name": "Send an Activity"
               },
               "activity": "${bfdactivity-662084()}"

--- a/Composer/packages/server/assets/projects/TodoRecognizerSetSample/ComposerDialogs/ShowToDos/ShowToDos.lg
+++ b/Composer/packages/server/assets/projects/TodoRecognizerSetSample/ComposerDialogs/ShowToDos/ShowToDos.lg
@@ -4,5 +4,5 @@
 # bfdactivity-339580
 -You have no todos.
 
-# bfdactivity-662084
+# bfdactivity-662004
 -${ShowTodo()}

--- a/Composer/packages/server/assets/projects/TodoSample/ComposerDialogs/ClearToDos/ClearToDos.dialog
+++ b/Composer/packages/server/assets/projects/TodoSample/ComposerDialogs/ClearToDos/ClearToDos.dialog
@@ -40,7 +40,7 @@
             {
               "$type": "Microsoft.SendActivity",
               "$designer": {
-                "id": "983761"
+                "id": "983766"
               },
               "activity": "${bfdactivity-983761()}"
             }

--- a/Composer/packages/server/assets/projects/TodoSample/ComposerDialogs/ClearToDos/ClearToDos.dialog
+++ b/Composer/packages/server/assets/projects/TodoSample/ComposerDialogs/ClearToDos/ClearToDos.dialog
@@ -15,7 +15,7 @@
         {
           "$type": "Microsoft.EditArray",
           "$designer": {
-            "id": "832307"
+            "id": "832300"
           },
           "changeType": "Clear",
           "itemsProperty": "user.todos",
@@ -24,7 +24,7 @@
         {
           "$type": "Microsoft.IfCondition",
           "$designer": {
-            "id": "983761"
+            "id": "983700"
           },
           "condition": "dialog.cleared",
           "actions": [
@@ -40,7 +40,7 @@
             {
               "$type": "Microsoft.SendActivity",
               "$designer": {
-                "id": "983766"
+                "id": "983761"
               },
               "activity": "${bfdactivity-983761()}"
             }

--- a/Composer/packages/server/assets/projects/TodoSample/ComposerDialogs/DeleteToDo/DeleteToDo.dialog
+++ b/Composer/packages/server/assets/projects/TodoSample/ComposerDialogs/DeleteToDo/DeleteToDo.dialog
@@ -53,7 +53,7 @@
             {
               "$type": "Microsoft.SendActivity",
               "$designer": {
-                "id": "549615"
+                "id": "549616"
               },
               "activity": "${bfdactivity-549615()}"
             }

--- a/Composer/packages/server/assets/projects/TodoSample/ComposerDialogs/DeleteToDo/DeleteToDo.dialog
+++ b/Composer/packages/server/assets/projects/TodoSample/ComposerDialogs/DeleteToDo/DeleteToDo.dialog
@@ -53,9 +53,9 @@
             {
               "$type": "Microsoft.SendActivity",
               "$designer": {
-                "id": "549616"
+                "id": "549600"
               },
-              "activity": "${bfdactivity-549615()}"
+              "activity": "${bfdactivity-549600()}"
             }
           ]
         }

--- a/Composer/packages/server/assets/projects/TodoSample/ComposerDialogs/DeleteToDo/DeleteToDo.lg
+++ b/Composer/packages/server/assets/projects/TodoSample/ComposerDialogs/DeleteToDo/DeleteToDo.lg
@@ -3,7 +3,7 @@
 # bfdactivity-725469
 -Successfully removed a todo named ${dialog.todo}
 
-# bfdactivity-549615
+# bfdactivity-549600
 -${dialog.todo} is not in the Todo List
 
 # bfdprompt-870620()


### PR DESCRIPTION
Some of the dialog files in the Sample files had duplicate ID fields. This change should eliminate these duplicates, letting the "duplicate-id" a11y test past.

## Description

The side dialog is created from the sample .dialog files, so the fix here was to check that the ids in each file contain no duplicate ID fields and change the ones that did.

## Task Item

Closes #2142 