### PR TITLE
fix: duplicated key in recent bot list

### DIFF
--- a/Composer/packages/client/src/pages/home/RecentBotList.tsx
+++ b/Composer/packages/client/src/pages/home/RecentBotList.tsx
@@ -28,7 +28,6 @@ interface RecentBotListProps {
 export function RecentBotList(props: RecentBotListProps): JSX.Element {
   const { onItemChosen, recentProjects } = props;
   // for detail file list in open panel
-  console.log(recentProjects);
   const tableColums = [
     {
       key: 'column1',

--- a/Composer/packages/client/src/pages/home/RecentBotList.tsx
+++ b/Composer/packages/client/src/pages/home/RecentBotList.tsx
@@ -28,6 +28,7 @@ interface RecentBotListProps {
 export function RecentBotList(props: RecentBotListProps): JSX.Element {
   const { onItemChosen, recentProjects } = props;
   // for detail file list in open panel
+  console.log(recentProjects);
   const tableColums = [
     {
       key: 'column1',
@@ -122,7 +123,7 @@ export function RecentBotList(props: RecentBotListProps): JSX.Element {
           items={recentProjects}
           compact={false}
           columns={tableColums}
-          getKey={item => item.name}
+          getKey={item => `${item.path}/${item.name}`}
           layoutMode={DetailsListLayoutMode.justified}
           onRenderDetailsHeader={onRenderDetailsHeader}
           isHeaderVisible={true}


### PR DESCRIPTION
## Description
The recent bot list use BotName as the key. The key maybe duplicated which causes the bug.
## Task Item
Closes #3048 

## Screenshots
