### PR TITLE
fix: simplify viewitem.en-us.lg

### DIFF
--- a/Composer/packages/server/assets/projects/ToDoBotWithLuisSample/dialogs/viewitem/language-generation/en-us/viewitem.en-us.lg
+++ b/Composer/packages/server/assets/projects/ToDoBotWithLuisSample/dialogs/viewitem/language-generation/en-us/viewitem.en-us.lg
@@ -16,14 +16,9 @@
         - ${list(user.lists.shopping, 'shopping')}
     - DEFAULT : 
         - ```
-## Todo list
-${list(user.lists.todo, 'todo')}
-
-## Grocery list
-${list(user.lists.grocery, 'grocery')}
-
-## Shopping list
-${list(user.lists.shopping, 'shopping')}
+        ${list(user.lists.todo, 'todo')}
+        ${list(user.lists.grocery, 'grocery')}
+        ${list(user.lists.shopping, 'shopping')}
         ```
 
 # list(collection, name)


### PR DESCRIPTION
## Description

Some of the lines in viewitem.en-us.lg start with ##, which seems to throw off the parser - it wanted to read those as templates instead of as a continuation of a ```-demarked block. This fix just reformats that message without the ## marks; if we wanted a more complete fix that would work in all cases, I think that would take a bigger change to the parser itself.

## Task Item

fixes #2859
