### PR TITLE
a11y: move FocusZone from NavItem to App

### DIFF
--- a/Composer/packages/client/src/App.tsx
+++ b/Composer/packages/client/src/App.tsx
@@ -6,6 +6,7 @@ import { jsx } from '@emotion/core';
 import React, { forwardRef, useContext, useState, Fragment, Suspense } from 'react';
 import { initializeIcons } from 'office-ui-fabric-react/lib/Icons';
 import { IconButton } from 'office-ui-fabric-react/lib/Button';
+import { FocusZone } from 'office-ui-fabric-react/lib/FocusZone';
 import formatMessage from 'format-message';
 
 import { Header } from './components/Header';
@@ -137,18 +138,20 @@ export const App: React.FC = () => {
               ariaLabel={sideBarExpand ? formatMessage('Collapse Nav') : formatMessage('Expand Nav')}
             />
             <div css={dividerTop} />{' '}
-            {topLinks(projectId).map((link, index) => {
-              return (
-                <NavItem
-                  key={'NavLeftBar' + index}
-                  to={mapNavItemTo(link.to)}
-                  iconName={link.iconName}
-                  labelName={link.labelName}
-                  exact={link.exact}
-                  disabled={link.disabled}
-                />
-              );
-            })}
+            <FocusZone allowFocusRoot={true}>
+              {topLinks(projectId).map((link, index) => {
+                return (
+                  <NavItem
+                    key={'NavLeftBar' + index}
+                    to={mapNavItemTo(link.to)}
+                    iconName={link.iconName}
+                    labelName={link.labelName}
+                    exact={link.exact}
+                    disabled={link.disabled}
+                  />
+                );
+              })}
+            </FocusZone>
           </div>
           <div css={leftNavBottom}>
             <div css={divider(sideBarExpand)} />{' '}

--- a/Composer/packages/client/src/components/NavItem/index.tsx
+++ b/Composer/packages/client/src/components/NavItem/index.tsx
@@ -6,7 +6,6 @@ import { jsx } from '@emotion/core';
 import { useCallback, useContext, useState } from 'react';
 import { Link, LinkGetProps } from '@reach/router';
 import { CommandBarButton } from 'office-ui-fabric-react/lib/Button';
-import { FocusZone } from 'office-ui-fabric-react/lib/FocusZone';
 
 import { StoreContext } from '../../store';
 

--- a/Composer/packages/client/src/components/NavItem/index.tsx
+++ b/Composer/packages/client/src/components/NavItem/index.tsx
@@ -38,32 +38,30 @@ export const NavItem: React.FC<INavItemProps> = props => {
   const addRef = useCallback(ref => onboardingAddCoachMarkRef({ [`nav${labelName.replace(' ', '')}`]: ref }), []);
 
   return (
-    <FocusZone allowFocusRoot={true} disabled={disabled}>
-      <Link
-        to={to}
-        css={link(active, disabled)}
-        getProps={(props: LinkGetProps) => {
-          const isActive = exact ? props.isCurrent : props.isPartiallyCurrent;
-          setActive(isActive);
-          return {};
-        }}
-        data-testid={'LeftNav-CommandBarButton' + labelName}
-        aria-disabled={disabled}
-        aria-label={labelName}
-        ref={addRef}
-      >
-        <div css={outer} aria-hidden="true">
-          <CommandBarButton
-            iconProps={{
-              iconName,
-            }}
-            text={labelName}
-            styles={commandBarButton(active)}
-            disabled={disabled}
-            ariaHidden
-          />
-        </div>
-      </Link>
-    </FocusZone>
+    <Link
+      to={to}
+      css={link(active, disabled)}
+      getProps={(props: LinkGetProps) => {
+        const isActive = exact ? props.isCurrent : props.isPartiallyCurrent;
+        setActive(isActive);
+        return {};
+      }}
+      data-testid={'LeftNav-CommandBarButton' + labelName}
+      aria-disabled={disabled}
+      aria-label={labelName}
+      ref={addRef}
+    >
+      <div css={outer} aria-hidden="true" tabIndex={-1}>
+        <CommandBarButton
+          iconProps={{
+            iconName,
+          }}
+          text={labelName}
+          styles={commandBarButton(active)}
+          disabled={disabled}
+          ariaHidden
+        />
+      </div>
+    </Link>
   );
 };

--- a/Composer/packages/extensions/visual-designer/src/schema/uischema.tsx
+++ b/Composer/packages/extensions/visual-designer/src/schema/uischema.tsx
@@ -216,8 +216,9 @@ export const uiSchema: UISchema = {
       <ListOverview
         items={data.assignments}
         itemPadding={8}
-        renderItem={item => {
-          const content = `${item.property} : ${item.value}`;
+        renderItem={({ property, value }) => {
+          const v = typeof value === 'object' ? JSON.stringify(value) : value;
+          const content = `${property} : ${v}`;
           return (
             <SingleLineDiv height={16} title={content}>
               {content}


### PR DESCRIPTION
## Description

This moves a FocusZone element from the sidebar's NavItems into the App itself; this lets us use up/down arrow keys instead of Tab to navigate between the icons, as requested in the Issue.

## Task Item

Closes #2040 
