### PR TITLE
docs: Fix for git clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The Bot Framework Composer is an open source tool based on the Bot Framework SDK
 To build and run the Composer project locally as a web application, clone the source code from Github and build the application using the instructions below.
 
 ```
-$ git clone git@github.com:microsoft/BotFramework-Composer.git
+$ git clone https://github.com/microsoft/BotFramework-Composer.git
 $ cd BotFramework-Composer
 $ cd Composer // switch to Composer folder
 $ yarn install // install dependencies


### PR DESCRIPTION
#minor

Running 
```
$ git clone git@github.com:microsoft/BotFramework-Composer.git
```
fails with:
```
C:\>git clone git@github.com:microsoft/BotFramework-Composer.git
Cloning into 'BotFramework-Composer'...
Warning: Permanently added the RSA host key for IP address '140.82.118.3' to the list of known hosts.
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

#minor