### PR TITLE
chore: use default button instead of button

### DIFF
--- a/Composer/packages/client/src/pages/home/ItemContainer.tsx
+++ b/Composer/packages/client/src/pages/home/ItemContainer.tsx
@@ -4,7 +4,7 @@
 /** @jsx jsx */
 import { jsx, SerializedStyles } from '@emotion/core';
 import React from 'react';
-import { Button, IButtonProps } from 'office-ui-fabric-react/lib/Button';
+import { DefaultButton, IButtonProps } from 'office-ui-fabric-react/lib/Button';
 import { Text } from 'office-ui-fabric-react/lib/Text';
 
 import {
@@ -71,7 +71,7 @@ export const ItemContainer: React.FC<ItemContainerProps> = ({
   };
 
   return (
-    <Button
+    <DefaultButton
       css={[itemContainerWrapper(disabled), styles.container]}
       onClick={async (e) => {
         // todo: clean this up


### PR DESCRIPTION


## Description

Fixes Fluent UI deprecation warning.

## Task Item

#minor 

## Screenshots

![image](https://user-images.githubusercontent.com/3619060/83287096-ee64bd80-a195-11ea-85c0-0aeb41581e15.png)

