### PR TITLE
fix: remove cache when getProjectById

### DIFF
--- a/Composer/packages/client/src/components/SkillForm/CreateSkillModal/index.tsx
+++ b/Composer/packages/client/src/components/SkillForm/CreateSkillModal/index.tsx
@@ -7,6 +7,7 @@ import { jsx } from '@emotion/core';
 import React, { useState, FormEvent, useEffect, useCallback, useRef } from 'react';
 import formatMessage from 'format-message';
 import { PrimaryButton, DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { Spinner, SpinnerSize } from 'office-ui-fabric-react/lib/Spinner';
 import { Stack, StackItem } from 'office-ui-fabric-react/lib/Stack';
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import { assignDefined, Skill } from '@bfc/shared';
@@ -17,7 +18,7 @@ import { DialogTypes } from '../../DialogWrapper/styles';
 import { addSkillDialog } from '../../../constants';
 import { ISkillFormData, ISkillFormDataErrors, SkillUrlRegex, SkillNameRegex } from '../types';
 
-import { FormFieldManifestUrl, FormFieldEditName, MarginLeftSmall, FormModalBody } from './styles';
+import { FormFieldManifestUrl, FormFieldEditName, MarginLeftSmall, FormModalBody, SpinnerLabel } from './styles';
 import { validateManifestUrl } from './validateManifestUrl';
 
 export interface ICreateSkillModalProps {
@@ -180,6 +181,9 @@ const CreateSkillModal: React.FC<ICreateSkillModalProps> = props => {
               required
               autoFocus
             />
+            {isValidating && (
+              <Spinner css={SpinnerLabel} size={SpinnerSize.medium} label="validating..." labelPosition="right" />
+            )}
             <TextField
               css={FormFieldEditName}
               label={formatMessage('Custom name (optional)')}

--- a/Composer/packages/client/src/components/SkillForm/CreateSkillModal/styles.ts
+++ b/Composer/packages/client/src/components/SkillForm/CreateSkillModal/styles.ts
@@ -19,3 +19,8 @@ export const FormFieldEditName = css`
 export const MarginLeftSmall = css`
   margin-left: ${FontSizes.small};
 `;
+
+export const SpinnerLabel = css`
+  justify-content: left;
+  margin-top: 0.4rem;
+`;

--- a/Composer/packages/lib/indexers/src/utils/diagnosticUtil.ts
+++ b/Composer/packages/lib/indexers/src/utils/diagnosticUtil.ts
@@ -75,7 +75,7 @@ export function filterSectionDiagnostics(diagnostics: Diagnostic[], section: LuI
   return filteredDiags.map(d => {
     const { range } = d;
     if (range) {
-      d.range = offsetRange(range, offset);
+      return { ...d, range: offsetRange(range, offset) };
     }
     return d;
   });

--- a/Composer/packages/server/src/models/bot/skillManager.ts
+++ b/Composer/packages/server/src/models/bot/skillManager.ts
@@ -60,7 +60,7 @@ export const extractSkillManifestUrl = async (
       const notify = new Diagnostic(
         `Accessing skill manifest url error, ${manifestUrl}`,
         'appsettings.json',
-        DiagnosticSeverity.Error
+        DiagnosticSeverity.Warning
       );
       diagnostics.push(notify);
     }

--- a/Composer/packages/server/src/services/project.ts
+++ b/Composer/packages/server/src/services/project.ts
@@ -195,9 +195,6 @@ export class BotProjectService {
   public static getProjectById = async (projectId: string, user?: UserIdentity): Promise<BotProject> => {
     BotProjectService.initialize();
 
-    const cachedProject = BotProjectService.getIndexedProjectById(projectId);
-    if (cachedProject) return cachedProject;
-
     if (!BotProjectService.projectLocationMap?.[projectId]) {
       throw new Error('project not found in cache');
     } else {


### PR DESCRIPTION
## Description

Remove use cache at getProjectById introduced by #2786 to prevent high frequency server index.
nowadays, benefit from LeiLei's work, client do not fetch project at every route change, so there is no need to use cache at `getProjectById` anymore. 

When use want a fresh from server, `ctrl-f` refresh page would work as expected.

Appends: 
Also fixed a skill validating ui.

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item

close #3068 

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

![Untitled1](https://user-images.githubusercontent.com/49866537/82013268-78982680-96ac-11ea-9a03-e9a32cfbb1d7.gif)

skill url validating spinner
![Untitled1](https://user-images.githubusercontent.com/49866537/82029002-ece0c300-96c8-11ea-829e-8ce102234ae7.gif)

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
