### PR TITLE
fix: cannot select nested actions in Visual Editor

### DIFF
--- a/Composer/cypress/integration/Breadcrumb.spec.ts
+++ b/Composer/cypress/integration/Breadcrumb.spec.ts
@@ -58,7 +58,7 @@ context('breadcrumb', () => {
     // Click on an action
     cy.withinEditor('VisualEditor', () => {
       cy.findByTestId('RuleEditor').within(() => {
-        cy.findByText('Send a response').click({ force: true });
+        cy.findByText('Send a response').click();
       });
     });
 

--- a/Composer/packages/extensions/visual-designer/src/widgets/ForeachWidget.tsx
+++ b/Composer/packages/extensions/visual-designer/src/widgets/ForeachWidget.tsx
@@ -67,6 +67,9 @@ export const ForeachWidget: FunctionComponent<ForeachWidgetProps> = ({ id, data,
   const { foreachNode, loopActionsNode, loopBeginNode, loopEndNode } = nodeMap;
   return (
     <div css={{ width: boundary.width, height: boundary.height, position: 'relative' }}>
+      <SVGContainer width={boundary.width} height={boundary.height}>
+        <FlowEdges edges={edges} />
+      </SVGContainer>
       <OffsetContainer offset={foreachNode.offset}>
         <ElementWrapper id={id} onEvent={onEvent}>
           <ElementMeasurer
@@ -97,9 +100,6 @@ export const ForeachWidget: FunctionComponent<ForeachWidgetProps> = ({ id, data,
             <LoopIndicator onClick={() => onEvent(NodeEventTypes.Focus, { id })} />
           </OffsetContainer>
         ))}
-      <SVGContainer width={boundary.width} height={boundary.height}>
-        <FlowEdges edges={edges} />
-      </SVGContainer>
     </div>
   );
 };

--- a/Composer/packages/extensions/visual-designer/src/widgets/IfConditionWidget.tsx
+++ b/Composer/packages/extensions/visual-designer/src/widgets/IfConditionWidget.tsx
@@ -70,6 +70,9 @@ export const IfConditionWidget: FunctionComponent<IfConditionWidgetProps> = ({
 
   return (
     <div css={{ width: boundary.width, height: boundary.height, position: 'relative' }}>
+      <SVGContainer width={boundary.width} height={boundary.height}>
+        <FlowEdges edges={edges} />
+      </SVGContainer>
       <OffsetContainer offset={conditionNode.offset}>
         <ElementWrapper id={conditionNode.id} onEvent={onEvent}>
           <ElementMeasurer
@@ -105,9 +108,6 @@ export const IfConditionWidget: FunctionComponent<IfConditionWidgetProps> = ({
           </OffsetContainer>
         );
       })}
-      <SVGContainer width={boundary.width} height={boundary.height}>
-        <FlowEdges edges={edges} />
-      </SVGContainer>
     </div>
   );
 };

--- a/Composer/packages/extensions/visual-designer/src/widgets/PromptWidget.tsx
+++ b/Composer/packages/extensions/visual-designer/src/widgets/PromptWidget.tsx
@@ -62,6 +62,9 @@ export const PromptWidget: FC<PromptWdigetProps> = ({
 
   return (
     <div className="Action-BaseInput" css={{ width: boundary.width, height: boundary.height, position: 'relative' }}>
+      <SVGContainer width={boundary.width} height={boundary.height}>
+        <FlowEdges edges={edges} />
+      </SVGContainer>
       <OffsetContainer offset={botAsksNode.offset}>
         <ElementWrapper id={botAsksNode.id} tab={PromptTab.BOT_ASKS} onEvent={onEvent}>
           <ElementMeasurer
@@ -91,9 +94,6 @@ export const PromptWidget: FC<PromptWdigetProps> = ({
           <IconBrick onClick={() => onEvent(NodeEventTypes.Focus, { id, tab: PromptTab.OTHER })} />
         </ElementWrapper>
       </OffsetContainer>
-      <SVGContainer width={boundary.width} height={boundary.height}>
-        <FlowEdges edges={edges} />
-      </SVGContainer>
     </div>
   );
 };

--- a/Composer/packages/extensions/visual-designer/src/widgets/SwitchConditionWidget.tsx
+++ b/Composer/packages/extensions/visual-designer/src/widgets/SwitchConditionWidget.tsx
@@ -81,6 +81,9 @@ export const SwitchConditionWidget: FunctionComponent<SwitchConditionWidgetProps
 
   return (
     <div css={{ width: boundary.width, height: boundary.height, position: 'relative' }}>
+      <SVGContainer width={boundary.width} height={boundary.height}>
+        <FlowEdges edges={edges} />
+      </SVGContainer>
       <OffsetContainer offset={switchNode.offset}>
         <ElementWrapper id={switchNode.id} onEvent={onEvent}>
           <ElementMeasurer
@@ -114,9 +117,6 @@ export const SwitchConditionWidget: FunctionComponent<SwitchConditionWidgetProps
           />
         </OffsetContainer>
       ))}
-      <SVGContainer width={boundary.width} height={boundary.height}>
-        <FlowEdges edges={edges} />
-      </SVGContainer>
     </div>
   );
 };


### PR DESCRIPTION
## Description
fix #2667 by putting svg before actions

A trick about DOM event capturing:
- elements declared **before** `<svg />` are unreachable
- elements declared **after** `<svg />` are reachable

![image](https://user-images.githubusercontent.com/8528761/79421193-e50c0100-7fec-11ea-9f14-fa97275329c9.png)

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
