### PR TITLE
fix: lg resolver with locale

### DIFF
--- a/Composer/packages/client/src/store/index.tsx
+++ b/Composer/packages/client/src/store/index.tsx
@@ -5,9 +5,9 @@ import React, { useReducer, useRef } from 'react';
 import once from 'lodash/once';
 import { ImportResolverDelegate, LGParser } from 'botbuilder-lg';
 import { LgFile, LuFile } from '@bfc/indexers';
+import { importResolverGenerator } from '@bfc/shared';
 
 import { prepareAxios } from '../utils/auth';
-import { getFileName } from '../utils/fileUtil';
 
 import { reducer } from './reducer';
 import bindActions from './action/bindActions';
@@ -121,17 +121,7 @@ export const StoreProvider: React.FC<StoreProviderProps> = props => {
     actions: boundActions,
     dispatch: interceptDispatch,
     resolvers: {
-      lgImportresolver: function(source: string, id: string) {
-        const sourceId = getFileName(source).replace(/\.lg$/, '');
-        const locale = sourceId.split('.').length > 1 ? sourceId.split('.').pop() : 'en-us';
-        const targetId = getFileName(id).replace(/\.lg$/, '');
-
-        const targetFile =
-          getState().lgFiles.find(({ id }) => id === `${targetId}.${locale}`) ||
-          getState().lgFiles.find(({ id }) => id === targetId);
-        if (!targetFile) throw new Error(`${id} lg file not found`);
-        return { id, content: targetFile.content };
-      } as ImportResolverDelegate,
+      lgImportresolver: importResolverGenerator(getState().lgFiles, '.lg'),
       lgFileResolver: function(id: string) {
         const state = getState();
         const { locale, lgFiles } = state;

--- a/Composer/packages/client/src/store/index.tsx
+++ b/Composer/packages/client/src/store/index.tsx
@@ -7,7 +7,7 @@ import { ImportResolverDelegate, LGParser } from 'botbuilder-lg';
 import { LgFile, LuFile } from '@bfc/indexers';
 
 import { prepareAxios } from '../utils/auth';
-import { getFileName, getBaseName, getExtension } from '../utils/fileUtil';
+import { getFileName } from '../utils/fileUtil';
 
 import { reducer } from './reducer';
 import bindActions from './action/bindActions';
@@ -122,13 +122,13 @@ export const StoreProvider: React.FC<StoreProviderProps> = props => {
     dispatch: interceptDispatch,
     resolvers: {
       lgImportresolver: function(source: string, id: string) {
-        const locale = getExtension(source);
-        const targetFileName = getFileName(id);
-        let targetFileId = getBaseName(targetFileName);
-        if (locale) {
-          targetFileId += `.${locale}`;
-        }
-        const targetFile = getState().lgFiles.find(({ id }) => id === targetFileId);
+        const sourceId = getFileName(source).replace(/\.lg$/, '');
+        const locale = sourceId.split('.').length > 1 ? sourceId.split('.').pop() : 'en-us';
+        const targetId = getFileName(id).replace(/\.lg$/, '');
+
+        const targetFile =
+          getState().lgFiles.find(({ id }) => id === `${targetId}.${locale}`) ||
+          getState().lgFiles.find(({ id }) => id === targetId);
         if (!targetFile) throw new Error(`${id} lg file not found`);
         return { id, content: targetFile.content };
       } as ImportResolverDelegate,

--- a/Composer/packages/client/src/store/reducer/index.ts
+++ b/Composer/packages/client/src/store/reducer/index.ts
@@ -11,7 +11,7 @@ import { ImportResolverDelegate } from 'botbuilder-lg';
 import { ActionTypes, FileTypes, BotStatus } from '../../constants';
 import { DialogSetting, ReducerFunc } from '../types';
 import { UserTokenPayload } from '../action/types';
-import { getExtension, getFileName, getBaseName } from '../../utils';
+import { getExtension, getFileName } from '../../utils';
 import settingStorage from '../../utils/dialogSettingStorage';
 import luFileStatusStorage from '../../utils/luFileStatusStorage';
 import { getReferredFiles } from '../../utils/luUtil';
@@ -147,13 +147,13 @@ const updateLgTemplate: ReducerFunc = (state, { id, content }) => {
     return lgFile;
   });
   const lgImportresolver: ImportResolverDelegate = function(source: string, id: string) {
-    const locale = getExtension(source);
-    const targetFileName = getFileName(id);
-    let targetFileId = getBaseName(targetFileName);
-    if (locale) {
-      targetFileId += `.${locale}`;
-    }
-    const targetFile = lgFiles.find(({ id }) => id === targetFileId);
+    const sourceId = getFileName(source).replace(/\.lg$/, '');
+    const locale = sourceId.split('.').length > 1 ? sourceId.split('.').pop() : 'en-us';
+    const targetId = getFileName(id).replace(/\.lg$/, '');
+
+    const targetFile =
+      lgFiles.find(({ id }) => id === `${targetId}.${locale}`) || lgFiles.find(({ id }) => id === targetId);
+
     if (!targetFile) throw new Error(`file not found`);
     return { id, content: targetFile.content };
   };

--- a/Composer/packages/client/src/store/reducer/index.ts
+++ b/Composer/packages/client/src/store/reducer/index.ts
@@ -4,14 +4,13 @@
 import get from 'lodash/get';
 import set from 'lodash/set';
 import formatMessage from 'format-message';
-import { SensitiveProperties } from '@bfc/shared';
+import { SensitiveProperties, importResolverGenerator } from '@bfc/shared';
 import { lgIndexer, luIndexer, LuFile, DialogInfo, dialogIndexer } from '@bfc/indexers';
-import { ImportResolverDelegate } from 'botbuilder-lg';
 
 import { ActionTypes, FileTypes, BotStatus } from '../../constants';
 import { DialogSetting, ReducerFunc } from '../types';
 import { UserTokenPayload } from '../action/types';
-import { getExtension, getFileName } from '../../utils';
+import { getExtension } from '../../utils';
 import settingStorage from '../../utils/dialogSettingStorage';
 import luFileStatusStorage from '../../utils/luFileStatusStorage';
 import { getReferredFiles } from '../../utils/luUtil';
@@ -146,18 +145,7 @@ const updateLgTemplate: ReducerFunc = (state, { id, content }) => {
     }
     return lgFile;
   });
-  const lgImportresolver: ImportResolverDelegate = function(source: string, id: string) {
-    const sourceId = getFileName(source).replace(/\.lg$/, '');
-    const locale = sourceId.split('.').length > 1 ? sourceId.split('.').pop() : 'en-us';
-    const targetId = getFileName(id).replace(/\.lg$/, '');
-
-    const targetFile =
-      lgFiles.find(({ id }) => id === `${targetId}.${locale}`) || lgFiles.find(({ id }) => id === targetId);
-
-    if (!targetFile) throw new Error(`file not found`);
-    return { id, content: targetFile.content };
-  };
-
+  const lgImportresolver = importResolverGenerator(lgFiles, '.lg');
   state.lgFiles = lgFiles.map(lgFile => {
     const { parse } = lgIndexer;
     const { id, content } = lgFile;

--- a/Composer/packages/lib/shared/src/index.ts
+++ b/Composer/packages/lib/shared/src/index.ts
@@ -15,3 +15,4 @@ export * from './constant';
 export * from './lgUtils';
 export * from './walkerUtils';
 export * from './copyUtils';
+export * from './resolverFactory';

--- a/Composer/packages/lib/shared/src/resolverFactory.ts
+++ b/Composer/packages/lib/shared/src/resolverFactory.ts
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export declare type ResolverResource = { content: string; id: string };
+export declare type ImportResolverDelegate = (source: string, resourceId: string) => ResolverResource;
+
+function getFileName(path: string): string {
+  return path.split('/').pop() || path;
+}
+
+/**
+ *
+ * @param resources  resources feed to resolver
+ * @param ext resource extension, e.g. .lg, .lu
+ * @param defaultLocale   complete resource id = [id].[locale][ext]
+ */
+export function importResolverGenerator(
+  resources: ResolverResource[],
+  ext = '',
+  defaultLocale = 'en-us'
+): ImportResolverDelegate {
+  /**
+   *  @param source current file id
+   *  @param resourceId imported file id
+   *  for example:
+   *  in todosample.en-us.lg:
+   *   [import](../common/common.lg)
+   *
+   *  would resolve to common.en-us.lg || common.lg
+   *
+   *  source =  todosample || todosample.en-us || todosample.en-us.lg || todosample.lg
+   *  resourceId =   common || common.lg || ../common/common.lg
+   *
+   */
+  return (source: string, resourceId: string) => {
+    // eslint-disable-next-line security/detect-non-literal-regexp
+    const extReg = new RegExp(ext + '$');
+    const sourceId = getFileName(source).replace(extReg, '');
+    const locale = sourceId.split('.').length > 1 ? sourceId.split('.').pop() : defaultLocale;
+    const targetId = getFileName(resourceId).replace(extReg, '');
+
+    const targetFile =
+      resources.find(({ id }) => id === `${targetId}.${locale}`) || resources.find(({ id }) => id === targetId);
+
+    if (!targetFile) throw new Error(`file not found`);
+    return {
+      id: resourceId,
+      content: targetFile.content,
+    };
+  };
+}

--- a/Composer/packages/server/src/models/bot/botProject.ts
+++ b/Composer/packages/server/src/models/bot/botProject.ts
@@ -528,18 +528,20 @@ export class BotProject {
    *  in todosample.en-us.lg:
    *   [import](../common/common.lg)
    *
-   *  resolve to common.en-us.lg
+   *  resolve to common.en-us.lg || common.lg
    *
-   *  source = todosample.en-us  || AddToDo
-   *  id = ../common/common.lg  || common.lg || common
+   *  source =  todosample || todosample.en-us || todosample.en-us.lg || todosample.lg
+   *  id =   common || common.lg || ../common/common.lg
+   *
    */
   private _lgImportResolver = (source: string, id: string) => {
-    const locale = source.split('.').length > 1 ? source.split('.').pop() : '';
-    let targetId = Path.basename(id, '.lg');
-    if (locale) {
-      targetId += `.${locale}`;
-    }
-    const targetFile = this.lgFiles.find(({ id }) => id === targetId);
+    const sourceId = Path.basename(source, '.lg');
+    const locale = sourceId.split('.').length > 1 ? sourceId.split('.').pop() : this.locale;
+    const targetId = Path.basename(id, '.lg');
+
+    const targetFile =
+      this.files.find(({ name }) => name === `${targetId}.${locale}.lg`) ||
+      this.files.find(({ name }) => name === `${targetId}.lg`);
     if (!targetFile) throw new Error('file not found');
     return {
       id,

--- a/Composer/packages/server/src/services/project.ts
+++ b/Composer/packages/server/src/services/project.ts
@@ -3,7 +3,7 @@
 
 import merge from 'lodash/merge';
 import find from 'lodash/find';
-import { TextFile } from '@bfc/indexers';
+import { importResolverGenerator, ResolverResource } from '@bfc/shared';
 
 import { BotProject } from '../models/bot/botProject';
 import { LocationRef } from '../models/bot/interface';
@@ -33,46 +33,22 @@ export class BotProjectService {
     }
   }
 
-  public static lgImportResolver(source: string, id: string, projectId: string): TextFile {
+  public static lgImportResolver(source: string, id: string, projectId: string): ResolverResource {
     BotProjectService.initialize();
-    const sourceId = Path.basename(source, '.lg');
-    const locale = sourceId.split('.').length > 1 ? sourceId.split('.').pop() : 'en-us';
-    const targetId = Path.basename(id, '.lg');
-
     const project = BotProjectService.currentBotProjects.find(({ id }) => id === projectId);
-
     if (!project) throw new Error('project not found');
 
-    const targetFile =
-      project.lgFiles.find(({ id }) => id === `${targetId}.${locale}`) ||
-      project.lgFiles.find(({ id }) => id === targetId);
-
-    if (!targetFile) throw new Error('lg file not found');
-    return {
-      id,
-      content: targetFile.content,
-    };
+    const resolver = importResolverGenerator(project.lgFiles, '.lg');
+    return resolver(source, id);
   }
 
-  public static luImportResolver(source: string, id: string, projectId: string): any {
+  public static luImportResolver(source: string, id: string, projectId: string): ResolverResource {
     BotProjectService.initialize();
-    const sourceId = Path.basename(source, '.lu');
-    const locale = sourceId.split('.').length > 1 ? sourceId.split('.').pop() : 'en-us';
-    const targetId = Path.basename(id, '.lu');
-
     const project = BotProjectService.currentBotProjects.find(({ id }) => id === projectId);
-
     if (!project) throw new Error('project not found');
 
-    const targetFile =
-      project.luFiles.find(({ id }) => id === `${targetId}.${locale}`) ||
-      project.luFiles.find(({ id }) => id === targetId);
-
-    if (!targetFile) throw new Error('lu file not found');
-    return {
-      id,
-      content: targetFile.content,
-    };
+    const resolver = importResolverGenerator(project.luFiles, '.lu');
+    return resolver(source, id);
   }
 
   public static staticMemoryResolver(projectId: string): string[] {

--- a/Composer/packages/server/src/services/project.ts
+++ b/Composer/packages/server/src/services/project.ts
@@ -35,14 +35,18 @@ export class BotProjectService {
 
   public static lgImportResolver(source: string, id: string, projectId: string): TextFile {
     BotProjectService.initialize();
-    let targetId = Path.basename(id, '.lg');
-    if (targetId.lastIndexOf('.') === -1) {
-      const locale = source.lastIndexOf('.') > 0 ? source.split('.').pop() : 'en-us';
-      targetId += `.${locale}`;
-    }
-    const targetFile = BotProjectService.currentBotProjects
-      .find(({ id }) => id === projectId)
-      ?.lgFiles.find(({ id }) => id === targetId);
+    const sourceId = Path.basename(source, '.lg');
+    const locale = sourceId.split('.').length > 1 ? sourceId.split('.').pop() : 'en-us';
+    const targetId = Path.basename(id, '.lg');
+
+    const project = BotProjectService.currentBotProjects.find(({ id }) => id === projectId);
+
+    if (!project) throw new Error('project not found');
+
+    const targetFile =
+      project.lgFiles.find(({ id }) => id === `${targetId}.${locale}`) ||
+      project.lgFiles.find(({ id }) => id === targetId);
+
     if (!targetFile) throw new Error('lg file not found');
     return {
       id,
@@ -52,14 +56,18 @@ export class BotProjectService {
 
   public static luImportResolver(source: string, id: string, projectId: string): any {
     BotProjectService.initialize();
-    let targetId = Path.basename(id, '.lu');
-    if (targetId.lastIndexOf('.') === -1) {
-      const locale = source.lastIndexOf('.') > 0 ? source.split('.').pop() : 'en-us';
-      targetId += `.${locale}`;
-    }
-    const targetFile = BotProjectService.currentBotProjects
-      .find(({ id }) => id === projectId)
-      ?.luFiles.find(({ id }) => id === targetId);
+    const sourceId = Path.basename(source, '.lu');
+    const locale = sourceId.split('.').length > 1 ? sourceId.split('.').pop() : 'en-us';
+    const targetId = Path.basename(id, '.lu');
+
+    const project = BotProjectService.currentBotProjects.find(({ id }) => id === projectId);
+
+    if (!project) throw new Error('project not found');
+
+    const targetFile =
+      project.luFiles.find(({ id }) => id === `${targetId}.${locale}`) ||
+      project.luFiles.find(({ id }) => id === targetId);
+
     if (!targetFile) throw new Error('lu file not found');
     return {
       id,


### PR DESCRIPTION
## Description

Enable resolve file with or without locale.

```
   *  for example:
   *  in todosample.en-us.lg:
   *   [import](common.lg)
   *
   *  would resolve to common.en-us.lg || common.lg
   *
```

## Task Item

close #2361 

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
