### PR TITLE
fix: defends tab move error raised by 'scrollIntoView()'

### DIFF
--- a/Composer/packages/extensions/visual-designer/src/utils/nodeOperation.ts
+++ b/Composer/packages/extensions/visual-designer/src/utils/nodeOperation.ts
@@ -2,6 +2,6 @@
 // Licensed under the MIT License.
 
 export function scrollNodeIntoView(selector: string) {
-  const node: Element = document.querySelector(selector) as Element;
-  node.scrollIntoView(true);
+  const node = document.querySelector(selector);
+  node?.scrollIntoView(true);
 }


### PR DESCRIPTION
## Description
fix #2649 

As reported in #2649 , pressing TAB in visual editor will trigger an error like this:
![image](https://user-images.githubusercontent.com/8528761/79292037-bdd90500-7f02-11ea-9a87-3cfced92b295.png)

This PR defends that error.
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
#2649 
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
