### PR TITLE
fix: set prettier rule end of line auto

### DIFF
--- a/Composer/.prettierrc
+++ b/Composer/.prettierrc
@@ -2,5 +2,6 @@
   "printWidth": 120,
   "parser": "typescript",
   "singleQuote": true,
-  "tabWidth": 2
+  "tabWidth": 2,
+  "endOfLine": "auto"
 }


### PR DESCRIPTION
## Description
![image](https://user-images.githubusercontent.com/39758135/82649580-02676700-9c4c-11ea-894f-e7242206940a.png)

add 
`endOfLine: auto`
in .prettierrc. this will maintain existing line endings


<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
refs #3164 
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
