### PR TITLE
fix: Populate env variable with AppData folder

### DIFF
--- a/Composer/packages/electron-server/src/main.ts
+++ b/Composer/packages/electron-server/src/main.ts
@@ -50,9 +50,12 @@ async function createAppDataDir() {
   const appDataBasePath: string = process.env.APPDATA || process.env.HOME || '';
   const compserAppDataDirectoryName = 'BotFrameworkComposer';
   const composerAppDataPath: string = resolve(appDataBasePath, compserAppDataDirectoryName);
+  const localPublishPath: string = join(composerAppDataPath, 'hostedBots');
   process.env.COMPOSER_APP_DATA = join(composerAppDataPath, 'data.json'); // path to the actual data file
   log('creating composer app data path at: ', composerAppDataPath);
-  await mkdirp(composerAppDataPath);
+  process.env.LOCAL_PUBLISH_PATH = localPublishPath;
+  log('creating local bot runtime publish path: ', localPublishPath);
+  await mkdirp(localPublishPath);
 }
 
 function initializeAppUpdater() {

--- a/Composer/packages/electron-server/src/main.ts
+++ b/Composer/packages/electron-server/src/main.ts
@@ -47,6 +47,7 @@ function processArgsForWindows(args: string[]): string {
 }
 
 async function createAppDataDir() {
+  // TODO: Move all ENV variable setting to an env file and update build process to leverage those variables too
   const appDataBasePath: string = process.env.APPDATA || process.env.HOME || '';
   const compserAppDataDirectoryName = 'BotFrameworkComposer';
   const composerAppDataPath: string = resolve(appDataBasePath, compserAppDataDirectoryName);


### PR DESCRIPTION
## Description
Local runtime plugin will publish bot using the environment variable populated from the electron process. This prevents the need to create a folder inside `Program Files` for windows which would require admin privileges.

## Task Item
Fixes #2862 
