### PR TITLE
fix: crosstrain for dialog without lu file

### DIFF
--- a/Composer/packages/client/__tests__/utils/luUtil.test.ts
+++ b/Composer/packages/client/__tests__/utils/luUtil.test.ts
@@ -25,6 +25,7 @@ describe('getReferredFiles', () => {
           { intent: 'dia2_trigger', dialogs: ['dia2'] },
           { intent: 'dias_trigger', dialogs: ['dia5', 'dia6'] },
           { intent: 'no_dialog', dialogs: [] },
+          { intent: 'dialog_without_lu', dialogs: ['dialog_without_lu'] },
           { intent: '', dialogs: ['start_dialog_without_intent'] },
         ],
       },
@@ -66,6 +67,10 @@ describe('getReferredFiles', () => {
         luFile: 'start_dialog_without_intent',
         intentTriggers: [],
       },
+      {
+        id: 'dialog_without_lu',
+        intentTriggers: [],
+      },
     ];
     const luFiles = [
       { id: 'main.en-us' },
@@ -86,6 +91,7 @@ describe('getReferredFiles', () => {
     expect(config.triggerRules['main.en-us.lu'].dias_trigger.length).toBe(2);
     expect(config.triggerRules['dia1.en-us.lu'].dia3_trigger).toEqual('dia3.en-us.lu');
     expect(config.triggerRules['dia1.en-us.lu']['dia4.en-us.lu']).toBeUndefined();
+    expect(config.triggerRules['main.en-us.lu'].dialog_without_lu).toEqual('');
   });
 
   it('check the lu files before publish', () => {

--- a/Composer/packages/client/src/utils/luUtil.ts
+++ b/Composer/packages/client/src/utils/luUtil.ts
@@ -121,9 +121,10 @@ export function createCrossTrainConfig(dialogs: DialogInfo[], luFiles: LuFile[])
         result[item.intent] = deduped[0];
       } else if (deduped.length) {
         result[item.intent] = deduped;
+      } else {
+        result[item.intent] = '';
       }
 
-      if (!item.dialogs.length) result[item.intent] = '';
       triggerRules[fileId] = { ...triggerRules[fileId], ...result };
     });
   });

--- a/Composer/packages/lib/indexers/src/dialogUtils/extractIntentTriggers.ts
+++ b/Composer/packages/lib/indexers/src/dialogUtils/extractIntentTriggers.ts
@@ -29,7 +29,7 @@ function ExtractIntentTriggers(value: any): IIntentTrigger[] {
     for (const trigger of triggers) {
       const dialogs = ExtractAllBeginDialogs(trigger);
 
-      if (trigger.$kind === SDKKinds.OnIntent && trigger.intent && trigger.actions?.length) {
+      if (trigger.$kind === SDKKinds.OnIntent && trigger.intent) {
         intentTriggers.push({ intent: trigger.intent, dialogs });
       } else if (trigger.$kind !== SDKKinds.OnIntent && dialogs.length) {
         const emptyIntent = intentTriggers.find(e => e.intent === '');


### PR DESCRIPTION
## Description
If a trigger start with OnIntent and there is no action or begin a dialog without lu
the config will be like   'tirgger_Intent':''
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
refs #2794
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
