### PR TITLE
fix: Goto Begin Dialog after clicking dialog

### DIFF
--- a/Composer/packages/client/src/pages/design/index.tsx
+++ b/Composer/packages/client/src/pages/design/index.tsx
@@ -130,7 +130,6 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
   }, [dialogId, dialogs, location]);
 
   useEffect(() => {
-    console.log(designPageLocation);
     const index = currentDialog.triggers.findIndex(({ type }) => type === SDKKinds.OnBeginDialog);
     if (index >= 0 && !designPageLocation.selected) {
       selectTo(createSelectedPath(index));

--- a/Composer/packages/client/src/pages/design/index.tsx
+++ b/Composer/packages/client/src/pages/design/index.tsx
@@ -130,11 +130,12 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
   }, [dialogId, dialogs, location]);
 
   useEffect(() => {
+    console.log(designPageLocation);
     const index = currentDialog.triggers.findIndex(({ type }) => type === SDKKinds.OnBeginDialog);
     if (index >= 0 && !designPageLocation.selected) {
       selectTo(createSelectedPath(index));
     }
-  }, [currentDialog?.id, designPageLocation]);
+  }, [currentDialog?.id]);
 
   useEffect(() => {
     if (location && props.dialogId && props.projectId) {


### PR DESCRIPTION
## Description
The `designPageLocation` object being included in the `usEffect` dependency array causes the selected trigger to be set to the `BeginDialog` trigger after the user selects the dialog because `designPageLocation.selected` gets set to null when a trigger isn't selected which causes the hook to execute unnecessarily. Removing `designPageLocation` from the `usEffect` dependency array resolves the issue.

## Task Item
Closes #3070

## Screenshots
![recording](https://user-images.githubusercontent.com/17039790/82068317-a4081a80-9686-11ea-80b2-8c50f35e6d5a.gif)

