### PR TITLE
fix: Copy skill manifests to the correct directory in the localPublish plugin

### DIFF
--- a/Composer/plugins/localPublish/src/index.ts
+++ b/Composer/plugins/localPublish/src/index.ts
@@ -127,7 +127,7 @@ class LocalPublisher implements PublishPlugin<PublishConfig> {
 
   private getManifestSrcDir = (srcDir: string) => path.resolve(srcDir, 'manifests');
 
-  private getManifestDstDir = (botId: string) => path.resolve(this.getBotRuntimeDir(botId), 'wwwroot', 'manifests');
+  private getManifestDstDir = (botId: string) => path.resolve(this.getBotRuntimeDir(botId), 'azurewebapp', 'wwwroot', 'manifests');
 
   private getDownloadPath = (botId: string, version: string) =>
     path.resolve(this.getHistoryDir(botId), `${version}.zip`);


### PR DESCRIPTION
## Description
Currently, the `manifests` directory is being copied to the `runtime/wwwroot` directory; however, due to recent changes, it should be copied to the `runtime/azurewebapp/wwwroot` directory.

## Task Item
closes #2918
