### PR TITLE
fix: save as can't navigate to the target project

### DIFF
--- a/Composer/packages/client/src/CreationFlow/index.js
+++ b/Composer/packages/client/src/CreationFlow/index.js
@@ -87,7 +87,6 @@ export function CreationFlow(props) {
 
   const openBot = async botFolder => {
     await openBotProject(botFolder);
-    // navigateTo(`/bot/${state.projectId}/dialogs/Main`);
     handleDismiss();
   };
 
@@ -105,11 +104,9 @@ export function CreationFlow(props) {
       case CreationFlowStatus.NEW_FROM_TEMPLATE:
       case CreationFlowStatus.NEW:
         handleCreateNew(formData);
-        //navigateTo(`/bot/${state.projectId}/dialogs/Main`);
         break;
       case CreationFlowStatus.SAVEAS:
         handleSaveAs(formData);
-        navigateTo(`/bot/${state.projectId}/dialogs/Main`);
         break;
       default:
         setStep(Steps.NONE);

--- a/Composer/packages/client/src/store/action/project.ts
+++ b/Composer/packages/client/src/store/action/project.ts
@@ -125,16 +125,15 @@ export const saveProjectAs: ActionCreator = async (store, projectId, name, descr
     };
     const response = await httpClient.post(`/projects/${projectId}/project/saveAs`, data);
     const files = response.data.files;
+    const newProjectId = response.data.id;
     store.dispatch({
       type: ActionTypes.GET_PROJECT_SUCCESS,
-      payload: {
-        response,
-      },
+      payload: { response },
     });
     if (files && files.length > 0) {
-      navTo(store, 'Main');
+      const mainUrl = `/bot/${newProjectId}/dialogs/Main`;
+      navigateTo(mainUrl);
     }
-    return response.data;
   } catch (err) {
     store.dispatch({ type: ActionTypes.GET_PROJECT_FAILURE, payload: null, error: err });
   }


### PR DESCRIPTION
## Description

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->
![image](https://user-images.githubusercontent.com/39758135/78974663-11370600-7b45-11ea-8368-185cdb086908.png)

Save as e2e test failed.
The reason is when navigating the function doesn't use the new project id and will fetch the previous project.
## Task Item
refs #2611
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
