### PR TITLE
fix: Fixed an issue with the Composer protocol

### DIFF
--- a/Composer/packages/electron-server/src/main.ts
+++ b/Composer/packages/electron-server/src/main.ts
@@ -118,10 +118,6 @@ async function main() {
 async function run() {
   fixPath(); // required PATH fix for Mac (https://github.com/electron/electron/issues/5626)
 
-  if (isDevelopment && !app.isDefaultProtocolClient('bfcomposer')) {
-    app.setAsDefaultProtocolClient('bfcomposer');
-  }
-
   // Force Single Instance Application
   const gotTheLock = app.requestSingleInstanceLock();
   if (gotTheLock) {


### PR DESCRIPTION
## Description

A call was being made to `app.setAsDefaultProtocolClient()` when building locally, which was causing deeplinks meant for production Composer Electron to misbehave and throw an error.

## Task Item

Fixes #2323

