### PR TITLE
fix: Updated Composer Electron app menu

### DIFF
--- a/Composer/packages/electron-server/__tests__/appMenu.test.ts
+++ b/Composer/packages/electron-server/__tests__/appMenu.test.ts
@@ -11,9 +11,7 @@ jest.mock('../src/utility/platform', () => ({
 const mockBuildFromTemplate = jest.fn();
 const mockSetApplicationMenu = jest.fn();
 jest.mock('electron', () => ({
-  app: {
-    name: 'Bot Framework Composer',
-  },
+  app: {},
   dialog: {},
   Menu: {
     buildFromTemplate: template => mockBuildFromTemplate(template),
@@ -54,7 +52,7 @@ describe('App menu', () => {
 
     // Help
     expect(menuTemplate[4].label).toBe('Help');
-    expect(menuTemplate[4].submenu.length).toBe(8);
+    expect(menuTemplate[4].submenu.length).toBe(9);
 
     expect(mockSetApplicationMenu).toHaveBeenCalledTimes(1);
   });
@@ -69,7 +67,7 @@ describe('App menu', () => {
 
     // App
     expect(menuTemplate[0].label).toBe('Bot Framework Composer');
-    expect(menuTemplate[0].submenu.length).toBe(9);
+    expect(menuTemplate[0].submenu.length).toBe(7);
 
     // File
     expect(menuTemplate[1].label).toBe('File');
@@ -89,7 +87,7 @@ describe('App menu', () => {
 
     // Help
     expect(menuTemplate[5].label).toBe('Help');
-    expect(menuTemplate[5].submenu.length).toBe(8);
+    expect(menuTemplate[5].submenu.length).toBe(9);
 
     expect(mockSetApplicationMenu).toHaveBeenCalledTimes(1);
   });

--- a/Composer/packages/electron-server/__tests__/appMenu.test.ts
+++ b/Composer/packages/electron-server/__tests__/appMenu.test.ts
@@ -52,7 +52,7 @@ describe('App menu', () => {
 
     // Help
     expect(menuTemplate[4].label).toBe('Help');
-    expect(menuTemplate[4].submenu.length).toBe(9);
+    expect(menuTemplate[4].submenu.length).toBe(10);
 
     expect(mockSetApplicationMenu).toHaveBeenCalledTimes(1);
   });
@@ -87,7 +87,7 @@ describe('App menu', () => {
 
     // Help
     expect(menuTemplate[5].label).toBe('Help');
-    expect(menuTemplate[5].submenu.length).toBe(9);
+    expect(menuTemplate[5].submenu.length).toBe(10);
 
     expect(mockSetApplicationMenu).toHaveBeenCalledTimes(1);
   });

--- a/Composer/packages/electron-server/__tests__/appMenu.test.ts
+++ b/Composer/packages/electron-server/__tests__/appMenu.test.ts
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { initAppMenu } from '../src/appMenu';
+
+const mockIsMac = jest.fn();
+jest.mock('../src/utility/platform', () => ({
+  isMac: () => mockIsMac(),
+}));
+
+const mockBuildFromTemplate = jest.fn();
+const mockSetApplicationMenu = jest.fn();
+jest.mock('electron', () => ({
+  app: {
+    name: 'Bot Framework Composer',
+  },
+  dialog: {},
+  Menu: {
+    buildFromTemplate: template => mockBuildFromTemplate(template),
+    setApplicationMenu: menu => mockSetApplicationMenu(menu),
+  },
+  shell: {},
+}));
+
+describe('App menu', () => {
+  beforeEach(() => {
+    mockBuildFromTemplate.mockClear();
+    mockSetApplicationMenu.mockClear();
+  });
+
+  it('should build the menu for windows / linux', () => {
+    mockIsMac.mockReturnValue(false);
+    initAppMenu();
+
+    expect(mockBuildFromTemplate).toHaveBeenCalledTimes(1);
+    const menuTemplate: any[] = mockBuildFromTemplate.mock.calls[0][0];
+    expect(menuTemplate.length).toBe(5); // File, Edit, View, Window, Help
+
+    // File
+    expect(menuTemplate[0].label).toBe('File');
+    expect(menuTemplate[0].submenu.length).toBe(1);
+
+    // Edit
+    expect(menuTemplate[1].label).toBe('Edit');
+    expect(menuTemplate[1].submenu.length).toBe(9);
+
+    // View
+    expect(menuTemplate[2].label).toBe('View');
+    expect(menuTemplate[2].submenu.length).toBe(7);
+
+    // Window
+    expect(menuTemplate[3].label).toBe('Window');
+    expect(menuTemplate[3].submenu.length).toBe(3);
+
+    // Help
+    expect(menuTemplate[4].label).toBe('Help');
+    expect(menuTemplate[4].submenu.length).toBe(8);
+
+    expect(mockSetApplicationMenu).toHaveBeenCalledTimes(1);
+  });
+
+  it('should build the menu for mac', () => {
+    mockIsMac.mockReturnValue(true);
+    initAppMenu();
+
+    expect(mockBuildFromTemplate).toHaveBeenCalledTimes(1);
+    const menuTemplate: any[] = mockBuildFromTemplate.mock.calls[0][0];
+    expect(menuTemplate.length).toBe(6); // App, File, Edit, View, Window, Help
+
+    // App
+    expect(menuTemplate[0].label).toBe('Bot Framework Composer');
+    expect(menuTemplate[0].submenu.length).toBe(9);
+
+    // File
+    expect(menuTemplate[1].label).toBe('File');
+    expect(menuTemplate[1].submenu.length).toBe(1);
+
+    // Edit
+    expect(menuTemplate[2].label).toBe('Edit');
+    expect(menuTemplate[2].submenu.length).toBe(9);
+
+    // View
+    expect(menuTemplate[3].label).toBe('View');
+    expect(menuTemplate[3].submenu.length).toBe(7);
+
+    // Window
+    expect(menuTemplate[4].label).toBe('Window');
+    expect(menuTemplate[4].submenu.length).toBe(6);
+
+    // Help
+    expect(menuTemplate[5].label).toBe('Help');
+    expect(menuTemplate[5].submenu.length).toBe(8);
+
+    expect(mockSetApplicationMenu).toHaveBeenCalledTimes(1);
+  });
+});

--- a/Composer/packages/electron-server/src/appMenu.ts
+++ b/Composer/packages/electron-server/src/appMenu.ts
@@ -9,17 +9,15 @@ function getAppMenu(): MenuItemConstructorOptions[] {
   if (isMac()) {
     return [
       {
-        label: app.name,
+        label: 'Bot Framework Composer',
         submenu: [
-          { role: 'about' },
-          { type: 'separator' },
           { role: 'services' },
           { type: 'separator' },
-          { role: 'hide' },
+          { label: 'Hide Bot Framework Composer', role: 'hide' },
           { role: 'hideOthers' },
           { role: 'unhide' },
           { type: 'separator' },
-          { role: 'quit' },
+          { label: 'Quit Bot Framework Composer', role: 'quit' },
         ],
       },
     ];
@@ -92,7 +90,13 @@ export function initAppMenu() {
       label: 'Help',
       submenu: [
         {
-          label: 'Learn More',
+          label: 'Documentation',
+          click: async () => {
+            await shell.openExternal('https://docs.microsoft.com/en-us/composer/');
+          },
+        },
+        {
+          label: 'Composer on GitHub',
           click: async () => {
             await shell.openExternal('https://github.com/microsoft/BotFramework-Composer/tree/master');
           },

--- a/Composer/packages/electron-server/src/appMenu.ts
+++ b/Composer/packages/electron-server/src/appMenu.ts
@@ -101,6 +101,12 @@ export function initAppMenu() {
             await shell.openExternal('https://github.com/microsoft/BotFramework-Composer/tree/master');
           },
         },
+        {
+          label: 'Learn More About Bot Framework',
+          click: async () => {
+            await shell.openExternal('https://dev.botframework.com/');
+          },
+        },
         { type: 'separator' },
         {
           label: 'Report an Issue',

--- a/Composer/packages/electron-server/src/appMenu.ts
+++ b/Composer/packages/electron-server/src/appMenu.ts
@@ -1,0 +1,146 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { app, dialog, Menu, MenuItemConstructorOptions, shell } from 'electron';
+
+import { isMac } from './utility/platform';
+
+function getAppMenu(): MenuItemConstructorOptions[] {
+  if (isMac()) {
+    return [
+      {
+        label: app.name,
+        submenu: [
+          { role: 'about' },
+          { type: 'separator' },
+          { role: 'services' },
+          { type: 'separator' },
+          { role: 'hide' },
+          { role: 'hideOthers' },
+          { role: 'unhide' },
+          { type: 'separator' },
+          { role: 'quit' },
+        ],
+      },
+    ];
+  }
+  return [];
+}
+
+function getRestOfEditMenu(): MenuItemConstructorOptions[] {
+  if (isMac()) {
+    return [
+      { role: 'delete' },
+      { type: 'separator' },
+      {
+        label: 'Speech',
+        submenu: [{ role: 'startSpeaking' }, { role: 'stopSpeaking' }],
+      },
+    ];
+  }
+  return [{ role: 'delete' }, { type: 'separator' }, { role: 'selectAll' }];
+}
+
+function getRestOfWindowMenu(): MenuItemConstructorOptions[] {
+  if (isMac()) {
+    return [{ type: 'separator' }, { role: 'front' }, { type: 'separator' }, { role: 'window' }];
+  }
+  return [{ role: 'close' }];
+}
+
+export function initAppMenu() {
+  const template: MenuItemConstructorOptions[] = [
+    // App (Mac)
+    ...getAppMenu(),
+    // File
+    {
+      label: 'File',
+      submenu: [isMac() ? { role: 'close' } : { role: 'quit' }],
+    },
+    // Edit
+    {
+      label: 'Edit',
+      submenu: [
+        { role: 'undo' },
+        { role: 'redo' },
+        { type: 'separator' },
+        { role: 'cut' },
+        { role: 'copy' },
+        { role: 'paste' },
+        ...getRestOfEditMenu(),
+      ],
+    },
+    // View
+    {
+      label: 'View',
+      submenu: [
+        { role: 'toggleDevTools' },
+        { type: 'separator' },
+        { role: 'resetZoom' },
+        { role: 'zoomIn' },
+        { role: 'zoomOut' },
+        { type: 'separator' },
+        { role: 'togglefullscreen' },
+      ],
+    },
+    // Window
+    {
+      label: 'Window',
+      submenu: [{ role: 'minimize' }, { role: 'zoom' }, ...getRestOfWindowMenu()],
+    },
+    {
+      label: 'Help',
+      submenu: [
+        {
+          label: 'Learn More',
+          click: async () => {
+            await shell.openExternal('https://github.com/microsoft/BotFramework-Composer/tree/master');
+          },
+        },
+        { type: 'separator' },
+        {
+          label: 'Report an Issue',
+          click: async () => {
+            await shell.openExternal('https://github.com/microsoft/BotFramework-Composer/issues/new/choose');
+          },
+        },
+        { type: 'separator' },
+        {
+          label: 'View License',
+          click: async () => {
+            await shell.openExternal('https://github.com/microsoft/BotFramework-Composer/blob/master/LICENSE.md');
+          },
+        },
+        {
+          label: 'Privacy Statement',
+          click: async () => {
+            await shell.openExternal('https://github.com/microsoft/BotFramework-Composer/blob/master/PRIVACY.md');
+          },
+        },
+        { type: 'separator' },
+        {
+          label: 'About',
+          click: async () => {
+            // show dialog with name and version
+            dialog.showMessageBox({
+              title: 'Bot Framework Composer',
+              message: `
+                Bot Framework Composer
+                
+                Version:  ${app.getVersion()}
+                Electron: ${process.versions.electron}
+                Chrome: ${process.versions.chrome}
+                NodeJS: ${process.versions.node}
+                V8: ${process.versions.v8}
+              `,
+              type: 'info',
+            });
+          },
+        },
+      ],
+    },
+  ];
+
+  const menu = Menu.buildFromTemplate(template);
+  Menu.setApplicationMenu(menu);
+}

--- a/Composer/packages/electron-server/src/main.ts
+++ b/Composer/packages/electron-server/src/main.ts
@@ -16,6 +16,7 @@ import log from './utility/logger';
 import { AppUpdater } from './appUpdater';
 import { parseDeepLinkUrl } from './utility/url';
 import { composerProtocol } from './constants';
+import { initAppMenu } from './appMenu';
 
 const error = log.extend('error');
 const baseUrl = isDevelopment ? 'http://localhost:3000/' : 'http://localhost:5000/';
@@ -96,6 +97,7 @@ async function loadServer() {
 }
 
 async function main() {
+  initAppMenu();
   const mainWindow = ElectronWindow.getInstance().browserWindow;
   if (mainWindow) {
     if (process.env.COMPOSER_DEV_TOOLS) {

--- a/Composer/packages/lib/code-editor/src/BaseEditor.tsx
+++ b/Composer/packages/lib/code-editor/src/BaseEditor.tsx
@@ -223,7 +223,7 @@ const BaseEditor: React.FC<BaseEditorProps> = props => {
       {(hasError || hasWarning) && (
         <MessageBar
           messageBarType={hasError ? MessageBarType.error : hasWarning ? MessageBarType.warning : MessageBarType.info}
-          isMultiline={false}
+          isMultiline={true}
           dismissButtonAriaLabel={formatMessage('Close')}
           overflowButtonAriaLabel={formatMessage('See more')}
         >


### PR DESCRIPTION
## Description

> Currently we do not set the application menu, so Electron uses the default menu which contains links to Electron documentation.

This PR addresses that and explicitly sets the menu so that it only contains info / functionality relevant to Composer and not Electron.

## Task Item

closes #2832 

## Screenshots

### Windows

**File**

![image](https://user-images.githubusercontent.com/3452012/80631448-93ab3b00-8a0a-11ea-8599-ad1a3030f605.png)

**Edit**

![image](https://user-images.githubusercontent.com/3452012/80631470-9e65d000-8a0a-11ea-89d3-96848a7d9e00.png)

**View**

![image](https://user-images.githubusercontent.com/3452012/80631516-afaedc80-8a0a-11ea-9e0c-2e18a6572876.png)

**Window**

![image](https://user-images.githubusercontent.com/3452012/80631586-cbb27e00-8a0a-11ea-9207-e7077a609eff.png)


**Help**

![image](https://user-images.githubusercontent.com/3452012/80631602-d40ab900-8a0a-11ea-91c7-239322695141.png)


### Linux

**File**

![image](https://user-images.githubusercontent.com/3452012/80632571-5051cc00-8a0c-11ea-985d-1401d55142bd.png)

**Edit**

![image](https://user-images.githubusercontent.com/3452012/80632656-6cee0400-8a0c-11ea-91d8-e684909a90ad.png)


**View**'

![image](https://user-images.githubusercontent.com/3452012/80632706-7d9e7a00-8a0c-11ea-8d02-2f910527d31b.png)


**Window**

![image](https://user-images.githubusercontent.com/3452012/80632732-87c07880-8a0c-11ea-9741-7ef5e995066f.png)


**Help**

![image](https://user-images.githubusercontent.com/3452012/80632753-9018b380-8a0c-11ea-875d-174d889af444.png)


### Mac

I don't have a Mac, but feel free to add screen shots if you test it out!