### PR TITLE
fix: disable mockremote plugin 

### DIFF
--- a/Composer/plugins/mockRemotePublish/package.json
+++ b/Composer/plugins/mockRemotePublish/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "tsc"
   },
-  "extendsComposer": true,
+  "extendsComposer": false,
   "author": "",
   "license": "ISC",
   "dependencies": {


### PR DESCRIPTION
mockremote plugin should not be enabled in master, it has no build script, will break if you haven't built it once. 

refs #2766