### PR TITLE
fix: can not capture events in visual editor

### DIFF
--- a/Composer/packages/client/src/pages/design/styles.ts
+++ b/Composer/packages/client/src/pages/design/styles.ts
@@ -83,18 +83,8 @@ export const visualPanel = css`
   position: relative;
 
   &:focus {
-    border-right: none;
+    border: black solid 1px;
     outline: none;
-
-    &::after {
-      content: '';
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      left: 0;
-      right: 0;
-      border: black solid 1px;
-    }
   }
 
   label: DesignPageVisualPanel;


### PR DESCRIPTION
## Description

Fixed: can not use event capture in visual editor.
- Before
![bug-focus-beh](https://user-images.githubusercontent.com/8528761/81139937-2b280500-8f9a-11ea-8ad8-86530aa72b1a.gif)

- After
![capture](https://user-images.githubusercontent.com/5860999/81150446-7cdc8980-8fb2-11ea-8583-30be425b97c4.gif)

After fixed it, the container focused state will be removed when children doms' event triggered.

## Why need  change the style?
This is because children doms' mouse event will be blocked when container dom has focus::after styles, like below
```
 &::after {
      content: '';
      position: absolute;
      top: 0;
      bottom: 0;
      left: 0;
      right: 0;
      border: black solid 1px;
    }
```
So I removed the after styles.

## Task Item

fix #2907 

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
