### PR TITLE
draft: 'Disable' selected nodes via toolbar

### DIFF
--- a/Composer/packages/extensions/extension/src/hooks/useDialogEditApi.ts
+++ b/Composer/packages/extensions/extension/src/hooks/useDialogEditApi.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { BaseSchema, DialogUtils, ShellApi } from '@bfc/shared';
+import { BaseSchema, DialogUtils, ShellApi, walkAdaptiveActionList } from '@bfc/shared';
 
 import { useActionApi } from './useActionApi';
 
@@ -69,6 +69,23 @@ export function useDialogEditApi(shellApi: ShellApi) {
     return dialogData;
   }
 
+  function disableSelectedActions(dialogId: string, dialogData, actionIds: string[]) {
+    // Disable selected actions and their children recursively.
+    const selectedActions = queryNodes(dialogData, actionIds);
+    walkAdaptiveActionList(selectedActions, action => {
+      // Set action.disbled to `false`
+      // TOOD: make `action` typed
+    });
+  }
+
+  function enableSelectedActions(dialogId: string, dialogData, actionIds: string[]) {
+    // Enable selected actions and children recursively.
+    const selectedActions = queryNodes(dialogData, actionIds);
+    walkAdaptiveActionList(selectedActions, action => {
+      // Set action.disbled to `true`
+    });
+  }
+
   return {
     insertAction,
     insertActions,
@@ -78,5 +95,7 @@ export function useDialogEditApi(shellApi: ShellApi) {
     copySelectedActions,
     cutSelectedActions,
     updateRecognizer,
+    disableSelectedActions,
+    enableSelectedActions,
   };
 }


### PR DESCRIPTION
## Description
User can disable/enable selected actions via toolbar buttons.
If a node is disabled, it won't be executed by runtime.

#### Works:
- [ ] 'disabled' effect - only apply to Node, won't apply to edge.
  ![image](https://user-images.githubusercontent.com/8528761/82018053-0aa52c80-96b7-11ea-967b-de57df43a02e.png)


- [ ] Shell toolbar - provides 2 buttons
  ![image](https://user-images.githubusercontent.com/8528761/81818585-cc95f480-9560-11ea-9237-52ae3d3fcb53.png)

- [ ] dialog editing API - implement an API to disable selected nodes (Form supports disable a single node)
    - provide 2 APIs named `disableSelectedNodes` and `enableSelectedNodes`
    - disabled/enabled state should be applied to all child nodes recursively consider IfCondition/SwitchCondition/Foreach

## Task Item
#2286 
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
