### PR TITLE
fix: ignore runtime folder zipping when local publish

### DIFF
--- a/Composer/plugins/localPublish/src/index.ts
+++ b/Composer/plugins/localPublish/src/index.ts
@@ -341,7 +341,7 @@ class LocalPublisher implements PublishPlugin<PublishConfig> {
     if (fs.existsSync(dstPath)) {
       await removeFile(dstPath);
     }
-    const files = await glob('**/*', { cwd: srcDir, dot: true });
+    const files = await glob('**/*', { cwd: srcDir, dot: true, ignore: ['runtime'] });
     return new Promise((resolve, reject) => {
       const archive = archiver('zip');
       const output = fs.createWriteStream(dstPath);


### PR DESCRIPTION
## Description

Ignore runtime folder zipping when localpublish.

## Task Item

close #3196 

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
