### PR TITLE
fix: Some editting bugs in Lu editor

### DIFF
--- a/Composer/packages/lib/code-editor/src/languages/lu.ts
+++ b/Composer/packages/lib/code-editor/src/languages/lu.ts
@@ -36,12 +36,12 @@ export function registerLULanguage(monaco: typeof monacoEditor) {
         [/^\s*>\s*[\s\S]*$/, { token: 'comments' }],
         [/^\s*-/, { token: 'utterrance-indentifier', next: 'utterrance' }],
         [
-          /(@\s*)(prebuilt\s*)(age|datetimeV2|dimension|email|geographyV2|keyPhrase|money|number|ordinal|ordinalV2|percentage|personName|phonenumber|temperature|url|datetime)(\s*[\w_,\s]+)/,
+          /(@\s*)(prebuilt\s+)(age|datetimeV2|dimension|email|geographyV2|keyPhrase|money|number|ordinal|ordinalV2|percentage|personName|phonenumber|temperature|url|datetime)(\s+[\w_,\s]+)/,
           ['intent-indentifier', 'entity-type', 'prebult-type', 'entity-name'],
         ],
         [
           // eslint-disable-next-line security/detect-unsafe-regex
-          /(@\s*)(ml|prebuilt|regex|list|composite|Pattern\.Any|phraseList)(\s*[\w_]+)/,
+          /(@\s*)(ml|prebuilt|regex|list|composite|Pattern\.Any|phraseList)(\s+[\w_]+)/,
           ['intent-indentifier', 'entity-type', 'entity-name'],
         ],
         [/(@\s*)(\s*[\w_]+)/, ['intent-indentifier', 'entity-name']],

--- a/Composer/packages/tools/language-servers/language-understanding/src/LUServer.ts
+++ b/Composer/packages/tools/language-servers/language-understanding/src/LUServer.ts
@@ -72,9 +72,7 @@ export class LUServer {
     this.connection.onCompletion(params => this.completion(params));
     this.connection.onDocumentOnTypeFormatting(docTypingParams => this.docTypeFormat(docTypingParams));
     this.connection.onRequest((method, params) => {
-      console.log(method);
       if (method === LABELEXPERIENCEREQUEST) {
-        console.log('inside');
         this.labelingExperienceHandler(params);
       } else if (InitializeDocumentsMethodName === method) {
         const { uri, luOption }: { uri: string; luOption?: LUOption } = params;

--- a/Composer/packages/tools/language-servers/language-understanding/src/LUServer.ts
+++ b/Composer/packages/tools/language-servers/language-understanding/src/LUServer.ts
@@ -72,7 +72,9 @@ export class LUServer {
     this.connection.onCompletion(params => this.completion(params));
     this.connection.onDocumentOnTypeFormatting(docTypingParams => this.docTypeFormat(docTypingParams));
     this.connection.onRequest((method, params) => {
+      console.log(method);
       if (method === LABELEXPERIENCEREQUEST) {
+        console.log('inside');
         this.labelingExperienceHandler(params);
       } else if (InitializeDocumentsMethodName === method) {
         const { uri, luOption }: { uri: string; luOption?: LUOption } = params;
@@ -193,11 +195,9 @@ export class LUServer {
     const range = Range.create(position.lineNumber - 1, 0, position.lineNumber - 1, position.column);
     const curLineContent = document.getText(range);
     // eslint-disable-next-line security/detect-unsafe-regex
-    const labeledUtterRegex = /^\s*-([^{}]*\s*\{[\w.@:\s]+\s*=\s*[\w.]+\}[^{}]*)+$/;
-
+    const labeledUtterRegex = /^\s*-([^{}]*\s*\{[\w.@:\s]+\s*=\s*[\w.\s]+\}[^{}]*)+$/;
     if (labeledUtterRegex.test(curLineContent)) {
       const newText = util.removeLabelsInUtterance(curLineContent);
-
       const newPos = Position.create(position.lineNumber, 0);
       const newUnlalbelText = newText + '\n';
       const editPreviousLine: TextEdit = TextEdit.insert(newPos, newUnlalbelText);
@@ -229,7 +229,7 @@ export class LUServer {
 
     const pos = params.position;
     if (key === '\n' && inputState === 'utterance' && lastLineContent.trim() !== '-') {
-      const newPos = Position.create(pos.line + 1, 0);
+      const newPos = Position.create(pos.line, 0);
       const item: TextEdit = TextEdit.insert(newPos, '- ');
       edits.push(item);
     }

--- a/Composer/packages/tools/language-servers/language-understanding/src/matchingPattern.ts
+++ b/Composer/packages/tools/language-servers/language-understanding/src/matchingPattern.ts
@@ -210,7 +210,7 @@ export function extractEntityNameInUseFeature(lineContent: string): string {
 }
 
 export function removeLabelsInUtterance(lineContent: string): string {
-  const entityLabelRegex = /\{\s*[\w.@:\s]+\s*=\s*[\w.]+\s*\}/g;
+  const entityLabelRegex = /\{\s*[\w.@:\s]+\s*=\s*[\w.@:\s]+\s*\}/g;
   let match: RegExpMatchArray | null;
   let resultStr = '';
   let startIdx = 0;


### PR DESCRIPTION
fixes #2141 

1. Incorrect syntax highlight for entity definition. For example:
![image](https://user-images.githubusercontent.com/17074777/76841582-f211c500-6873-11ea-989c-e97f0a7e1277.png)

2. Wrong place of inserting '-' in auto-completion of utterance
![docFormat](https://user-images.githubusercontent.com/17074777/76841797-3ef59b80-6874-11ea-9e0a-ba976a259e90.gif)

3. trigger error of lebeling experience
![labeling](https://user-images.githubusercontent.com/17074777/76841809-4321b900-6874-11ea-94e6-4983ab89d520.gif)
