### PR TITLE
feat: Copy skill manifests to static files

### DIFF
--- a/Composer/packages/client/src/store/persistence/FilePersistence.ts
+++ b/Composer/packages/client/src/store/persistence/FilePersistence.ts
@@ -21,9 +21,9 @@ const actionType2ChangeType = {
   [ActionTypes.UPDATE_LU]: { changeType: ChangeType.UPDATE, fileExtension: FileExtensions.Lu },
   [ActionTypes.CREATE_LU]: { changeType: ChangeType.CREATE, fileExtension: FileExtensions.Lu },
   [ActionTypes.REMOVE_LU]: { changeType: ChangeType.DELETE, fileExtension: FileExtensions.Lu },
-  [ActionTypes.CREATE_SKILL_MANIFEST]: { changeType: ChangeType.CREATE, fileType: FileExtensions.Manifest },
-  [ActionTypes.REMOVE_SKILL_MANIFEST]: { changeType: ChangeType.DELETE, fileType: FileExtensions.Manifest },
-  [ActionTypes.UPDATE_SKILL_MANIFEST]: { changeType: ChangeType.UPDATE, fileType: FileExtensions.Manifest },
+  [ActionTypes.CREATE_SKILL_MANIFEST]: { changeType: ChangeType.CREATE, fileExtension: FileExtensions.Manifest },
+  [ActionTypes.REMOVE_SKILL_MANIFEST]: { changeType: ChangeType.DELETE, fileExtension: FileExtensions.Manifest },
+  [ActionTypes.UPDATE_SKILL_MANIFEST]: { changeType: ChangeType.UPDATE, fileExtension: FileExtensions.Manifest },
 };
 
 class FilePersistence {

--- a/Composer/plugins/localPublish/src/index.ts
+++ b/Composer/plugins/localPublish/src/index.ts
@@ -59,6 +59,7 @@ class LocalPublisher implements PublishPlugin<PublishConfig> {
       this.composer.log('Using managed runtime');
       await this.initBot(botId);
       await this.saveContent(botId, version, project.dataDir, user);
+      await this.saveSkillManifests(botId, project.dataDir);
     } else if (!project.settings.runtime.path || !project.settings.runtime.command) {
       return {
         status: 400,
@@ -121,6 +122,10 @@ class LocalPublisher implements PublishPlugin<PublishConfig> {
 
   private getHistoryDir = (botId: string) => path.resolve(this.getBotDir(botId), 'history');
 
+  private getManifestSrcDir = (srcDir: string) =>  path.resolve(srcDir, 'skill-manifests');
+
+  private getManifestDstDir = (botId: string) => path.resolve(this.getBotRuntimeDir(botId), 'wwwroot', 'skill-manifests');
+
   private getDownloadPath = (botId: string, version: string) =>
     path.resolve(this.getHistoryDir(botId), `${version}.zip`);
 
@@ -175,6 +180,19 @@ class LocalPublisher implements PublishPlugin<PublishConfig> {
     const dstPath = this.getDownloadPath(botId, version);
     await this.zipBot(dstPath, srcDir);
   };
+
+  private saveSkillManifests = async (botId: string, srcDir: string) => {
+    const manifestSrcDir = this.getManifestSrcDir(srcDir);
+    const manifestDstDir = this.getManifestDstDir(botId);
+
+    if (await this.dirExist(manifestDstDir)) {
+      await rmDir(manifestDstDir);
+    }
+
+    if (await this.dirExist(manifestSrcDir)) {
+      this.copyDir(manifestSrcDir, manifestDstDir);
+    }
+  }
 
   // start bot in current version
   private setBot = async (botId: string, version: string, settings: any, project: any = undefined) => {


### PR DESCRIPTION
## Description
Copied the `skill-manifests` directory to the runtime's wwwroot directory when the bot is publish locally, which makes the manifest available at `http://localhost:3979/skill-manifests/*`.

## Task
Closes #2327
