### PR TITLE
fix: prevent infinite render loop

### DIFF
--- a/Composer/packages/extensions/adaptive-form/src/utils/__tests__/getUIOptions.test.ts
+++ b/Composer/packages/extensions/adaptive-form/src/utils/__tests__/getUIOptions.test.ts
@@ -19,7 +19,11 @@ describe('getUIOptions', () => {
         },
       },
     };
-    expect(getUIOptions(schema)).toMatchInlineSnapshot(`Object {}`);
+    expect(getUIOptions(schema)).toMatchInlineSnapshot(`
+Object {
+  "field": undefined,
+}
+`);
   });
 
   it('merges overrides into default schema', () => {
@@ -39,6 +43,7 @@ describe('getUIOptions', () => {
     };
     expect(getUIOptions(schema, uiSchema)).toMatchInlineSnapshot(`
 Object {
+  "field": undefined,
   "label": "First Label",
   "order": Array [
     "*",
@@ -73,6 +78,7 @@ Object {
 
     expect(getUIOptions(schema, uiSchema, plugin)).toMatchInlineSnapshot(`
 Object {
+  "field": undefined,
   "helpLink": "https://example.com/plugin",
   "label": "First Label",
   "order": Array [

--- a/Composer/packages/extensions/adaptive-form/src/utils/getUIOptions.ts
+++ b/Composer/packages/extensions/adaptive-form/src/utils/getUIOptions.ts
@@ -13,5 +13,7 @@ export function getUIOptions(schema?: JSONSchema7, uiSchema?: UISchema, roleSche
   const formOptions = uiSchema && kind && uiSchema[kind] ? uiSchema[kind] : {};
   const roleOptions = roleSchema && $role && roleSchema[$role] ? roleSchema[$role] : {};
 
-  return { ...roleOptions, ...formOptions };
+  // remove the field from the role schema
+  const combined = { ...roleOptions, field: undefined, ...formOptions };
+  return combined;
 }


### PR DESCRIPTION
## Description

Fixes an issue where opening HTTPRequest or ConfirmInput results in a browser crash.

## Task Item

fixes #2867 
