### PR TITLE
fix: use currentDialog.id for JsonEditor

### DIFF
--- a/Composer/packages/client/src/pages/design/index.tsx
+++ b/Composer/packages/client/src/pages/design/index.tsx
@@ -429,7 +429,7 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
                 {dialogJsonVisible ? (
                   <JsonEditor
                     key={'dialogjson'}
-                    id={'dialogjson'}
+                    id={currentDialog.id}
                     onChange={data => {
                       actions.updateDialog({ id: currentDialog.id, projectId, content: data });
                     }}


### PR DESCRIPTION
## Description

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

According to BaseEditor, if id is not changed, it will use memo value.
Then when switching dialogs, the json content will not change.

closes #3126

## Task Item

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
