### PR TITLE
fix: memory variables suggestions in lgEditor

### DIFF
--- a/Composer/packages/lib/indexers/src/dialogIndexer.ts
+++ b/Composer/packages/lib/indexers/src/dialogIndexer.ts
@@ -18,7 +18,6 @@ import { createPath } from './dialogUtils/dialogChecker';
 import { checkerFuncs } from './dialogUtils/dialogChecker';
 import { JsonWalk, VisitorFunc } from './utils/jsonWalk';
 import { getBaseName } from './utils/help';
-import ExtractMemoryPaths from './dialogUtils/extractMemoryPaths';
 import ExtractIntentTriggers from './dialogUtils/extractIntentTriggers';
 // find out all lg templates given dialog
 function ExtractLgTemplates(id, dialog): LgTemplateJsonPath[] {
@@ -207,7 +206,6 @@ function parse(id: string, content: any, schema: any) {
     diagnostics: validate(id, content, schema),
     referredDialogs: ExtractReferredDialogs(content),
     lgTemplates: ExtractLgTemplates(id, content),
-    userDefinedVariables: ExtractMemoryPaths(content),
     referredLuIntents: ExtractLuIntents(content, id),
     luFile: getBaseName(luFile, '.lu'),
     lgFile: getBaseName(lgFile, '.lg'),

--- a/Composer/packages/lib/indexers/src/dialogUtils/extractMemoryPaths.ts
+++ b/Composer/packages/lib/indexers/src/dialogUtils/extractMemoryPaths.ts
@@ -44,7 +44,7 @@ export function getProperties(value: any): string[] {
 }
 
 // find out all properties from given dialog
-function ExtractMemoryPaths(dialog): string[] {
+function ExtractMemoryPaths(dialog: { [key: string]: any }): string[] {
   let properties: string[] = [];
 
   const visitor: VisitorFunc = (path: string, value: any): boolean => {

--- a/Composer/packages/lib/shared/src/types/indexers.ts
+++ b/Composer/packages/lib/shared/src/types/indexers.ts
@@ -35,7 +35,6 @@ export interface DialogInfo {
   luFile: string;
   referredLuIntents: ReferredLuIntents[];
   referredDialogs: string[];
-  userDefinedVariables: string[];
   triggers: ITrigger[];
   intentTriggers: IIntentTrigger[];
 }

--- a/Composer/packages/server/src/services/project.ts
+++ b/Composer/packages/server/src/services/project.ts
@@ -3,6 +3,7 @@
 
 import merge from 'lodash/merge';
 import find from 'lodash/find';
+import flatten from 'lodash/flatten';
 import { importResolverGenerator, ResolverResource } from '@bfc/shared';
 import extractMemoryPaths from '@bfc/indexers/lib/dialogUtils/extractMemoryPaths';
 import { UserIdentity } from '@bfc/plugin-loader';
@@ -89,15 +90,15 @@ export class BotProjectService {
       'turn.repeatedIds',
       'turn.activityProcessed',
     ];
-    const projectVariables = BotProjectService.getIndexedProjectById(projectId)
-      ?.files.filter(file => file.name.endsWith('.dialog'))
-      .map(({ content }) => extractMemoryPaths(content));
+    const projectVariables =
+      BotProjectService.getIndexedProjectById(projectId)
+        ?.files.filter(file => file.name.endsWith('.dialog'))
+        .map(({ content }) => {
+          const dialogJson = JSON.parse(content);
+          return extractMemoryPaths(dialogJson);
+        }) || [];
 
-    const userDefined: string[] =
-      projectVariables?.reduce((result: string[], variables) => {
-        result = [...variables, ...result];
-        return result;
-      }, []) || [];
+    const userDefined: string[] = flatten(projectVariables);
     return [...defaultProperties, ...userDefined];
   }
 


### PR DESCRIPTION
## Description

1. fix memory variables tracking
2. remove extract memory variables in dialog indexer at client, cause it's only used at server.

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item

close #2895 
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots
![Untitled1](https://user-images.githubusercontent.com/49866537/81135039-3c1c4a80-8f89-11ea-82f7-22cbdefbb82a.gif)
<!---
Please include screenshots or gifs if your PR include UX changes.
--->
