### PR TITLE
fix: did not open default path when we have the new install

### DIFF
--- a/Composer/packages/client/src/CreationFlow/LocationBrowser/FileSelector.tsx
+++ b/Composer/packages/client/src/CreationFlow/LocationBrowser/FileSelector.tsx
@@ -206,12 +206,13 @@ export const FileSelector: React.FC<FileSelectorProps> = props => {
       title: item, // title shown on hover
     };
   });
-  breadcrumbItems.splice(0, 0, {
-    text: '/', // displayed text
-    key: '/', // value returned
-    title: '/', // title shown on hover
-  });
-
+  if (currentPath) {
+    breadcrumbItems.splice(0, 0, {
+      text: '/', // displayed text
+      key: '/', // value returned
+      title: '/', // title shown on hover
+    });
+  }
   breadcrumbItems.reverse();
   const updateLocation = (e, item?: IDropdownOption) => {
     onCurrentPathUpdate(item ? (item.key as string) : '');


### PR DESCRIPTION
## Description
During rendering, the currentPath is empty. And it is selected in the dropdown although it does not match any option. This behavior will make the dropdown select the first option by default, which is '/'. In our code, when currentPath is empty, the dropdown should not have any option.
## Task Item
Closes #2453 
## Screenshots
![aaaaa](https://user-images.githubusercontent.com/24380525/78141138-a0fdf580-745d-11ea-83bd-c70aebac6f34.gif)
