### PR TITLE
fix: make error messages multiline

### DIFF
--- a/Composer/packages/lib/code-editor/src/BaseEditor.tsx
+++ b/Composer/packages/lib/code-editor/src/BaseEditor.tsx
@@ -223,7 +223,7 @@ const BaseEditor: React.FC<BaseEditorProps> = props => {
       {(hasError || hasWarning) && (
         <MessageBar
           messageBarType={hasError ? MessageBarType.error : hasWarning ? MessageBarType.warning : MessageBarType.info}
-          isMultiline={false}
+          isMultiline={true}
           dismissButtonAriaLabel={formatMessage('Close')}
           overflowButtonAriaLabel={formatMessage('See more')}
         >


### PR DESCRIPTION
## Description

This makes our error messages multiline, which is needed since we removed the reveal arrows (for a11y reasons).

## Task Item

fixes #2792

## Screenshots

![image](https://user-images.githubusercontent.com/61990921/80519071-42cd1100-893c-11ea-978f-ea3c66ac60df.png)