### PR TITLE
a11y: Added aria label to help links

### DIFF
--- a/Composer/packages/extensions/adaptive-form/src/components/AdaptiveForm/FormTitle.tsx
+++ b/Composer/packages/extensions/adaptive-form/src/components/AdaptiveForm/FormTitle.tsx
@@ -6,6 +6,7 @@ import { jsx } from '@emotion/core';
 import React from 'react';
 import { FontWeights } from '@uifabric/styling';
 import { FontSizes } from '@uifabric/fluent-theme';
+import { Link } from 'office-ui-fabric-react/lib/Link';
 import startCase from 'lodash/startCase';
 import formatMessage from 'format-message';
 import { UIOptions, JSONSchema7 } from '@bfc/extension';
@@ -43,6 +44,10 @@ const FormTitle: React.FC<FormTitleProps> = props => {
     const designerName = formData.$designer?.name;
 
     return designerName || uiLabel || schema.title || startCase(name);
+  };
+
+  const getHelpLinkLabel = (): string => {
+    return (uiLabel || schema.title || startCase(name) || '').toLowerCase();
   };
 
   const getSubTitle = (): string => {
@@ -92,9 +97,14 @@ const FormTitle: React.FC<FormTitleProps> = props => {
             <React.Fragment>
               <br />
               <br />
-              <a href={uiOptions?.helpLink} target="_blank" rel="noopener noreferrer">
+              <Link
+                href={uiOptions?.helpLink}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={formatMessage('Learn more about {title}', { title: getHelpLinkLabel() })}
+              >
                 {formatMessage('Learn more')}
-              </a>
+              </Link>
             </React.Fragment>
           )}
         </p>

--- a/Composer/packages/extensions/adaptive-form/src/components/FieldLabel.tsx
+++ b/Composer/packages/extensions/adaptive-form/src/components/FieldLabel.tsx
@@ -37,7 +37,12 @@ const DescriptionCallout: React.FC<DescriptionCalloutProps> = function Descripti
             </h3>
             <p>{description}</p>
             {helpLink && (
-              <Link href={helpLink} target="_blank" rel="noopener noreferrer">
+              <Link
+                href={helpLink}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={formatMessage('Learn more about {title}', { title: title.toLowerCase() })}
+              >
                 {formatMessage('Learn more')}
               </Link>
             )}


### PR DESCRIPTION
## Description
Used the form title and field labels to add a more descriptive aria-label to the "learn more" link.

## Task Item
closes #2133

