### PR TITLE
fix: file serialization regressions

### DIFF
--- a/Composer/cypress/integration/NotificationPage.spec.ts
+++ b/Composer/cypress/integration/NotificationPage.spec.ts
@@ -40,7 +40,7 @@ context('Notification Page', () => {
     cy.get('[data-testid="notifications-info-button"]').click();
 
     cy.get('[data-testid="notifications-table-view"]').within(() => {
-      cy.findAllByText('todobotwithluissample.en-us.lu')
+      cy.findAllByText('__testtodobotwithluissample.en-us.lu')
         .should('exist')
         .first()
         .click();
@@ -68,7 +68,7 @@ context('Notification Page', () => {
     cy.get('[data-testid="notifications-info-button"]').click();
 
     cy.get('[data-testid="notifications-table-view"]').within(() => {
-      cy.findAllByText('todobotwithluissample.dialog')
+      cy.findAllByText('__testtodobotwithluissample.dialog')
         .should('exist')
         .first()
         .click();

--- a/Composer/packages/server/src/models/bot/botProject.ts
+++ b/Composer/packages/server/src/models/bot/botProject.ts
@@ -200,9 +200,12 @@ export class BotProject {
   public updateBotInfo = async (name: string, description: string) => {
     const dialogs = this.dialogs;
     const mainDialog = dialogs.find(item => item.isRoot);
+    if (!mainDialog) return;
+    const entryDialogId = name.trim().toLowerCase();
+    const { content, relativePath } = mainDialog;
 
-    if (mainDialog && mainDialog.content) {
-      const oldDesigner = mainDialog.content.$designer;
+    if (content) {
+      const oldDesigner = content.$designer;
 
       let newDesigner;
       if (oldDesigner && oldDesigner.id) {
@@ -215,8 +218,29 @@ export class BotProject {
         newDesigner = getNewDesigner(name, description);
       }
 
-      mainDialog.content.$designer = newDesigner;
-      await this.updateDialog(mainDialog.id, mainDialog.content);
+      content.$designer = newDesigner;
+
+      const updatedContent = this._autofixReferInDialog(entryDialogId, JSON.stringify(content, null, 2));
+      await this._updateFile(relativePath, updatedContent);
+    }
+
+    // when create/saveAs bot, serialize entry dialog/lg/lu
+    const entryPatterns = [
+      templateInterpolate(BotStructureTemplate.entry, { BOTNAME: '*' }),
+      templateInterpolate(BotStructureTemplate.dialogs.lg, { LOCALE: '*', DIALOGNAME: '*' }),
+      templateInterpolate(BotStructureTemplate.dialogs.lu, { LOCALE: '*', DIALOGNAME: '*' }),
+    ];
+    for (const pattern of entryPatterns) {
+      const root = this.dataDir;
+      const paths = await this.fileStorage.glob(pattern, root);
+      for (const filePath of paths.sort()) {
+        const realFilePath = Path.join(root, filePath);
+        // skip common file, do not rename.
+        if (Path.basename(realFilePath).startsWith('common.')) continue;
+        // rename file to new botname
+        const targetFilePath = realFilePath.replace(/(.*)\/[^.]*(\..*$)/i, `$1/${entryDialogId}$2`);
+        await this.fileStorage.rename(realFilePath, targetFilePath);
+      }
     }
   };
 
@@ -893,7 +917,7 @@ export class BotProject {
    * - "dialog": 'AddTodos'
    * + "dialog": 'addtodos'
    */
-  private _autofixReferInDialog = (dialogId: string, content: string) => {
+  private _autofixReferInDialog = (dialogId: string, content: string): string => {
     try {
       const dialogJson = JSON.parse(content);
 


### PR DESCRIPTION
## Description

when create or save as bot, rename entry dialog/lg/lu

## Task Item

refs #2357 
> 1. serialization has a couple minor issues:
>  when a template is selected for creation, the main/entry dialog is the name of the template, when it should be the name the user gave for the bot.
## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
