### PR TITLE
fix: update expression and publish doc links

### DIFF
--- a/Composer/packages/client/src/pages/setting/dialog-settings/index.tsx
+++ b/Composer/packages/client/src/pages/setting/dialog-settings/index.tsx
@@ -50,10 +50,7 @@ export const DialogSettings: React.FC<RouteComponentProps> = () => {
       <p>
         {hostControlLabels.botSettingDescription}
         &nbsp;
-        <Link
-          href={'https://github.com/microsoft/BotFramework-Composer/blob/stable/docs/deploy-bot.md'}
-          target="_blank"
-        >
+        <Link href={'https://aka.ms/bf-composer-docs-publish-bot'} target="_blank">
           {hostControlLabels.learnMore}
         </Link>
       </p>

--- a/Composer/packages/ui-plugins/expressions/src/index.ts
+++ b/Composer/packages/ui-plugins/expressions/src/index.ts
@@ -10,7 +10,7 @@ const config: PluginConfig = {
   roleSchema: {
     [SDKRoles.expression]: {
       field: ExpressionField,
-      helpLink: 'https://github.com/microsoft/BotBuilder-Samples/tree/master/experimental/common-expression-language',
+      helpLink: 'https://aka.ms/bot-builder-adaptive-expressions-concept',
     },
   },
 };


### PR DESCRIPTION
## Description
Addressing issue #3222
Addressing issue #3224  
#minor

## Additional 
Tested by local build and both doc links reported in the issues now point to the right places. 
