### PR TITLE
feat: Copy boilerplate material into new bot projects

### DIFF
--- a/Composer/packages/server/assets/shared/README.md
+++ b/Composer/packages/server/assets/shared/README.md
@@ -1,0 +1,6 @@
+This folder contains a Bot Project created with Bot Framework Composer.
+
+The full documentation for Composer lives here:
+https://github.com/microsoft/botframework-composer
+
+To test this bot locally, open this folder in Composer, then click "Start Bot"

--- a/Composer/packages/server/assets/shared/scripts/test.js
+++ b/Composer/packages/server/assets/shared/scripts/test.js
@@ -1,0 +1,1 @@
+console.log('hello world');

--- a/Composer/packages/server/assets/shared/scripts/test.js
+++ b/Composer/packages/server/assets/shared/scripts/test.js
@@ -1,1 +1,0 @@
-console.log('hello world');

--- a/Composer/packages/server/src/controllers/project.ts
+++ b/Composer/packages/server/src/controllers/project.ts
@@ -48,6 +48,10 @@ async function createProject(req: Request, res: Response) {
     const newProjRef = await AssectService.manager.copyProjectTemplateTo(templateId, locationRef, user);
     const id = await BotProjectService.openProject(newProjRef, user);
     const currentProject = await BotProjectService.getProjectById(id, user);
+
+    // inject shared content into every new project.  this comes from assets/shared
+    await AssectService.manager.copyBoilerplate(currentProject.dataDir, currentProject.fileStorage);
+
     if (currentProject !== undefined) {
       await currentProject.updateBotInfo(name, description);
       if (schemaUrl) {

--- a/Composer/packages/server/src/models/asset/assetManager.ts
+++ b/Composer/packages/server/src/models/asset/assetManager.ts
@@ -160,6 +160,15 @@ export class AssetManager {
     return output;
   }
 
+  // Copy material from the boilerplate into the project
+  // This is used to copy shared content into every new project
+  public async copyBoilerplate(dstDir: string, dstStorage: IFileStorage) {
+    const boilerplatePath = Path.join(this.assetsLibraryPath, 'shared');
+    if (await this.templateStorage.exists(boilerplatePath)) {
+      await copyDir(boilerplatePath, this.templateStorage, dstDir, dstStorage);
+    }
+  }
+
   public async copyDataFilesTo(templateId: string, dstDir: string, dstStorage: IFileStorage) {
     const template = find(this.projectTemplates, { id: templateId });
     if (template === undefined || template.path === undefined) {


### PR DESCRIPTION
## Description
This introduces a step in the bot project creation process that copies a set of files from the `assets/shared` folder into the project.

This will be used to copy the new provisioning script into the projects so they can be provisioned and deployed without first requiring a full eject.

Currently the shared assets include just a README file with a link to the Composer repo. However, this file will soon include instructions on using the provisioning tool and the publishing tool inside Composer to provision and deploy the bot to Azure.

I wanted to do this as a clean PR, but this is needed to finish #2733 


## Task Item
Closes #2451 
