### PR TITLE
fix: bug about deleting empty folder

### DIFF
--- a/Composer/packages/server/src/models/bot/botProject.ts
+++ b/Composer/packages/server/src/models/bot/botProject.ts
@@ -298,7 +298,11 @@ export class BotProject {
   private _removeEmptyFolder = async (folderPath: string) => {
     const files = await this.fileStorage.readDir(folderPath);
     if (files.length === 0) {
-      await this.fileStorage.rmDir(folderPath);
+      try {
+        await this.fileStorage.rmDir(folderPath);
+      } catch (e) {
+        console.log(e);
+      }
     }
   };
 
@@ -393,7 +397,6 @@ export class BotProject {
 
     const absolutePath = `${this.dir}/${relativePath}`;
     await this.fileStorage.removeFile(absolutePath);
-
     this.files.splice(index, 1);
   };
 

--- a/Composer/packages/server/src/models/bot/botProject.ts
+++ b/Composer/packages/server/src/models/bot/botProject.ts
@@ -283,7 +283,16 @@ export class BotProject {
   private _cleanUp = async (relativePath: string) => {
     const absolutePath = `${this.dir}/${relativePath}`;
     const dirPath = Path.dirname(absolutePath);
-    await this._removeEmptyFolder(dirPath);
+    await this._removeEmptyFolderFromBottomToUp(dirPath);
+  };
+
+  private _removeEmptyFolderFromBottomToUp = async (folderPath: string) => {
+    let currentFolder = folderPath;
+    //make sure the folder to delete is in current project
+    while (currentFolder.startsWith(this.dataDir)) {
+      await this._removeEmptyFolder(currentFolder);
+      currentFolder = Path.dirname(currentFolder);
+    }
   };
 
   private _removeEmptyFolder = async (folderPath: string) => {


### PR DESCRIPTION
## Description
I think the project folder structure is changed since the last time we add the cleanUp function in Composer/packages/server/src/models/bot/botProject.ts. Add some more code to check empty folder from bottom to up. Stop at the root folder of the project.
## Task Item
Closes #2526 
## Screenshots
![aaaaa](https://user-images.githubusercontent.com/24380525/78983035-f91bb280-7b55-11ea-90ca-aadc39ff5e57.gif)
