### PR TITLE
test: use api to create bot in e2e tests

### DIFF
--- a/Composer/cypress.json
+++ b/Composer/cypress.json
@@ -10,7 +10,5 @@
   "viewportWidth": 1600,
   "viewportHeight": 1200,
   "defaultCommandTimeout": 8000,
-  "env": {
-    "COMPOSER_URL": "http://localhost:3000"
-  }
+  "baseUrl": "http://localhost:3000"
 }

--- a/Composer/cypress/integration/Breadcrumb.spec.ts
+++ b/Composer/cypress/integration/Breadcrumb.spec.ts
@@ -3,7 +3,7 @@
 
 context('breadcrumb', () => {
   beforeEach(() => {
-    cy.visit(Cypress.env('COMPOSER_URL'));
+    cy.visit('/home');
     cy.createBot('TodoSample');
 
     // Return to Main.dialog

--- a/Composer/cypress/integration/CreateNewBot.spec.ts
+++ b/Composer/cypress/integration/CreateNewBot.spec.ts
@@ -3,7 +3,7 @@
 
 context('Creating a new bot', () => {
   beforeEach(() => {
-    cy.visit(Cypress.env('COMPOSER_URL'));
+    cy.visit('/home');
     cy.findByTestId('LeftNav-CommandBarButtonHome').click();
     cy.findByTestId('homePage-ToolBar-New').within(() => {
       cy.findByText('New').click();

--- a/Composer/cypress/integration/HomePage.spec.ts
+++ b/Composer/cypress/integration/HomePage.spec.ts
@@ -3,7 +3,7 @@
 
 context('Home Page ', () => {
   beforeEach(() => {
-    cy.visit(Cypress.env('COMPOSER_URL'));
+    cy.visit('/home');
   });
 
   it('can open buttons in home page', () => {

--- a/Composer/cypress/integration/LGPage.spec.ts
+++ b/Composer/cypress/integration/LGPage.spec.ts
@@ -3,7 +3,7 @@
 
 context('LG Page', () => {
   beforeEach(() => {
-    cy.visit(Cypress.env('COMPOSER_URL'));
+    cy.visit('/home');
     cy.createBot('TodoSample');
   });
 

--- a/Composer/cypress/integration/LUPage.spec.ts
+++ b/Composer/cypress/integration/LUPage.spec.ts
@@ -3,7 +3,7 @@
 
 context('LU Page', () => {
   beforeEach(() => {
-    cy.visit(Cypress.env('COMPOSER_URL'));
+    cy.visit('/home');
     cy.createBot('ToDoBotWithLuisSample');
   });
 

--- a/Composer/cypress/integration/LeftNavBar.spec.ts
+++ b/Composer/cypress/integration/LeftNavBar.spec.ts
@@ -3,7 +3,7 @@
 
 context('Left Nav Bar', () => {
   beforeEach(() => {
-    cy.visit(Cypress.env('COMPOSER_URL'));
+    cy.visit('/home');
     cy.createBot('TodoSample');
   });
 

--- a/Composer/cypress/integration/LuisDeploy.spec.ts
+++ b/Composer/cypress/integration/LuisDeploy.spec.ts
@@ -7,7 +7,7 @@ context('Luis Deploy', () => {
     cy.route('POST', '/api/publish/*/publish/default', { endpointURL: 'anything' });
     cy.route('POST', '/api/projects/*/settings', 'OK');
     cy.route('GET', '/api/publish/*/status/default', { endpointURL: 'anything' });
-    cy.visit(Cypress.env('COMPOSER_URL'));
+    cy.visit('/home');
     cy.createBot('ToDoBotWithLuisSample');
   });
 

--- a/Composer/cypress/integration/NavigateUrls.ts
+++ b/Composer/cypress/integration/NavigateUrls.ts
@@ -3,22 +3,22 @@
 
 context('Navigate Url', () => {
   beforeEach(() => {
-    cy.visit(Cypress.env('COMPOSER_URL'));
+    cy.visit('/home');
   });
 
   it('should open Create From Scratch/Template window from a url', () => {
-    cy.visit(`${Cypress.env('COMPOSER_URL')}/projects/create`);
+    cy.visit('/projects/create');
     cy.get('[data-testid="Create from scratch"]').should('be.visible');
     cy.get('[data-testid="Create from template"]').should('be.visible');
   });
 
   it('should open Define Conversations window from a url', () => {
-    cy.visit(`${Cypress.env('COMPOSER_URL')}/projects/create/TodoSample`);
+    cy.visit('/projects/create/TodoSample');
     cy.get('[data-testid="NewDialogName"]').should('be.visible');
   });
 
   it('should create the Open a Bot window from a location through the specified url', () => {
-    cy.visit(`${Cypress.env('COMPOSER_URL')}/projects/open`);
+    cy.visit('/projects/open');
     cy.get('[data-testid="SelectLocation"]').should('be.visible');
   });
 });

--- a/Composer/cypress/integration/NewDialog.spec.ts
+++ b/Composer/cypress/integration/NewDialog.spec.ts
@@ -3,7 +3,7 @@
 
 context('Creating a new Dialog', () => {
   beforeEach(() => {
-    cy.visit(Cypress.env('COMPOSER_URL'));
+    cy.visit('/home');
     cy.createBot('TodoSample');
     cy.findByTestId('LeftNav-CommandBarButtonDesign Flow').click();
   });

--- a/Composer/cypress/integration/NotificationPage.spec.ts
+++ b/Composer/cypress/integration/NotificationPage.spec.ts
@@ -3,7 +3,7 @@
 
 context('Notification Page', () => {
   beforeEach(() => {
-    cy.visit(Cypress.env('COMPOSER_URL'));
+    cy.visit('/home');
     cy.createBot('ToDoBotWithLuisSample');
     cy.visitPage('Notifications');
   });

--- a/Composer/cypress/integration/Onboarding.spec.ts
+++ b/Composer/cypress/integration/Onboarding.spec.ts
@@ -3,7 +3,7 @@
 
 context('Onboarding', () => {
   beforeEach(() => {
-    cy.visit(Cypress.env('COMPOSER_URL'));
+    cy.visit('/home');
     cy.createBot('TodoSample', 'Onboarding');
 
     //enable onboarding setting

--- a/Composer/cypress/integration/RemoveDialog.spec.ts
+++ b/Composer/cypress/integration/RemoveDialog.spec.ts
@@ -3,7 +3,7 @@
 
 context('RemoveDialog', () => {
   beforeEach(() => {
-    cy.visit(Cypress.env('COMPOSER_URL'));
+    cy.visit('/home');
     cy.createBot('ToDoBotWithLuisSample');
   });
 

--- a/Composer/cypress/integration/SaveAs.spec.ts
+++ b/Composer/cypress/integration/SaveAs.spec.ts
@@ -3,7 +3,7 @@
 
 context('Saving As', () => {
   beforeEach(() => {
-    cy.visit(Cypress.env('COMPOSER_URL'));
+    cy.visit('/home');
     cy.createBot('EchoBot', 'TestBot');
   });
 

--- a/Composer/cypress/integration/ToDoBot.spec.ts
+++ b/Composer/cypress/integration/ToDoBot.spec.ts
@@ -22,9 +22,7 @@ context('ToDo Bot', () => {
       cy.findByText('addtodo').click();
     });
 
-    cy.withinEditor('PropertyEditor', () => {
-      cy.findByDisplayValue('addtodo').should('exist');
-    });
+    cy.url().should('contain', 'addtodo');
   });
 
   it('can open the ClearToDos dialog', () => {
@@ -33,10 +31,8 @@ context('ToDo Bot', () => {
       cy.findByText('cleartodos').click();
     });
 
-    cy.withinEditor('PropertyEditor', () => {
-      cy.findByDisplayValue('cleartodos').should('exist');
+    cy.url().should('contain', 'cleartodos');
     });
-  });
 
   it('can open the DeleteToDo dialog', () => {
     cy.findByTestId('ProjectTree').within(() => {
@@ -44,9 +40,7 @@ context('ToDo Bot', () => {
       cy.findByText('deletetodo').click();
     });
 
-    cy.withinEditor('PropertyEditor', () => {
-      cy.findByDisplayValue('deletetodo').should('exist');
-    });
+    cy.url().should('contain', 'deletetodo');
   });
 
   it('can open the ShowToDos dialog', () => {
@@ -55,8 +49,6 @@ context('ToDo Bot', () => {
       cy.findByText('showtodos').click();
     });
 
-    cy.withinEditor('PropertyEditor', () => {
-      cy.findByDisplayValue('showtodos').should('exist');
-    });
+    cy.url().should('contain', 'showtodos');
   });
 });

--- a/Composer/cypress/integration/ToDoBot.spec.ts
+++ b/Composer/cypress/integration/ToDoBot.spec.ts
@@ -3,7 +3,7 @@
 
 context('ToDo Bot', () => {
   beforeEach(() => {
-    cy.visit(Cypress.env('COMPOSER_URL'));
+    cy.visit('/home');
     cy.createBot('TodoSample');
   });
 
@@ -32,7 +32,7 @@ context('ToDo Bot', () => {
     });
 
     cy.url().should('contain', 'cleartodos');
-    });
+  });
 
   it('can open the DeleteToDo dialog', () => {
     cy.findByTestId('ProjectTree').within(() => {

--- a/Composer/cypress/integration/TriggerCreation.spec.ts
+++ b/Composer/cypress/integration/TriggerCreation.spec.ts
@@ -3,7 +3,7 @@
 
 context('Creating a new trigger', () => {
   beforeEach(() => {
-    cy.visit(Cypress.env('COMPOSER_URL'));
+    cy.visit('/home');
     cy.createBot('EmptyBot');
   });
 

--- a/Composer/cypress/integration/VisualDesigner.spec.ts
+++ b/Composer/cypress/integration/VisualDesigner.spec.ts
@@ -3,7 +3,7 @@
 
 context('Visual Designer', () => {
   beforeEach(() => {
-    cy.visit(Cypress.env('COMPOSER_URL'));
+    cy.visit('/home');
     cy.createBot('TodoSample');
     // Return to Main.dialog
     cy.findByTestId('ProjectTree').within(() => {

--- a/Composer/cypress/support/commands.ts
+++ b/Composer/cypress/support/commands.ts
@@ -3,16 +3,20 @@
 
 import '@testing-library/cypress/add-commands';
 
-Cypress.Commands.add('createBot', (bobotId: string, botName?: string) => {
-  cy.findByTestId('LeftNav-CommandBarButtonHome').click();
-  cy.findByTestId('homePage-ToolBar-New').within(() => {
-    cy.findByText('New').click();
+Cypress.Commands.add('createBot', (botId: string, botName?: string) => {
+  const name = `__Test${botName || botId}`;
+
+  const params = {
+    storageId: 'default',
+    name,
+    description: '',
+    templateId: botId,
+  };
+
+  cy.request('post', '/api/projects', params).then(res => {
+    const { id: projectId } = res.body;
+    cy.visit(`/bot/${projectId}/dialogs/${name.toLowerCase()}`);
   });
-  cy.findByTestId('Create from template').click({ force: true });
-  cy.findByTestId(`${bobotId}`).click({ force: true });
-  cy.findByTestId('NextStepButton').click();
-  cy.enterTextAndSubmit('NewDialogName', `__Test${botName || bobotId}`, 'SubmitNewBotBtn');
-  cy.url().should('match', /\/bot\/.*\/dialogs/);
 });
 
 Cypress.Commands.add('withinEditor', (editorName, cb) => {


### PR DESCRIPTION
## Description

- Short circuit the ui to create bot for most tests (create bot spec still uses UI). This should help speed up test runs.
- Uses baseUrl config option instead of COMPOSER_URL env var
- Also fixes todo spec.

## Task Item
refs #3081