### PR TITLE
a11y: restructure field labels for better a11y

### DIFF
--- a/Composer/packages/extensions/adaptive-form/src/components/FieldLabel.tsx
+++ b/Composer/packages/extensions/adaptive-form/src/components/FieldLabel.tsx
@@ -16,7 +16,7 @@ interface DescriptionCalloutProps {
 }
 
 const DescriptionCallout: React.FC<DescriptionCalloutProps> = function DescriptionCallout(props) {
-  const { description, title, id, helpLink } = props;
+  const { description, title, helpLink } = props;
 
   if (!description) {
     return null;
@@ -26,7 +26,6 @@ const DescriptionCallout: React.FC<DescriptionCalloutProps> = function Descripti
     <TooltipHost
       delay={TooltipDelay.zero}
       directionalHint={DirectionalHint.bottomAutoEdge}
-      id={`${id}-description`}
       styles={{ root: { display: 'inline-block' } }}
       tooltipProps={{
         styles: { root: { width: '288px', padding: '17px 28px' } },
@@ -47,7 +46,7 @@ const DescriptionCallout: React.FC<DescriptionCalloutProps> = function Descripti
     >
       <div tabIndex={0}>
         <Icon
-          aria-labelledby={`${id}-description`}
+          aria-label={title+'; '+description}
           iconName={'Unknown'}
           styles={{
             root: {
@@ -83,26 +82,24 @@ const FieldLabel: React.FC<FieldLabelProps> = props => {
   }
 
   return (
-    <Label
-      htmlFor={id}
-      styles={{
-        root: {
-          fontWeight: '400',
-          display: 'flex',
-          alignItems: 'center',
-          marginLeft: inline ? '4px' : '0',
-        },
-      }}
-    >
-      <div
-        style={{
-          marginRight: '4px',
+    <div style={{
+      display: 'flex',
+      alignItems: 'center'
+    }}>
+      <Label
+        htmlFor={id}
+        styles={{
+          root: {
+            fontWeight: '400',
+            marginLeft: inline ? '4px' : '0',
+            marginRight: '4px'
+          },
         }}
       >
         {label}
-      </div>
+      </Label>
       <DescriptionCallout description={description} id={id} title={label} helpLink={helpLink} />
-    </Label>
+    </div>
   );
 };
 

--- a/Composer/packages/extensions/adaptive-form/src/components/FieldLabel.tsx
+++ b/Composer/packages/extensions/adaptive-form/src/components/FieldLabel.tsx
@@ -46,7 +46,7 @@ const DescriptionCallout: React.FC<DescriptionCalloutProps> = function Descripti
     >
       <div tabIndex={0}>
         <Icon
-          aria-label={title+'; '+description}
+          aria-label={title + '; ' + description}
           iconName={'Unknown'}
           styles={{
             root: {
@@ -82,17 +82,19 @@ const FieldLabel: React.FC<FieldLabelProps> = props => {
   }
 
   return (
-    <div style={{
-      display: 'flex',
-      alignItems: 'center'
-    }}>
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+      }}
+    >
       <Label
         htmlFor={id}
         styles={{
           root: {
             fontWeight: '400',
             marginLeft: inline ? '4px' : '0',
-            marginRight: '4px'
+            marginRight: '4px',
           },
         }}
       >


### PR DESCRIPTION
## Description

This change adjusts FieldLabel.tsx so the SR reads out a sensible label for a field when it ought to and the a11y checker doesn't complain about fields without labels (this used to happen because the "aria-labelledby" attribute referred to an object which only existed while the tooltip was open).

## Task Item

closes #2063
closes #2122

## Screenshots

SR: "Entities: Required entities - group."
![image](https://user-images.githubusercontent.com/61990921/79152493-29936480-7d81-11ea-847e-fe9788e21eb0.png)

(tab)

SR: "Form editor - new value - edit."
![image](https://user-images.githubusercontent.com/61990921/79152545-3fa12500-7d81-11ea-9aaa-8243d0fe0272.png)

