### PR TITLE
a11y: use formError state in "New Dialog" form

### DIFF
--- a/Composer/packages/client/src/pages/design/createDialogModal.tsx
+++ b/Composer/packages/client/src/pages/design/createDialogModal.tsx
@@ -52,12 +52,10 @@ export const CreateDialogModal: React.FC<CreateDialogModalProps> = props => {
 
     if (name) {
       if (!nameRegex.test(name)) {
-        errors.name = formatMessage(
-          'Spaces and special characters are not allowed. Use letters, numbers, -, or _., numbers, -, and _'
-        );
+        errors.name = formatMessage('Spaces and special characters are not allowed. Use letters, numbers, -, or _.');
       }
       if (dialogs.some(dialog => dialog.id === name)) {
-        errors.name = formatMessage('Duplicaton of dialog name');
+        errors.name = formatMessage('Duplicate dialog name');
       }
     } else {
       errors.name = formatMessage('Please input a name');
@@ -90,6 +88,7 @@ export const CreateDialogModal: React.FC<CreateDialogModalProps> = props => {
               errorMessage={formDataErrors.name}
               data-testid="NewDialogName"
               required
+              autoFocus
             />
           </StackItem>
           <StackItem grow={0} styles={wizardStyles.halfstack}>

--- a/Composer/packages/client/src/pages/design/createDialogModal.tsx
+++ b/Composer/packages/client/src/pages/design/createDialogModal.tsx
@@ -36,17 +36,18 @@ export const CreateDialogModal: React.FC<CreateDialogModalProps> = props => {
   const [formDataErrors, setFormDataErrors] = useState<{ name?: string }>({});
 
   const updateForm = (field: string) => (e: FormEvent, newValue: string | undefined) => {
-    validateForm();
-    setFormData({
+    const newData: DialogFormData = {
       ...formData,
       [field]: newValue,
-    });
+    };
+    validateForm(newData);
+    setFormData(newData);
   };
 
   const nameRegex = /^[a-zA-Z0-9-_.]+$/;
-  const validateForm = () => {
+  const validateForm = (newData: DialogFormData) => {
     const errors: { name?: string } = {};
-    const { name } = formData;
+    const { name } = newData;
 
     if (name) {
       if (!nameRegex.test(name)) {

--- a/Composer/packages/client/src/pages/design/createDialogModal.tsx
+++ b/Composer/packages/client/src/pages/design/createDialogModal.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-import React, { useState, useContext } from 'react';
+import React, { useState, useContext, FormEvent } from 'react';
 import formatMessage from 'format-message';
 import { PrimaryButton, DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { DialogFooter } from 'office-ui-fabric-react/lib/Dialog';
@@ -35,7 +35,8 @@ export const CreateDialogModal: React.FC<CreateDialogModalProps> = props => {
   const [formData, setFormData] = useState(initialFormData);
   const [formDataErrors, setFormDataErrors] = useState<{ name?: string }>({});
 
-  const updateForm = field => (e, newValue) => {
+  const updateForm = (field: string) => (e: FormEvent, newValue: string | undefined) => {
+    validateForm();
     setFormData({
       ...formData,
       [field]: newValue,
@@ -43,9 +44,9 @@ export const CreateDialogModal: React.FC<CreateDialogModalProps> = props => {
   };
 
   const nameRegex = /^[a-zA-Z0-9-_.]+$/;
-  const validateForm = (data: DialogFormData) => {
+  const validateForm = () => {
     const errors: { name?: string } = {};
-    const { name } = data;
+    const { name } = formData;
 
     if (name) {
       if (!nameRegex.test(name)) {
@@ -59,14 +60,12 @@ export const CreateDialogModal: React.FC<CreateDialogModalProps> = props => {
     } else {
       errors.name = formatMessage('Please input a name');
     }
-    return errors;
+    setFormDataErrors(errors);
   };
 
   const handleSubmit = e => {
     e.preventDefault();
-    const errors = validateForm(formData);
-    if (Object.keys(errors).length) {
-      setFormDataErrors(errors);
+    if (Object.keys(formDataErrors).length > 0) {
       return;
     }
 


### PR DESCRIPTION
## Description

We already have form errors in our state, so we should be able to just clean up our validation code and use existing methods to make them happen every form change and not just on submit.

## Task Item

Closes #2060
Closes #2074