### PR TITLE
a11y: add SR labels to Bot Responses "used" column

### DIFF
--- a/Composer/packages/client/src/pages/language-generation/table-view.tsx
+++ b/Composer/packages/client/src/pages/language-generation/table-view.tsx
@@ -183,9 +183,9 @@ const TableView: React.FC<TableViewProps> = props => {
         data: 'string',
         onRender: item => {
           return activeDialog?.lgTemplates.find(({ name }) => name === item.name) ? (
-            <IconButton iconProps={{ iconName: 'Accept' }} />
+            <IconButton iconProps={{ iconName: 'Accept' }} ariaLabel={formatMessage('Used')} />
           ) : (
-            <div />
+            <div aria-label={formatMessage('Unused')} />
           );
         },
       };


### PR DESCRIPTION
## Description

This adds proper screen-reader labels to the "Been used" column in Bot Responses. Now, instead of "read-only, button" and "read-only", the cells are read as "used" and "unused".

## Task Item

Closes #2049