### PR TITLE
fix: show code mess up the dialog content and the persistence layer block issue

### DIFF
--- a/Composer/packages/client/__tests__/store/persistence/filePersistence.test.ts
+++ b/Composer/packages/client/__tests__/store/persistence/filePersistence.test.ts
@@ -41,7 +41,7 @@ describe('test persistence layer', () => {
       luFiles: [{ id: 'a.en-us', content: 'a.lu' }] as LuFile[],
     } as State;
 
-    await filePersistence.notify(state1, state2, { type: ActionTypes.UPDATE_DIALOG, payload: { id: 'a' } });
+    filePersistence.notify(state1, state2, { type: ActionTypes.UPDATE_DIALOG, payload: { id: 'a' } });
     filePersistence.notify(state1, state2, { type: ActionTypes.UPDATE_DIALOG, payload: { id: 'a' } });
     expect(JSON.parse(filePersistence.taskQueue['a.dialog'][0].change).a).toBe('a');
     filePersistence.notify(state1, state2, { type: ActionTypes.UPDATE_LG, payload: { id: 'a.en-us' } });
@@ -72,7 +72,7 @@ describe('test persistence layer', () => {
       ] as LuFile[],
     } as State;
 
-    await filePersistence.notify(state1, state2, { type: ActionTypes.UPDATE_DIALOG, payload: { id: 'a' } });
+    filePersistence.notify(state1, state2, { type: ActionTypes.UPDATE_DIALOG, payload: { id: 'a' } });
     filePersistence.notify(state1, state2, { type: ActionTypes.CREATE_DIALOG, payload: { id: 'b' } });
     expect(JSON.parse(filePersistence.taskQueue['b.dialog'][0].change).b).toBe('b');
     expect(filePersistence.taskQueue['b.en-us.lg'][0].change).toBe('b.lg');
@@ -100,10 +100,10 @@ describe('test persistence layer', () => {
       lgFiles: [{ id: 'a.en-us', content: 'a' }] as LgFile[],
       luFiles: [{ id: 'a.en-us', content: 'a' }] as LuFile[],
     } as State;
-    await filePersistence.notify(state1, state2, { type: ActionTypes.UPDATE_DIALOG, payload: { id: 'a' } });
+    filePersistence.notify(state1, state2, { type: ActionTypes.UPDATE_DIALOG, payload: { id: 'a' } });
     filePersistence.notify(state1, state2, { type: ActionTypes.REMOVE_DIALOG, payload: { id: 'b' } });
-    expect(JSON.parse(filePersistence.taskQueue['b.dialog'][1].change).b).toBe('b.pre');
-    expect(filePersistence.taskQueue['b.en-us.lg'][1].change).toBe('b.pre.lg');
-    expect(filePersistence.taskQueue['b.en-us.lu'][1].change).toBe('b.pre.lu');
+    expect(JSON.parse(filePersistence.taskQueue['b.dialog'][0].change).b).toBe('b.pre');
+    expect(filePersistence.taskQueue['b.en-us.lg'][0].change).toBe('b.pre.lg');
+    expect(filePersistence.taskQueue['b.en-us.lu'][0].change).toBe('b.pre.lu');
   });
 });

--- a/Composer/packages/client/__tests__/store/persistence/filePersistence.test.ts
+++ b/Composer/packages/client/__tests__/store/persistence/filePersistence.test.ts
@@ -45,7 +45,9 @@ describe('test persistence layer', () => {
     filePersistence.notify(state1, state2, { type: ActionTypes.UPDATE_DIALOG, payload: { id: 'a' } });
     expect(JSON.parse(filePersistence.taskQueue['a.dialog'][0].change).a).toBe('a');
     filePersistence.notify(state1, state2, { type: ActionTypes.UPDATE_LG, payload: { id: 'a.en-us' } });
+    filePersistence.notify(state1, state2, { type: ActionTypes.UPDATE_LG, payload: { id: 'a.en-us' } });
     expect(filePersistence.taskQueue['a.en-us.lg'][0].change).toBe('a.lg');
+    filePersistence.notify(state1, state2, { type: ActionTypes.UPDATE_LU, payload: { id: 'a.en-us' } });
     filePersistence.notify(state1, state2, { type: ActionTypes.UPDATE_LU, payload: { id: 'a.en-us' } });
     expect(filePersistence.taskQueue['a.en-us.lu'][0].change).toBe('a.lu');
   });

