### PR TITLE
ci: update utils.ts to allow for "#minor" tag

### DIFF
--- a/.github/actions/conventional-pr/src/utils.ts
+++ b/.github/actions/conventional-pr/src/utils.ts
@@ -54,7 +54,7 @@ export function validateBody(body: string): ValidationResult {
 
   if (!refMatch.test(body)) {
     errors.push(
-      `[Body] Must either reference an issue (ex. 'fixes #1234') or, if this is a minor change with no related issue, tags it as '#minor'.\nSee ${helpLink} for more details.`
+      `[Body] Must either reference an issue (ex. 'fixes #1234') or, if this is a minor change with no related issue, tag it as '#minor'.\nSee ${helpLink} for more details.`
     );
   }
 

--- a/.github/actions/conventional-pr/src/utils.ts
+++ b/.github/actions/conventional-pr/src/utils.ts
@@ -9,7 +9,9 @@ type ValidationResult = string[];
 
 const validTypes = [
   'feat',
+  'feature',
   'fix',
+  'doc',
   'docs',
   'style',
   'refactor',
@@ -43,7 +45,7 @@ export function validateTitle(title: string): ValidationResult {
   return errors;
 }
 
-const refMatch = /(refs?|close(d|s)?|fix(ed|es)?) \#\d+/i;
+const refMatch = /((refs?|close(d|s)?|fix(ed|es)?) \#\d+)|(#minor)/i;
 const helpLink =
   'https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords';
 
@@ -52,7 +54,7 @@ export function validateBody(body: string): ValidationResult {
 
   if (!refMatch.test(body)) {
     errors.push(
-      `[Body] Must reference an issue (ex. 'fixes #1234').\nSee ${helpLink} for more details.`
+      `[Body] Must either reference an issue (ex. 'fixes #1234') or, if this is a minor change with no related issue, tags it as '#minor'.\nSee ${helpLink} for more details.`
     );
   }
 


### PR DESCRIPTION
## Description

Adds a check for "#minor" as a signal for a minor PR without a related issue number. Intended only for use with minor changes (e.g. doc or typo fixes).

## Task Item

closes #3147 
