### PR TITLE
fix: align *Input nodes to design

### DIFF
--- a/Composer/packages/ui-plugins/prompts/src/flowSchema.tsx
+++ b/Composer/packages/ui-plugins/prompts/src/flowSchema.tsx
@@ -6,7 +6,7 @@ import { FlowWidget } from '@bfc/extension';
 import { SDKKinds, getInputType } from '@bfc/shared';
 import { VisualEditorColors as Colors, ListOverview, BorderedDiv, FixedInfo } from '@bfc/ui-shared';
 
-const BaseInputSchema: FlowWidget = {
+const generateInputSchema = (inputBody?, inputFooter?): FlowWidget => ({
   widget: 'PromptWidget',
   nowrap: true,
   botAsks: {
@@ -39,30 +39,37 @@ const BaseInputSchema: FlowWidget = {
         icon: Colors.AzureBlue,
       },
     },
-    body: data =>
-      data.$kind === SDKKinds.ChoiceInput && Array.isArray(data.choices) && data.choices.length ? (
-        <ListOverview
-          items={data.choices}
-          renderItem={item => {
-            const value = typeof item === 'object' ? item.value : item;
-            return (
-              <BorderedDiv height={20} title={value}>
-                {value}
-              </BorderedDiv>
-            );
-          }}
-        />
-      ) : (
-        <>{data.choices}</>
-      ),
-    footer: data =>
-      data.property ? (
-        <>
-          {data.property} <FixedInfo>= Input({getInputType(data.$kind)})</FixedInfo>
-        </>
-      ) : null,
+    body: inputBody,
+    footer: inputFooter,
   },
-};
+});
+
+const PropertyInfo = data =>
+  data.property ? (
+    <>
+      {data.property} <FixedInfo>= Input({getInputType(data.$kind)})</FixedInfo>
+    </>
+  ) : null;
+
+const ChoiceInputBody = data =>
+  Array.isArray(data.choices) && data.choices.length ? (
+    <ListOverview
+      items={data.choices}
+      renderItem={item => {
+        const value = typeof item === 'object' ? item.value : item;
+        return (
+          <BorderedDiv height={20} title={value}>
+            {value}
+          </BorderedDiv>
+        );
+      }}
+    />
+  ) : (
+    <>{data.choices}</>
+  );
+
+const ChoiceInputSchema = generateInputSchema(ChoiceInputBody, PropertyInfo);
+const BaseInputSchema = generateInputSchema(PropertyInfo);
 
 export default {
   [SDKKinds.AttachmentInput]: BaseInputSchema,
@@ -70,5 +77,5 @@ export default {
   [SDKKinds.DateTimeInput]: BaseInputSchema,
   [SDKKinds.NumberInput]: BaseInputSchema,
   [SDKKinds.TextInput]: BaseInputSchema,
-  [SDKKinds.ChoiceInput]: BaseInputSchema,
+  [SDKKinds.ChoiceInput]: ChoiceInputSchema,
 };


### PR DESCRIPTION
## Description
close #2598 

ChoiceInput not changed;
To other input types, they will be displayed as a one-line card in the 'UserInput' part.
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
#2598 
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots
### Design
![image](https://user-images.githubusercontent.com/8528761/79957545-4d0e8b80-84b4-11ea-843d-13f188c5c123.png)

### Before
![image](https://user-images.githubusercontent.com/8528761/78962316-93fc9880-7b26-11ea-82ee-22720db3af60.png)
### After
![image](https://user-images.githubusercontent.com/8528761/79957396-16d10c00-84b4-11ea-990f-7e017a8b9fa1.png)

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
