### PR TITLE
Add telemetry wire-up to template

### DIFF
--- a/BotProject/Templates/CSharp/BotProject.csproj
+++ b/BotProject/Templates/CSharp/BotProject.csproj
@@ -22,16 +22,16 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.8.0-rc0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.8.0-rc0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.8.0-rc0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.9.0-preview-200417-121019" />
+    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.9.0-preview-200417-121019" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.9.0-preview-200417-121019" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.9.0-preview-200417-121019" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.9.0-preview-200417-121019" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.9.0-preview-200417-121019" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.9.0-preview-200417-121019" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.9.0-preview-200417-121019" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.9.0-preview-200417-121019" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.9.0-preview-200417-121019" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.66">
       <PrivateAssets>all</PrivateAssets>

--- a/BotProject/Templates/CSharp/BotSettings.cs
+++ b/BotProject/Templates/CSharp/BotSettings.cs
@@ -30,6 +30,8 @@ namespace Microsoft.Bot.Builder.ComposerBot.Json
         public class AdditionalTelemetryConfiguration
         {
             public bool LogPersonalInformation { get; set; }
+
+            public bool LogActivities { get; set; }
         }
     }
 }

--- a/BotProject/Templates/CSharp/BotSettings.cs
+++ b/BotProject/Templates/CSharp/BotSettings.cs
@@ -18,11 +18,18 @@ namespace Microsoft.Bot.Builder.ComposerBot.Json
 
         public TelemetryConfiguration AppInsights { get; set; }
 
+        public AdditionalTelemetryConfiguration Telemetry { get; set; }
+
         public class BlobStorageConfiguration
         {
             public string ConnectionString { get; set; }
 
             public string Container { get; set; }
+        }
+
+        public class AdditionalTelemetryConfiguration
+        {
+            public bool LogPersonalInformation { get; set; }
         }
     }
 }

--- a/BotProject/Templates/CSharp/ComposerBot.cs
+++ b/BotProject/Templates/CSharp/ComposerBot.cs
@@ -21,8 +21,9 @@ namespace Microsoft.Bot.Builder.ComposerBot.Json
         private readonly ConversationState conversationState;
         private readonly IStatePropertyAccessor<DialogState> dialogState;
         private readonly string rootDialogFile;
+        private readonly IBotTelemetryClient telemetryClient;
 
-        public ComposerBot(ConversationState conversationState, UserState userState, ResourceExplorer resourceExplorer, BotFrameworkClient skillClient, SkillConversationIdFactoryBase conversationIdFactory, string rootDialog)
+        public ComposerBot(ConversationState conversationState, UserState userState, ResourceExplorer resourceExplorer, BotFrameworkClient skillClient, SkillConversationIdFactoryBase conversationIdFactory, IBotTelemetryClient telemetryClient, string rootDialog)
         {
             HostContext.Current.Set(skillClient);
             HostContext.Current.Set(conversationIdFactory);
@@ -31,6 +32,7 @@ namespace Microsoft.Bot.Builder.ComposerBot.Json
             this.dialogState = conversationState.CreateProperty<DialogState>("DialogState");
             this.resourceExplorer = resourceExplorer;
             this.rootDialogFile = rootDialog;
+            this.telemetryClient = telemetryClient;
             LoadRootDialogAsync();
         }
         
@@ -47,7 +49,8 @@ namespace Microsoft.Bot.Builder.ComposerBot.Json
             var rootDialog = resourceExplorer.LoadType<Dialog>(rootFile); 
             this.dialogManager = new DialogManager(rootDialog)
                                 .UseResourceExplorer(resourceExplorer)
-                                .UseLanguageGeneration();
+                                .UseLanguageGeneration()
+                                .UseTelemetry(this.telemetryClient);
         }       
     }
 }

--- a/BotProject/Templates/CSharp/Tests/ActionsTests.cs
+++ b/BotProject/Templates/CSharp/Tests/ActionsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using Microsoft.Bot.Builder;
@@ -8,7 +8,6 @@ using Microsoft.Bot.Builder.Dialogs.Adaptive;
 using Microsoft.Bot.Builder.Dialogs.Debugging;
 using Microsoft.Bot.Builder.Dialogs.Declarative;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
