### PR TITLE
fix: changed manifest file type from '.manifest' to '.json'

### DIFF
--- a/Composer/packages/client/src/pages/design/exportSkillModal/content/SelectManifest.tsx
+++ b/Composer/packages/client/src/pages/design/exportSkillModal/content/SelectManifest.tsx
@@ -37,12 +37,13 @@ const styles = {
 };
 
 export const SelectManifest: React.FC<ContentProps> = ({ completeStep, skillManifests, setSkillManifest }) => {
-  const { actions } = useContext(StoreContext);
+  const { actions, state } = useContext(StoreContext);
+  const { botName } = state;
   const [manifestVersion, setManifestVersion] = useState<string>(SCHEMA_URIS[0]);
   const [errors, setErrors] = useState<{ version?: string }>({});
 
   const [version] = VERSION_REGEX.exec(manifestVersion) || [''];
-  const fileName = `skill-manifest-${version.replace(/\./g, '-')}`;
+  const fileName = `${botName}-${version.replace(/\./g, '-')}-manifest`;
 
   const options: IDropdownOption[] = useMemo(
     () =>

--- a/Composer/packages/client/src/store/persistence/types.ts
+++ b/Composer/packages/client/src/store/persistence/types.ts
@@ -9,7 +9,7 @@ export enum ChangeType {
 
 export enum FileExtensions {
   Dialog = '.dialog',
-  Manifest = '.manifest',
+  Manifest = '.json',
   Lu = '.lu',
   Lg = '.lg',
 }

--- a/Composer/packages/lib/indexers/src/skillManifestIndexer.ts
+++ b/Composer/packages/lib/indexers/src/skillManifestIndexer.ts
@@ -9,7 +9,7 @@ const index = (skillManifestFiles: FileInfo[]) => {
   return skillManifestFiles.reduce((manifests: SkillManifestInfo[], { content, name, lastModified }) => {
     try {
       const jsonContent = JSON.parse(content);
-      return [...manifests, { content: jsonContent, id: getBaseName(name, '.manifest'), lastModified }];
+      return [...manifests, { content: jsonContent, id: getBaseName(name, '.json'), lastModified }];
     } catch (error) {
       return manifests;
     }

--- a/Composer/packages/lib/indexers/src/utils/fileExtensions.ts
+++ b/Composer/packages/lib/indexers/src/utils/fileExtensions.ts
@@ -5,5 +5,5 @@ export enum FileExtensions {
   Dialog = '.dialog',
   Lu = '.lu',
   lg = '.lg',
-  Manifest = '.manifest',
+  Manifest = '.json',
 }

--- a/Composer/packages/server/src/models/bot/botProject.ts
+++ b/Composer/packages/server/src/models/bot/botProject.ts
@@ -46,7 +46,7 @@ const BotStructureTemplate = {
     lg: 'language-generation/${LOCALE}/${DIALOGNAME}.${LOCALE}.lg',
     lu: 'language-understanding/${LOCALE}/${DIALOGNAME}.${LOCALE}.lu',
   },
-  skillManifests: 'skill-manifests/${MANIFESTNAME}.manifest',
+  skillManifests: 'manifests/${MANIFESTNAME}.json',
 };
 
 const templateInterpolate = (str: string, obj: { [key: string]: string }) =>
@@ -368,7 +368,7 @@ export class BotProject {
         DIALOGNAME,
         LOCALE,
       });
-    } else if (fileType === '.manifest') {
+    } else if (fileType === '.json') {
       dir = templateInterpolate(
         Path.dirname(Path.join(BotStructureTemplate.folder, BotStructureTemplate.skillManifests)),
         {
@@ -457,7 +457,7 @@ export class BotProject {
     }
 
     const fileList: FileInfo[] = [];
-    const patterns = ['**/*.dialog', '**/*.lg', '**/*.lu', '**/*.manifest'];
+    const patterns = ['**/*.dialog', '**/*.lg', '**/*.lu', 'manifests/*.json'];
     for (const pattern of patterns) {
       // load only from the data dir, otherwise may get "build" versions from
       // deployment process

--- a/Composer/plugins/localPublish/src/index.ts
+++ b/Composer/plugins/localPublish/src/index.ts
@@ -124,9 +124,9 @@ class LocalPublisher implements PublishPlugin<PublishConfig> {
 
   private getHistoryDir = (botId: string) => path.resolve(this.getBotDir(botId), 'history');
 
-  private getManifestSrcDir = (srcDir: string) =>  path.resolve(srcDir, 'skill-manifests');
+  private getManifestSrcDir = (srcDir: string) =>  path.resolve(srcDir, 'manifests');
 
-  private getManifestDstDir = (botId: string) => path.resolve(this.getBotRuntimeDir(botId), 'wwwroot', 'skill-manifests');
+  private getManifestDstDir = (botId: string) => path.resolve(this.getBotRuntimeDir(botId), 'wwwroot', 'manifests');
 
   private getDownloadPath = (botId: string, version: string) =>
     path.resolve(this.getHistoryDir(botId), `${version}.zip`);


### PR DESCRIPTION
## Description
- Changed the manifest file type from `.manifest` to `.json`
- Renamed the `skill-manifests` directory to `manifests`
  - Manifest can be found at http://localhost:{PORT}/manifests/{BOTNAME}-{MANIFESTVERSION}-manifest.json
- Changed manifests names to `${botName}-{manifestVersion}-manifest.json`

## Task Item
Closes #2327
