### PR TITLE
fix: render correct field when value is '0'

### DIFF
--- a/Composer/packages/extensions/adaptive-form/src/components/fields/OneOfField/OneOfField.tsx
+++ b/Composer/packages/extensions/adaptive-form/src/components/fields/OneOfField/OneOfField.tsx
@@ -4,87 +4,16 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import React, { useState, useMemo } from 'react';
-import { FieldProps, JSONSchema7, JSONSchema7Definition } from '@bfc/extension';
+import { FieldProps } from '@bfc/extension';
 import { Dropdown, IDropdownOption, ResponsiveMode } from 'office-ui-fabric-react/lib/Dropdown';
 import formatMessage from 'format-message';
 
-import { FieldLabel } from '../FieldLabel';
-import { resolveRef, resolveFieldWidget, getValueType } from '../../utils';
-import { usePluginConfig } from '../../hooks';
+import { FieldLabel } from '../../FieldLabel';
+import { resolveFieldWidget } from '../../../utils';
+import { usePluginConfig } from '../../../hooks';
+import { oneOfField } from '../styles';
 
-import { oneOfField } from './styles';
-
-const getOptions = (schema: JSONSchema7, definitions?: { [key: string]: JSONSchema7Definition }): IDropdownOption[] => {
-  const { type, oneOf } = schema;
-
-  if (type && Array.isArray(type)) {
-    const options: IDropdownOption[] = type.map(t => ({
-      key: t,
-      text: t,
-      data: { schema: { ...schema, type: t } },
-    }));
-
-    options.sort(({ text: t1 }, { text: t2 }) => (t1 > t2 ? 1 : -1));
-
-    return options;
-  }
-
-  if (oneOf && Array.isArray(oneOf)) {
-    return oneOf
-      .map(s => {
-        if (typeof s === 'object') {
-          const resolved = resolveRef(s, definitions);
-
-          return {
-            key: resolved.title?.toLowerCase() || resolved.type,
-            text: resolved.title?.toLowerCase() || resolved.type,
-            data: { schema: resolved },
-          } as IDropdownOption;
-        }
-      })
-      .filter(Boolean) as IDropdownOption[];
-  }
-
-  return [];
-};
-
-const getSelectedOption = (value: any | undefined, options: IDropdownOption[]): IDropdownOption | undefined => {
-  if (options.length === 0) {
-    return;
-  }
-
-  const valueType = getValueType(value);
-
-  if (valueType === 'array') {
-    const item = value[0];
-    const firstArrayOption = options.find(o => o.data.schema.type === 'array');
-
-    // if there is nothing in the array, default to the first array type
-    if (!item) {
-      return firstArrayOption;
-    }
-
-    // else, find the option with an item schema that matches item type
-    return (
-      options.find(o => {
-        const {
-          data: { schema },
-        } = o;
-
-        const itemSchema = Array.isArray(schema.items) ? schema.items[0] : schema.items;
-        return itemSchema && typeof item === itemSchema.type;
-      }) || firstArrayOption
-    );
-  }
-
-  // if the value if undefined, default to the first option
-  if (!value) {
-    return options[0];
-  }
-
-  // lastly, attempt to find the option based on value type
-  return options.find(({ data }) => data.schema.type === valueType) || options[0];
-};
+import { getOptions, getSelectedOption } from './utils';
 
 const OneOfField: React.FC<FieldProps> = props => {
   const { schema, value, definitions } = props;

--- a/Composer/packages/extensions/adaptive-form/src/components/fields/OneOfField/__tests__/utils.test.ts
+++ b/Composer/packages/extensions/adaptive-form/src/components/fields/OneOfField/__tests__/utils.test.ts
@@ -1,0 +1,186 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { getOptions, getSelectedOption } from '../utils';
+
+function makeOption(schema, type) {
+  return {
+    key: type,
+    text: type,
+    data: { schema: { ...schema, type } },
+  };
+}
+
+describe('getOptions', () => {
+  describe('when there is an array of types', () => {
+    const schema = {
+      title: 'test schema',
+      type: ['string' as const, 'boolean' as const, 'number' as const],
+    };
+
+    it('returns all of the types, sorted', () => {
+      expect(getOptions(schema, {})).toEqual([
+        makeOption(schema, 'boolean'),
+        makeOption(schema, 'number'),
+        makeOption(schema, 'string'),
+      ]);
+    });
+  });
+
+  describe('when there is a oneOf property', () => {
+    const schema = {
+      title: 'Test Schema',
+      oneOf: [
+        {
+          type: 'string' as const,
+          title: 'My Awesome String',
+        },
+        {
+          type: 'boolean' as const,
+        },
+        {
+          type: 'number' as const,
+        },
+        {
+          $ref: '#/definitions/Microsoft.AnotherType',
+        },
+      ],
+    };
+
+    const definitions = {
+      'Microsoft.AnotherType': {
+        title: 'Another Type',
+        type: 'object' as const,
+      },
+    };
+
+    it('returns one of options', () => {
+      expect(getOptions(schema, definitions)).toEqual([
+        {
+          key: 'my awesome string',
+          text: 'my awesome string',
+          data: {
+            schema: {
+              title: 'My Awesome String',
+              type: 'string',
+            },
+          },
+        },
+        {
+          key: 'boolean',
+          text: 'boolean',
+          data: {
+            schema: {
+              type: 'boolean',
+            },
+          },
+        },
+        {
+          key: 'number',
+          text: 'number',
+          data: {
+            schema: {
+              type: 'number',
+            },
+          },
+        },
+        {
+          key: 'another type',
+          text: 'another type',
+          data: {
+            schema: {
+              title: 'Another Type',
+              type: 'object',
+            },
+          },
+        },
+      ]);
+    });
+  });
+});
+
+describe('getSelectedOption', () => {
+  const options = [
+    {
+      key: 'string',
+      text: 'string',
+      data: {
+        schema: {
+          type: 'string',
+        },
+      },
+    },
+    {
+      key: 'integer',
+      text: 'integer',
+      data: {
+        schema: {
+          type: 'integer',
+        },
+      },
+    },
+    {
+      key: 'object',
+      text: 'object',
+      data: {
+        schema: {
+          type: 'object',
+        },
+      },
+    },
+    {
+      key: 'array1',
+      text: 'array1',
+      data: {
+        schema: {
+          type: 'array',
+        },
+      },
+    },
+    {
+      key: 'array2',
+      text: 'array2',
+      data: {
+        schema: {
+          type: 'array',
+          items: {
+            type: 'integer',
+          },
+        },
+      },
+    },
+  ];
+
+  it('returns undefined if there are no options', () => {
+    expect(getSelectedOption(123, [])).toBe(undefined);
+  });
+
+  it('returns the first option if the value is null or undefined', () => {
+    expect(getSelectedOption(undefined, options)).toEqual(options[0]);
+    expect(getSelectedOption(null, options)).toEqual(options[0]);
+  });
+
+  it('returns the option that matches the value type', () => {
+    expect(getSelectedOption('foo', options)).toEqual(options[0]);
+    expect(getSelectedOption(123, options)).toEqual(options[1]);
+    expect(getSelectedOption({ foo: 'bar' }, options)).toEqual(options[2]);
+  });
+
+  it("returns the first option if it can't find a match", () => {
+    expect(getSelectedOption(true, options)).toEqual(options[0]);
+  });
+
+  describe('when the value is an array', () => {
+    it('returns the first array type if there are no array items', () => {
+      expect(getSelectedOption([], options)).toEqual(options[3]);
+    });
+
+    it('returns the option that matches the first item type', () => {
+      expect(getSelectedOption([123], options)).toEqual(options[4]);
+    });
+
+    it('returns the first option if no type match found', () => {
+      expect(getSelectedOption(['foo'], options)).toEqual(options[3]);
+    });
+  });
+});

--- a/Composer/packages/extensions/adaptive-form/src/components/fields/OneOfField/index.ts
+++ b/Composer/packages/extensions/adaptive-form/src/components/fields/OneOfField/index.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export { OneOfField } from './OneOfField';

--- a/Composer/packages/extensions/adaptive-form/src/components/fields/OneOfField/utils.ts
+++ b/Composer/packages/extensions/adaptive-form/src/components/fields/OneOfField/utils.ts
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { JSONSchema7, JSONSchema7Definition } from '@bfc/extension';
+import { IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
+
+import { resolveRef, getValueType } from '../../../utils';
+
+export function getOptions(
+  schema: JSONSchema7,
+  definitions?: { [key: string]: JSONSchema7Definition }
+): IDropdownOption[] {
+  const { type, oneOf } = schema;
+
+  if (type && Array.isArray(type)) {
+    const options: IDropdownOption[] = type.map(t => ({
+      key: t,
+      text: t,
+      data: { schema: { ...schema, type: t } },
+    }));
+
+    options.sort(({ text: t1 }, { text: t2 }) => (t1 > t2 ? 1 : -1));
+
+    return options;
+  }
+
+  if (oneOf && Array.isArray(oneOf)) {
+    return oneOf
+      .map(s => {
+        if (typeof s === 'object') {
+          const resolved = resolveRef(s, definitions);
+
+          return {
+            key: resolved.title?.toLowerCase() || resolved.type,
+            text: resolved.title?.toLowerCase() || resolved.type,
+            data: { schema: resolved },
+          } as IDropdownOption;
+        }
+      })
+      .filter(Boolean) as IDropdownOption[];
+  }
+
+  return [];
+}
+
+export function getSelectedOption(value: any | undefined, options: IDropdownOption[]): IDropdownOption | undefined {
+  if (options.length === 0) {
+    return;
+  }
+
+  // if the value if undefined, default to the first option
+  if (typeof value === 'undefined' || value === null) {
+    return options[0];
+  }
+
+  const valueType = getValueType(value);
+
+  if (valueType === 'array') {
+    const item = value[0];
+    const firstArrayOption = options.find(o => o.data.schema.type === 'array');
+
+    // if there is nothing in the array, default to the first array type
+    if (!item) {
+      return firstArrayOption;
+    }
+
+    // else, find the option with an item schema that matches item type
+    return (
+      options.find(o => {
+        const {
+          data: { schema },
+        } = o;
+
+        const itemSchema = Array.isArray(schema.items) ? schema.items[0] : schema.items;
+        return itemSchema && getValueType(item) === itemSchema.type;
+      }) || firstArrayOption
+    );
+  }
+
+  // lastly, attempt to find the option based on value type
+  return options.find(({ data }) => data.schema.type === valueType) || options[0];
+}

--- a/Composer/packages/ui-plugins/expressions/jest.config.js
+++ b/Composer/packages/ui-plugins/expressions/jest.config.js
@@ -12,6 +12,7 @@ module.exports = {
     'office-ui-fabric-react/lib/(.*)$': 'office-ui-fabric-react/lib-commonjs/$1',
     '@uifabric/fluent-theme/lib/(.*)$': '@uifabric/fluent-theme/lib-commonjs/$1',
   },
+  testPathIgnorePatterns: ['/node_modules/'],
   globals: {
     'ts-jest': {
       tsConfig: path.resolve(__dirname, './tsconfig.json'),

--- a/Composer/packages/ui-plugins/expressions/src/ExpressionField.tsx
+++ b/Composer/packages/ui-plugins/expressions/src/ExpressionField.tsx
@@ -4,13 +4,14 @@
 /** @jsx jsx */
 import { jsx, css } from '@emotion/core';
 import React, { useMemo, useState } from 'react';
-import { FieldProps, JSONSchema7 } from '@bfc/extension';
-import { FieldLabel, resolveRef, resolveFieldWidget, usePluginConfig, getValueType } from '@bfc/adaptive-form';
+import { FieldProps } from '@bfc/extension';
+import { FieldLabel, resolveFieldWidget, usePluginConfig } from '@bfc/adaptive-form';
 import { Dropdown, IDropdownOption, ResponsiveMode } from 'office-ui-fabric-react/lib/Dropdown';
 import { JsonEditor } from '@bfc/code-editor';
 import formatMessage from 'format-message';
 
 import { ExpressionEditor } from './ExpressionEditor';
+import { getOptions, getSelectedOption } from './utils';
 
 const styles = {
   container: css`
@@ -23,103 +24,6 @@ const styles = {
   field: css`
     min-height: 66px;
   `,
-};
-
-const getOptions = (schema: JSONSchema7, definitions): IDropdownOption[] => {
-  const { type, oneOf, enum: enumOptions } = schema;
-
-  const expressionOption = {
-    key: 'expression',
-    text: 'expression',
-    data: { schema: { ...schema, type: 'string' } },
-  };
-
-  if (type && Array.isArray(type)) {
-    const options: IDropdownOption[] = type.map(t => ({
-      key: t,
-      text: t,
-      data: { schema: { ...schema, type: t } },
-    }));
-
-    type.length > 2 && options.push(expressionOption);
-
-    options.sort(({ text: t1 }, { text: t2 }) => (t1 > t2 ? 1 : -1));
-
-    return options;
-  }
-
-  if (oneOf && Array.isArray(oneOf)) {
-    return oneOf
-      .map(s => {
-        if (typeof s === 'object') {
-          const resolved = resolveRef(s, definitions);
-
-          return {
-            key: resolved.title?.toLowerCase() || resolved.type,
-            text: resolved.title?.toLowerCase() || resolved.type,
-            data: { schema: resolved },
-          } as IDropdownOption;
-        }
-      })
-      .filter(Boolean) as IDropdownOption[];
-  }
-
-  // this could either be an expression or an enum value
-  if (Array.isArray(enumOptions)) {
-    return [
-      {
-        key: 'dropdown',
-        text: 'dropdown',
-        data: { schema: { ...schema, $role: undefined } },
-      },
-      expressionOption,
-    ];
-  }
-
-  return [expressionOption];
-};
-
-const getSelectedOption = (value: any | undefined, options: IDropdownOption[]): IDropdownOption | undefined => {
-  const expressionOption = options.find(({ key }) => key === 'expression');
-  const valueType = getValueType(value);
-
-  // if its an array, we know it's not an expression
-  if (valueType === 'array') {
-    const item = value[0];
-    const firstArrayOption = options.find(o => o.data.schema.type === 'array');
-
-    // if there is nothing in the array, default to the first array type
-    if (!item) {
-      return firstArrayOption;
-    }
-
-    // else, find the option with an item schema that matches item type
-    return (
-      options.find(o => {
-        const {
-          data: { schema },
-        } = o;
-
-        const itemSchema = Array.isArray(schema.items) ? schema.items[0] : schema.items;
-        return itemSchema && typeof item === itemSchema.type;
-      }) || firstArrayOption
-    );
-  }
-
-  // if the value if undefined, either default to expression or the first option
-  if (typeof value === 'undefined' || value === null) {
-    return options.length > 2 ? expressionOption : options[0];
-    // else if the value is a string and starts with '=' it is an expression
-  } else if (
-    expressionOption &&
-    valueType === 'string' &&
-    (value.startsWith('=') || !options.find(({ key }) => key === 'string'))
-  ) {
-    return expressionOption;
-  }
-
-  // lastly, attempt to find the option based on value type
-  return options.find(({ data, key }) => data.schema.type === valueType && key !== 'expression') || options[0];
 };
 
 const ExpressionField: React.FC<FieldProps> = props => {

--- a/Composer/packages/ui-plugins/expressions/src/__tests__/utils.test.ts
+++ b/Composer/packages/ui-plugins/expressions/src/__tests__/utils.test.ts
@@ -1,0 +1,187 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { getOptions, getSelectedOption } from '../utils';
+
+describe('getOptions', () => {
+  describe('when there is an array of types', () => {
+    describe('when there are more than 2 types', () => {
+      const schema = {
+        title: 'test schema',
+        type: ['string' as const, 'boolean' as const, 'number' as const],
+      };
+
+      it('returns the types and expression', () => {
+        const options = getOptions(schema, {}).map(o => o.key);
+        expect(options).toEqual(['boolean', 'expression', 'number', 'string']);
+      });
+    });
+
+    describe('when there is only 2 options', () => {
+      const schema = {
+        title: 'test schema',
+        type: ['boolean' as const, 'number' as const],
+      };
+
+      it('returns the types without expression', () => {
+        const options = getOptions(schema, {}).map(o => o.key);
+        expect(options).toEqual(['boolean', 'number']);
+      });
+    });
+  });
+
+  describe('when there is a oneOf property', () => {
+    const schema = {
+      title: 'Test Schema',
+      oneOf: [
+        {
+          type: 'string' as const,
+          title: 'My Awesome String',
+        },
+        {
+          type: 'boolean' as const,
+        },
+        {
+          type: 'number' as const,
+        },
+        {
+          $ref: '#/definitions/Microsoft.AnotherType',
+        },
+      ],
+    };
+
+    const definitions = {
+      'Microsoft.AnotherType': {
+        title: 'Another Type',
+        type: 'object' as const,
+      },
+    };
+
+    it('returns one of options', () => {
+      const options = getOptions(schema, definitions).map(o => o.key);
+      expect(options).toEqual(['my awesome string', 'boolean', 'number', 'another type']);
+    });
+  });
+
+  describe('when there are enum options', () => {
+    const schema = {
+      title: 'Test Schema',
+      type: 'string' as const,
+      enum: ['one', 'two', 'three'],
+    };
+
+    it('returns dropdown and expression options', () => {
+      const options = getOptions(schema, {}).map(o => o.key);
+      expect(options).toEqual(['dropdown', 'expression']);
+    });
+  });
+
+  it('returns expression option by default', () => {
+    const options = getOptions({}, {}).map(o => o.key);
+    expect(options).toEqual(['expression']);
+  });
+});
+
+describe('getSelectedOption', () => {
+  const options = [
+    {
+      key: 'string',
+      text: 'string',
+      data: {
+        schema: {
+          type: 'string',
+        },
+      },
+    },
+    {
+      key: 'integer',
+      text: 'integer',
+      data: {
+        schema: {
+          type: 'integer',
+        },
+      },
+    },
+    {
+      key: 'object',
+      text: 'object',
+      data: {
+        schema: {
+          type: 'object',
+        },
+      },
+    },
+    {
+      key: 'array1',
+      text: 'array1',
+      data: {
+        schema: {
+          type: 'array',
+        },
+      },
+    },
+    {
+      key: 'array2',
+      text: 'array2',
+      data: {
+        schema: {
+          type: 'array',
+          items: {
+            type: 'integer',
+          },
+        },
+      },
+    },
+    {
+      key: 'expression',
+      text: 'expression',
+      data: {
+        schema: { type: 'string' },
+      },
+    },
+  ];
+
+  it('returns undefined if there are no options', () => {
+    expect(getSelectedOption(123, [])).toBe(undefined);
+  });
+
+  describe('when the value is undefined', () => {
+    describe('when there are more than 2 options', () => {
+      it('returns the expression option', () => {
+        expect(getSelectedOption(undefined, options)).toEqual(options[5]);
+        expect(getSelectedOption(null, options)).toEqual(options[5]);
+      });
+    });
+
+    describe('when there are 2 or less options', () => {
+      it('returns the first option', () => {
+        expect(getSelectedOption(undefined, options.slice(0, 2))).toEqual(options[0]);
+        expect(getSelectedOption(null, options.slice(0, 2))).toEqual(options[0]);
+      });
+    });
+  });
+
+  it('returns the option that matches the value type', () => {
+    expect(getSelectedOption('foo', options)).toEqual(options[0]);
+    expect(getSelectedOption(123, options)).toEqual(options[1]);
+    expect(getSelectedOption({ foo: 'bar' }, options)).toEqual(options[2]);
+  });
+
+  it("returns the first option if it can't find a match", () => {
+    expect(getSelectedOption(true, options)).toEqual(options[0]);
+  });
+
+  describe('when the value is an array', () => {
+    it('returns the first array type if there are no array items', () => {
+      expect(getSelectedOption([], options)).toEqual(options[3]);
+    });
+
+    it('returns the option that matches the first item type', () => {
+      expect(getSelectedOption([123], options)).toEqual(options[4]);
+    });
+
+    it('returns the first option if no type match found', () => {
+      expect(getSelectedOption(['foo'], options)).toEqual(options[3]);
+    });
+  });
+});

--- a/Composer/packages/ui-plugins/expressions/src/utils.ts
+++ b/Composer/packages/ui-plugins/expressions/src/utils.ts
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { JSONSchema7 } from '@bfc/extension';
+import { resolveRef, getValueType } from '@bfc/adaptive-form';
+import { IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
+
+export function getOptions(schema: JSONSchema7, definitions): IDropdownOption[] {
+  const { type, oneOf, enum: enumOptions } = schema;
+
+  const expressionOption = {
+    key: 'expression',
+    text: 'expression',
+    data: { schema: { ...schema, type: 'string' } },
+  };
+
+  if (type && Array.isArray(type)) {
+    const options: IDropdownOption[] = type.map(t => ({
+      key: t,
+      text: t,
+      data: { schema: { ...schema, type: t } },
+    }));
+
+    type.length > 2 && options.push(expressionOption);
+
+    options.sort(({ text: t1 }, { text: t2 }) => (t1 > t2 ? 1 : -1));
+
+    return options;
+  }
+
+  if (oneOf && Array.isArray(oneOf)) {
+    return oneOf
+      .map(s => {
+        if (typeof s === 'object') {
+          const resolved = resolveRef(s, definitions);
+
+          return {
+            key: resolved.title?.toLowerCase() || resolved.type,
+            text: resolved.title?.toLowerCase() || resolved.type,
+            data: { schema: resolved },
+          } as IDropdownOption;
+        }
+      })
+      .filter(Boolean) as IDropdownOption[];
+  }
+
+  // this could either be an expression or an enum value
+  if (Array.isArray(enumOptions)) {
+    return [
+      {
+        key: 'dropdown',
+        text: 'dropdown',
+        data: { schema: { ...schema, $role: undefined } },
+      },
+      expressionOption,
+    ];
+  }
+
+  return [expressionOption];
+}
+
+export function getSelectedOption(value: any | undefined, options: IDropdownOption[]): IDropdownOption | undefined {
+  const expressionOption = options.find(({ key }) => key === 'expression');
+  const valueType = getValueType(value);
+
+  // if its an array, we know it's not an expression
+  if (valueType === 'array') {
+    const item = value[0];
+    const firstArrayOption = options.find(o => o.data.schema.type === 'array');
+
+    // if there is nothing in the array, default to the first array type
+    if (!item) {
+      return firstArrayOption;
+    }
+
+    // else, find the option with an item schema that matches item type
+    return (
+      options.find(o => {
+        const {
+          data: { schema },
+        } = o;
+
+        const itemSchema = Array.isArray(schema.items) ? schema.items[0] : schema.items;
+        return itemSchema && getValueType(item) === itemSchema.type;
+      }) || firstArrayOption
+    );
+  }
+
+  // if the value if undefined, either default to expression or the first option
+  if (typeof value === 'undefined' || value === null) {
+    return options.length > 2 ? expressionOption : options[0];
+    // else if the value is a string and starts with '=' it is an expression
+  } else if (
+    expressionOption &&
+    valueType === 'string' &&
+    (value.startsWith('=') || !options.find(({ key }) => key === 'string'))
+  ) {
+    return expressionOption;
+  }
+
+  // lastly, attempt to find the option based on value type
+  return options.find(({ data, key }) => data.schema.type === valueType && key !== 'expression') || options[0];
+}


### PR DESCRIPTION
## Description

We were checking `if (!value)` to determine which field type to render. This change hardens that check to only check for undefined or null.

## Task Item

closes #2658 
