### PR TITLE
a11y: have screen-reader extract card titles from headers

### DIFF
--- a/Composer/packages/extensions/visual-designer/src/components/groups/StepGroup.tsx
+++ b/Composer/packages/extensions/visual-designer/src/components/groups/StepGroup.tsx
@@ -51,17 +51,17 @@ export const StepGroup: FunctionComponent<NodeProps> = ({ id, data, onEvent, onR
 
   return (
     <div css={{ width: boundary.width, height: boundary.height, position: 'relative' }}>
-      <SVGContainer>{Array.isArray(edges) ? edges.map(x => renderEdge(x)) : null}</SVGContainer>
+      <SVGContainer hidden>{Array.isArray(edges) ? edges.map(x => renderEdge(x)) : null}</SVGContainer>
       {nodes
-        ? nodes.map((x, index) => (
-            <OffsetContainer key={`stepGroup/${x.id}/offset`} offset={x.offset}>
+        ? nodes.map((node, index) => (
+            <OffsetContainer key={`stepGroup/${node.id}/offset`} offset={node.offset}>
               <StepRenderer
-                key={`stepGroup/${x.id}`}
-                id={x.id}
-                data={x.data}
+                key={`stepGroup/${node.id}`}
+                id={node.id}
+                data={node.data}
                 onEvent={onEvent}
                 onResize={size => {
-                  designerCache.cacheBoundary(x.data, size);
+                  designerCache.cacheBoundary(node.data, size);
                   updateNodeBoundary(getStepKey(index), size);
                 }}
               />

--- a/Composer/packages/extensions/visual-designer/src/components/lib/SVGContainer.tsx
+++ b/Composer/packages/extensions/visual-designer/src/components/lib/SVGContainer.tsx
@@ -3,8 +3,8 @@
 
 import React from 'react';
 
-export const SVGContainer = ({ children }) => (
-  <svg width="100" height="100" overflow="visible">
+export const SVGContainer = ({ children, hidden = false }) => (
+  <svg width="100" height="100" overflow="visible" aria-hidden={hidden}>
     {children}
   </svg>
 );

--- a/Composer/packages/extensions/visual-designer/src/components/renderers/ElementWrapper.tsx
+++ b/Composer/packages/extensions/visual-designer/src/components/renderers/ElementWrapper.tsx
@@ -27,7 +27,7 @@ const nodeBorderDoubleSelectedStyle = css`
 export interface ElementWrapperProps {
   id: string;
   tab?: string;
-  ariaLabel?: string;
+  titleInHeader?: boolean;
   onEvent: (eventName: NodeEventTypes, eventData: any) => any;
 }
 
@@ -35,16 +35,18 @@ function checkHasProps(node: ReactNode): node is ReactElement {
   return (node as ReactElement).props != null;
 }
 
-function extractNodeTitle(node: ReactNode): string {
+function extractNodeTitle(node: ReactNode, titleInHeader: boolean): string {
   if (node == null || typeof node !== 'object') {
     return '';
   }
   if (checkHasProps(node)) {
     const { props } = node;
-    if (props?.data != null) {
+    if (props?.header != null && titleInHeader) {
+      return props?.header?.props?.title || '';
+    } else if (props?.data != null) {
       return generateSDKTitle(props.data);
     } else if (props?.children != null) {
-      return extractNodeTitle(props.children);
+      return extractNodeTitle(props.children, titleInHeader);
     } else {
       return '';
     }
@@ -52,7 +54,7 @@ function extractNodeTitle(node: ReactNode): string {
   return '';
 }
 
-export const ElementWrapper: FC<ElementWrapperProps> = ({ id, tab, onEvent, children }): JSX.Element => {
+export const ElementWrapper: FC<ElementWrapperProps> = ({ id, tab, titleInHeader, onEvent, children }): JSX.Element => {
   const selectableId = tab ? `${id}${tab}` : id;
   const { focusedId, focusedEvent, focusedTab } = useContext(NodeRendererContext);
   const { selectedIds, getNodeIndex } = useContext(SelectionContext);
@@ -72,9 +74,7 @@ export const ElementWrapper: FC<ElementWrapperProps> = ({ id, tab, onEvent, chil
     };
   };
 
-  console.log(children);
-
-  const ariaLabel = extractNodeTitle(children);
+  const ariaLabel = extractNodeTitle(children, titleInHeader ?? false);
 
   return (
     <div

--- a/Composer/packages/extensions/visual-designer/src/widgets/ActionHeader.tsx
+++ b/Composer/packages/extensions/visual-designer/src/widgets/ActionHeader.tsx
@@ -79,6 +79,7 @@ export const ActionHeader: WidgetComponent<ActionHeaderProps> = ({
               justifyContent: 'center',
               marginRight: '5px',
             }}
+            aria-hidden={true}
           >
             <Icon icon={icon} color={colors.icon} size={16} />
           </div>
@@ -89,6 +90,7 @@ export const ActionHeader: WidgetComponent<ActionHeaderProps> = ({
             line-height: 16px;
             transform: translateY(-1px);
           `}
+          aria-label={headerContent}
         >
           {headerContent}
         </div>

--- a/Composer/packages/extensions/visual-designer/src/widgets/PromptWidget.tsx
+++ b/Composer/packages/extensions/visual-designer/src/widgets/PromptWidget.tsx
@@ -75,7 +75,7 @@ export const PromptWidget: FC<PromptWdigetProps> = ({
         </ElementWrapper>
       </OffsetContainer>
       <OffsetContainer offset={userAnswersNode.offset}>
-        <ElementWrapper id={userAnswersNode.id} tab={PromptTab.USER_INPUT} onEvent={onEvent}>
+        <ElementWrapper id={userAnswersNode.id} tab={PromptTab.USER_INPUT} onEvent={onEvent} titleInHeader={true}>
           <ElementMeasurer
             onResize={boundary => {
               designerCache.cacheBoundary(userAnswersNode.data, boundary);

--- a/Composer/packages/lib/shared/src/viewUtils.ts
+++ b/Composer/packages/lib/shared/src/viewUtils.ts
@@ -293,12 +293,12 @@ const truncateSDKType = $type => (typeof $type === 'string' ? $type.split('Micro
  * Title priority: $designer.name > title from sdk schema > customize title > $type suffix
  * @param customizedTitile customized title
  */
-export function generateSDKTitle(data, customizedTitile?: string) {
+export function generateSDKTitle(data, customizedTitle?: string) {
   const $type = get(data, '$type');
   const titleFrom$designer = get(data, '$designer.name');
   const titleFromShared = get(ConceptLabels, [$type, 'title']);
   const titleFrom$type = truncateSDKType($type);
-  return titleFrom$designer || customizedTitile || titleFromShared || titleFrom$type;
+  return titleFrom$designer || customizedTitle || titleFromShared || titleFrom$type;
 }
 
 export function getInputType($type: string): string {


### PR DESCRIPTION
## Description

The label that gets read by the screen reader turns out to come from the ElementWrapper component, so this adds some mechanisms to that code so it can reach in and extract the title of what it's rendering. I couldn't use a callback because ElementWrapper just has generic "children" with no guarantee of that having any shape in particular, and I didn't want to add a whole new "ariaLabel" field to our schema when it would just duplicate the same information already in "title".

There are a lot more screen-reader-related issues going on in this codebase, but this at least fixes one of them.

## Task Item

Closes #2058 