### PR TITLE
fix: Silent auto updates now explicitly call the quitAndInstall() method

### DIFF
--- a/Composer/packages/electron-server/__tests__/appUpdater.test.ts
+++ b/Composer/packages/electron-server/__tests__/appUpdater.test.ts
@@ -33,6 +33,7 @@ describe('App updater', () => {
     appUpdater = AppUpdater.getInstance();
     (appUpdater as any).checkingForUpdate = false;
     (appUpdater as any).downloadingUpdate = false;
+    (appUpdater as any)._downloadedUpdate = false;
     (appUpdater as any).settings = { autoDownload: false, useNightly: true };
     mockAutoUpdater.checkForUpdates.mockClear();
     mockAutoUpdater.checkForUpdates.mockClear();
@@ -173,10 +174,12 @@ describe('App updater', () => {
     const emitSpy = jest.spyOn(appUpdater, 'emit');
     (appUpdater as any).checkingForUpdate = true;
     (appUpdater as any).downloadingUpdate = true;
+    (appUpdater as any)._downloadedUpdate = false;
     (appUpdater as any).onUpdateDownloaded('update info');
 
     expect((appUpdater as any).checkingForUpdate).toBe(false);
     expect((appUpdater as any).downloadingUpdate).toBe(false);
+    expect(appUpdater.downloadedUpdate).toBe(true);
     expect(emitSpy).toHaveBeenCalledWith('update-downloaded', 'update info');
   });
 

--- a/Composer/packages/electron-server/src/appUpdater.ts
+++ b/Composer/packages/electron-server/src/appUpdater.ts
@@ -15,6 +15,7 @@ let appUpdater: AppUpdater | undefined;
 export class AppUpdater extends EventEmitter {
   private checkingForUpdate = false;
   private downloadingUpdate = false;
+  private _downloadedUpdate = false;
   private explicitCheck = false;
   private settings: AppUpdaterSettings = { autoDownload: false, useNightly: false };
 
@@ -23,6 +24,7 @@ export class AppUpdater extends EventEmitter {
 
     autoUpdater.allowDowngrade = false;
     autoUpdater.allowPrerelease = true;
+    autoUpdater.autoInstallOnAppQuit = false; // we will explicitly call the install logic
 
     autoUpdater.on('error', this.onError.bind(this));
     autoUpdater.on('checking-for-update', this.onCheckingForUpdate.bind(this));
@@ -71,6 +73,10 @@ export class AppUpdater extends EventEmitter {
     this.settings = settings;
   }
 
+  public get downloadedUpdate(): boolean {
+    return this._downloadedUpdate;
+  }
+
   private onError(err: Error) {
     logger('Got error while checking for updates: ', err);
     this.resetToIdle();
@@ -109,6 +115,7 @@ export class AppUpdater extends EventEmitter {
 
   private onUpdateDownloaded(updateInfo: UpdateInfo) {
     log('Update downloaded: %O', updateInfo);
+    this._downloadedUpdate = true;
     this.resetToIdle();
     if (!this.settings.autoDownload) {
       this.emit('update-downloaded', updateInfo);

--- a/Composer/packages/electron-server/src/main.ts
+++ b/Composer/packages/electron-server/src/main.ts
@@ -97,6 +97,12 @@ function initializeAppUpdater(settings: AppUpdaterSettings) {
     ipcMain.on('update-user-settings', (_ev, settings: UserSettings) => {
       appUpdater.setSettings(settings.appUpdater);
     });
+    app.once('quit', () => {
+      if (appUpdater.downloadedUpdate) {
+        console.log('App quit detected and update was downloaded. Installing update.');
+        appUpdater.quitAndInstall();
+      }
+    });
     appUpdater.checkForUpdates();
   } else {
     throw new Error('Main application window undefined during app updater initialization.');

--- a/Composer/packages/electron-server/src/main.ts
+++ b/Composer/packages/electron-server/src/main.ts
@@ -99,7 +99,6 @@ function initializeAppUpdater(settings: AppUpdaterSettings) {
     });
     app.once('quit', () => {
       if (appUpdater.downloadedUpdate) {
-        console.log('App quit detected and update was downloaded. Installing update.');
         appUpdater.quitAndInstall();
       }
     });


### PR DESCRIPTION
## Description

There was an error in the scenario that:

- The user installed Composer for all users (Windows only)
- The user enabled auto updates (silent install)
- The user **did not** run Composer as administrator

in which once the user exited Composer, a system prompt would ask the user to uninstall the old composer and then fail to run the new installer, resulting in just deleting the current Composer install.

This PR fixes that by explicitly calling the `.quitAndInstall()` method on the app updater class instead of relying on the auto install on app quit logic. The `.quitAndInstall()` API was already working in the explicit update dialog flow, and so no we are just using that in the auto update flow as well.

## Task Item

closes #3237

