### PR TITLE
fix: unable to clear form title

### DIFF
--- a/Composer/packages/client/src/pages/design/PropertyEditor.tsx
+++ b/Composer/packages/client/src/pages/design/PropertyEditor.tsx
@@ -122,12 +122,7 @@ const PropertyEditor: React.FC = () => {
       }}
       onResizeStop={handleResize}
     >
-      <div
-        css={formEditor}
-        aria-label={formatMessage('form editor')}
-        data-testid="PropertyEditor"
-        key={shellData.focusPath}
-      >
+      <div css={formEditor} aria-label={formatMessage('form editor')} data-testid="PropertyEditor">
         <Extension shell={shellApi} shellData={shellData} plugins={plugins}>
           <AdaptiveForm
             errors={errors}

--- a/Composer/packages/client/src/pages/design/PropertyEditor.tsx
+++ b/Composer/packages/client/src/pages/design/PropertyEditor.tsx
@@ -106,10 +106,6 @@ const PropertyEditor: React.FC = () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const handleDataChange = (newData?: any) => {
     setLocalData(newData);
-
-    if (!isEqual(formData, newData)) {
-      shellApi.saveData(newData, focusedSteps[0]);
-    }
   };
 
   return (

--- a/Composer/packages/client/src/pages/design/index.tsx
+++ b/Composer/packages/client/src/pages/design/index.tsx
@@ -85,7 +85,7 @@ const getTabFromFragment = () => {
 const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: string }>> = props => {
   const { state, actions } = useContext(StoreContext);
   const visualPanelRef: React.RefObject<HTMLDivElement> = useRef<HTMLDivElement>(null);
-  const { dialogs, designPageLocation, breadcrumb, visualEditorSelection, projectId, schemas } = state;
+  const { dialogs, designPageLocation, breadcrumb, visualEditorSelection, projectId, schemas, focusPath } = state;
   const {
     removeDialog,
     setDesignPageLocation,
@@ -424,7 +424,7 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
                   <VisualEditor openNewTriggerModal={openNewTriggerModal} />
                 )}
               </div>
-              <PropertyEditor />
+              <PropertyEditor key={focusPath} />
             </div>
           </Conversation>
         </div>

--- a/Composer/packages/extensions/adaptive-form/src/components/AdaptiveForm/FormTitle.tsx
+++ b/Composer/packages/extensions/adaptive-form/src/components/AdaptiveForm/FormTitle.tsx
@@ -3,11 +3,10 @@
 
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { FontWeights } from '@uifabric/styling';
 import { FontSizes } from '@uifabric/fluent-theme';
 import { Link } from 'office-ui-fabric-react/lib/Link';
-import startCase from 'lodash/startCase';
 import formatMessage from 'format-message';
 import { UIOptions, JSONSchema7 } from '@bfc/extension';
 
@@ -19,35 +18,32 @@ interface FormTitleProps {
   description?: string;
   formData: any;
   id: string;
-  name?: string;
-  onChange?: (data: any) => void;
+  onChange: ($designer: object) => void;
   schema: JSONSchema7;
   title?: string;
   uiOptions?: UIOptions;
 }
 
 const FormTitle: React.FC<FormTitleProps> = props => {
-  const { name, description, schema, formData, uiOptions = {} } = props;
+  const { description, schema, formData, uiOptions = {} } = props;
 
   const handleTitleChange = (newTitle?: string): void => {
-    if (props.onChange) {
-      props.onChange({
-        ...formData.$designer,
-        name: newTitle,
-      });
-    }
+    props.onChange({
+      ...formData.$designer,
+      name: newTitle,
+    });
   };
 
   const uiLabel = typeof uiOptions?.label === 'function' ? uiOptions.label(formData) : uiOptions.label;
   const uiSubtitle = typeof uiOptions?.subtitle === 'function' ? uiOptions.subtitle(formData) : uiOptions.subtitle;
-  const getTitle = (): string => {
+  const initialValue = useMemo(() => {
     const designerName = formData.$designer?.name;
 
-    return designerName || uiLabel || schema.title || startCase(name);
-  };
+    return designerName || uiLabel || schema.title;
+  }, [formData.$designer?.name, uiLabel, schema.title]);
 
   const getHelpLinkLabel = (): string => {
-    return (uiLabel || schema.title || startCase(name) || '').toLowerCase();
+    return (uiLabel || schema.title || '').toLowerCase();
   };
 
   const getSubTitle = (): string => {
@@ -86,7 +82,7 @@ const FormTitle: React.FC<FormTitleProps> = props => {
             root: { margin: '5px 0 7px -9px' },
           }}
           uiOptions={{}}
-          value={getTitle()}
+          value={initialValue}
           onChange={handleTitleChange}
           ariaLabel={formatMessage('form title')}
         />

--- a/Composer/packages/extensions/adaptive-form/src/components/AdaptiveForm/FormTitle.tsx
+++ b/Composer/packages/extensions/adaptive-form/src/components/AdaptiveForm/FormTitle.tsx
@@ -47,7 +47,7 @@ const FormTitle: React.FC<FormTitleProps> = props => {
   };
 
   const getSubTitle = (): string => {
-    return uiSubtitle || formData.$kind;
+    return uiSubtitle || uiLabel || formData.$kind;
   };
 
   const getDescription = (): string => {

--- a/Composer/packages/extensions/adaptive-form/src/components/AdaptiveForm/FormTitle.tsx
+++ b/Composer/packages/extensions/adaptive-form/src/components/AdaptiveForm/FormTitle.tsx
@@ -47,7 +47,7 @@ const FormTitle: React.FC<FormTitleProps> = props => {
   };
 
   const getSubTitle = (): string => {
-    return uiSubtitle || uiLabel || formData.$kind;
+    return uiSubtitle || formData.$kind;
   };
 
   const getDescription = (): string => {

--- a/Composer/packages/extensions/adaptive-form/src/defaultUiSchema.ts
+++ b/Composer/packages/extensions/adaptive-form/src/defaultUiSchema.ts
@@ -256,7 +256,7 @@ const DefaultUISchema: UISchema = {
     order: ['dialog', 'options', 'includeActivity', '*'],
   },
   [SDKKinds.SendActivity]: {
-    label: () => formatMessage('Send an Activity'),
+    label: () => formatMessage('Send a response'),
     helpLink: 'https://aka.ms/bfc-send-activity',
     order: ['activity', '*'],
   },

--- a/Composer/packages/extensions/adaptive-form/src/defaultUiSchema.ts
+++ b/Composer/packages/extensions/adaptive-form/src/defaultUiSchema.ts
@@ -39,7 +39,6 @@ const DefaultUISchema: UISchema = {
   },
   [SDKKinds.OnCancelDialog]: {
     label: () => formatMessage('Dialog cancelled'),
-    subtitle: () => formatMessage('Cancel dialog event'),
   },
   [SDKKinds.CancelAllDialogs]: {
     label: () => formatMessage('Cancel All Dialogs'),
@@ -132,23 +131,19 @@ const DefaultUISchema: UISchema = {
   [SDKKinds.OnActivity]: {
     ...triggerUiSchema,
     label: () => formatMessage('Activities'),
-    subtitle: () => formatMessage('Activity recieved'),
   },
   [SDKKinds.OnBeginDialog]: {
     ...triggerUiSchema,
     label: () => formatMessage('Dialog started'),
-    subtitle: () => formatMessage('Begin dialog event'),
   },
   [SDKKinds.OnCancelDialog]: { ...triggerUiSchema },
   [SDKKinds.OnCondition]: {
     ...triggerUiSchema,
     label: () => formatMessage('Handle a condition'),
-    subtitle: () => formatMessage('Condition'),
   },
   [SDKKinds.OnConversationUpdateActivity]: {
     ...triggerUiSchema,
     label: () => formatMessage('Greeting'),
-    subtitle: () => formatMessage('ConversationUpdate activity'),
     description: () => formatMessage('Handle the events fired when a user begins a new conversation with the bot.'),
     helpLink:
       'https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-conversations?view=azure-bot-service-4.0#conversation-lifetime',
@@ -156,36 +151,29 @@ const DefaultUISchema: UISchema = {
   [SDKKinds.OnCustomEvent]: {
     ...triggerUiSchema,
     label: () => formatMessage('Handle an Event'),
-    subtitle: () => formatMessage('Custom event'),
   },
   [SDKKinds.OnDialogEvent]: {
     ...triggerUiSchema,
     label: () => formatMessage('Dialog events'),
-    subtitle: () => formatMessage('Dialog event'),
   },
   [SDKKinds.OnEndOfConversationActivity]: {
     ...triggerUiSchema,
     label: () => formatMessage('Conversation ended'),
-    subtitle: () => formatMessage('EndOfConversation activity'),
   },
   [SDKKinds.OnError]: {
     ...triggerUiSchema,
     label: () => formatMessage('Error occurred'),
-    subtitle: () => formatMessage('Error event'),
   },
   [SDKKinds.OnEventActivity]: {
     ...triggerUiSchema,
     label: () => formatMessage('Event received'),
-    subtitle: () => formatMessage('Event activity'),
   },
   [SDKKinds.OnHandoffActivity]: {
     ...triggerUiSchema,
     label: () => formatMessage('Handover to human'),
-    subtitle: () => formatMessage('Handoff activity'),
   },
   [SDKKinds.OnIntent]: {
     label: () => formatMessage('Intent recognized'),
-    subtitle: () => formatMessage('Intent recognized'),
     order: ['intent', 'condition', 'entities', '*'],
     hidden: ['actions'],
     properties: {
@@ -197,42 +185,34 @@ const DefaultUISchema: UISchema = {
   [SDKKinds.OnInvokeActivity]: {
     ...triggerUiSchema,
     label: () => formatMessage('Conversation invoked'),
-    subtitle: () => formatMessage('Invoke activity'),
   },
   [SDKKinds.OnMessageActivity]: {
     ...triggerUiSchema,
     label: () => formatMessage('Message recieved'),
-    subtitle: () => formatMessage('Message recieved activity'),
   },
   [SDKKinds.OnMessageDeleteActivity]: {
     ...triggerUiSchema,
     label: () => formatMessage('Message deleted'),
-    subtitle: () => formatMessage('Message deleted activity'),
   },
   [SDKKinds.OnMessageReactionActivity]: {
     ...triggerUiSchema,
     label: () => formatMessage('Message reaction'),
-    subtitle: () => formatMessage('Message reaction activity'),
   },
   [SDKKinds.OnMessageUpdateActivity]: {
     ...triggerUiSchema,
     label: () => formatMessage('Message updated'),
-    subtitle: () => formatMessage('Message updated activity'),
   },
   [SDKKinds.OnRepromptDialog]: {
     ...triggerUiSchema,
     label: () => formatMessage('Re-prompt for input'),
-    subtitle: () => formatMessage('Reprompt dialog event'),
   },
   [SDKKinds.OnTypingActivity]: {
     ...triggerUiSchema,
     label: () => formatMessage('User is typing'),
-    subtitle: () => formatMessage('Typing activity'),
   },
   [SDKKinds.OnUnknownIntent]: {
     ...triggerUiSchema,
     label: () => formatMessage('Unknown intent'),
-    subtitle: () => formatMessage('Unknown intent recognized'),
   },
   [SDKKinds.QnAMakerDialog]: {
     label: () => formatMessage('QnAMakerDialog'),

--- a/Composer/packages/extensions/adaptive-form/src/defaultUiSchema.ts
+++ b/Composer/packages/extensions/adaptive-form/src/defaultUiSchema.ts
@@ -39,6 +39,7 @@ const DefaultUISchema: UISchema = {
   },
   [SDKKinds.OnCancelDialog]: {
     label: () => formatMessage('Dialog cancelled'),
+    subtitle: () => formatMessage('Cancel dialog event'),
   },
   [SDKKinds.CancelAllDialogs]: {
     label: () => formatMessage('Cancel All Dialogs'),
@@ -131,19 +132,23 @@ const DefaultUISchema: UISchema = {
   [SDKKinds.OnActivity]: {
     ...triggerUiSchema,
     label: () => formatMessage('Activities'),
+    subtitle: () => formatMessage('Activity recieved'),
   },
   [SDKKinds.OnBeginDialog]: {
     ...triggerUiSchema,
     label: () => formatMessage('Dialog started'),
+    subtitle: () => formatMessage('Begin dialog event'),
   },
   [SDKKinds.OnCancelDialog]: { ...triggerUiSchema },
   [SDKKinds.OnCondition]: {
     ...triggerUiSchema,
     label: () => formatMessage('Handle a condition'),
+    subtitle: () => formatMessage('Condition'),
   },
   [SDKKinds.OnConversationUpdateActivity]: {
     ...triggerUiSchema,
     label: () => formatMessage('Greeting'),
+    subtitle: () => formatMessage('ConversationUpdate activity'),
     description: () => formatMessage('Handle the events fired when a user begins a new conversation with the bot.'),
     helpLink:
       'https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-conversations?view=azure-bot-service-4.0#conversation-lifetime',
@@ -151,29 +156,36 @@ const DefaultUISchema: UISchema = {
   [SDKKinds.OnCustomEvent]: {
     ...triggerUiSchema,
     label: () => formatMessage('Handle an Event'),
+    subtitle: () => formatMessage('Custom event'),
   },
   [SDKKinds.OnDialogEvent]: {
     ...triggerUiSchema,
     label: () => formatMessage('Dialog events'),
+    subtitle: () => formatMessage('Dialog event'),
   },
   [SDKKinds.OnEndOfConversationActivity]: {
     ...triggerUiSchema,
     label: () => formatMessage('Conversation ended'),
+    subtitle: () => formatMessage('EndOfConversation activity'),
   },
   [SDKKinds.OnError]: {
     ...triggerUiSchema,
     label: () => formatMessage('Error occurred'),
+    subtitle: () => formatMessage('Error event'),
   },
   [SDKKinds.OnEventActivity]: {
     ...triggerUiSchema,
     label: () => formatMessage('Event received'),
+    subtitle: () => formatMessage('Event activity'),
   },
   [SDKKinds.OnHandoffActivity]: {
     ...triggerUiSchema,
     label: () => formatMessage('Handover to human'),
+    subtitle: () => formatMessage('Handoff activity'),
   },
   [SDKKinds.OnIntent]: {
     label: () => formatMessage('Intent recognized'),
+    subtitle: () => formatMessage('Intent recognized'),
     order: ['intent', 'condition', 'entities', '*'],
     hidden: ['actions'],
     properties: {
@@ -185,34 +197,42 @@ const DefaultUISchema: UISchema = {
   [SDKKinds.OnInvokeActivity]: {
     ...triggerUiSchema,
     label: () => formatMessage('Conversation invoked'),
+    subtitle: () => formatMessage('Invoke activity'),
   },
   [SDKKinds.OnMessageActivity]: {
     ...triggerUiSchema,
     label: () => formatMessage('Message recieved'),
+    subtitle: () => formatMessage('Message recieved activity'),
   },
   [SDKKinds.OnMessageDeleteActivity]: {
     ...triggerUiSchema,
     label: () => formatMessage('Message deleted'),
+    subtitle: () => formatMessage('Message deleted activity'),
   },
   [SDKKinds.OnMessageReactionActivity]: {
     ...triggerUiSchema,
     label: () => formatMessage('Message reaction'),
+    subtitle: () => formatMessage('Message reaction activity'),
   },
   [SDKKinds.OnMessageUpdateActivity]: {
     ...triggerUiSchema,
     label: () => formatMessage('Message updated'),
+    subtitle: () => formatMessage('Message updated activity'),
   },
   [SDKKinds.OnRepromptDialog]: {
     ...triggerUiSchema,
     label: () => formatMessage('Re-prompt for input'),
+    subtitle: () => formatMessage('Reprompt dialog event'),
   },
   [SDKKinds.OnTypingActivity]: {
     ...triggerUiSchema,
     label: () => formatMessage('User is typing'),
+    subtitle: () => formatMessage('Typing activity'),
   },
   [SDKKinds.OnUnknownIntent]: {
     ...triggerUiSchema,
     label: () => formatMessage('Unknown intent'),
+    subtitle: () => formatMessage('Unknown intent recognized'),
   },
   [SDKKinds.QnAMakerDialog]: {
     label: () => formatMessage('QnAMakerDialog'),

--- a/Composer/packages/extensions/adaptive-form/src/utils/__tests__/mergePluginConfigs.test.ts
+++ b/Composer/packages/extensions/adaptive-form/src/utils/__tests__/mergePluginConfigs.test.ts
@@ -37,482 +37,463 @@ describe('mergePluginConfigs', () => {
     };
 
     expect(mergePluginConfigs(overrides)).toMatchInlineSnapshot(`
-Object {
-  "formSchema": Object {
-    "Microsoft.AdaptiveDialog": Object {
-      "description": [Function],
-      "helpLink": "https://aka.ms/botframework",
-      "hidden": Array [
-        "recognizer",
-      ],
-      "label": "Adaptive dialog",
-      "order": Array [
-        "recognizer",
-        "*",
-      ],
-      "properties": Object {
-        "recognizer": Object {
-          "description": [Function],
-          "label": [Function],
+      Object {
+        "formSchema": Object {
+          "Microsoft.AdaptiveDialog": Object {
+            "description": [Function],
+            "helpLink": "https://aka.ms/botframework",
+            "hidden": Array [
+              "recognizer",
+            ],
+            "label": "Adaptive dialog",
+            "order": Array [
+              "recognizer",
+              "*",
+            ],
+            "properties": Object {
+              "recognizer": Object {
+                "description": [Function],
+                "label": [Function],
+              },
+              "triggers": Object {
+                "label": "Foo",
+              },
+            },
+          },
+          "Microsoft.AttachmentInput": Object {
+            "helpLink": "https://aka.ms/bfc-ask-for-user-input",
+            "label": "Prompt for Attachment",
+          },
+          "Microsoft.BeginDialog": Object {
+            "helpLink": "https://aka.ms/bfc-understanding-dialogs",
+            "label": "Begin a Dialog",
+            "order": Array [
+              "dialog",
+              "options",
+              "resultProperty",
+              "includeActivity",
+              "*",
+            ],
+          },
+          "Microsoft.BreakLoop": Object {
+            "label": [Function],
+          },
+          "Microsoft.CancelAllDialogs": Object {
+            "helpLink": "https://aka.ms/bfc-understanding-dialogs",
+            "label": [Function],
+            "order": Array [
+              "dialog",
+              "property",
+              "*",
+            ],
+          },
+          "Microsoft.ChoiceInput": Object {
+            "helpLink": "https://aka.ms/bfc-ask-for-user-input",
+            "label": [Function],
+          },
+          "Microsoft.ConfirmInput": Object {
+            "helpLink": "https://aka.ms/bfc-ask-for-user-input",
+            "label": [Function],
+          },
+          "Microsoft.ContinueLoop": Object {
+            "label": [Function],
+          },
+          "Microsoft.DateTimeInput": Object {
+            "helpLink": "https://aka.ms/bfc-ask-for-user-input",
+            "label": [Function],
+          },
+          "Microsoft.DebugBreak": Object {
+            "label": [Function],
+          },
+          "Microsoft.DeleteProperties": Object {
+            "helpLink": "https://aka.ms/bfc-using-memory",
+            "label": [Function],
+          },
+          "Microsoft.DeleteProperty": Object {
+            "helpLink": "https://aka.ms/bfc-using-memory",
+            "label": [Function],
+          },
+          "Microsoft.EditActions": Object {
+            "label": [Function],
+          },
+          "Microsoft.EditArray": Object {
+            "helpLink": "https://aka.ms/bfc-using-memory",
+            "label": [Function],
+          },
+          "Microsoft.EmitEvent": Object {
+            "helpLink": "https://aka.ms/bfc-custom-events",
+            "label": [Function],
+          },
+          "Microsoft.EndDialog": Object {
+            "helpLink": "https://aka.ms/bfc-understanding-dialogs",
+            "label": [Function],
+          },
+          "Microsoft.EndTurn": Object {
+            "helpLink": "https://aka.ms/bfc-understanding-dialogs",
+            "label": [Function],
+          },
+          "Microsoft.Foreach": Object {
+            "helpLink": "https://aka.ms/bfc-controlling-conversation-flow",
+            "hidden": Array [
+              "actions",
+            ],
+            "label": [Function],
+            "order": Array [
+              "itemsProperty",
+              "*",
+            ],
+          },
+          "Microsoft.ForeachPage": Object {
+            "helpLink": "https://aka.ms/bfc-controlling-conversation-flow",
+            "hidden": Array [
+              "actions",
+            ],
+            "label": [Function],
+            "order": Array [
+              "itemsProperty",
+              "pageSize",
+              "*",
+            ],
+          },
+          "Microsoft.HttpRequest": Object {
+            "helpLink": "https://aka.ms/bfc-using-http",
+            "label": [Function],
+            "order": Array [
+              "method",
+              "url",
+              "body",
+              "headers",
+              "*",
+            ],
+          },
+          "Microsoft.IRecognizer": Object {
+            "field": [Function],
+            "helpLink": "https://aka.ms/BFC-Using-LU",
+          },
+          "Microsoft.IfCondition": Object {
+            "helpLink": "https://aka.ms/bfc-controlling-conversation-flow",
+            "hidden": Array [
+              "actions",
+              "elseActions",
+            ],
+            "label": [Function],
+          },
+          "Microsoft.LogAction": Object {
+            "helpLink": "https://aka.ms/bfc-debugging-bots",
+            "label": [Function],
+          },
+          "Microsoft.NumberInput": Object {
+            "helpLink": "https://aka.ms/bfc-ask-for-user-input",
+            "label": [Function],
+          },
+          "Microsoft.OAuthInput": Object {
+            "helpLink": "https://aka.ms/bfc-using-oauth",
+            "label": [Function],
+            "order": Array [
+              "connectionName",
+              "*",
+            ],
+          },
+          "Microsoft.OnActivity": Object {
+            "hidden": Array [
+              "actions",
+            ],
+            "label": [Function],
+            "order": Array [
+              "condition",
+              "*",
+            ],
+          },
+          "Microsoft.OnBeginDialog": Object {
+            "hidden": Array [
+              "actions",
+            ],
+            "label": [Function],
+            "order": Array [
+              "condition",
+              "*",
+            ],
+          },
+          "Microsoft.OnCancelDialog": Object {
+            "hidden": Array [
+              "actions",
+            ],
+            "order": Array [
+              "condition",
+              "*",
+            ],
+          },
+          "Microsoft.OnCondition": Object {
+            "hidden": Array [
+              "actions",
+            ],
+            "label": [Function],
+            "order": Array [
+              "condition",
+              "*",
+            ],
+          },
+          "Microsoft.OnConversationUpdateActivity": Object {
+            "description": [Function],
+            "helpLink": "https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-conversations?view=azure-bot-service-4.0#conversation-lifetime",
+            "hidden": Array [
+              "actions",
+            ],
+            "label": [Function],
+            "order": Array [
+              "condition",
+              "*",
+            ],
+          },
+          "Microsoft.OnCustomEvent": Object {
+            "hidden": Array [
+              "actions",
+            ],
+            "label": [Function],
+            "order": Array [
+              "condition",
+              "*",
+            ],
+          },
+          "Microsoft.OnDialogEvent": Object {
+            "hidden": Array [
+              "actions",
+            ],
+            "label": [Function],
+            "order": Array [
+              "condition",
+              "*",
+            ],
+          },
+          "Microsoft.OnEndOfConversationActivity": Object {
+            "hidden": Array [
+              "actions",
+            ],
+            "label": [Function],
+            "order": Array [
+              "condition",
+              "*",
+            ],
+          },
+          "Microsoft.OnError": Object {
+            "hidden": Array [
+              "actions",
+            ],
+            "label": [Function],
+            "order": Array [
+              "condition",
+              "*",
+            ],
+          },
+          "Microsoft.OnEventActivity": Object {
+            "hidden": Array [
+              "actions",
+            ],
+            "label": [Function],
+            "order": Array [
+              "condition",
+              "*",
+            ],
+          },
+          "Microsoft.OnHandoffActivity": Object {
+            "hidden": Array [
+              "actions",
+            ],
+            "label": [Function],
+            "order": Array [
+              "condition",
+              "*",
+            ],
+          },
+          "Microsoft.OnIntent": Object {
+            "hidden": Array [
+              "actions",
+            ],
+            "label": [Function],
+            "order": Array [
+              "intent",
+              "condition",
+              "entities",
+              "*",
+            ],
+            "properties": Object {
+              "intent": Object {
+                "field": [Function],
+              },
+            },
+          },
+          "Microsoft.OnInvokeActivity": Object {
+            "hidden": Array [
+              "actions",
+            ],
+            "label": [Function],
+            "order": Array [
+              "condition",
+              "*",
+            ],
+          },
+          "Microsoft.OnMessageActivity": Object {
+            "hidden": Array [
+              "actions",
+            ],
+            "label": [Function],
+            "order": Array [
+              "condition",
+              "*",
+            ],
+          },
+          "Microsoft.OnMessageDeleteActivity": Object {
+            "hidden": Array [
+              "actions",
+            ],
+            "label": [Function],
+            "order": Array [
+              "condition",
+              "*",
+            ],
+          },
+          "Microsoft.OnMessageReactionActivity": Object {
+            "hidden": Array [
+              "actions",
+            ],
+            "label": [Function],
+            "order": Array [
+              "condition",
+              "*",
+            ],
+          },
+          "Microsoft.OnMessageUpdateActivity": Object {
+            "hidden": Array [
+              "actions",
+            ],
+            "label": [Function],
+            "order": Array [
+              "condition",
+              "*",
+            ],
+          },
+          "Microsoft.OnRepromptDialog": Object {
+            "hidden": Array [
+              "actions",
+            ],
+            "label": [Function],
+            "order": Array [
+              "condition",
+              "*",
+            ],
+          },
+          "Microsoft.OnTypingActivity": Object {
+            "hidden": Array [
+              "actions",
+            ],
+            "label": [Function],
+            "order": Array [
+              "condition",
+              "*",
+            ],
+          },
+          "Microsoft.OnUnknownIntent": Object {
+            "hidden": Array [
+              "actions",
+            ],
+            "label": [Function],
+            "order": Array [
+              "condition",
+              "*",
+            ],
+          },
+          "Microsoft.QnAMakerDialog": Object {
+            "helpLink": "https://aka.ms/bfc-using-QnA",
+            "label": [Function],
+          },
+          "Microsoft.RegexRecognizer": Object {
+            "hidden": Array [
+              "entities",
+            ],
+          },
+          "Microsoft.RepeatDialog": Object {
+            "helpLink": "https://aka.ms/bfc-understanding-dialogs",
+            "label": [Function],
+            "order": Array [
+              "options",
+              "includeActivity",
+              "*",
+            ],
+          },
+          "Microsoft.ReplaceDialog": Object {
+            "helpLink": "https://aka.ms/bfc-understanding-dialogs",
+            "label": [Function],
+            "order": Array [
+              "dialog",
+              "options",
+              "includeActivity",
+              "*",
+            ],
+          },
+          "Microsoft.SendActivity": Object {
+            "helpLink": "https://aka.ms/bfc-send-activity",
+            "label": [Function],
+            "order": Array [
+              "activity",
+              "*",
+            ],
+          },
+          "Microsoft.SetProperties": Object {
+            "helpLink": "https://aka.ms/bfc-using-memory",
+            "label": [Function],
+          },
+          "Microsoft.SetProperty": Object {
+            "helpLink": "https://aka.ms/bfc-using-memory",
+            "label": [Function],
+          },
+          "Microsoft.SkillDialog": Object {
+            "helpLink": "https://aka.ms/bfc-call-skill",
+            "label": [Function],
+          },
+          "Microsoft.SwitchCondition": Object {
+            "helpLink": "https://aka.ms/bfc-controlling-conversation-flow",
+            "hidden": Array [
+              "default",
+            ],
+            "label": [Function],
+            "properties": Object {
+              "cases": Object {
+                "hidden": Array [
+                  "actions",
+                ],
+              },
+            },
+          },
+          "Microsoft.TextInput": Object {
+            "helpLink": "https://aka.ms/bfc-ask-for-user-input",
+            "label": [Function],
+          },
+          "Microsoft.TraceActivity": Object {
+            "helpLink": "https://aka.ms/bfc-debugging-bots",
+            "label": [Function],
+          },
         },
-        "triggers": Object {
-          "label": "Foo",
+        "recognizers": Array [
+          Object {
+            "displayName": [Function],
+            "handleRecognizerChange": [Function],
+            "id": "none",
+            "isSelected": [Function],
+          },
+          Object {
+            "displayName": [Function],
+            "editor": [Function],
+            "handleRecognizerChange": [Function],
+            "id": "Microsoft.RegexRecognizer",
+            "isSelected": [Function],
+          },
+        ],
+        "roleSchema": Object {
+          "expression": Object {
+            "label": "expression label",
+          },
         },
-      },
-    },
-    "Microsoft.AttachmentInput": Object {
-      "helpLink": "https://aka.ms/bfc-ask-for-user-input",
-      "label": "Prompt for Attachment",
-    },
-    "Microsoft.BeginDialog": Object {
-      "helpLink": "https://aka.ms/bfc-understanding-dialogs",
-      "label": "Begin a Dialog",
-      "order": Array [
-        "dialog",
-        "options",
-        "resultProperty",
-        "includeActivity",
-        "*",
-      ],
-    },
-    "Microsoft.BreakLoop": Object {
-      "label": [Function],
-    },
-    "Microsoft.CancelAllDialogs": Object {
-      "helpLink": "https://aka.ms/bfc-understanding-dialogs",
-      "label": [Function],
-      "order": Array [
-        "dialog",
-        "property",
-        "*",
-      ],
-    },
-    "Microsoft.ChoiceInput": Object {
-      "helpLink": "https://aka.ms/bfc-ask-for-user-input",
-      "label": [Function],
-    },
-    "Microsoft.ConfirmInput": Object {
-      "helpLink": "https://aka.ms/bfc-ask-for-user-input",
-      "label": [Function],
-    },
-    "Microsoft.ContinueLoop": Object {
-      "label": [Function],
-    },
-    "Microsoft.DateTimeInput": Object {
-      "helpLink": "https://aka.ms/bfc-ask-for-user-input",
-      "label": [Function],
-    },
-    "Microsoft.DebugBreak": Object {
-      "label": [Function],
-    },
-    "Microsoft.DeleteProperties": Object {
-      "helpLink": "https://aka.ms/bfc-using-memory",
-      "label": [Function],
-    },
-    "Microsoft.DeleteProperty": Object {
-      "helpLink": "https://aka.ms/bfc-using-memory",
-      "label": [Function],
-    },
-    "Microsoft.EditActions": Object {
-      "label": [Function],
-    },
-    "Microsoft.EditArray": Object {
-      "helpLink": "https://aka.ms/bfc-using-memory",
-      "label": [Function],
-    },
-    "Microsoft.EmitEvent": Object {
-      "helpLink": "https://aka.ms/bfc-custom-events",
-      "label": [Function],
-    },
-    "Microsoft.EndDialog": Object {
-      "helpLink": "https://aka.ms/bfc-understanding-dialogs",
-      "label": [Function],
-    },
-    "Microsoft.EndTurn": Object {
-      "helpLink": "https://aka.ms/bfc-understanding-dialogs",
-      "label": [Function],
-    },
-    "Microsoft.Foreach": Object {
-      "helpLink": "https://aka.ms/bfc-controlling-conversation-flow",
-      "hidden": Array [
-        "actions",
-      ],
-      "label": [Function],
-      "order": Array [
-        "itemsProperty",
-        "*",
-      ],
-    },
-    "Microsoft.ForeachPage": Object {
-      "helpLink": "https://aka.ms/bfc-controlling-conversation-flow",
-      "hidden": Array [
-        "actions",
-      ],
-      "label": [Function],
-      "order": Array [
-        "itemsProperty",
-        "pageSize",
-        "*",
-      ],
-    },
-    "Microsoft.HttpRequest": Object {
-      "helpLink": "https://aka.ms/bfc-using-http",
-      "label": [Function],
-      "order": Array [
-        "method",
-        "url",
-        "body",
-        "headers",
-        "*",
-      ],
-    },
-    "Microsoft.IRecognizer": Object {
-      "field": [Function],
-      "helpLink": "https://aka.ms/BFC-Using-LU",
-    },
-    "Microsoft.IfCondition": Object {
-      "helpLink": "https://aka.ms/bfc-controlling-conversation-flow",
-      "hidden": Array [
-        "actions",
-        "elseActions",
-      ],
-      "label": [Function],
-    },
-    "Microsoft.LogAction": Object {
-      "helpLink": "https://aka.ms/bfc-debugging-bots",
-      "label": [Function],
-    },
-    "Microsoft.NumberInput": Object {
-      "helpLink": "https://aka.ms/bfc-ask-for-user-input",
-      "label": [Function],
-    },
-    "Microsoft.OAuthInput": Object {
-      "helpLink": "https://aka.ms/bfc-using-oauth",
-      "label": [Function],
-      "order": Array [
-        "connectionName",
-        "*",
-      ],
-    },
-    "Microsoft.OnActivity": Object {
-      "hidden": Array [
-        "actions",
-      ],
-      "label": [Function],
-      "order": Array [
-        "condition",
-        "*",
-      ],
-      "subtitle": [Function],
-    },
-    "Microsoft.OnBeginDialog": Object {
-      "hidden": Array [
-        "actions",
-      ],
-      "label": [Function],
-      "order": Array [
-        "condition",
-        "*",
-      ],
-      "subtitle": [Function],
-    },
-    "Microsoft.OnCancelDialog": Object {
-      "hidden": Array [
-        "actions",
-      ],
-      "order": Array [
-        "condition",
-        "*",
-      ],
-    },
-    "Microsoft.OnCondition": Object {
-      "hidden": Array [
-        "actions",
-      ],
-      "label": [Function],
-      "order": Array [
-        "condition",
-        "*",
-      ],
-      "subtitle": [Function],
-    },
-    "Microsoft.OnConversationUpdateActivity": Object {
-      "description": [Function],
-      "helpLink": "https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-conversations?view=azure-bot-service-4.0#conversation-lifetime",
-      "hidden": Array [
-        "actions",
-      ],
-      "label": [Function],
-      "order": Array [
-        "condition",
-        "*",
-      ],
-      "subtitle": [Function],
-    },
-    "Microsoft.OnCustomEvent": Object {
-      "hidden": Array [
-        "actions",
-      ],
-      "label": [Function],
-      "order": Array [
-        "condition",
-        "*",
-      ],
-      "subtitle": [Function],
-    },
-    "Microsoft.OnDialogEvent": Object {
-      "hidden": Array [
-        "actions",
-      ],
-      "label": [Function],
-      "order": Array [
-        "condition",
-        "*",
-      ],
-      "subtitle": [Function],
-    },
-    "Microsoft.OnEndOfConversationActivity": Object {
-      "hidden": Array [
-        "actions",
-      ],
-      "label": [Function],
-      "order": Array [
-        "condition",
-        "*",
-      ],
-      "subtitle": [Function],
-    },
-    "Microsoft.OnError": Object {
-      "hidden": Array [
-        "actions",
-      ],
-      "label": [Function],
-      "order": Array [
-        "condition",
-        "*",
-      ],
-      "subtitle": [Function],
-    },
-    "Microsoft.OnEventActivity": Object {
-      "hidden": Array [
-        "actions",
-      ],
-      "label": [Function],
-      "order": Array [
-        "condition",
-        "*",
-      ],
-      "subtitle": [Function],
-    },
-    "Microsoft.OnHandoffActivity": Object {
-      "hidden": Array [
-        "actions",
-      ],
-      "label": [Function],
-      "order": Array [
-        "condition",
-        "*",
-      ],
-      "subtitle": [Function],
-    },
-    "Microsoft.OnIntent": Object {
-      "hidden": Array [
-        "actions",
-      ],
-      "label": [Function],
-      "order": Array [
-        "intent",
-        "condition",
-        "entities",
-        "*",
-      ],
-      "properties": Object {
-        "intent": Object {
-          "field": [Function],
-        },
-      },
-      "subtitle": [Function],
-    },
-    "Microsoft.OnInvokeActivity": Object {
-      "hidden": Array [
-        "actions",
-      ],
-      "label": [Function],
-      "order": Array [
-        "condition",
-        "*",
-      ],
-      "subtitle": [Function],
-    },
-    "Microsoft.OnMessageActivity": Object {
-      "hidden": Array [
-        "actions",
-      ],
-      "label": [Function],
-      "order": Array [
-        "condition",
-        "*",
-      ],
-      "subtitle": [Function],
-    },
-    "Microsoft.OnMessageDeleteActivity": Object {
-      "hidden": Array [
-        "actions",
-      ],
-      "label": [Function],
-      "order": Array [
-        "condition",
-        "*",
-      ],
-      "subtitle": [Function],
-    },
-    "Microsoft.OnMessageReactionActivity": Object {
-      "hidden": Array [
-        "actions",
-      ],
-      "label": [Function],
-      "order": Array [
-        "condition",
-        "*",
-      ],
-      "subtitle": [Function],
-    },
-    "Microsoft.OnMessageUpdateActivity": Object {
-      "hidden": Array [
-        "actions",
-      ],
-      "label": [Function],
-      "order": Array [
-        "condition",
-        "*",
-      ],
-      "subtitle": [Function],
-    },
-    "Microsoft.OnRepromptDialog": Object {
-      "hidden": Array [
-        "actions",
-      ],
-      "label": [Function],
-      "order": Array [
-        "condition",
-        "*",
-      ],
-      "subtitle": [Function],
-    },
-    "Microsoft.OnTypingActivity": Object {
-      "hidden": Array [
-        "actions",
-      ],
-      "label": [Function],
-      "order": Array [
-        "condition",
-        "*",
-      ],
-      "subtitle": [Function],
-    },
-    "Microsoft.OnUnknownIntent": Object {
-      "hidden": Array [
-        "actions",
-      ],
-      "label": [Function],
-      "order": Array [
-        "condition",
-        "*",
-      ],
-      "subtitle": [Function],
-    },
-    "Microsoft.QnAMakerDialog": Object {
-      "helpLink": "https://aka.ms/bfc-using-QnA",
-      "label": [Function],
-    },
-    "Microsoft.RegexRecognizer": Object {
-      "hidden": Array [
-        "entities",
-      ],
-    },
-    "Microsoft.RepeatDialog": Object {
-      "helpLink": "https://aka.ms/bfc-understanding-dialogs",
-      "label": [Function],
-      "order": Array [
-        "options",
-        "includeActivity",
-        "*",
-      ],
-    },
-    "Microsoft.ReplaceDialog": Object {
-      "helpLink": "https://aka.ms/bfc-understanding-dialogs",
-      "label": [Function],
-      "order": Array [
-        "dialog",
-        "options",
-        "includeActivity",
-        "*",
-      ],
-    },
-    "Microsoft.SendActivity": Object {
-      "helpLink": "https://aka.ms/bfc-send-activity",
-      "label": [Function],
-      "order": Array [
-        "activity",
-        "*",
-      ],
-    },
-    "Microsoft.SetProperties": Object {
-      "helpLink": "https://aka.ms/bfc-using-memory",
-      "label": [Function],
-    },
-    "Microsoft.SetProperty": Object {
-      "helpLink": "https://aka.ms/bfc-using-memory",
-      "label": [Function],
-    },
-    "Microsoft.SkillDialog": Object {
-      "helpLink": "https://aka.ms/bfc-call-skill",
-      "label": [Function],
-    },
-    "Microsoft.SwitchCondition": Object {
-      "helpLink": "https://aka.ms/bfc-controlling-conversation-flow",
-      "hidden": Array [
-        "default",
-      ],
-      "label": [Function],
-      "properties": Object {
-        "cases": Object {
-          "hidden": Array [
-            "actions",
-          ],
-        },
-      },
-    },
-    "Microsoft.TextInput": Object {
-      "helpLink": "https://aka.ms/bfc-ask-for-user-input",
-      "label": [Function],
-    },
-    "Microsoft.TraceActivity": Object {
-      "helpLink": "https://aka.ms/bfc-debugging-bots",
-      "label": [Function],
-    },
-  },
-  "recognizers": Array [
-    Object {
-      "displayName": [Function],
-      "handleRecognizerChange": [Function],
-      "id": "none",
-      "isSelected": [Function],
-    },
-    Object {
-      "displayName": [Function],
-      "editor": [Function],
-      "handleRecognizerChange": [Function],
-      "id": "Microsoft.RegexRecognizer",
-      "isSelected": [Function],
-    },
-  ],
-  "roleSchema": Object {
-    "expression": Object {
-      "label": "expression label",
-    },
-  },
-}
-`);
+      }
+    `);
   });
 });

--- a/Composer/packages/extensions/adaptive-form/src/utils/__tests__/mergePluginConfigs.test.ts
+++ b/Composer/packages/extensions/adaptive-form/src/utils/__tests__/mergePluginConfigs.test.ts
@@ -203,6 +203,7 @@ describe('mergePluginConfigs', () => {
               "condition",
               "*",
             ],
+            "subtitle": [Function],
           },
           "Microsoft.OnBeginDialog": Object {
             "hidden": Array [
@@ -213,6 +214,7 @@ describe('mergePluginConfigs', () => {
               "condition",
               "*",
             ],
+            "subtitle": [Function],
           },
           "Microsoft.OnCancelDialog": Object {
             "hidden": Array [
@@ -232,6 +234,7 @@ describe('mergePluginConfigs', () => {
               "condition",
               "*",
             ],
+            "subtitle": [Function],
           },
           "Microsoft.OnConversationUpdateActivity": Object {
             "description": [Function],
@@ -244,6 +247,7 @@ describe('mergePluginConfigs', () => {
               "condition",
               "*",
             ],
+            "subtitle": [Function],
           },
           "Microsoft.OnCustomEvent": Object {
             "hidden": Array [
@@ -254,6 +258,7 @@ describe('mergePluginConfigs', () => {
               "condition",
               "*",
             ],
+            "subtitle": [Function],
           },
           "Microsoft.OnDialogEvent": Object {
             "hidden": Array [
@@ -264,6 +269,7 @@ describe('mergePluginConfigs', () => {
               "condition",
               "*",
             ],
+            "subtitle": [Function],
           },
           "Microsoft.OnEndOfConversationActivity": Object {
             "hidden": Array [
@@ -274,6 +280,7 @@ describe('mergePluginConfigs', () => {
               "condition",
               "*",
             ],
+            "subtitle": [Function],
           },
           "Microsoft.OnError": Object {
             "hidden": Array [
@@ -284,6 +291,7 @@ describe('mergePluginConfigs', () => {
               "condition",
               "*",
             ],
+            "subtitle": [Function],
           },
           "Microsoft.OnEventActivity": Object {
             "hidden": Array [
@@ -294,6 +302,7 @@ describe('mergePluginConfigs', () => {
               "condition",
               "*",
             ],
+            "subtitle": [Function],
           },
           "Microsoft.OnHandoffActivity": Object {
             "hidden": Array [
@@ -304,6 +313,7 @@ describe('mergePluginConfigs', () => {
               "condition",
               "*",
             ],
+            "subtitle": [Function],
           },
           "Microsoft.OnIntent": Object {
             "hidden": Array [
@@ -321,6 +331,7 @@ describe('mergePluginConfigs', () => {
                 "field": [Function],
               },
             },
+            "subtitle": [Function],
           },
           "Microsoft.OnInvokeActivity": Object {
             "hidden": Array [
@@ -331,6 +342,7 @@ describe('mergePluginConfigs', () => {
               "condition",
               "*",
             ],
+            "subtitle": [Function],
           },
           "Microsoft.OnMessageActivity": Object {
             "hidden": Array [
@@ -341,6 +353,7 @@ describe('mergePluginConfigs', () => {
               "condition",
               "*",
             ],
+            "subtitle": [Function],
           },
           "Microsoft.OnMessageDeleteActivity": Object {
             "hidden": Array [
@@ -351,6 +364,7 @@ describe('mergePluginConfigs', () => {
               "condition",
               "*",
             ],
+            "subtitle": [Function],
           },
           "Microsoft.OnMessageReactionActivity": Object {
             "hidden": Array [
@@ -361,6 +375,7 @@ describe('mergePluginConfigs', () => {
               "condition",
               "*",
             ],
+            "subtitle": [Function],
           },
           "Microsoft.OnMessageUpdateActivity": Object {
             "hidden": Array [
@@ -371,6 +386,7 @@ describe('mergePluginConfigs', () => {
               "condition",
               "*",
             ],
+            "subtitle": [Function],
           },
           "Microsoft.OnRepromptDialog": Object {
             "hidden": Array [
@@ -381,6 +397,7 @@ describe('mergePluginConfigs', () => {
               "condition",
               "*",
             ],
+            "subtitle": [Function],
           },
           "Microsoft.OnTypingActivity": Object {
             "hidden": Array [
@@ -391,6 +408,7 @@ describe('mergePluginConfigs', () => {
               "condition",
               "*",
             ],
+            "subtitle": [Function],
           },
           "Microsoft.OnUnknownIntent": Object {
             "hidden": Array [
@@ -401,6 +419,7 @@ describe('mergePluginConfigs', () => {
               "condition",
               "*",
             ],
+            "subtitle": [Function],
           },
           "Microsoft.QnAMakerDialog": Object {
             "helpLink": "https://aka.ms/bfc-using-QnA",

--- a/Composer/packages/extensions/extension/src/types/formSchema.ts
+++ b/Composer/packages/extensions/extension/src/types/formSchema.ts
@@ -45,7 +45,7 @@ export interface UIOptions {
     get: (value: any) => any;
     set: (value: any) => any;
   };
-  /** subtitle rendered in form title */
+  /** subtitle rendered in form title, defaults to schema.$kind */
   subtitle?: UIOptionValue<string>;
 }
 

--- a/Composer/packages/server/assets/projects/ToDoBotWithLuisSample/todobotwithluissample.dialog
+++ b/Composer/packages/server/assets/projects/ToDoBotWithLuisSample/todobotwithluissample.dialog
@@ -1,7 +1,7 @@
 {
   "$kind": "Microsoft.AdaptiveDialog",
   "$designer": {
-    "name": "ToDoBotWithLuisSample-17",
+    "name": "ToDoBotWithLuisSample",
     "id": "232009"
   },
   "autoEndDialog": true,

--- a/Composer/packages/server/assets/projects/ToDoBotWithLuisSample/todobotwithluissample.dialog
+++ b/Composer/packages/server/assets/projects/ToDoBotWithLuisSample/todobotwithluissample.dialog
@@ -1,12 +1,10 @@
 {
   "$kind": "Microsoft.AdaptiveDialog",
   "$designer": {
-    "$designer": {
-      "name": "ToDoBotWithLuisSample-17",
-      "id": "232009"
-    }
+    "name": "ToDoBotWithLuisSample-17",
+    "id": "232009"
   },
-  "autoEndDialog": "true",
+  "autoEndDialog": true,
   "defaultResultProperty": "dialog.result",
   "recognizer": "todobotwithluissample.lu",
   "triggers": [


### PR DESCRIPTION
## Description

This allows users to completely clear the form title. It will show the original title as a placeholder. If the user leaves that page and comes back, we will use the default heuristic to determine the title to use.

Also fixes an issue in the TodoLuis sample.

## Task Item

closes #2662 
closes #2841

# Screenshots

![image](https://user-images.githubusercontent.com/3619060/81006487-7d372200-8e04-11ea-81a8-ca32d6414f36.png)
![image](https://user-images.githubusercontent.com/3619060/81006511-845e3000-8e04-11ea-919e-5b26f45111df.png)
