### PR TITLE
a11y: accessibility issue 2068

### DIFF
--- a/Composer/packages/client/__tests__/components/TestController/errorCallout.test.tsx
+++ b/Composer/packages/client/__tests__/components/TestController/errorCallout.test.tsx
@@ -21,7 +21,7 @@ describe('<ErrorCallout />', () => {
       />
     );
 
-    const container = document.querySelector('[role="alertdialog"]');
+    const container = document.querySelector('[ data-testid="errorCallout"]');
     expect(container).toHaveTextContent('title test');
 
     const tryButton = getByText(container as HTMLElement, 'Try again');

--- a/Composer/packages/client/src/components/TestController/errorCallout.tsx
+++ b/Composer/packages/client/src/components/TestController/errorCallout.tsx
@@ -26,6 +26,7 @@ export const ErrorCallout: React.FC<IErrorCalloutProps> = props => {
       onDismiss={onDismiss}
       setInitialFocus={true}
       hidden={!visible}
+      data-testid={'errorCallout'}
       ariaLabel={formatMessage(`{title}. {msg}`, { title: error.title, msg: error.message })}
     >
       <div css={calloutContainer}>

--- a/Composer/packages/client/src/components/TestController/errorCallout.tsx
+++ b/Composer/packages/client/src/components/TestController/errorCallout.tsx
@@ -21,14 +21,12 @@ export const ErrorCallout: React.FC<IErrorCalloutProps> = props => {
   const { onDismiss, onTry, target, visible, error } = props;
   return (
     <Callout
-      role="alertdialog"
-      ariaLabelledBy="callout-label-id"
-      ariaDescribedBy="callout-description-id"
       gapSpace={0}
       target={target}
       onDismiss={onDismiss}
       setInitialFocus={true}
       hidden={!visible}
+      ariaLabel={formatMessage(`{title}. {msg}`, { title: error.title, msg: error.message })}
     >
       <div css={calloutContainer}>
         <p css={calloutLabel} id="callout-label-id">

--- a/Composer/packages/client/src/components/TestController/index.tsx
+++ b/Composer/packages/client/src/components/TestController/index.tsx
@@ -135,6 +135,12 @@ export const TestController: React.FC = () => {
           hidden={showError}
           onClick={handleOpenEmulator}
         />
+        <div
+          aria-live={'assertive'}
+          aria-label={formatMessage(`{ botStatus}`, {
+            botStatus: publishing ? 'Publishing' : reloading ? 'Reloading' : '',
+          })}
+        />
         <Loading botStatus={botStatus} />
         <div ref={addRef}>
           <ErrorInfo hidden={!showError} onClick={handleErrorButtonClick} count={errorLength} />


### PR DESCRIPTION
## Description
I update the code to make the 'reloading' status easier to be read out before the status changed.
In most cases, the reloading status exists for a very short period. And while narrator announce 'reloading', it may also be interrupted by an error message. @ashish315 Can you help checking whether the current behavior acceptable?

I think the current process is like: 
1. Click start bot button, the narrator starts to read the status 'publishing' or 'reloading'
2. Before the narrator finish, an error dialog may be pop up and get the focus. (We must focus on that dialog, otherwise we cannot click the try again or cancel button using keyboard)
3. Since the focus changed, the narrator start to read something else.
## Task Item
closes #2068 
## Screenshots
