### PR TITLE
fix: Fixed packaged folder structure.

### DIFF
--- a/Composer/packages/electron-server/README.md
+++ b/Composer/packages/electron-server/README.md
@@ -27,8 +27,8 @@ This package is a wrapper that will spin up the Composer web application inside 
 
 **Method 2**
 
-1. Run `yarn copy-templates` in the `/Composer/package/electron-server` directory.
-2. Run `yarn run pack` in the `/Composer/package/electron-server` directory. 
+1. Run `yarn run pack` in the `/Composer/package/electron-server` directory. 
+2. Run `yarn copy-templates` in the `/Composer/package/electron-server` directory.
 3. Run `yarn copy-plugins` in the `/Composer/package/electron-server` directory.
 4. Run `yarn dist`in the `/Composer/package/electron-server` directory.
 5. Find your portable binary inside of `/Composer/package/electron-server/dist`.

--- a/Composer/packages/electron-server/package.json
+++ b/Composer/packages/electron-server/package.json
@@ -14,7 +14,7 @@
     "copy-plugins": "node scripts/copy-plugins.js",
     "copy-templates": "node scripts/copy-templates.js",
     "dist": "node scripts/electronBuilderDist.js",
-    "dist:full": "yarn clean && yarn build && yarn copy-templates && yarn run pack && yarn copy-plugins && yarn dist",
+    "dist:full": "yarn clean && yarn build && yarn run pack && yarn copy-templates && yarn copy-plugins && yarn dist",
     "lint": "eslint --quiet --ext .js,.jsx,.ts,.tsx ./src",
     "lint:fix": "yarn lint --fix",
     "pack": "node scripts/electronBuilderPack.js",

--- a/Composer/packages/electron-server/scripts/copy-templates.js
+++ b/Composer/packages/electron-server/scripts/copy-templates.js
@@ -3,10 +3,34 @@
 
 const fs = require('fs-extra');
 const { resolve } = require('path');
+const electronBuildConfig = require('../electron-builder-config.json');
 
-const source = resolve(__dirname, '../../../../BotProject/Templates');
-const destination = resolve(__dirname, '../build/templates');
-console.log(`[copy-templates.js] Copying templates from ${source} to ${destination}`);
+const source = resolve(__dirname, '../../../../BotProject');
+
+let destination;
+switch (process.platform) {
+  case 'darwin':
+    const productName = electronBuildConfig.productName;
+    destination = resolve(__dirname, `../dist/mac/${productName}.app/Contents/Resources/app.asar.unpacked/BotProject`);
+    console.log('[copy-plugins.js] Mac detected. Copying plugins to: ', destination);
+    break;
+
+  case 'linux':
+    destination = resolve(__dirname, '../dist/linux-unpacked/resources/app.asar.unpacked/BotProject');
+    console.log('[copy-plugins.js] Linux detected. Copying plugins to: ', destination);
+    break;
+
+  case 'win32':
+    destination = resolve(__dirname, '../dist/win-unpacked/resources/app.asar.unpacked/BotProject');
+    console.log(`[copy-plugins.js] Windows detected. Copying plugins from ${source} to ${destination}`);
+    break;
+
+  default:
+    console.error('[copy-plugins.js] Detected platform is not Mac / Linux / Windows');
+    process.exit(1);
+}
+
+console.log(`[copy-templates.js] Copying BotProject from ${source} to ${destination}`);
 
 // copy project templates to build directory to be packaged
 fs.copy(source, destination, err => {

--- a/Composer/packages/electron-server/src/main.ts
+++ b/Composer/packages/electron-server/src/main.ts
@@ -97,7 +97,7 @@ async function loadServer() {
   if (!isDevelopment) {
     // only change paths if packaged electron app
     const unpackedDir = getUnpackedAsarPath();
-    process.env.COMPOSER_RUNTIME_FOLDER = join(unpackedDir, 'build', 'templates');
+    process.env.COMPOSER_RUNTIME_FOLDER = join(unpackedDir, 'BotProject', 'Templates');
     pluginsDir = join(unpackedDir, 'build', 'plugins');
   }
 


### PR DESCRIPTION
## Description

The runtime eject feature was broken due to an outdated folder structure within the packaged version of Composer Electron.

Before, the folder structure was:

```
/app.asar.unpacked/
  /build/
    /templates/    <--- runtime templates
    /plugins/
```

This was causing the eject functionality to break when looking for the runtime templates in `/app.asar.unpacked/BotProject/Templates/`.

The new folder structure is:

```
/app.asar.unpacked/
  /BotProject/Templates/   <--- runtime templates
  /build/
    /plugins/
```

The runtime templates are no longer packed by electron-builder, but copied in after the `yarn pack` step, like the plugins.

## Task Item

Fixes #2868 

