### PR TITLE
fix: Fixed unset electron production flag.

### DIFF
--- a/Composer/packages/electron-server/src/main.ts
+++ b/Composer/packages/electron-server/src/main.ts
@@ -32,6 +32,12 @@ const getBaseUrl = () => {
   return `http://localhost:${serverPort}/`;
 };
 
+// set production flag
+if (app.isPackaged) {
+  process.env.NODE_ENV = 'production';
+}
+log(`${process.env.NODE_ENV} environment detected.`);
+
 function processArgsForWindows(args: string[]): string {
   const deepLinkUrl = args.find(arg => arg.startsWith(composerProtocol));
   if (deepLinkUrl) {

--- a/Composer/packages/electron-server/src/utility/logger.ts
+++ b/Composer/packages/electron-server/src/utility/logger.ts
@@ -3,4 +3,4 @@
 
 import debug from 'debug';
 
-export default debug('composer');
+export default debug('composer:electron');


### PR DESCRIPTION
## Description

The `NODE_ENV` env variable was expected to be set to `production` when executing the packaged Composer Electron app, but it was not being set. This was breaking some production functionality such as dynamically finding an open port to mount the server on.

## Task Item

fixes #2770 

