### PR TITLE
fix: add composer startup message back

### DIFF
--- a/Composer/packages/server/package.json
+++ b/Composer/packages/server/package.json
@@ -56,8 +56,8 @@
   },
   "dependencies": {
     "@azure/ms-rest-js": "^1.8.7",
-    "@bfc/indexers": "*",
     "@bfc/client": "*",
+    "@bfc/indexers": "*",
     "@bfc/lg-languageserver": "*",
     "@bfc/lu-languageserver": "*",
     "@bfc/shared": "*",
@@ -66,6 +66,7 @@
     "axios": "^0.18.0",
     "azure-storage": "^2.10.3",
     "body-parser": "^1.18.3",
+    "chalk": "^4.0.0",
     "compression": "^1.7.4",
     "cookie-parser": "^1.4.4",
     "debug": "^4.1.1",

--- a/Composer/packages/server/src/server.ts
+++ b/Composer/packages/server/src/server.ts
@@ -14,6 +14,7 @@ import * as rpc from 'vscode-ws-jsonrpc';
 import { IConnection, createConnection } from 'vscode-languageserver';
 import { LGServer } from '@bfc/lg-languageserver';
 import { LUServer } from '@bfc/lu-languageserver';
+import chalk from 'chalk';
 
 import { BotProjectService } from './services/project';
 import { getAuthProvider } from './router/auth';
@@ -115,7 +116,9 @@ export async function start(pluginDir?: string) {
   await new Promise(resolve => {
     server = app.listen(port, () => {
       if (process.env.NODE_ENV === 'production') {
-        log(`\n\nComposer now running at:\n\nhttp://localhost:${port}\n`);
+        // We don't use the debug logger here because we always want it to be shown.
+        // eslint-disable-next-line no-console
+        console.log(`\n\n${chalk.green('Composer now running at:')}\n\n${chalk.blue(`http://localhost:${port}`)}\n`);
       }
       resolve();
     });

--- a/Composer/yarn.lock
+++ b/Composer/yarn.lock
@@ -5976,6 +5976,14 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.0.0.tgz#6e98081ed2d17faab615eb52ac66ec1fe6209e72"
+  integrity sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"


### PR DESCRIPTION
## Description

Adds 'Composer now running at: <url>' back after startup.

## Task Item

closes #2648

## Screenshots

![image](https://user-images.githubusercontent.com/3619060/79589814-decc6200-808a-11ea-9802-ab113f111d26.png)
