### PR TITLE
fix: open bot read property 'sdk' is undefined

### DIFF
--- a/Composer/packages/client/src/router.tsx
+++ b/Composer/packages/client/src/router.tsx
@@ -74,7 +74,7 @@ const ProjectRouter: React.FC<RouteComponentProps<{ projectId: string }>> = prop
   const { actions, state } = useContext(StoreContext);
 
   useEffect(() => {
-    if (state.projectId !== props.projectId) {
+    if (state.projectId !== props.projectId && props.projectId) {
       actions.fetchProjectById(props.projectId);
     }
   }, [props.projectId, state.projectId]);

--- a/Composer/packages/client/src/store/action/navigation.ts
+++ b/Composer/packages/client/src/store/action/navigation.ts
@@ -29,8 +29,12 @@ export const navTo: ActionCreator = ({ getState }, dialogId, breadcrumb = []) =>
 export const selectTo: ActionCreator = ({ getState }, selectPath) => {
   const state = getState();
   if (!selectPath) return;
-  const { dialogId, projectId } = state.designPageLocation;
+  // initial dialogId, projectId maybe empty string  ""
+  let { dialogId, projectId } = state.designPageLocation;
   const { breadcrumb } = state;
+  if (!dialogId) dialogId = 'Main';
+  if (!projectId) projectId = state.projectId;
+
   let currentUri = `/bot/${projectId}/dialogs/${dialogId}`;
 
   currentUri = `${currentUri}?selected=${selectPath}`;


### PR DESCRIPTION
## Description

seems imported by #2922 , which `visual editor` call navigate methods with empty `projectId, dialogId`.
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item

close #3015 
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