--- a/Composer/packages/client/src/store/persistence/FilePersistence.ts
+++ b/Composer/packages/client/src/store/persistence/FilePersistence.ts
@@ -111,12 +111,12 @@ class FilePersistence {
         });
         await Promise.all(tasks);
       }
-      this._isFlushing = false;
       return Promise.resolve(true);
     } catch (error) {
       this._handleError('')(error);
-      this._isFlushing = false;
       return Promise.resolve(false);
+    } finally {
+      this._isFlushing = false;
     }
   }
 

--- a/Composer/packages/client/src/store/persistence/FilePersistence.ts
+++ b/Composer/packages/client/src/store/persistence/FilePersistence.ts
@@ -115,6 +115,7 @@ class FilePersistence {
       return Promise.resolve(true);
     } catch (error) {
       this._handleError('')(error);
+      this._isFlushing = false;
       return Promise.resolve(false);
     }
   }

--- a/Composer/packages/lib/code-editor/src/BaseEditor.tsx
+++ b/Composer/packages/lib/code-editor/src/BaseEditor.tsx
@@ -137,11 +137,7 @@ const BaseEditor: React.FC<BaseEditorProps> = props => {
 
   // initialValue is designed to imporve local performance
   // it should be force updated if id change, or previous value is empty.
-  useEffect(() => {
-    if (editor) {
-      editor.setValue(value || (hidePlaceholder ? '' : placeholder));
-    }
-  }, [id, !!value, editor]);
+  const initialValue = useMemo(() => value || (hidePlaceholder ? '' : placeholder), [id, !!value]);
 
   const onEditorMount: EditorDidMount = (getValue, editor) => {
     setEditor(editor);
@@ -226,7 +222,7 @@ const BaseEditor: React.FC<BaseEditorProps> = props => {
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
       >
-        <Editor {...rest} editorDidMount={onEditorMount} options={editorOptions} />
+        <Editor {...rest} key={id} value={initialValue || ''} editorDidMount={onEditorMount} options={editorOptions} />
       </div>
       {(hasError || hasWarning) && (
         <MessageBar

--- a/Composer/packages/lib/code-editor/src/BaseEditor.tsx
+++ b/Composer/packages/lib/code-editor/src/BaseEditor.tsx
@@ -137,7 +137,11 @@ const BaseEditor: React.FC<BaseEditorProps> = props => {
 
   // initialValue is designed to imporve local performance
   // it should be force updated if id change, or previous value is empty.
-  const initialValue = useMemo(() => value || (hidePlaceholder ? '' : placeholder), [id, !!value]);
+  useEffect(() => {
+    if (editor) {
+      editor.setValue(value || (hidePlaceholder ? '' : placeholder));
+    }
+  }, [id, !!value, editor]);
 
   const onEditorMount: EditorDidMount = (getValue, editor) => {
     setEditor(editor);
@@ -222,7 +226,7 @@ const BaseEditor: React.FC<BaseEditorProps> = props => {
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
       >
-        <Editor {...rest} value={initialValue || ''} editorDidMount={onEditorMount} options={editorOptions} />
+        <Editor {...rest} editorDidMount={onEditorMount} options={editorOptions} />
       </div>
       {(hasError || hasWarning) && (
         <MessageBar


### PR DESCRIPTION
## Description

1. If the server return error when handling file update. The flushing flag was not set to false, then the task queue will never do flush.

2. When click show code button, the editor will get initial value. If we switch the dialog, the value will update to the editor, and the editor will call the onChange function to update dialog. The update function in design page will use a stale dialog id to update, so the previous dialog was covered by the new dialog.

In this PR I just re-render the the editor if the id changed. 

It works If we use a reference attached the dialog id to update the dialog too. But the ctrl-z will undo the update and the value will be covered again.

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
refs #3134
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
