### PR TITLE
fix: all up view dialog tree

### DIFF
--- a/Composer/packages/client/src/pages/language-generation/index.tsx
+++ b/Composer/packages/client/src/pages/language-generation/index.tsx
@@ -100,8 +100,6 @@ const LGPage: React.FC<LGPageProps> = props => {
   return (
     <Fragment>
       <div css={pageRoot} data-testid="LGPage">
-        <DialogTree navLinks={navLinks} onSelect={onSelect} dialogId={dialogId} />
-
         <div css={contentWrapper}>
           <ToolBar toolbarItems={toolbarItems} />
 
@@ -119,8 +117,9 @@ const LGPage: React.FC<LGPageProps> = props => {
               />
             </div>
           </div>
-          <div role="main" css={ContentStyle} data-testid="LGEditor">
-            <div css={contentEditor}>
+          <div role="main" css={ContentStyle}>
+            <DialogTree navLinks={navLinks} onSelect={onSelect} dialogId={dialogId} />
+            <div css={contentEditor} data-testid="LGEditor">
               <Suspense fallback={<LoadingSpinner />}>
                 <Router primary={false} component={Fragment}>
                   <CodeEditor path="/edit/*" dialogId={dialogId} />

--- a/Composer/packages/client/src/pages/language-understanding/index.tsx
+++ b/Composer/packages/client/src/pages/language-understanding/index.tsx
@@ -100,8 +100,6 @@ const LUPage: React.FC<LUPageProps> = props => {
 
   return (
     <div css={pageRoot} data-testid="LUPage">
-      <DialogTree navLinks={navLinks} onSelect={onSelect} dialogId={dialogId} />
-
       <div css={contentWrapper}>
         <ToolBar toolbarItems={toolbarItems} />
         <div css={ContentHeaderStyle}>
@@ -120,8 +118,9 @@ const LUPage: React.FC<LUPageProps> = props => {
             )}
           </div>
         </div>
-        <div role="main" css={ContentStyle} data-testid="LUEditor">
-          <div css={contentEditor}>
+        <div role="main" css={ContentStyle}>
+          <DialogTree navLinks={navLinks} onSelect={onSelect} dialogId={dialogId} />
+          <div css={contentEditor} data-testid="LUEditor">
             <Suspense fallback={<LoadingSpinner />}>
               <Router primary={false} component={Fragment}>
                 <CodeEditor path="/edit" dialogId={dialogId} />

--- a/Composer/packages/client/src/pages/language-understanding/styles.ts
+++ b/Composer/packages/client/src/pages/language-understanding/styles.ts
@@ -52,6 +52,7 @@ export const HeaderText = css`
 
 export const ContentStyle = css`
   margin-left: 2px;
+  height: calc(100vh - 180px);
   display: flex;
   border-top: 1px solid #dddddd;
   position: relative;
@@ -65,7 +66,6 @@ export const ContentStyle = css`
 export const contentEditor = css`
   flex: 4;
   margin: 20px;
-  height: calc(100vh - 200px);
   position: relative;
   overflow: visible;
 


### PR DESCRIPTION
## Description

Flow up fix of #2747 , move dialog tree down to origin place.
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item

close #2791 
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots
<img width="1200" alt="image" src="https://user-images.githubusercontent.com/49866537/80464763-d9192b00-896c-11ea-9236-4a3e99ca9d22.png">

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
