### PR TITLE
fix: Fixed expression array styling

### DIFF
--- a/Composer/packages/extensions/adaptive-form/src/components/fields/ArrayField.tsx
+++ b/Composer/packages/extensions/adaptive-form/src/components/fields/ArrayField.tsx
@@ -68,6 +68,7 @@ const ArrayField: React.FC<FieldProps<any[]>> = (props) => {
             label={false}
             rawErrors={rawErrors[idx]}
             schema={itemSchema}
+            stackArrayItems={true}
             uiOptions={uiOptions}
             value={element.value}
             {...getArrayItemProps(arrayItems, idx, handleChange)}

--- a/Composer/packages/extensions/adaptive-form/src/components/fields/ArrayField.tsx
+++ b/Composer/packages/extensions/adaptive-form/src/components/fields/ArrayField.tsx
@@ -62,13 +62,13 @@ const ArrayField: React.FC<FieldProps<any[]>> = (props) => {
           <ArrayFieldItem
             {...rest}
             key={element.id}
+            stackArrayItems
             transparentBorder
             error={rawErrors[idx]}
             id={id}
             label={false}
             rawErrors={rawErrors[idx]}
             schema={itemSchema}
-            stackArrayItems={true}
             uiOptions={uiOptions}
             value={element.value}
             {...getArrayItemProps(arrayItems, idx, handleChange)}

--- a/Composer/packages/extensions/adaptive-form/src/components/fields/ArrayFieldItem.tsx
+++ b/Composer/packages/extensions/adaptive-form/src/components/fields/ArrayFieldItem.tsx
@@ -31,6 +31,7 @@ const ArrayFieldItem: React.FC<ArrayFieldItemProps> = (props) => {
     onReorder,
     onRemove,
     index,
+    label,
     depth,
     onBlur,
     stackArrayItems,
@@ -89,7 +90,7 @@ const ArrayFieldItem: React.FC<ArrayFieldItemProps> = (props) => {
           {...rest}
           css={arrayItem.schemaFieldOverride(!!stackArrayItems)}
           depth={depth + 1}
-          label={!stackArrayItems ? false : undefined}
+          label={!stackArrayItems || label === false ? false : undefined}
           rawErrors={typeof rawErrors === 'object' ? rawErrors[index] : rawErrors}
           transparentBorder={!stackArrayItems ? transparentBorder : undefined}
           uiOptions={uiOptions}

--- a/Composer/packages/ui-plugins/expressions/src/ExpressionField.tsx
+++ b/Composer/packages/ui-plugins/expressions/src/ExpressionField.tsx
@@ -15,14 +15,19 @@ import { getOptions, getSelectedOption, SchemaOption } from './utils';
 
 const styles = {
   container: css`
+    width: 100%;
+
+    label: ExpressionFieldContainer;
+  `,
+  field: css`
+    min-height: 66px;
+  `,
+  labelContainer: css`
     display: flex;
     justify-content: space-between;
     align-items: center;
 
     label: ExpressionField;
-  `,
-  field: css`
-    min-height: 66px;
   `,
 };
 

--- a/Composer/packages/ui-plugins/expressions/src/ExpressionField.tsx
+++ b/Composer/packages/ui-plugins/expressions/src/ExpressionField.tsx
@@ -116,9 +116,9 @@ const ExpressionField: React.FC<FieldProps> = (props) => {
   );
 
   return (
-    <div className={className}>
+    <div css={styles.container} className={className}>
       {shouldRenderContainer && (
-        <div css={styles.container}>
+        <div css={styles.labelContainer}>
           <FieldLabel
             description={description}
             helpLink={uiOptions?.helpLink}

--- a/Composer/packages/ui-plugins/expressions/src/ExpressionField.tsx
+++ b/Composer/packages/ui-plugins/expressions/src/ExpressionField.tsx
@@ -116,7 +116,7 @@ const ExpressionField: React.FC<FieldProps> = (props) => {
   );
 
   return (
-    <div css={styles.container} className={className}>
+    <div className={className} css={styles.container}>
       {shouldRenderContainer && (
         <div css={styles.labelContainer}>
           <FieldLabel


### PR DESCRIPTION
## Description
Fixed the 'Validation Rules' array styling so the expression expands to use the full width of the property editor and errors render below the text field instead of next to it.

## Task Item
Closes #3187

## Screenshots
![ca0007b2-7a78-4ff7-92e8-2f1f56ebf260](https://user-images.githubusercontent.com/17039790/82950818-3d76dc80-9f63-11ea-88e4-9a8f771f40b5.jpg)