-using Microsoft.Bot.Builder.Dialogs.Declarative.Types;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Configuration;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -243,5 +242,4 @@ namespace Tests
         }
     }
 }
-  
   

--- a/BotProject/Templates/CSharp/Tests/ControllingConversationTests.cs
+++ b/BotProject/Templates/CSharp/Tests/ControllingConversationTests.cs
@@ -8,7 +8,6 @@ using Microsoft.Bot.Builder.Dialogs.Adaptive;
 using Microsoft.Bot.Builder.Dialogs.Debugging;
 using Microsoft.Bot.Builder.Dialogs.Declarative;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
-using Microsoft.Bot.Builder.Dialogs.Declarative.Types;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Configuration;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/BotProject/Templates/CSharp/Tests/InputsTests.cs
+++ b/BotProject/Templates/CSharp/Tests/InputsTests.cs
@@ -9,7 +9,6 @@ using Microsoft.Bot.Builder.Dialogs.Adaptive;
 using Microsoft.Bot.Builder.Dialogs.Debugging;
 using Microsoft.Bot.Builder.Dialogs.Declarative;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
-using Microsoft.Bot.Builder.Dialogs.Declarative.Types;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Configuration;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/BotProject/Templates/CSharp/Tests/MessageTests.cs
+++ b/BotProject/Templates/CSharp/Tests/MessageTests.cs
@@ -8,7 +8,6 @@ using Microsoft.Bot.Builder.Dialogs.Adaptive;
 using Microsoft.Bot.Builder.Dialogs.Debugging;
 using Microsoft.Bot.Builder.Dialogs.Declarative;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
-using Microsoft.Bot.Builder.Dialogs.Declarative.Types;
 using Microsoft.Bot.Builder.LanguageGeneration;
 using Microsoft.Bot.Builder.ComposerBot.Json;
 using Microsoft.Bot.Schema;

--- a/BotProject/Templates/CSharp/Tests/ToDoBotTests.cs
+++ b/BotProject/Templates/CSharp/Tests/ToDoBotTests.cs
@@ -8,7 +8,6 @@ using Microsoft.Bot.Builder.Dialogs.Adaptive;
 using Microsoft.Bot.Builder.Dialogs.Debugging;
 using Microsoft.Bot.Builder.Dialogs.Declarative;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
-using Microsoft.Bot.Builder.Dialogs.Declarative.Types;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Configuration;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/BotProject/Templates/CSharp/appsettings.json
+++ b/BotProject/Templates/CSharp/appsettings.json
@@ -11,7 +11,8 @@
     "InstrumentationKey": ""
   },
   "telemetry": {
-    "logPersonalInformation": false
+    "logPersonalInformation": false,
+    "logActivities": true
   },
   "blobStorage": {
     "connectionString": "",

--- a/BotProject/Templates/CSharp/appsettings.json
+++ b/BotProject/Templates/CSharp/appsettings.json
@@ -10,6 +10,9 @@
   "applicationInsights": {
     "InstrumentationKey": ""
   },
+  "telemetry": {
+    "logPersonalInformation": false
+  },
   "blobStorage": {
     "connectionString": "",
     "container": "transcripts"

--- a/Composer/packages/server/src/models/settings/defaultSettingManager.ts
+++ b/Composer/packages/server/src/models/settings/defaultSettingManager.ts
@@ -35,6 +35,9 @@ export class DefaultSettingManager extends FileSettingManager {
         endpointkey: '',
         hostname: '',
       },
+      telemetry: {
+        logPersonalInformation: false,
+      },
     };
   };
 


### PR DESCRIPTION
Addresses #2697 

* Wires up telemetry in runtime template
* Adds new logPersonalInformation setting to template appSettings.json and also to the default composer settings UI
* Updated BotSettings class to allow access to the new telemetry setting