### PR TITLE
chore: add default alwaysPrompt value in OAuthInput step

### DIFF
--- a/Composer/packages/extensions/obiformeditor/src/schema/uischema.ts
+++ b/Composer/packages/extensions/obiformeditor/src/schema/uischema.ts
@@ -197,6 +197,7 @@ export const uiSchema: { [key in SDKTypes]?: UiSchema } = {
       'ui:widget': 'TextareaWidget',
     },
     'ui:order': ['connectionName', '*'],
+    'ui:hidden': ['alwaysPrompt'],
   },
   [SDKTypes.QnAMakerDialog]: {
     strictFilters: {

--- a/Composer/packages/lib/shared/src/appschema.ts
+++ b/Composer/packages/lib/shared/src/appschema.ts
@@ -1967,6 +1967,13 @@ export const appschema: OBISchema = {
           examples: ['dialog.token'],
           type: 'string',
         },
+        alwaysPrompt: {
+          type: 'boolean',
+          title: 'Always prompt',
+          description: "Collect information even if the specified 'property' is not empty.",
+          default: true,
+          examples: [false],
+        },
       },
     },
     'Microsoft.OnActivity': {


### PR DESCRIPTION
## Description

add default alwaysPrompt value in OAuthInput step.

There is a bug in SDK, that requires alwaysPrompt property must have value, otherwise it will throw an exception called : Object reference to null.

This PR is to hotfix that issue in Composer side to work around that bug. 

## Task Item

fixes #2266 

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
