### PR TITLE
fix: improper visual node content in SetProperty / SetProperties

### DIFF
--- a/Composer/packages/extensions/visual-designer/src/schema/defaultFlowSchema.tsx
+++ b/Composer/packages/extensions/visual-designer/src/schema/defaultFlowSchema.tsx
@@ -6,7 +6,7 @@ import formatMessage from 'format-message';
 import React from 'react';
 import get from 'lodash/get';
 import { FlowSchema, FlowWidget } from '@bfc/extension';
-import { FixedInfo, SingleLineDiv, ListOverview } from '@bfc/ui-shared';
+import { FixedInfo, SingleLineDiv, ListOverview, PropertyAssignment } from '@bfc/ui-shared';
 
 import { ObiColors } from '../constants/ElementColors';
 
@@ -130,7 +130,7 @@ export const defaultFlowSchema: FlowSchema = {
   },
   [SDKKinds.SetProperty]: {
     widget: 'ActionCard',
-    body: data => `${data.property || '?'} : ${data.value || '?'}`,
+    body: data => <PropertyAssignment property={data.property} value={data.value} />,
   },
   [SDKKinds.SetProperties]: {
     widget: 'ActionCard',
@@ -138,15 +138,7 @@ export const defaultFlowSchema: FlowSchema = {
       <ListOverview
         items={data.assignments}
         itemPadding={8}
-        renderItem={({ property, value }) => {
-          const v = typeof value === 'object' ? JSON.stringify(value) : value;
-          const content = `${property} : ${v}`;
-          return (
-            <SingleLineDiv height={16} title={content}>
-              {content}
-            </SingleLineDiv>
-          );
-        }}
+        renderItem={({ property, value }) => <PropertyAssignment property={property} value={value} />}
       />
     ),
   },

--- a/Composer/packages/lib/ui-shared/src/components/PropertyAssignment.tsx
+++ b/Composer/packages/lib/ui-shared/src/components/PropertyAssignment.tsx
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import React, { FC } from 'react';
+
+import { SingleLineDiv } from '../styled';
+
+type Expression = string;
+type AssignmentValue = string | number | boolean | Expression | object | any[];
+
+export interface PropertyAssignmentProps {
+  property: string;
+  value?: AssignmentValue;
+}
+
+const AssignmentOpt = ':';
+const NullValuePlaceholder = '?';
+
+const serializeAssignmentValue = (value?: AssignmentValue): string | number | boolean => {
+  if (typeof value === 'object') {
+    return JSON.stringify(value);
+  }
+  return value ?? NullValuePlaceholder;
+};
+
+export const PropertyAssignment: FC<PropertyAssignmentProps> = ({ property, value }) => {
+  const valueStr = serializeAssignmentValue(value);
+  const content = `${property} ${AssignmentOpt} ${valueStr}`;
+  return (
+    <SingleLineDiv height={16} title={content}>
+      {content}
+    </SingleLineDiv>
+  );
+};

--- a/Composer/packages/lib/ui-shared/src/components/index.ts
+++ b/Composer/packages/lib/ui-shared/src/components/index.ts
@@ -2,3 +2,4 @@
 // Licensed under the MIT License.
 
 export * from './ListOverview';
+export * from './PropertyAssignment';


### PR DESCRIPTION
## Description
fixes #2877 incorrect SetProperty content in visual nodes

#### Problems in Visual node:
1. If `value` set to `false` or `0`, SetProperty shows `?` instead of real value
2. Content in SetProperty and SetProperties are not consistent.

#### Changes:
1. Let SetProperty and SetProperties share the same component `<PropertyAssignment>`
2. Update Flow Editor schema.

#### Preview:
![image](https://user-images.githubusercontent.com/8528761/81267604-55042900-9079-11ea-94c5-f114e5efe48d.png)

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
