### PR TITLE
a11y: Fix missing aria-labels on radio buttons 

### DIFF
--- a/Composer/packages/client/src/CreationFlow/CreateOptions/index.js
+++ b/Composer/packages/client/src/CreationFlow/CreateOptions/index.js
@@ -113,12 +113,14 @@ export function CreateOptions(props) {
         defaultSelectedKey="CreateFromScratch"
         options={[
           {
+            ariaLabel: 'Create from scratch',
             key: 'CreateFromScratch',
             'data-testid': 'Create from scratch',
             text: formatMessage('Create from scratch'),
             onRenderField: SelectOption,
           },
           {
+            ariaLabel: 'Create from template',
             key: 'CreateFromTemplate',
             'data-testid': 'Create from template',
             text: formatMessage('Create from template'),


### PR DESCRIPTION
## Description

This is fixing the issue where the individual radio buttons did not have an aria label. 

## Task Item
Fix #2018 - missing `aria-label`s on radio buttons 