### PR TITLE
fix: Updated some auto-update UX copy to be more accurate.

### DIFF
--- a/Composer/packages/client/__tests__/components/appUpdater.test.jsx
+++ b/Composer/packages/client/__tests__/components/appUpdater.test.jsx
@@ -55,7 +55,7 @@ describe('<AppUpdater />', () => {
     getByText('New update available');
     getByText('Bot Framework Composer v1.0.0');
     getByText('Install the update and restart Composer.');
-    getByText('Download the new version manually.');
+    getByText('Download now and install when you close Composer.');
   });
 
   it('should render the update unavailable dialog', () => {

--- a/Composer/packages/client/src/components/AppUpdater/index.tsx
+++ b/Composer/packages/client/src/components/AppUpdater/index.tsx
@@ -142,7 +142,7 @@ export const AppUpdater: React.FC<{}> = _props => {
               },
               {
                 key: downloadOptions.downloadOnly,
-                text: formatMessage('Download the new version manually.'),
+                text: formatMessage('Download now and install when you close Composer.'),
                 onRenderField: SelectOption,
               },
             ]}
@@ -175,7 +175,7 @@ export const AppUpdater: React.FC<{}> = _props => {
         const text =
           downloadOption === downloadOptions.installAndUpdate
             ? formatMessage('Composer will restart.')
-            : formatMessage('Composer will update the next time you start the app.');
+            : formatMessage('Composer will update the next time you close the app.');
         return <p css={dialogCopy}>{text}</p>;
       }
 


### PR DESCRIPTION
## Description

Updated some copy in the auto-update UX to more accurately represent what is actually happening under the hood.

## Task Item

refs #2226 

## Screenshots

**Update available (Before)**

![copy-before](https://user-images.githubusercontent.com/3452012/80019584-9d71f300-848c-11ea-8a59-3cc5d357d9fd.PNG)

**Update available (After)**

![copy-after](https://user-images.githubusercontent.com/3452012/80019582-9d71f300-848c-11ea-95a6-b4038e1ded21.PNG)

**Update succeeded (Before)**

![copy2-before](https://user-images.githubusercontent.com/3452012/80019598-a6fb5b00-848c-11ea-97c5-75bde19ccb46.PNG)

**Update succeeded (After)**

![copy2-after](https://user-images.githubusercontent.com/3452012/80019604-a95db500-848c-11ea-9f6a-38f65f21c8b3.PNG)



