### PR TITLE
fix: lu/lg editor update strategy

### DIFF
--- a/Composer/packages/lib/code-editor/src/BaseEditor.tsx
+++ b/Composer/packages/lib/code-editor/src/BaseEditor.tsx
@@ -118,6 +118,7 @@ const BaseEditor: React.FC<BaseEditorProps> = props => {
     placeholder,
     hidePlaceholder,
     value,
+    id,
     errorMessage,
     warningMessage,
     diagnostics = [],
@@ -133,7 +134,10 @@ const BaseEditor: React.FC<BaseEditorProps> = props => {
   const [hovered, setHovered] = useState(false);
   const [focused, setFocused] = useState(false);
   const [editor, setEditor] = useState<any>();
-  const initialValue = useMemo(() => value || (hidePlaceholder ? '' : placeholder), []);
+
+  // initialValue is designed to imporve local performance
+  // it should be force updated if id change, or previous value is empty.
+  const initialValue = useMemo(() => value || (hidePlaceholder ? '' : placeholder), [id, !!value]);
 
   const onEditorMount: EditorDidMount = (getValue, editor) => {
     setEditor(editor);

--- a/Composer/packages/lib/code-editor/src/LgEditor.tsx
+++ b/Composer/packages/lib/code-editor/src/LgEditor.tsx
@@ -62,6 +62,12 @@ export function LgEditor(props: LGLSPEditorProps) {
   const { lgOption, languageServer, onInit: onInitProp, ...restProps } = props;
   const lgServer = languageServer || defaultLGServer;
 
+  let editorId = '';
+  if (lgOption) {
+    const { projectId, fileId, templateId } = lgOption;
+    editorId = [projectId, fileId, templateId].join('/');
+  }
+
   const onInit: OnInit = monaco => {
     registerLGLanguage(monaco);
 
@@ -105,6 +111,7 @@ export function LgEditor(props: LGLSPEditorProps) {
     <BaseEditor
       placeholder={placeholder}
       helpURL={LG_HELP}
+      id={editorId}
       {...restProps}
       onInit={onInit}
       theme="lgtheme"

--- a/Composer/packages/lib/code-editor/src/LuEditor.tsx
+++ b/Composer/packages/lib/code-editor/src/LuEditor.tsx
@@ -85,6 +85,12 @@ const LuEditor: React.FC<LULSPEditorProps> = props => {
   const { luOption, languageServer, onInit: onInitProp, placeholder = defaultPlaceholder, ...restProps } = props;
   const luServer = languageServer || defaultLUServer;
 
+  let editorId = '';
+  if (luOption) {
+    const { projectId, fileId, sectionId } = luOption;
+    editorId = [projectId, fileId, sectionId].join('/');
+  }
+
   const onInit: OnInit = monaco => {
     registerLULanguage(monaco);
     monacoRef.current = monaco;
@@ -145,6 +151,7 @@ const LuEditor: React.FC<LULSPEditorProps> = props => {
     <BaseEditor
       placeholder={placeholder}
       helpURL={LU_HELP}
+      id={editorId}
       {...restProps}
       onInit={onInit}
       theme="lu"

--- a/Composer/packages/ui-plugins/lg/src/LgField.tsx
+++ b/Composer/packages/ui-plugins/lg/src/LgField.tsx
@@ -3,14 +3,12 @@
 
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
-import React, { useCallback, useState, useRef, useEffect } from 'react';
+import React, { useCallback } from 'react';
 import { LgEditor } from '@bfc/code-editor';
 import { FieldProps, useShellApi } from '@bfc/extension';
 import { FieldLabel } from '@bfc/adaptive-form';
 import { LgMetaData, LgTemplateRef, LgType, CodeEditorSettings } from '@bfc/shared';
 import { filterTemplateDiagnostics } from '@bfc/indexers';
-import debounce from 'lodash/debounce';
-import isEqual from 'lodash/isEqual';
 
 const lspServerPath = '/lg-language-server';
 
@@ -68,23 +66,6 @@ const LgField: React.FC<FieldProps<string>> = props => {
 
   const diagnostics = lgFile ? filterTemplateDiagnostics(lgFile.diagnostics, template) : [];
 
-  const [localValue, setLocalValue] = useState(template.body);
-  const sync = useRef(
-    debounce((shellData: any, localData: any) => {
-      if (!isEqual(shellData, localData)) {
-        setLocalValue(shellData);
-      }
-    }, 750)
-  ).current;
-
-  useEffect(() => {
-    sync(template.body, localValue);
-
-    return () => {
-      sync.cancel();
-    };
-  }, [template.body]);
-
   const lgOption = {
     projectId,
     fileId: lgFileId,
@@ -92,7 +73,6 @@ const LgField: React.FC<FieldProps<string>> = props => {
   };
 
   const onChange = (body: string) => {
-    setLocalValue(body);
     if (designerId) {
       if (body) {
         updateLgTemplate(body);
@@ -113,7 +93,7 @@ const LgField: React.FC<FieldProps<string>> = props => {
       <FieldLabel id={id} label={label} description={description} helpLink={uiOptions?.helpLink} required={required} />
       <LgEditor
         height={225}
-        value={localValue}
+        value={template.body}
         onChange={onChange}
         diagnostics={diagnostics}
         hidePlaceholder

--- a/Composer/packages/ui-plugins/luis/src/LuisIntentEditor.tsx
+++ b/Composer/packages/ui-plugins/luis/src/LuisIntentEditor.tsx
@@ -3,7 +3,7 @@
 
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
-import React, { useState } from 'react';
+import React from 'react';
 import { LuEditor, inlineModePlaceholder } from '@bfc/code-editor';
 import { FieldProps, useShellApi } from '@bfc/extension';
 import { filterSectionDiagnostics } from '@bfc/indexers';
@@ -20,13 +20,12 @@ const LuisIntentEditor: React.FC<FieldProps<string>> = props => {
     $kind.const && (intentName = new LuMetaData(new LuType($kind.const).toString(), designerId).toString());
   }
 
-  const [luIntent, setLuIntent] = useState<LuIntentSection>(
+  const luIntent =
     (luFile && luFile.intents.find(intent => intent.Name === intentName)) ||
-      ({
-        Name: intentName,
-        Body: '',
-      } as LuIntentSection)
-  );
+    ({
+      Name: intentName,
+      Body: '',
+    } as LuIntentSection);
 
   if (!luFile || !intentName) {
     return null;
@@ -38,7 +37,6 @@ const LuisIntentEditor: React.FC<FieldProps<string>> = props => {
     }
 
     const newIntent = { Name: intentName, Body: newValue };
-    setLuIntent(newIntent);
     shellApi.updateLuIntent(luFile.id, intentName, newIntent);
     onChange(intentName);
   };


### PR DESCRIPTION
## Description

Removed form-editor previous maintained localValue( for performance consideration ), let `BaseEditor` handle it, it would check `id` to see need update from external value or not. 

Because of no `localValue` anymore, we also don't need `sync` method.

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item

close #2982 
refs #2627 
refs #2904 

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots
![Untitled1](https://user-images.githubusercontent.com/49866537/81638519-07f2cf00-944c-11ea-8e9b-593142310ba9.gif)

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
