### PR TITLE
fix: Added missing flag to prevent concurrent downloads of the same update.

### DIFF
--- a/Composer/packages/electron-server/__tests__/appUpdater.test.ts
+++ b/Composer/packages/electron-server/__tests__/appUpdater.test.ts
@@ -117,6 +117,7 @@ describe('App updater', () => {
     appUpdater.downloadUpdate();
 
     expect(mockAutoUpdater.downloadUpdate).toHaveBeenCalled();
+    expect((appUpdater as any).downloadingUpdate).toBe(true);
   });
 
   it('should not download an update if it is already downloading an update', () => {

--- a/Composer/packages/electron-server/src/appUpdater.ts
+++ b/Composer/packages/electron-server/src/appUpdater.ts
@@ -57,6 +57,7 @@ export class AppUpdater extends EventEmitter {
 
   public downloadUpdate() {
     if (!this.downloadingUpdate) {
+      this.downloadingUpdate = true;
       autoUpdater.downloadUpdate();
     }
   }


### PR DESCRIPTION
## Description

This PR adds a line that flips a flag to prevent multiple downloads of the same update.

(Must have missed this in the original auto update PR 😮)

[This check was already there](https://github.com/microsoft/BotFramework-Composer/blob/master/Composer/packages/electron-server/src/appUpdater.ts#L49), but nothing was ever flipping `downloadingUpdate` to `true`.

## Task Item

fixes #2226 

