### PR TITLE
fix: load lu content need add system locale

### DIFF
--- a/Composer/packages/server/src/models/bot/botProject.ts
+++ b/Composer/packages/server/src/models/bot/botProject.ts
@@ -82,7 +82,7 @@ export class BotProject {
 
     this.settingManager = new DefaultSettingManager(this.dir);
     this.fileStorage = StorageService.getStorageClient(this.ref.storageId, user);
-    this.luPublisher = new LuPublisher(this.dir, this.fileStorage);
+    this.luPublisher = new LuPublisher(this.dir, this.fileStorage, this.locale);
   }
 
   public init = async () => {

--- a/Composer/packages/server/src/models/bot/luPublisher.ts
+++ b/Composer/packages/server/src/models/bot/luPublisher.ts
@@ -43,6 +43,7 @@ export class LuPublisher {
   public storage: IFileStorage;
   public config: ILuisConfig | null = null;
   public downSamplingConfig: IDownSamplingConfig = { maxImbalanceRatio: 0, maxUtteranceAllowed: 0 };
+  private _locale: string;
 
   public crossTrainConfig: ICrossTrainConfig = {
     rootIds: [],
@@ -55,12 +56,13 @@ export class LuPublisher {
     log(message);
   });
 
-  constructor(path: string, storage: IFileStorage) {
+  constructor(path: string, storage: IFileStorage, locale: string) {
     this.botDir = path;
     this.dialogsDir = this.botDir;
     this.generatedFolderPath = Path.join(this.dialogsDir, GENERATEDFOLDER);
     this.interuptionFolderPath = Path.join(this.generatedFolderPath, INTERUPTION);
     this.storage = storage;
+    this._locale = locale;
   }
 
   public publish = async (files: FileInfo[]) => {
@@ -86,6 +88,14 @@ export class LuPublisher {
     this.config = luisConfig;
     this.crossTrainConfig = crossTrainConfig;
     this.downSamplingConfig = downSamplingConfig;
+  }
+
+  public get locale(): string {
+    return this._locale;
+  }
+
+  public set locale(v: string) {
+    this._locale = v;
   }
 
   private async _createGeneratedDir() {
@@ -222,7 +232,7 @@ export class LuPublisher {
   private _loadLuConatents = async (paths: string[]) => {
     return await this.builder.loadContents(
       paths,
-      'en-us',
+      this._locale,
       this.config?.environment || '',
       this.config?.authoringRegion || ''
     );


### PR DESCRIPTION
## Description
The defaultLanguage in luis setting is used as fallback local. And fallbacklocal is used to set default recognizer when we use multi language.

When we load the lu content, the local is used to check the file local. 
lubuild will check the filename, if the filename is 'a.en-us.lu', the local will set to 'en-us'. 
If the file name is 'a.lu', lubuild will use the passed local. 
But if the file is 'a.en-us.lu', and the local is 'it-it', the function will throw an error.

![105ee385-30b9-4cb5-9497-757e0d911b01](https://user-images.githubusercontent.com/39758135/83584192-f39c8080-a578-11ea-81f4-8708c8c1b505.jpg)

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
#minor
refs #3274
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
