### PR TITLE
a11y: make dialog name required

### DIFF
--- a/Composer/packages/client/src/pages/design/createDialogModal.tsx
+++ b/Composer/packages/client/src/pages/design/createDialogModal.tsx
@@ -89,6 +89,7 @@ export const CreateDialogModal: React.FC<CreateDialogModalProps> = props => {
               onChange={updateForm('name')}
               errorMessage={formDataErrors.name}
               data-testid="NewDialogName"
+              required
             />
           </StackItem>
           <StackItem grow={0} styles={wizardStyles.halfstack}>


### PR DESCRIPTION
## Description

One-line fix to make it clear that this field is mandatory

## Task Item

Closes #2073 

## Screenshots

![name-required](https://user-images.githubusercontent.com/61990921/76911248-9d6b4b80-686d-11ea-8fd3-5f3b75e6f74c.png)
