### PR TITLE
ci: only run main workflow for ready-to-review PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Composer CI
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [review_requested, ready_for_review, synchronize]
   push:
     branches:
       - master


### PR DESCRIPTION
## Description

Only run main ci when PRs are ready for review. Saves compute time by not running for draft PRs.

<!-- #minor -->