### PR TITLE
docs: Correct download links (mac and linux are swapped)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The Bot Framework Composer is an open source tool based on the Bot Framework SDK
 
 ## Get Started
 
-- Download Composer for [Windows][201], [Mac][202] and [Linux][203].
+- Download Composer for [Windows][201], [Mac][203] and [Linux][202].
 - To learn about the Bot Framework Composer, read the [documentation][5].
 - To get yourself familiar with the Composer, read [Introduction to Bot Framework Composer][1].
 - [Create your first bot][3]!


### PR DESCRIPTION
## Description

The download links for mac and linux are currently swapped. This fixes them.

#minor  