### PR TITLE
fix: 3278 fixed itemTitle typo in add and delete dialogs

### DIFF
--- a/Composer/plugins/samples/assets/projects/ToDoBotWithLuisSample/dialogs/additem/additem.dialog
+++ b/Composer/plugins/samples/assets/projects/ToDoBotWithLuisSample/dialogs/additem/additem.dialog
@@ -23,7 +23,7 @@
           "assignments": [
             {
               "property": "dialog.itemTitle",
-              "value": "=coalesce(@itemTite, $itemTitle)"
+              "value": "=coalesce(@itemTitle, $itemTitle)"
             },
             {
               "property": "dialog.listType",

--- a/Composer/plugins/samples/assets/projects/ToDoBotWithLuisSample/dialogs/deleteitem/deleteitem.dialog
+++ b/Composer/plugins/samples/assets/projects/ToDoBotWithLuisSample/dialogs/deleteitem/deleteitem.dialog
@@ -23,7 +23,7 @@
           "assignments": [
             {
               "property": "dialog.itemTitle",
-              "value": "=coalesce(@itemTite, $itemTitle)"
+              "value": "=coalesce(@itemTitle, $itemTitle)"
             },
             {
               "property": "dialog.listType",


### PR DESCRIPTION
## Description
ToDoBotWithLuisSample has itemTite in dialog properties, fixed addItem and deleteItem dialogs to have @itemTitle

## Task Item
[fixes #3278](https://github.com/microsoft/BotFramework-Composer/issues/3278)