### PR TITLE
a11y: img display incorrect when zoom in 400%

### DIFF
--- a/Composer/packages/client/src/pages/design/VisualEditor.tsx
+++ b/Composer/packages/client/src/pages/design/VisualEditor.tsx
@@ -39,10 +39,10 @@ function onRenderBlankVisual(isTriggerEmpty, onClickAddTrigger) {
             </ActionButton>
           </React.Fragment>
         ) : (
-          <div>
+          <React.Fragment>
             <img alt={formatMessage('bot framework composer icon gray')} src={grayComposerIcon} />
             {formatMessage('Select a trigger on the left')} <br /> {formatMessage('navigation to see actions')}
-          </div>
+          </React.Fragment>
         )}
       </div>
     </div>

--- a/Composer/packages/client/src/pages/design/styles.ts
+++ b/Composer/packages/client/src/pages/design/styles.ts
@@ -121,6 +121,7 @@ export const middleTriggerContainer = css`
   width: 100%;
   margin-top: 55px;
   height: calc(100% - 48px);
+  min-height: 285px;
   position: absolute;
 `;
 


### PR DESCRIPTION
## Description

img dispaly incorrent when zoom in 400%

- before
![image](https://user-images.githubusercontent.com/5860999/78985542-9d542800-7b5b-11ea-887a-78518f004a60.png)

- after
![image](https://user-images.githubusercontent.com/5860999/78985612-d391a780-7b5b-11ea-8b56-9cdd35a1b1df.png)


## Task Item

Fix #2053 

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
