### PR TITLE
fix: fix issue rendering delete properties action

### DIFF
--- a/Composer/packages/extensions/adaptive-form/src/utils/__tests__/resolvePropSchema.test.ts
+++ b/Composer/packages/extensions/adaptive-form/src/utils/__tests__/resolvePropSchema.test.ts
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { resolvePropSchema } from '../resolvePropSchema';
+import { resolveRef } from '../resolveRef';
+
+jest.mock('../resolveRef', () => ({
+  resolveRef: jest.fn().mockImplementation(obj => ({
+    ...obj,
+    resolved: true,
+  })),
+}));
+
+describe('resolvePropSchema', () => {
+  const definitions = {
+    foo: {
+      title: 'Foo Title',
+    },
+  };
+
+  it('returns undefined if the schema does not have properties', () => {
+    expect(resolvePropSchema({}, 'foo', definitions)).toBe(undefined);
+  });
+
+  it('resolves the property schema', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        foo: {
+          type: 'object',
+          properties: {
+            bar: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    };
+
+    // @ts-ignore
+    const resolved = resolvePropSchema(schema, 'foo', definitions);
+    expect(resolveRef).toBeCalledWith(schema.properties.foo, definitions);
+
+    expect(resolved).toMatchObject({
+      ...schema.properties.foo,
+      resolved: true,
+    });
+  });
+});

--- a/Composer/packages/extensions/adaptive-form/src/utils/index.ts
+++ b/Composer/packages/extensions/adaptive-form/src/utils/index.ts
@@ -7,6 +7,6 @@ export * from './getUISchema';
 export * from './mergePluginConfigs';
 export * from './resolveBaseSchema';
 export * from './resolveFieldWidget';
-export * from './resolvePropertySchema';
+export * from './resolvePropSchema';
 export * from './resolveRef';
 export * from './uiOptionsHelpers';

--- a/Composer/packages/extensions/adaptive-form/src/utils/resolvePropSchema.ts
+++ b/Composer/packages/extensions/adaptive-form/src/utils/resolvePropSchema.ts
@@ -11,16 +11,11 @@ export function resolvePropSchema(
     [k: string]: JSONSchema7Definition;
   } = {}
 ): JSONSchema7 | undefined {
-  if (!schema.properties) {
+  const propSchema = schema.properties?.[path];
+
+  if (!propSchema || typeof propSchema !== 'object') {
     return;
   }
 
-  const pathParts = path.split('.');
-  let propSchema: JSONSchema7 = schema.properties;
-
-  for (const part of pathParts) {
-    propSchema = resolveRef(propSchema?.[part], definitions);
-  }
-
-  return propSchema;
+  return resolveRef(propSchema, definitions);
 }

--- a/Composer/packages/extensions/adaptive-form/src/utils/resolvePropSchema.ts
+++ b/Composer/packages/extensions/adaptive-form/src/utils/resolvePropSchema.ts
@@ -19,7 +19,7 @@ export function resolvePropSchema(
   let propSchema: JSONSchema7 = schema.properties;
 
   for (const part of pathParts) {
-    propSchema = resolveRef((propSchema?.properties || propSchema)?.[part], definitions);
+    propSchema = resolveRef(propSchema?.[part], definitions);
   }
 
   return propSchema;


### PR DESCRIPTION
## Description

This happened because I was recursing on object types with properties defined which collided with a schema property named properties. This is unnecessary now as I don't need to recurse the schema.

## Task Item

fixes #2458 

## Screenshots

![image](https://user-images.githubusercontent.com/3619060/78086145-e93fe980-7371-11ea-8e48-a73363a83ad6.png)
