### PR TITLE
fix: update recent bots list after deleting a bot project

### DIFF
--- a/Composer/packages/client/src/pages/setting/index.tsx
+++ b/Composer/packages/client/src/pages/setting/index.tsx
@@ -104,7 +104,7 @@ const SettingPage: React.FC<RouteComponentProps<{ '*': string }>> = () => {
     };
     const res = await OpenConfirmModal(title, null, settings);
     if (res) {
-      actions.deleteBotProject(projectId);
+      await actions.deleteBotProject(projectId);
       navigateTo('home');
     }
   };

--- a/Composer/packages/client/src/router.tsx
+++ b/Composer/packages/client/src/router.tsx
@@ -77,7 +77,7 @@ const ProjectRouter: React.FC<RouteComponentProps<{ projectId: string }>> = prop
     if (state.projectId !== props.projectId && props.projectId) {
       actions.fetchProjectById(props.projectId);
     }
-  }, [props.projectId, state.projectId]);
+  }, [props.projectId]);
 
   if (props.projectId !== state.projectId) {
     return <LoadingSpinner />;

--- a/Composer/packages/client/src/store/action/project.ts
+++ b/Composer/packages/client/src/store/action/project.ts
@@ -87,7 +87,13 @@ export const deleteBotProject: ActionCreator = async (store, projectId) => {
       type: ActionTypes.REMOVE_PROJECT_SUCCESS,
     });
   } catch (e) {
-    console.log(e);
+    store.dispatch({
+      type: ActionTypes.SET_ERROR,
+      payload: {
+        message: e.message,
+        summary: 'Delete Bot Error',
+      },
+    });
   }
 };
 


### PR DESCRIPTION
## Description
You can repro this bug easily by deleting an Empty bot.

1. The root reason is a race condition. Pls check the code I have commented there.

2. Set a global error, if we fail to delete a bot.

## Task Item

Closes #3110 

## Screenshots

![aaaa](https://user-images.githubusercontent.com/24380525/82221948-3b08f700-9953-11ea-96d6-6c9ca132cafa.gif)
