### PR TITLE
fix: can't find referred lu files for publishing

### DIFF
--- a/Composer/packages/server/src/models/bot/botProject.ts
+++ b/Composer/packages/server/src/models/bot/botProject.ts
@@ -933,10 +933,7 @@ export class BotProject {
 
   private isReferred = (LUFile: LuFile) => {
     const dialogs = this.dialogs;
-    if (dialogs.findIndex(dialog => dialog.luFile === LUFile.id) !== -1) {
-      return true;
-    }
-    return false;
+    return !!~dialogs.findIndex(dialog => dialog.luFile === Path.basename(LUFile.id, `.${this.locale}`));
   };
 
   private generateErrorMessage = (invalidLuFile: LuFile[]) => {

--- a/Composer/packages/server/src/models/bot/botProject.ts
+++ b/Composer/packages/server/src/models/bot/botProject.ts
@@ -931,9 +931,13 @@ export class BotProject {
     return true;
   };
 
+  private removeLocale(id: string): string {
+    return id.substring(0, id.lastIndexOf('.')) || id;
+  }
+
   private isReferred = (LUFile: LuFile) => {
     const dialogs = this.dialogs;
-    return !!~dialogs.findIndex(dialog => dialog.luFile === Path.basename(LUFile.id, `.${this.locale}`));
+    return !!~dialogs.findIndex(dialog => dialog.luFile === this.removeLocale(LUFile.id));
   };
 
   private generateErrorMessage = (invalidLuFile: LuFile[]) => {


### PR DESCRIPTION
## Description
The referred lu id should add locale before search
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
refs #2357
-> 2. Configuring LUIS as recognizer appears to break. (500's from emulator)
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots
for the multi locale publish result will be like:
![imgos](https://user-images.githubusercontent.com/39758135/77502921-39610c80-6e97-11ea-9f28-f4a8d98ffb3c.jpg)
![imgos (2)](https://user-images.githubusercontent.com/39758135/77502925-3a923980-6e97-11ea-826d-7c26004b1906.jpg)
![imgo](https://user-images.githubusercontent.com/39758135/77502927-3bc36680-6e97-11ea-93a4-006799b36333.jpg)

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
