### PR TITLE
fix: set luis  recognizer type for dialog in formEditor 

### DIFF
--- a/Composer/packages/extensions/obiformeditor/src/Form/fields/RecognizerField/index.tsx
+++ b/Composer/packages/extensions/obiformeditor/src/Form/fields/RecognizerField/index.tsx
@@ -35,7 +35,7 @@ export const RecognizerField: React.FC<FieldProps<MicrosoftIRecognizer>> = props
         }
         case 'luis': {
           if (selectedFile) {
-            onChange(currentDialog.luFile);
+            onChange(`${currentDialogId}.lu`);
           } else {
             const { createLuFile } = shellApi;
 


### PR DESCRIPTION
## Description
 set luis  recognizer type for dialog recognizer property in formEditor.

There is the code to `set luis recognizer type` in current master branch.
```
 if (selectedFile) {
  onChange(currentDialog.luFile);
}
```
![image](https://user-images.githubusercontent.com/5860999/77404954-72dd3d80-6ded-11ea-8524-bee991b7f719.png)

But `currentDialog.luFile` is '',  it will cause the recognizer is '', and can not create recognizered intent, So I revert the code to 
```
if (selectedFile) {
  onChange(`${currentDialogId}.lu`);
}
```


## Task Item

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
