### PR TITLE
docs: fix broken link for getting started docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ the [Security TechCenter][103].
 
 [1]: ./docs/bfcomposer-intro.md
 [2]: ./docs/setup-yarn.md
-[3]: ./docs/tutorial-create-echobot.md
+[3]: ./docs/quickstart-create-bot.md
 [4]: https://aka.ms/BF-Composer-Docs
 [5]: ./toc.md
 [10]: https://stackoverflow.com/questions/tagged/botframework?tab=Newest


### PR DESCRIPTION
Broken link

unless this should be https://github.com/microsoft/BotFramework-Composer/blob/stable/docs/tutorial/tutorial-create-bot.md instead?

closes #2437