### PR TITLE
feat: Multiple language

### DIFF
--- a/Composer/cypress/integration/NotificationPage.spec.ts
+++ b/Composer/cypress/integration/NotificationPage.spec.ts
@@ -59,7 +59,7 @@ context('Notification Page', () => {
       cy.findByTestId('FieldErrorMessage').should('exist');
     });
 
-    cy.findByTestId('LeftNav-CommandBarButtonNotifications').click();
+    cy.findByTestId('notifications-info-button').click();
 
     // move away from the Notifications button (clicking the logo should do nothing)
     cy.findByAltText('Composer Logo').click();

--- a/Composer/packages/client/__tests__/components/MultiLanguage/MultiLanguage.test.tsx
+++ b/Composer/packages/client/__tests__/components/MultiLanguage/MultiLanguage.test.tsx
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import * as React from 'react';
+import { render, fireEvent } from '@bfc/test-utils';
+
+import { AddLanguageModal, DeleteLanguageModal } from '../../../src/components/MultiLanguage';
+
+const defaultLanguage = 'en-us';
+const languages = ['en-us', 'zh-cn'];
+const locale = 'zh-cn';
+describe('<AddLanguageModal />', () => {
+  it('should render the AddLanguageModal form, and do add language', () => {
+    jest.useFakeTimers();
+    const onSubmit = jest.fn(() => {});
+    const onDismiss = jest.fn(() => {});
+    const { getByText } = render(
+      <AddLanguageModal
+        isOpen
+        defaultLanguage={defaultLanguage}
+        languages={languages}
+        locale={locale}
+        onDismiss={onDismiss}
+        onSubmit={onSubmit}
+      />
+    );
+
+    const engCheckBox = getByText('English (United States) - Original');
+    expect(engCheckBox).toBeTruthy();
+
+    const submitButton = getByText('Done');
+    fireEvent.click(submitButton);
+    expect(onSubmit).toBeCalled();
+
+    const cancelButton = getByText('Cancel');
+    fireEvent.click(cancelButton);
+    expect(onDismiss).toBeCalled();
+  });
+});
+
+describe('<DeleteLanguageModal />', () => {
+  it('should render the DeleteLanguageModal form, and do add language', () => {
+    jest.useFakeTimers();
+    const onSubmit = jest.fn(() => {});
+    const onDismiss = jest.fn(() => {});
+    const { getByText } = render(
+      <DeleteLanguageModal
+        isOpen
+        defaultLanguage={defaultLanguage}
+        languages={languages}
+        locale={locale}
+        onDismiss={onDismiss}
+        onSubmit={onSubmit}
+      />
+    );
+
+    const checkBox = getByText('Chinese (Simplified, China) - Current');
+    expect(checkBox).toBeTruthy();
+
+    const submitButton = getByText('Done');
+    fireEvent.click(submitButton);
+    expect(onSubmit).toBeCalled();
+
+    const cancelButton = getByText('Cancel');
+    fireEvent.click(cancelButton);
+    expect(onDismiss).toBeCalled();
+  });
+});

--- a/Composer/packages/client/__tests__/pages/language-generation/LGPage.test.tsx
+++ b/Composer/packages/client/__tests__/pages/language-generation/LGPage.test.tsx
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import React from 'react';
+
+import { renderWithRecoil } from '../../testUtils';
+import TableView from '../../../src/pages/language-generation/table-view';
+import CodeEditor from '../../../src/pages/language-generation/code-editor';
+import {
+  projectIdState,
+  localeState,
+  dialogsState,
+  luFilesState,
+  lgFilesState,
+  settingsState,
+} from '../../../src/recoilModel';
+
+const initialContent = `
+# Greeting
+- hello
+`;
+
+const initialTemplates = [
+  {
+    name: 'Greeting',
+    body: '- hello',
+  },
+];
+
+const state = {
+  projectId: 'test',
+  dialogs: [{ id: '1' }, { id: '2' }],
+  locale: 'en-us',
+  lgFiles: [
+    { id: 'a.en-us', content: initialContent, templates: initialTemplates },
+    { id: 'a.fr-fr', content: initialContent, templates: initialTemplates },
+  ],
+  luFiles: [
+    { id: 'a.en-us', content: initialContent, templates: initialTemplates },
+    { id: 'a.fr-fr', content: initialContent, templates: initialTemplates },
+  ],
+  settings: {
+    defaultLanguage: 'en-us',
+    languages: ['en-us', 'fr-fr'],
+  },
+};
+
+const initRecoilState = ({ set }) => {
+  set(projectIdState, state.projectId);
+  set(localeState, state.locale);
+  set(dialogsState, state.dialogs);
+  set(luFilesState, state.luFiles);
+  set(lgFilesState, state.lgFiles);
+  set(settingsState, state.settings);
+};
+
+describe('LG page all up view', () => {
+  it('should render lg page table view', () => {
+    const { getByText, getByTestId } = renderWithRecoil(<TableView dialogId={'a'} />, initRecoilState);
+    getByTestId('table-view');
+    getByText('Name');
+  });
+
+  it('should render lg page code editor', () => {
+    renderWithRecoil(<CodeEditor dialogId={'a'} />, initRecoilState);
+  });
+});

--- a/Composer/packages/client/__tests__/pages/language-understanding/LUPage.test.tsx
+++ b/Composer/packages/client/__tests__/pages/language-understanding/LUPage.test.tsx
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import React from 'react';
+
+import TableView from '../../../src/pages/language-understanding/table-view';
+import CodeEditor from '../../../src/pages/language-understanding/code-editor';
+import { renderWithRecoil } from '../../testUtils';
+import {
+  projectIdState,
+  localeState,
+  dialogsState,
+  luFilesState,
+  lgFilesState,
+  settingsState,
+} from '../../../src/recoilModel';
+
+const initialContent = `
+# Greeting
+- hello
+`;
+
+const state = {
+  projectId: 'test',
+  dialogs: [{ id: '1' }, { id: '2' }],
+  locale: 'en-us',
+  lgFiles: [
+    { id: 'a.en-us', content: initialContent },
+    { id: 'a.fr-fr', content: initialContent },
+  ],
+  luFiles: [
+    { id: 'a.en-us', content: initialContent },
+    { id: 'a.fr-fr', content: initialContent },
+  ],
+  settings: {
+    defaultLanguage: 'en-us',
+    languages: ['en-us', 'fr-fr'],
+  },
+};
+
+const initRecoilState = ({ set }) => {
+  set(projectIdState, state.projectId);
+  set(localeState, state.locale);
+  set(dialogsState, state.dialogs);
+  set(luFilesState, state.luFiles);
+  set(lgFilesState, state.lgFiles);
+  set(settingsState, state.settings);
+};
+
+describe('LU page all up view', () => {
+  it('should render lu page table view', () => {
+    const { getByText, getByTestId } = renderWithRecoil(<TableView dialogId={'a'} />, initRecoilState);
+    getByTestId('table-view');
+    getByText('Intent');
+  });
+
+  it('should render lu page code editor', () => {
+    renderWithRecoil(<CodeEditor dialogId={'a'} />, initRecoilState);
+  });
+});

--- a/Composer/packages/client/src/components/MultiLanguage/AddLanguageModal.tsx
+++ b/Composer/packages/client/src/components/MultiLanguage/AddLanguageModal.tsx
@@ -1,0 +1,176 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/** @jsx jsx */
+import without from 'lodash/without';
+import cloneDeep from 'lodash/cloneDeep';
+import { jsx } from '@emotion/core';
+import React, { useState, useCallback, useMemo, useEffect } from 'react';
+import formatMessage from 'format-message';
+import { PrimaryButton, DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { ScrollablePane, IScrollablePaneStyles } from 'office-ui-fabric-react/lib/ScrollablePane';
+import { Stack, StackItem } from 'office-ui-fabric-react/lib/Stack';
+import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
+import { Label } from 'office-ui-fabric-react/lib/Label';
+import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
+
+import { DialogWrapper, DialogTypes } from '../DialogWrapper';
+import { MultiLanguagesDialog } from '../../constants';
+
+import { ILanguageFormData } from './types';
+import { classNames } from './styles';
+import { languageListTemplatesSorted, languageListTemplates } from './utils';
+
+export interface IAddLanguageModalProps {
+  isOpen: boolean;
+  languages: string[];
+  locale: string;
+  defaultLanguage: string;
+  onSubmit: (formData: ILanguageFormData) => void;
+  onDismiss: () => void;
+}
+
+const AddLanguageModal: React.FC<IAddLanguageModalProps> = (props) => {
+  const { languages: currentLanguages, locale, defaultLanguage, isOpen } = props;
+
+  const initialFormData = {
+    languages: [],
+    defaultLang: defaultLanguage,
+    switchTo: false,
+  };
+  const [formData, setFormData] = useState<ILanguageFormData>(initialFormData);
+
+  useEffect(() => {
+    setFormData({ ...formData, defaultLang: defaultLanguage });
+  }, [defaultLanguage]);
+
+  const onChange = (locale: string) => (ev?: React.FormEvent<HTMLElement | HTMLInputElement>, checked?: boolean) => {
+    const newFormData: ILanguageFormData = cloneDeep(formData);
+
+    if (checked) {
+      newFormData.languages.push(locale);
+    } else {
+      newFormData.languages = without(newFormData.languages, locale);
+    }
+
+    setFormData(newFormData);
+  };
+
+  const onDefaultLanguageChange = (
+    _event: React.FormEvent<HTMLDivElement>,
+    option?: IDropdownOption,
+    _index?: number
+  ) => {
+    const selectedLang = option?.key as string;
+    if (selectedLang && selectedLang !== formData.defaultLang) {
+      setFormData({ ...formData, defaultLang: selectedLang });
+    }
+  };
+
+  const onCheckSwitch = (ev?: React.FormEvent<HTMLElement | HTMLInputElement>, checked?: boolean) => {
+    const newFormData: ILanguageFormData = cloneDeep(formData);
+    if (checked) {
+      newFormData.switchTo = true;
+    } else {
+      newFormData.switchTo = false;
+    }
+    setFormData(newFormData);
+  };
+
+  const onSubmit = useCallback(
+    (e) => {
+      e.preventDefault();
+      setFormData(initialFormData);
+      props.onSubmit(formData);
+    },
+    [formData]
+  );
+
+  const onDismiss = useCallback((e) => {
+    e.preventDefault();
+    setFormData(initialFormData);
+    props.onDismiss();
+  }, []);
+
+  const formTitles = { ...MultiLanguagesDialog.ADD_DIALOG };
+
+  const languageCheckBoxList = languageListTemplatesSorted(currentLanguages, locale, defaultLanguage).map((item) => {
+    const { language, isEnabled, isCurrent, isDefault, locale } = item;
+    let label = language;
+    if (isDefault) {
+      label += formatMessage(' - Original');
+    }
+    if (isCurrent) {
+      label += formatMessage(' - Current');
+    }
+    return (
+      <Checkbox
+        key={locale}
+        className={classNames.checkboxItem}
+        defaultChecked={isEnabled}
+        disabled={isEnabled}
+        label={label}
+        onChange={onChange(locale)}
+      />
+    );
+  });
+
+  const defalutLanguageListOptions = useMemo(() => {
+    const languageList = languageListTemplates(currentLanguages, locale, defaultLanguage);
+    const enableLanguages = languageList.filter(({ isEnabled }) => !!isEnabled);
+    return enableLanguages.map((item) => {
+      const { language, locale } = item;
+      return {
+        key: locale,
+        text: language,
+      };
+    });
+  }, [currentLanguages]);
+
+  const scrollablePaneStyles: Partial<IScrollablePaneStyles> = { root: classNames.pane };
+
+  return (
+    <DialogWrapper isOpen={isOpen} onDismiss={onDismiss} {...formTitles} dialogType={DialogTypes.CreateFlow}>
+      <form className={classNames.form} onSubmit={onSubmit}>
+        <input style={{ display: 'none' }} type="submit" />
+        <Stack tokens={{ childrenGap: '3rem' }}>
+          <StackItem grow={0}>
+            <Label>{MultiLanguagesDialog.ADD_DIALOG.selectDefaultLangTitle}</Label>
+            <Dropdown
+              disabled={defalutLanguageListOptions.length === 1}
+              options={defalutLanguageListOptions}
+              placeholder="Select an option"
+              selectedKey={formData.defaultLang}
+              styles={{ dropdown: { width: 300, marginTop: 10 } }}
+              onChange={onDefaultLanguageChange}
+            />
+          </StackItem>
+          <StackItem grow={0}>
+            <Label>{MultiLanguagesDialog.ADD_DIALOG.selectionTitle}</Label>
+            <ScrollablePane styles={scrollablePaneStyles}>{languageCheckBoxList}</ScrollablePane>
+          </StackItem>
+          <StackItem>
+            <Checkbox
+              key={'switchTo'}
+              className={classNames.checkboxSwitchToNew}
+              label={MultiLanguagesDialog.ADD_DIALOG.whenDoneText}
+              onChange={onCheckSwitch}
+            />
+          </StackItem>
+          <StackItem>
+            <PrimaryButton className={classNames.confirmBtn} text={formatMessage('Done')} onClick={onSubmit} />
+
+            <DefaultButton
+              className={classNames.confirmBtn}
+              data-testid="AddLanguageFormCancel"
+              text={formatMessage('Cancel')}
+              onClick={onDismiss}
+            />
+          </StackItem>
+        </Stack>
+      </form>
+    </DialogWrapper>
+  );
+};
+
+export { AddLanguageModal };

--- a/Composer/packages/client/src/components/MultiLanguage/AddLanguageModal.tsx
+++ b/Composer/packages/client/src/components/MultiLanguage/AddLanguageModal.tsx
@@ -110,6 +110,7 @@ const AddLanguageModal: React.FC<IAddLanguageModalProps> = (props) => {
         defaultChecked={isEnabled}
         disabled={isEnabled}
         label={label}
+        title={locale}
         onChange={onChange(locale)}
       />
     );
@@ -122,6 +123,7 @@ const AddLanguageModal: React.FC<IAddLanguageModalProps> = (props) => {
       const { language, locale } = item;
       return {
         key: locale,
+        title: locale,
         text: language,
       };
     });

--- a/Composer/packages/client/src/components/MultiLanguage/DeleteLanguageModal.tsx
+++ b/Composer/packages/client/src/components/MultiLanguage/DeleteLanguageModal.tsx
@@ -1,0 +1,118 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/** @jsx jsx */
+import without from 'lodash/without';
+import cloneDeep from 'lodash/cloneDeep';
+import { jsx } from '@emotion/core';
+import React, { useState, useCallback } from 'react';
+import formatMessage from 'format-message';
+import { PrimaryButton, DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { ScrollablePane, IScrollablePaneStyles } from 'office-ui-fabric-react/lib/ScrollablePane';
+import { Stack, StackItem } from 'office-ui-fabric-react/lib/Stack';
+import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
+import { Label } from 'office-ui-fabric-react/lib/Label';
+
+import { DialogWrapper, DialogTypes } from '../DialogWrapper';
+import { MultiLanguagesDialog } from '../../constants';
+
+import { ILanguageFormData } from './types';
+import { classNames } from './styles';
+import { languageListTemplatesSorted } from './utils';
+
+export interface IDeleteLanguageModalProps {
+  isOpen: boolean;
+  languages: string[];
+  locale: string;
+  defaultLanguage: string;
+  onSubmit: (formData: ILanguageFormData) => void;
+  onDismiss: () => void;
+}
+
+const DeleteLanguageModal: React.FC<IDeleteLanguageModalProps> = (props) => {
+  const { languages: currentLanguages, locale, defaultLanguage, isOpen } = props;
+
+  const initialFormData = {
+    languages: [],
+  };
+  const [formData, setFormData] = useState<ILanguageFormData>(initialFormData);
+
+  const onChange = (locale: string) => (ev?: React.FormEvent<HTMLElement | HTMLInputElement>, checked?: boolean) => {
+    const newFormData: ILanguageFormData = cloneDeep(formData);
+
+    if (checked) {
+      newFormData.languages.push(locale);
+    } else {
+      newFormData.languages = without(newFormData.languages, locale);
+    }
+
+    setFormData(newFormData);
+  };
+
+  const onSubmit = useCallback(
+    (e) => {
+      e.preventDefault();
+      props.onSubmit(formData);
+      setFormData(initialFormData);
+    },
+    [formData]
+  );
+
+  const onDismiss = useCallback((e) => {
+    e.preventDefault();
+    props.onDismiss();
+    setFormData(initialFormData);
+  }, []);
+
+  const formTitles = { ...MultiLanguagesDialog.DELETE_DIALOG };
+
+  const languageCheckBoxList = languageListTemplatesSorted(currentLanguages, locale, defaultLanguage)
+    .filter(({ isEnabled }) => isEnabled)
+    .map((item) => {
+      const { language, isCurrent, isDefault, locale } = item;
+      let label = language;
+      if (isDefault) {
+        label += formatMessage(' - Original');
+      }
+      if (isCurrent) {
+        label += formatMessage(' - Current');
+      }
+      return (
+        <Checkbox
+          key={locale}
+          className={classNames.checkboxItem}
+          disabled={isDefault || isCurrent}
+          label={label}
+          onChange={onChange(locale)}
+        />
+      );
+    });
+
+  const scrollablePaneStyles: Partial<IScrollablePaneStyles> = { root: classNames.pane };
+
+  return (
+    <DialogWrapper isOpen={isOpen} onDismiss={onDismiss} {...formTitles} dialogType={DialogTypes.CreateFlow}>
+      <form className={classNames.form} onSubmit={onSubmit}>
+        <input style={{ display: 'none' }} type="submit" />
+        <Stack tokens={{ childrenGap: '3rem' }}>
+          <StackItem grow={0}>
+            <Label>{MultiLanguagesDialog.ADD_DIALOG.selectionTitle}</Label>
+            <ScrollablePane styles={scrollablePaneStyles}>{languageCheckBoxList}</ScrollablePane>
+          </StackItem>
+          <StackItem>
+            <PrimaryButton className={classNames.confirmBtn} text={formatMessage('Done')} onClick={onSubmit} />
+
+            <DefaultButton
+              className={classNames.confirmBtn}
+              data-testid="DeleteLanguageFormCancel"
+              text={formatMessage('Cancel')}
+              onClick={onDismiss}
+            />
+          </StackItem>
+        </Stack>
+      </form>
+    </DialogWrapper>
+  );
+};
+
+export { DeleteLanguageModal };

--- a/Composer/packages/client/src/components/MultiLanguage/DeleteLanguageModal.tsx
+++ b/Composer/packages/client/src/components/MultiLanguage/DeleteLanguageModal.tsx
@@ -83,6 +83,7 @@ const DeleteLanguageModal: React.FC<IDeleteLanguageModalProps> = (props) => {
           className={classNames.checkboxItem}
           disabled={isDefault || isCurrent}
           label={label}
+          title={locale}
           onChange={onChange(locale)}
         />
       );

--- a/Composer/packages/client/src/components/MultiLanguage/index.tsx
+++ b/Composer/packages/client/src/components/MultiLanguage/index.tsx
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/** @jsx jsx */
+
+export * from './AddLanguageModal';
+export * from './DeleteLanguageModal';
+export * from './utils';

--- a/Composer/packages/client/src/components/MultiLanguage/styles.ts
+++ b/Composer/packages/client/src/components/MultiLanguage/styles.ts
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { FontSizes, getTheme, mergeStyleSets } from 'office-ui-fabric-react/lib/Styling';
+import { css } from '@emotion/core';
+
+const theme = getTheme();
+
+export const FormModalBody = css`
+  padding: 24px;
+`;
+
+export const MarginLeftSmall = css`
+  margin-left: ${FontSizes.small};
+`;
+
+export const SpinnerLabel = css`
+  justify-content: left;
+  margin-top: 0.4rem;
+`;
+
+export const classNames = mergeStyleSets({
+  pane: {
+    maxWidth: 400,
+    height: 150,
+    padding: 10,
+    marginTop: 10,
+    position: 'relative',
+    border: '1px solid ' + theme.palette.neutralLight,
+  },
+  checkboxItem: {
+    padding: 10,
+  },
+  checkboxSwitchToNew: {
+    marginLeft: 10,
+  },
+  form: {
+    padding: '0',
+  },
+  confirmBtn: {
+    float: 'right',
+    marginLeft: '14px',
+  },
+});

--- a/Composer/packages/client/src/components/MultiLanguage/types.ts
+++ b/Composer/packages/client/src/components/MultiLanguage/types.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export interface ILanguageFormData {
+  languages: string[];
+  defaultLang?: string;
+  switchTo?: boolean;
+}
+
+export interface ILanguage {
+  fullName: string;
+  abbrName: string;
+  locale: string;
+}

--- a/Composer/packages/client/src/components/MultiLanguage/utils.ts
+++ b/Composer/packages/client/src/components/MultiLanguage/utils.ts
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+import without from 'lodash/without';
+
+import { Locales } from '../../locales';
+
+export const languageListTemplatesSorted = (languages: string[], locale: string, defaultLanguage: string) => {
+  const defaultLanguageTemplate =
+    Locales.find((lang) => lang.locale === defaultLanguage) || Locales.find((lang) => lang.locale === 'en-us');
+  if (!defaultLanguageTemplate) {
+    throw new Error(`Invalid default language ${defaultLanguage}`);
+  }
+  const restLanguages = without(Locales, defaultLanguageTemplate);
+  const resortedLanguages = [defaultLanguageTemplate, ...restLanguages];
+  const languageList = resortedLanguages.map((lang) => {
+    const isEnabled = languages.includes(lang.locale);
+    const isCurrent = locale === lang.locale;
+    const isDefault = defaultLanguage === lang.locale;
+    return {
+      ...lang,
+      isEnabled,
+      isDefault,
+      isCurrent,
+    };
+  });
+  return languageList;
+};
+
+export const languageListTemplates = (languages: string[], locale: string, defaultLanguage: string) => {
+  const languageList = Locales.map((lang) => {
+    const isEnabled = languages.includes(lang.locale);
+    const isCurrent = locale === lang.locale;
+    const isDefault = defaultLanguage === lang.locale;
+    return {
+      ...lang,
+      isEnabled,
+      isDefault,
+      isCurrent,
+    };
+  });
+  return languageList;
+};

--- a/Composer/packages/client/src/constants.ts
+++ b/Composer/packages/client/src/constants.ts
@@ -106,6 +106,13 @@ export enum ActionTypes {
   SET_CUSTOM_RUNTIME_TOGGLE = 'SET_CUSTOM_RUNTIME_TOGGLE',
   SET_RUNTIME_FIELD = 'SET_RUNTIME_FIELD',
   GET_BOILERPLATE_SUCCESS = 'GET_BOILERPLATE_SUCCESS',
+  SET_LOCALE = 'SET_LOCALE',
+  ADD_LANGUAGES = 'ADD_LANGUAGES',
+  DELETE_LANGUAGES = 'DELETE_LANGUAGES',
+  ADD_LANGUAGE_DIALOG_BEGIN = 'ADD_LANGUAGE_DIALOG_BEGIN',
+  ADD_LANGUAGE_DIALOG_END = 'ADD_LANGUAGE_DIALOG_END',
+  DEL_LANGUAGE_DIALOG_BEGIN = 'DEL_LANGUAGE_DIALOG_BEGIN',
+  DEL_LANGUAGE_DIALOG_END = 'DEL_LANGUAGE_DIALOG_END',
 }
 
 export const Tips = {
@@ -211,6 +218,28 @@ export const DialogDeleting = {
     `The dialog you have tried to delete is currently used in the below dialog(s). Removing this dialog will cause your Bot to malfunction without additional action.`
   ),
   CONFIRM_CONTENT: formatMessage('Do you wish to continue?'),
+};
+
+export const MultiLanguagesDialog = {
+  ADD_DIALOG: {
+    title: formatMessage('Copy content for translation'),
+    subText: formatMessage(
+      `Composer cannot yet translate your bot automatically.\nTo create a translation manually, Composer will create a copy of your bot’s content with the name of the additional language. This content can then be translated without affecting the original bot logic or flow and you can switch between languages to ensure the responses are correctly and appropriately translated.`
+    ),
+    selectDefaultLangTitle: formatMessage(
+      'This language will be copied and used as the basis (and fallback language) for the translation.'
+    ),
+    selectionTitle: formatMessage('To which language will you be translating your bot?'),
+    whenDoneText: formatMessage(
+      'When done, switch to the newly created language and start the (manual) translation process.'
+    ),
+  },
+  DELETE_DIALOG: {
+    title: formatMessage('Select language to delete'),
+    subText: formatMessage(
+      `When deleting a lanuage, only the content will be removed. The flow and logic of the conversation and dialog will remain functional.`
+    ),
+  },
 };
 
 export const addSkillDialog = {

--- a/Composer/packages/client/src/locales.ts
+++ b/Composer/packages/client/src/locales.ts
@@ -1,0 +1,3365 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export const Locales = [
+  {
+    locale: 'af',
+    language: 'Afrikaans',
+  },
+  {
+    locale: 'af-na',
+    language: 'Afrikaans (Namibië)',
+  },
+  {
+    locale: 'af-za',
+    language: 'Afrikaans (South Africa)',
+  },
+  {
+    locale: 'agq',
+    language: 'Aghem',
+  },
+  {
+    locale: 'agq-cm',
+    language: 'Aghem (Kàmàlûŋ)',
+  },
+  {
+    locale: 'ak',
+    language: 'Akan',
+  },
+  {
+    locale: 'ak-gh',
+    language: 'Akan (Gaana)',
+  },
+  {
+    locale: 'sq',
+    language: 'Albanian',
+  },
+  {
+    locale: 'sq-al',
+    language: 'Albanian (Albania)',
+  },
+  {
+    locale: 'gsw-fr',
+    language: 'Alsatian (France)',
+  },
+  {
+    locale: 'am',
+    language: 'Amharic',
+  },
+  {
+    locale: 'am-et',
+    language: 'Amharic (Ethiopia)',
+  },
+  {
+    locale: 'ar',
+    language: 'Arabic',
+  },
+  {
+    locale: 'ar-dz',
+    language: 'Arabic (Algeria)',
+  },
+  {
+    locale: 'ar-bh',
+    language: 'Arabic (Bahrain)',
+  },
+  {
+    locale: 'ar-eg',
+    language: 'Arabic (Egypt)',
+  },
+  {
+    locale: 'ar-iq',
+    language: 'Arabic (Iraq)',
+  },
+  {
+    locale: 'ar-jo',
+    language: 'Arabic (Jordan)',
+  },
+  {
+    locale: 'ar-kw',
+    language: 'Arabic (Kuwait)',
+  },
+  {
+    locale: 'ar-lb',
+    language: 'Arabic (Lebanon)',
+  },
+  {
+    locale: 'ar-ly',
+    language: 'Arabic (Libya)',
+  },
+  {
+    locale: 'ar-ma',
+    language: 'Arabic (Morocco)',
+  },
+  {
+    locale: 'ar-om',
+    language: 'Arabic (Oman)',
+  },
+  {
+    locale: 'ar-qa',
+    language: 'Arabic (Qatar)',
+  },
+  {
+    locale: 'ar-sa',
+    language: 'Arabic (Saudi Arabia)',
+  },
+  {
+    locale: 'ar-sy',
+    language: 'Arabic (Syria)',
+  },
+  {
+    locale: 'ar-tn',
+    language: 'Arabic (Tunisia)',
+  },
+  {
+    locale: 'ar-ae',
+    language: 'Arabic (United Arab Emirates)',
+  },
+  {
+    locale: 'ar-ye',
+    language: 'Arabic (Yemen)',
+  },
+  {
+    locale: 'hy',
+    language: 'Armenian',
+  },
+  {
+    locale: 'hy-am',
+    language: 'Armenian (Armenia)',
+  },
+  {
+    locale: 'as',
+    language: 'Assamese',
+  },
+  {
+    locale: 'as-in',
+    language: 'Assamese (India)',
+  },
+  {
+    locale: 'az',
+    language: 'Azerbaijani',
+  },
+  {
+    locale: 'az-cyrl',
+    language: 'Azerbaijani (Cyrillic)',
+  },
+  {
+    locale: 'az-cyrl-az',
+    language: 'Azerbaijani (Cyrillic, Azerbaijan)',
+  },
+  {
+    locale: 'az-latn',
+    language: 'Azerbaijani (Latin)',
+  },
+  {
+    locale: 'az-latn-az',
+    language: 'Azerbaijani (Latin, Azerbaijan)',
+  },
+  {
+    locale: 'bn',
+    language: 'Bangla',
+  },
+  {
+    locale: 'bn-bd',
+    language: 'Bangla (Bangladesh)',
+  },
+  {
+    locale: 'bn-in',
+    language: 'Bangla (India)',
+  },
+  {
+    locale: 'jv',
+    language: 'Basa Jawa',
+  },
+  {
+    locale: 'jv-latn',
+    language: 'Basa Jawa',
+  },
+  {
+    locale: 'jv-latn-id',
+    language: 'Basa Jawa (Indonesia)',
+  },
+  {
+    locale: 'ba',
+    language: 'Bashkir',
+  },
+  {
+    locale: 'ba-ru',
+    language: 'Bashkir (Russia)',
+  },
+  {
+    locale: 'eu',
+    language: 'Basque',
+  },
+  {
+    locale: 'eu-es',
+    language: 'Basque (Basque)',
+  },
+  {
+    locale: 'be',
+    language: 'Belarusian',
+  },
+  {
+    locale: 'be-by',
+    language: 'Belarusian (Belarus)',
+  },
+  {
+    locale: 'bs',
+    language: 'Bosnian',
+  },
+  {
+    locale: 'bs-cyrl',
+    language: 'Bosnian (Cyrillic)',
+  },
+  {
+    locale: 'bs-cyrl-ba',
+    language: 'Bosnian (Cyrillic, Bosnia and Herzegovina)',
+  },
+  {
+    locale: 'bs-latn',
+    language: 'Bosnian (Latin)',
+  },
+  {
+    locale: 'bs-latn-ba',
+    language: 'Bosnian (Latin, Bosnia and Herzegovina)',
+  },
+  {
+    locale: 'br',
+    language: 'Breton',
+  },
+  {
+    locale: 'br-fr',
+    language: 'Breton (France)',
+  },
+  {
+    locale: 'bg',
+    language: 'Bulgarian',
+  },
+  {
+    locale: 'bg-bg',
+    language: 'Bulgarian (Bulgaria)',
+  },
+  {
+    locale: 'my',
+    language: 'Burmese',
+  },
+  {
+    locale: 'my-mm',
+    language: 'Burmese (Myanmar)',
+  },
+  {
+    locale: 'ca',
+    language: 'Catalan',
+  },
+  {
+    locale: 'ca-es',
+    language: 'Catalan (Catalan)',
+  },
+  {
+    locale: 'tzm',
+    language: 'Central Atlas Tamazight',
+  },
+  {
+    locale: 'tzm-arab-ma',
+    language: 'Central Atlas Tamazight (Arabic, Morocco)',
+  },
+  {
+    locale: 'tzm-latn',
+    language: 'Central Atlas Tamazight (Latin)',
+  },
+  {
+    locale: 'tzm-latn-dz',
+    language: 'Central Atlas Tamazight (Latin, Algeria)',
+  },
+  {
+    locale: 'tzm-tfng',
+    language: 'Central Atlas Tamazight (Tifinagh)',
+  },
+  {
+    locale: 'tzm-tfng-ma',
+    language: 'Central Atlas Tamazight (Tifinagh, Morocco)',
+  },
+  {
+    locale: 'ku',
+    language: 'Central Kurdish',
+  },
+  {
+    locale: 'ku-arab',
+    language: 'Central Kurdish',
+  },
+  {
+    locale: 'ku-arab-iq',
+    language: 'Central Kurdish (Iraq)',
+  },
+  {
+    locale: 'chr',
+    language: 'Cherokee',
+  },
+  {
+    locale: 'chr-cher',
+    language: 'Cherokee',
+  },
+  {
+    locale: 'chr-cher-us',
+    language: 'Cherokee (Cherokee, United States)',
+  },
+  {
+    locale: 'kde',
+    language: 'Chimakonde',
+  },
+  {
+    locale: 'kde-tz',
+    language: 'Chimakonde (Tanzania)',
+  },
+  {
+    locale: 'zh',
+    language: 'Chinese',
+  },
+  {
+    locale: 'zh-hans',
+    language: 'Chinese (Simplified)',
+  },
+  {
+    locale: 'zh-cn',
+    language: 'Chinese (Simplified, China)',
+  },
+  {
+    locale: 'zh-sg',
+    language: 'Chinese (Simplified, Singapore)',
+  },
+  {
+    locale: 'zh-hant',
+    language: 'Chinese (Traditional)',
+  },
+  {
+    locale: 'zh-hk',
+    language: 'Chinese (Traditional, Hong Kong SAR)',
+  },
+  {
+    locale: 'zh-mo',
+    language: 'Chinese (Traditional, Macao SAR)',
+  },
+  {
+    locale: 'zh-tw',
+    language: 'Chinese (Traditional, Taiwan)',
+  },
+  {
+    locale: 'co',
+    language: 'Corsican',
+  },
+  {
+    locale: 'co-fr',
+    language: 'Corsican (France)',
+  },
+  {
+    locale: 'hr',
+    language: 'Croatian',
+  },
+  {
+    locale: 'hr-ba',
+    language: 'Croatian (Bosnia and Herzegovina)',
+  },
+  {
+    locale: 'hr-hr',
+    language: 'Croatian (Croatia)',
+  },
+  {
+    locale: 'cs',
+    language: 'Czech',
+  },
+  {
+    locale: 'cs-cz',
+    language: 'Czech (Czechia)',
+  },
+  {
+    locale: 'da',
+    language: 'Danish',
+  },
+  {
+    locale: 'da-dk',
+    language: 'Danish (Denmark)',
+  },
+  {
+    locale: 'prs',
+    language: 'Dari',
+  },
+  {
+    locale: 'prs-af',
+    language: 'Dari (Afghanistan)',
+  },
+  {
+    locale: 'de-be',
+    language: 'Deutsch (Belgien)',
+  },
+  {
+    locale: 'de-it',
+    language: 'Deutsch (Italien)',
+  },
+  {
+    locale: 'luo',
+    language: 'Dholuo',
+  },
+  {
+    locale: 'luo-ke',
+    language: 'Dholuo (Kenya)',
+  },
+  {
+    locale: 'dv',
+    language: 'Divehi',
+  },
+  {
+    locale: 'dv-mv',
+    language: 'Divehi (Maldives)',
+  },
+  {
+    locale: 'nl',
+    language: 'Dutch',
+  },
+  {
+    locale: 'nl-be',
+    language: 'Dutch (Belgium)',
+  },
+  {
+    locale: 'nl-nl',
+    language: 'Dutch (Netherlands)',
+  },
+  {
+    locale: 'dz-bt',
+    language: 'Dzongkha (Bhutan)',
+  },
+  {
+    locale: 'bin',
+    language: 'Edo',
+  },
+  {
+    locale: 'bin-ng',
+    language: 'Edo (Nigeria)',
+  },
+  {
+    locale: 'guz',
+    language: 'Ekegusii',
+  },
+  {
+    locale: 'guz-ke',
+    language: 'Ekegusii (Kenya)',
+  },
+  {
+    locale: 'en',
+    language: 'English',
+  },
+  {
+    locale: 'en-as',
+    language: 'English (American Samoa)',
+  },
+  {
+    locale: 'en-ai',
+    language: 'English (Anguilla)',
+  },
+  {
+    locale: 'en-ag',
+    language: 'English (Antigua and Barbuda)',
+  },
+  {
+    locale: 'en-au',
+    language: 'English (Australia)',
+  },
+  {
+    locale: 'en-at',
+    language: 'English (Austria)',
+  },
+  {
+    locale: 'en-bs',
+    language: 'English (Bahamas)',
+  },
+  {
+    locale: 'en-bb',
+    language: 'English (Barbados)',
+  },
+  {
+    locale: 'en-be',
+    language: 'English (Belgium)',
+  },
+  {
+    locale: 'en-bz',
+    language: 'English (Belize)',
+  },
+  {
+    locale: 'en-bm',
+    language: 'English (Bermuda)',
+  },
+  {
+    locale: 'en-bw',
+    language: 'English (Botswana)',
+  },
+  {
+    locale: 'en-io',
+    language: 'English (British Indian Ocean Territory)',
+  },
+  {
+    locale: 'en-vg',
+    language: 'English (British Virgin Islands)',
+  },
+  {
+    locale: 'en-bi',
+    language: 'English (Burundi)',
+  },
+  {
+    locale: 'en-cm',
+    language: 'English (Cameroon)',
+  },
+  {
+    locale: 'en-ca',
+    language: 'English (Canada)',
+  },
+  {
+    locale: 'en-029',
+    language: 'English (Caribbean)',
+  },
+  {
+    locale: 'en-ky',
+    language: 'English (Cayman Islands)',
+  },
+  {
+    locale: 'en-cx',
+    language: 'English (Christmas Island)',
+  },
+  {
+    locale: 'en-cc',
+    language: 'English (Cocos (Keeling) Islands)',
+  },
+  {
+    locale: 'en-ck',
+    language: 'English (Cook Islands)',
+  },
+  {
+    locale: 'en-cy',
+    language: 'English (Cyprus)',
+  },
+  {
+    locale: 'en-dk',
+    language: 'English (Denmark)',
+  },
+  {
+    locale: 'en-dm',
+    language: 'English (Dominica)',
+  },
+  {
+    locale: 'en-er',
+    language: 'English (Eritrea)',
+  },
+  {
+    locale: 'en-150',
+    language: 'English (Europe)',
+  },
+  {
+    locale: 'en-fk',
+    language: 'English (Falkland Islands)',
+  },
+  {
+    locale: 'en-fj',
+    language: 'English (Fiji)',
+  },
+  {
+    locale: 'en-fi',
+    language: 'English (Finland)',
+  },
+  {
+    locale: 'en-gm',
+    language: 'English (Gambia)',
+  },
+  {
+    locale: 'en-de',
+    language: 'English (Germany)',
+  },
+  {
+    locale: 'en-gh',
+    language: 'English (Ghana)',
+  },
+  {
+    locale: 'en-gi',
+    language: 'English (Gibraltar)',
+  },
+  {
+    locale: 'en-gd',
+    language: 'English (Grenada)',
+  },
+  {
+    locale: 'en-gu',
+    language: 'English (Guam)',
+  },
+  {
+    locale: 'en-gg',
+    language: 'English (Guernsey)',
+  },
+  {
+    locale: 'en-gy',
+    language: 'English (Guyana)',
+  },
+  {
+    locale: 'en-hk',
+    language: 'English (Hong Kong SAR)',
+  },
+  {
+    locale: 'en-in',
+    language: 'English (India)',
+  },
+  {
+    locale: 'en-id',
+    language: 'English (Indonesia)',
+  },
+  {
+    locale: 'en-ie',
+    language: 'English (Ireland)',
+  },
+  {
+    locale: 'en-im',
+    language: 'English (Isle of Man)',
+  },
+  {
+    locale: 'en-il',
+    language: 'English (Israel)',
+  },
+  {
+    locale: 'en-jm',
+    language: 'English (Jamaica)',
+  },
+  {
+    locale: 'en-je',
+    language: 'English (Jersey)',
+  },
+  {
+    locale: 'en-ke',
+    language: 'English (Kenya)',
+  },
+  {
+    locale: 'en-ki',
+    language: 'English (Kiribati)',
+  },
+  {
+    locale: 'en-ls',
+    language: 'English (Lesotho)',
+  },
+  {
+    locale: 'en-lr',
+    language: 'English (Liberia)',
+  },
+  {
+    locale: 'en-mo',
+    language: 'English (Macao SAR)',
+  },
+  {
+    locale: 'en-mg',
+    language: 'English (Madagascar)',
+  },
+  {
+    locale: 'en-mw',
+    language: 'English (Malawi)',
+  },
+  {
+    locale: 'en-my',
+    language: 'English (Malaysia)',
+  },
+  {
+    locale: 'en-mt',
+    language: 'English (Malta)',
+  },
+  {
+    locale: 'en-mh',
+    language: 'English (Marshall Islands)',
+  },
+  {
+    locale: 'en-mu',
+    language: 'English (Mauritius)',
+  },
+  {
+    locale: 'en-fm',
+    language: 'English (Micronesia)',
+  },
+  {
+    locale: 'en-ms',
+    language: 'English (Montserrat)',
+  },
+  {
+    locale: 'en-na',
+    language: 'English (Namibia)',
+  },
+  {
+    locale: 'en-nr',
+    language: 'English (Nauru)',
+  },
+  {
+    locale: 'en-nl',
+    language: 'English (Netherlands)',
+  },
+  {
+    locale: 'en-nz',
+    language: 'English (New Zealand)',
+  },
+  {
+    locale: 'en-ng',
+    language: 'English (Nigeria)',
+  },
+  {
+    locale: 'en-nu',
+    language: 'English (Niue)',
+  },
+  {
+    locale: 'en-nf',
+    language: 'English (Norfolk Island)',
+  },
+  {
+    locale: 'en-mp',
+    language: 'English (Northern Mariana Islands)',
+  },
+  {
+    locale: 'en-pk',
+    language: 'English (Pakistan)',
+  },
+  {
+    locale: 'en-pw',
+    language: 'English (Palau)',
+  },
+  {
+    locale: 'en-pg',
+    language: 'English (Papua New Guinea)',
+  },
+  {
+    locale: 'en-ph',
+    language: 'English (Philippines)',
+  },
+  {
+    locale: 'en-pn',
+    language: 'English (Pitcairn Islands)',
+  },
+  {
+    locale: 'en-pr',
+    language: 'English (Puerto Rico)',
+  },
+  {
+    locale: 'en-rw',
+    language: 'English (Rwanda)',
+  },
+  {
+    locale: 'en-kn',
+    language: 'English (Saint Kitts and Nevis)',
+  },
+  {
+    locale: 'en-lc',
+    language: 'English (Saint Lucia)',
+  },
+  {
+    locale: 'en-vc',
+    language: 'English (Saint Vincent and the Grenadines)',
+  },
+  {
+    locale: 'en-ws',
+    language: 'English (Samoa)',
+  },
+  {
+    locale: 'en-sc',
+    language: 'English (Seychelles)',
+  },
+  {
+    locale: 'en-sl',
+    language: 'English (Sierra Leone)',
+  },
+  {
+    locale: 'en-sg',
+    language: 'English (Singapore)',
+  },
+  {
+    locale: 'en-sx',
+    language: 'English (Sint Maarten)',
+  },
+  {
+    locale: 'en-si',
+    language: 'English (Slovenia)',
+  },
+  {
+    locale: 'en-sb',
+    language: 'English (Solomon Islands)',
+  },
+  {
+    locale: 'en-za',
+    language: 'English (South Africa)',
+  },
+  {
+    locale: 'en-ss',
+    language: 'English (South Sudan)',
+  },
+  {
+    locale: 'en-sh',
+    language: 'English (St Helena, Ascension, Tristan da Cunha)',
+  },
+  {
+    locale: 'en-sd',
+    language: 'English (Sudan)',
+  },
+  {
+    locale: 'en-sz',
+    language: 'English (Swaziland)',
+  },
+  {
+    locale: 'en-se',
+    language: 'English (Sweden)',
+  },
+  {
+    locale: 'en-ch',
+    language: 'English (Switzerland)',
+  },
+  {
+    locale: 'en-tz',
+    language: 'English (Tanzania)',
+  },
+  {
+    locale: 'en-tk',
+    language: 'English (Tokelau)',
+  },
+  {
+    locale: 'en-to',
+    language: 'English (Tonga)',
+  },
+  {
+    locale: 'en-tt',
+    language: 'English (Trinidad and Tobago)',
+  },
+  {
+    locale: 'en-tc',
+    language: 'English (Turks and Caicos Islands)',
+  },
+  {
+    locale: 'en-tv',
+    language: 'English (Tuvalu)',
+  },
+  {
+    locale: 'en-um',
+    language: 'English (U.S. Outlying Islands)',
+  },
+  {
+    locale: 'en-vi',
+    language: 'English (U.S. Virgin Islands)',
+  },
+  {
+    locale: 'en-ug',
+    language: 'English (Uganda)',
+  },
+  {
+    locale: 'en-gb',
+    language: 'English (United Kingdom)',
+  },
+  {
+    locale: 'en-us',
+    language: 'English (United States)',
+  },
+  {
+    locale: 'en-vu',
+    language: 'English (Vanuatu)',
+  },
+  {
+    locale: 'en-001',
+    language: 'English (World)',
+  },
+  {
+    locale: 'en-zm',
+    language: 'English (Zambia)',
+  },
+  {
+    locale: 'en-zw',
+    language: 'English (Zimbabwe)',
+  },
+  {
+    locale: 'et',
+    language: 'Estonian',
+  },
+  {
+    locale: 'et-ee',
+    language: 'Estonian (Estonia)',
+  },
+  {
+    locale: 'ee',
+    language: 'Eʋegbe',
+  },
+  {
+    locale: 'ee-gh',
+    language: 'Eʋegbe (Ghana nutome)',
+  },
+  {
+    locale: 'ee-tg',
+    language: 'Eʋegbe (Togo nutome)',
+  },
+  {
+    locale: 'fo',
+    language: 'Faroese',
+  },
+  {
+    locale: 'fo-fo',
+    language: 'Faroese (Faroe Islands)',
+  },
+  {
+    locale: 'fil',
+    language: 'Filipino',
+  },
+  {
+    locale: 'fil-ph',
+    language: 'Filipino (Philippines)',
+  },
+  {
+    locale: 'fi',
+    language: 'Finnish',
+  },
+  {
+    locale: 'fi-fi',
+    language: 'Finnish (Finland)',
+  },
+  {
+    locale: 'fr',
+    language: 'French',
+  },
+  {
+    locale: 'fr-be',
+    language: 'French (Belgium)',
+  },
+  {
+    locale: 'fr-cm',
+    language: 'French (Cameroon)',
+  },
+  {
+    locale: 'fr-ca',
+    language: 'French (Canada)',
+  },
+  {
+    locale: 'fr-029',
+    language: 'French (Caribbean)',
+  },
+  {
+    locale: 'fr-ci',
+    language: 'French (Côte d’Ivoire)',
+  },
+  {
+    locale: 'fr-fr',
+    language: 'French (France)',
+  },
+  {
+    locale: 'fr-ht',
+    language: 'French (Haiti)',
+  },
+  {
+    locale: 'fr-lu',
+    language: 'French (Luxembourg)',
+  },
+  {
+    locale: 'fr-ml',
+    language: 'French (Mali)',
+  },
+  {
+    locale: 'fr-mc',
+    language: 'French (Monaco)',
+  },
+  {
+    locale: 'fr-ma',
+    language: 'French (Morocco)',
+  },
+  {
+    locale: 'fr-re',
+    language: 'French (Réunion)',
+  },
+  {
+    locale: 'fr-sn',
+    language: 'French (Senegal)',
+  },
+  {
+    locale: 'fr-ch',
+    language: 'French (Switzerland)',
+  },
+  {
+    locale: 'fr-cd',
+    language: 'French Congo (DRC)',
+  },
+  {
+    locale: 'ff',
+    language: 'Fulah',
+  },
+  {
+    locale: 'ff-latn',
+    language: 'Fulah',
+  },
+  {
+    locale: 'ff-latn-sn',
+    language: 'Fulah (Latin, Senegal)',
+  },
+  {
+    locale: 'ff-ng',
+    language: 'Fulah (Nigeria)',
+  },
+  {
+    locale: 'gv',
+    language: 'Gaelg',
+  },
+  {
+    locale: 'gv-im',
+    language: 'Gaelg (Ellan Vannin)',
+  },
+  {
+    locale: 'gl',
+    language: 'Galician',
+  },
+  {
+    locale: 'gl-es',
+    language: 'Galician (Galician)',
+  },
+  {
+    locale: 'ka',
+    language: 'Georgian',
+  },
+  {
+    locale: 'ka-ge',
+    language: 'Georgian (Georgia)',
+  },
+  {
+    locale: 'de',
+    language: 'German',
+  },
+  {
+    locale: 'de-at',
+    language: 'German (Austria)',
+  },
+  {
+    locale: 'de-de',
+    language: 'German (Germany)',
+  },
+  {
+    locale: 'de-li',
+    language: 'German (Liechtenstein)',
+  },
+  {
+    locale: 'de-lu',
+    language: 'German (Luxembourg)',
+  },
+  {
+    locale: 'de-ch',
+    language: 'German (Switzerland)',
+  },
+  {
+    locale: 'ki',
+    language: 'Gikuyu',
+  },
+  {
+    locale: 'ki-ke',
+    language: 'Gikuyu (Kenya)',
+  },
+  {
+    locale: 'el',
+    language: 'Greek',
+  },
+  {
+    locale: 'el-gr',
+    language: 'Greek (Greece)',
+  },
+  {
+    locale: 'kl',
+    language: 'Greenlandic',
+  },
+  {
+    locale: 'kl-gl',
+    language: 'Greenlandic (Greenland)',
+  },
+  {
+    locale: 'gn',
+    language: 'Guarani',
+  },
+  {
+    locale: 'gn-py',
+    language: 'Guarani (Paraguay)',
+  },
+  {
+    locale: 'gu',
+    language: 'Gujarati',
+  },
+  {
+    locale: 'gu-in',
+    language: 'Gujarati (India)',
+  },
+  {
+    locale: 'ha',
+    language: 'Hausa',
+  },
+  {
+    locale: 'ha-latn-gh',
+    language: 'Hausa (Gana)',
+  },
+  {
+    locale: 'ha-latn',
+    language: 'Hausa (Latin)',
+  },
+  {
+    locale: 'ha-latn-ng',
+    language: 'Hausa (Latin, Nigeria)',
+  },
+  {
+    locale: 'ha-latn-ne',
+    language: 'Hausa (Nijar)',
+  },
+  {
+    locale: 'haw',
+    language: 'Hawaiian',
+  },
+  {
+    locale: 'haw-us',
+    language: 'Hawaiian (United States)',
+  },
+  {
+    locale: 'he',
+    language: 'Hebrew',
+  },
+  {
+    locale: 'he-il',
+    language: 'Hebrew (Israel)',
+  },
+  {
+    locale: 'bez',
+    language: 'Hibena',
+  },
+  {
+    locale: 'bez-tz',
+    language: 'Hibena (Hutanzania)',
+  },
+  {
+    locale: 'hi',
+    language: 'Hindi',
+  },
+  {
+    locale: 'hi-in',
+    language: 'Hindi (India)',
+  },
+  {
+    locale: 'hu',
+    language: 'Hungarian',
+  },
+  {
+    locale: 'hu-hu',
+    language: 'Hungarian (Hungary)',
+  },
+  {
+    locale: 'ibb',
+    language: 'Ibibio',
+  },
+  {
+    locale: 'ibb-ng',
+    language: 'Ibibio (Nigeria)',
+  },
+  {
+    locale: 'is',
+    language: 'Icelandic',
+  },
+  {
+    locale: 'is-is',
+    language: 'Icelandic (Iceland)',
+  },
+  {
+    locale: 'bem',
+    language: 'Ichibemba',
+  },
+  {
+    locale: 'bem-zm',
+    language: 'Ichibemba (Zambia)',
+  },
+  {
+    locale: 'ig',
+    language: 'Igbo',
+  },
+  {
+    locale: 'ig-ng',
+    language: 'Igbo (Nigeria)',
+  },
+  {
+    locale: 'rn',
+    language: 'Ikirundi',
+  },
+  {
+    locale: 'rn-bi',
+    language: 'Ikirundi (Uburundi)',
+  },
+  {
+    locale: 'id',
+    language: 'Indonesian',
+  },
+  {
+    locale: 'id-id',
+    language: 'Indonesian (Indonesia)',
+  },
+  {
+    locale: 'iu',
+    language: 'Inuktitut',
+  },
+  {
+    locale: 'iu-latn',
+    language: 'Inuktitut (Latin)',
+  },
+  {
+    locale: 'iu-latn-ca',
+    language: 'Inuktitut (Latin, Canada)',
+  },
+  {
+    locale: 'iu-cans',
+    language: 'Inuktitut (Syllabics)',
+  },
+  {
+    locale: 'iu-cans-ca',
+    language: 'Inuktitut (Syllabics, Canada)',
+  },
+  {
+    locale: 'ga',
+    language: 'Irish',
+  },
+  {
+    locale: 'ga-ie',
+    language: 'Irish (Ireland)',
+  },
+  {
+    locale: 'sbp',
+    language: 'Ishisangu',
+  },
+  {
+    locale: 'sbp-tz',
+    language: 'Ishisangu (Tansaniya)',
+  },
+  {
+    locale: 'it',
+    language: 'Italian',
+  },
+  {
+    locale: 'it-it',
+    language: 'Italian (Italy)',
+  },
+  {
+    locale: 'it-ch',
+    language: 'Italian (Switzerland)',
+  },
+  {
+    locale: 'ja',
+    language: 'Japanese',
+  },
+  {
+    locale: 'ja-jp',
+    language: 'Japanese (Japan)',
+  },
+  {
+    locale: 'quc',
+    language: "K'iche'",
+  },
+  {
+    locale: 'quc-latn',
+    language: "K'iche'",
+  },
+  {
+    locale: 'quc-latn-gt',
+    language: "K'iche' (Guatemala)",
+  },
+  {
+    locale: 'kln',
+    language: 'Kalenjin',
+  },
+  {
+    locale: 'kln-ke',
+    language: 'Kalenjin (Emetab Kenya)',
+  },
+  {
+    locale: 'kn',
+    language: 'Kannada',
+  },
+  {
+    locale: 'kn-in',
+    language: 'Kannada (India)',
+  },
+  {
+    locale: 'kr',
+    language: 'Kanuri',
+  },
+  {
+    locale: 'kr-ng',
+    language: 'Kanuri (Nigeria)',
+  },
+  {
+    locale: 'ks',
+    language: 'Kashmiri',
+  },
+  {
+    locale: 'ks-deva-in',
+    language: 'Kashmiri (Devanagari)',
+  },
+  {
+    locale: 'ks-arab',
+    language: 'Kashmiri (Perso-Arabic)',
+  },
+  {
+    locale: 'kk',
+    language: 'Kazakh',
+  },
+  {
+    locale: 'kk-kz',
+    language: 'Kazakh (Kazakhstan)',
+  },
+  {
+    locale: 'km',
+    language: 'Khmer',
+  },
+  {
+    locale: 'km-kh',
+    language: 'Khmer (Cambodia)',
+  },
+  {
+    locale: 'naq',
+    language: 'Khoekhoegowab',
+  },
+  {
+    locale: 'naq-na',
+    language: 'Khoekhoegowab (Namibiab)',
+  },
+  {
+    locale: 'rof',
+    language: 'Kihorombo',
+  },
+  {
+    locale: 'rof-tz',
+    language: 'Kihorombo (Tanzania)',
+  },
+  {
+    locale: 'kam',
+    language: 'Kikamba',
+  },
+  {
+    locale: 'kam-ke',
+    language: 'Kikamba (Kenya)',
+  },
+  {
+    locale: 'jmc',
+    language: 'Kimachame',
+  },
+  {
+    locale: 'jmc-tz',
+    language: 'Kimachame (Tanzania)',
+  },
+  {
+    locale: 'rw',
+    language: 'Kinyarwanda',
+  },
+  {
+    locale: 'rw-rw',
+    language: 'Kinyarwanda (Rwanda)',
+  },
+  {
+    locale: 'asa',
+    language: 'Kipare',
+  },
+  {
+    locale: 'asa-tz',
+    language: 'Kipare (Tadhania)',
+  },
+  {
+    locale: 'rwk',
+    language: 'Kiruwa',
+  },
+  {
+    locale: 'rwk-tz',
+    language: 'Kiruwa (Tanzania)',
+  },
+  {
+    locale: 'saq',
+    language: 'Kisampur',
+  },
+  {
+    locale: 'saq-ke',
+    language: 'Kisampur (Kenya)',
+  },
+  {
+    locale: 'ksb',
+    language: 'Kishambaa',
+  },
+  {
+    locale: 'ksb-tz',
+    language: 'Kishambaa (Tanzania)',
+  },
+  {
+    locale: 'sw',
+    language: 'Kiswahili',
+  },
+  {
+    locale: 'sw-cd',
+    language: 'Kiswahili (Jamhuri ya Kidemokrasia ya Kongo)',
+  },
+  {
+    locale: 'sw-ke',
+    language: 'Kiswahili (Kenya)',
+  },
+  {
+    locale: 'sw-tz',
+    language: 'Kiswahili (Tanzania)',
+  },
+  {
+    locale: 'sw-ug',
+    language: 'Kiswahili (Uganda)',
+  },
+  {
+    locale: 'dav',
+    language: 'Kitaita',
+  },
+  {
+    locale: 'dav-ke',
+    language: 'Kitaita (Kenya)',
+  },
+  {
+    locale: 'teo',
+    language: 'Kiteso',
+  },
+  {
+    locale: 'teo-ke',
+    language: 'Kiteso (Kenia)',
+  },
+  {
+    locale: 'teo-ug',
+    language: 'Kiteso (Uganda)',
+  },
+  {
+    locale: 'kok',
+    language: 'Konkani',
+  },
+  {
+    locale: 'kok-in',
+    language: 'Konkani (India)',
+  },
+  {
+    locale: 'ko',
+    language: 'Korean',
+  },
+  {
+    locale: 'ko-kr',
+    language: 'Korean (Korea)',
+  },
+  {
+    locale: 'khq',
+    language: 'Koyra ciini',
+  },
+  {
+    locale: 'khq-ml',
+    language: 'Koyra ciini (Maali)',
+  },
+  {
+    locale: 'ses',
+    language: 'Koyraboro senni',
+  },
+  {
+    locale: 'ses-ml',
+    language: 'Koyraboro senni (Maali)',
+  },
+  {
+    locale: 'nmg',
+    language: 'Kwasio',
+  },
+  {
+    locale: 'nmg-cm',
+    language: 'Kwasio (Kamerun)',
+  },
+  {
+    locale: 'vun',
+    language: 'Kyivunjo',
+  },
+  {
+    locale: 'vun-tz',
+    language: 'Kyivunjo (Tanzania)',
+  },
+  {
+    locale: 'ky',
+    language: 'Kyrgyz',
+  },
+  {
+    locale: 'ky-kg',
+    language: 'Kyrgyz (Kyrgyzstan)',
+  },
+  {
+    locale: 'ksh',
+    language: 'Kölsch',
+  },
+  {
+    locale: 'ksh-de',
+    language: 'Kölsch (Doütschland)',
+  },
+  {
+    locale: 'ebu',
+    language: 'Kĩembu',
+  },
+  {
+    locale: 'ebu-ke',
+    language: 'Kĩembu (Kenya)',
+  },
+  {
+    locale: 'mer',
+    language: 'Kĩmĩrũ',
+  },
+  {
+    locale: 'mer-ke',
+    language: 'Kĩmĩrũ (Kenya)',
+  },
+  {
+    locale: 'lag',
+    language: 'Kɨlaangi',
+  },
+  {
+    locale: 'lag-tz',
+    language: 'Kɨlaangi (Taansanía)',
+  },
+  {
+    locale: 'lkt',
+    language: 'Lakȟólʼiyapi',
+  },
+  {
+    locale: 'lkt-us',
+    language: 'Lakȟólʼiyapi (Mílahaŋska Tȟamákȟočhe)',
+  },
+  {
+    locale: 'lo',
+    language: 'Lao',
+  },
+  {
+    locale: 'lo-la',
+    language: 'Lao (Laos)',
+  },
+  {
+    locale: 'la',
+    language: 'Latin',
+  },
+  {
+    locale: 'la-001',
+    language: 'Latin (World)',
+  },
+  {
+    locale: 'lv',
+    language: 'Latvian',
+  },
+  {
+    locale: 'lv-lv',
+    language: 'Latvian (Latvia)',
+  },
+  {
+    locale: 'lt',
+    language: 'Lithuanian',
+  },
+  {
+    locale: 'lt-lt',
+    language: 'Lithuanian (Lithuania)',
+  },
+  {
+    locale: 'dsb',
+    language: 'Lower Sorbian',
+  },
+  {
+    locale: 'dsb-de',
+    language: 'Lower Sorbian (Germany)',
+  },
+  {
+    locale: 'lg',
+    language: 'Luganda',
+  },
+  {
+    locale: 'lg-ug',
+    language: 'Luganda (Yuganda)',
+  },
+  {
+    locale: 'luy',
+    language: 'Luluhia',
+  },
+  {
+    locale: 'luy-ke',
+    language: 'Luluhia (Kenya)',
+  },
+  {
+    locale: 'lb',
+    language: 'Luxembourgish',
+  },
+  {
+    locale: 'lb-lu',
+    language: 'Luxembourgish (Luxembourg)',
+  },
+  {
+    locale: 'mua',
+    language: 'MUNDAŊ',
+  },
+  {
+    locale: 'mua-cm',
+    language: 'MUNDAŊ (kameruŋ)',
+  },
+  {
+    locale: 'mas',
+    language: 'Maa',
+  },
+  {
+    locale: 'mas-ke',
+    language: 'Maa (Kenya)',
+  },
+  {
+    locale: 'mas-tz',
+    language: 'Maa (Tansania)',
+  },
+  {
+    locale: 'mk',
+    language: 'Macedonian',
+  },
+  {
+    locale: 'mk-mk',
+    language: 'Macedonian (Macedonia, FYRO)',
+  },
+  {
+    locale: 'mgh',
+    language: 'Makua',
+  },
+  {
+    locale: 'mgh-mz',
+    language: 'Makua (Umozambiki)',
+  },
+  {
+    locale: 'mg',
+    language: 'Malagasy',
+  },
+  {
+    locale: 'mg-mg',
+    language: 'Malagasy (Madagasikara)',
+  },
+  {
+    locale: 'ms',
+    language: 'Malay',
+  },
+  {
+    locale: 'ms-bn',
+    language: 'Malay (Brunei)',
+  },
+  {
+    locale: 'ms-my',
+    language: 'Malay (Malaysia)',
+  },
+  {
+    locale: 'ml',
+    language: 'Malayalam',
+  },
+  {
+    locale: 'ml-in',
+    language: 'Malayalam (India)',
+  },
+  {
+    locale: 'mt',
+    language: 'Maltese',
+  },
+  {
+    locale: 'mt-mt',
+    language: 'Maltese (Malta)',
+  },
+  {
+    locale: 'mni',
+    language: 'Manipuri',
+  },
+  {
+    locale: 'mni-in',
+    language: 'Manipuri (India)',
+  },
+  {
+    locale: 'mi',
+    language: 'Maori',
+  },
+  {
+    locale: 'mi-nz',
+    language: 'Maori (New Zealand)',
+  },
+  {
+    locale: 'arn',
+    language: 'Mapudungun',
+  },
+  {
+    locale: 'arn-cl',
+    language: 'Mapudungun (Chile)',
+  },
+  {
+    locale: 'mr',
+    language: 'Marathi',
+  },
+  {
+    locale: 'mr-in',
+    language: 'Marathi (India)',
+  },
+  {
+    locale: 'ms-sg',
+    language: 'Melayu (Singapura)',
+  },
+  {
+    locale: 'moh',
+    language: 'Mohawk',
+  },
+  {
+    locale: 'moh-ca',
+    language: 'Mohawk (Mohawk)',
+  },
+  {
+    locale: 'mn',
+    language: 'Mongolian',
+  },
+  {
+    locale: 'mn-cyrl',
+    language: 'Mongolian',
+  },
+  {
+    locale: 'mn-mn',
+    language: 'Mongolian (Mongolia)',
+  },
+  {
+    locale: 'mn-mong',
+    language: 'Mongolian (Traditional Mongolian)',
+  },
+  {
+    locale: 'mn-mong-cn',
+    language: 'Mongolian (Traditional Mongolian, China)',
+  },
+  {
+    locale: 'mn-mong-mn',
+    language: 'Mongolian (Traditional Mongolian, Mongolia)',
+  },
+  {
+    locale: 'jgo',
+    language: 'Ndaꞌa',
+  },
+  {
+    locale: 'jgo-cm',
+    language: 'Ndaꞌa (Kamɛlûn)',
+  },
+  {
+    locale: 'nds',
+    language: 'Neddersass’sch',
+  },
+  {
+    locale: 'nds-de',
+    language: 'Neddersass’sch (Düütschland)',
+  },
+  {
+    locale: 'nds-nl',
+    language: 'Neddersass’sch (Nedderlannen)',
+  },
+  {
+    locale: 'nl-aw',
+    language: 'Nederlands (Aruba)',
+  },
+  {
+    locale: 'nl-bq',
+    language: 'Nederlands (Bonaire, Sint Eustatius en Saba)',
+  },
+  {
+    locale: 'nl-cw',
+    language: 'Nederlands (Curaçao)',
+  },
+  {
+    locale: 'nl-sx',
+    language: 'Nederlands (Sint-Maarten)',
+  },
+  {
+    locale: 'nl-sr',
+    language: 'Nederlands (Suriname)',
+  },
+  {
+    locale: 'ne',
+    language: 'Nepali',
+  },
+  {
+    locale: 'ne-in',
+    language: 'Nepali (India)',
+  },
+  {
+    locale: 'ne-np',
+    language: 'Nepali (Nepal)',
+  },
+  {
+    locale: 'se',
+    language: 'Northern Sami',
+  },
+  {
+    locale: 'no',
+    language: 'Norwegian',
+  },
+  {
+    locale: 'nb',
+    language: 'Norwegian Bokmål',
+  },
+  {
+    locale: 'nb-no',
+    language: 'Norwegian Bokmål (Norway)',
+  },
+  {
+    locale: 'nn',
+    language: 'Norwegian Nynorsk',
+  },
+  {
+    locale: 'nn-no',
+    language: 'Norwegian Nynorsk (Norway)',
+  },
+  {
+    locale: 'oc',
+    language: 'Occitan',
+  },
+  {
+    locale: 'oc-fr',
+    language: 'Occitan (France)',
+  },
+  {
+    locale: 'or',
+    language: 'Odia',
+  },
+  {
+    locale: 'or-in',
+    language: 'Odia (India)',
+  },
+  {
+    locale: 'xog',
+    language: 'Olusoga',
+  },
+  {
+    locale: 'xog-ug',
+    language: 'Olusoga (Yuganda)',
+  },
+  {
+    locale: 'om',
+    language: 'Oromo',
+  },
+  {
+    locale: 'om-et',
+    language: 'Oromo (Ethiopia)',
+  },
+  {
+    locale: 'om-ke',
+    language: 'Oromoo (Keeniyaa)',
+  },
+  {
+    locale: 'pap',
+    language: 'Papiamento',
+  },
+  {
+    locale: 'pap-029',
+    language: 'Papiamento (Caribbean)',
+  },
+  {
+    locale: 'ps',
+    language: 'Pashto',
+  },
+  {
+    locale: 'ps-af',
+    language: 'Pashto (Afghanistan)',
+  },
+  {
+    locale: 'fa',
+    language: 'Persian',
+  },
+  {
+    locale: 'fa-ir',
+    language: 'Persian (Iran)',
+  },
+  {
+    locale: 'pl',
+    language: 'Polish',
+  },
+  {
+    locale: 'pl-pl',
+    language: 'Polish (Poland)',
+  },
+  {
+    locale: 'pt',
+    language: 'Portuguese',
+  },
+  {
+    locale: 'pt-br',
+    language: 'Portuguese (Brazil)',
+  },
+  {
+    locale: 'pt-pt',
+    language: 'Portuguese (Portugal)',
+  },
+  {
+    locale: 'ff-gn',
+    language: 'Pulaar (Gine)',
+  },
+  {
+    locale: 'ff-cm',
+    language: 'Pulaar (Kameruun)',
+  },
+  {
+    locale: 'ff-mr',
+    language: 'Pulaar (Muritani)',
+  },
+  {
+    locale: 'pa',
+    language: 'Punjabi',
+  },
+  {
+    locale: 'pa-arab',
+    language: 'Punjabi',
+  },
+  {
+    locale: 'pa-in',
+    language: 'Punjabi (India)',
+  },
+  {
+    locale: 'pa-arab-pk',
+    language: 'Punjabi (Pakistan)',
+  },
+  {
+    locale: 'aa',
+    language: 'Qafar',
+  },
+  {
+    locale: 'aa-er',
+    language: 'Qafar (Eretria)',
+  },
+  {
+    locale: 'aa-et',
+    language: 'Qafar (Otobbia)',
+  },
+  {
+    locale: 'aa-dj',
+    language: 'Qafar (Yabuuti)',
+  },
+  {
+    locale: 'quz',
+    language: 'Quechua',
+  },
+  {
+    locale: 'quz-bo',
+    language: 'Quechua (Bolivia)',
+  },
+  {
+    locale: 'quz-pe',
+    language: 'Quechua (Peru)',
+  },
+  {
+    locale: 'quz-ec',
+    language: 'Quichua (Ecuador)',
+  },
+  {
+    locale: 'ro',
+    language: 'Romanian',
+  },
+  {
+    locale: 'ro-md',
+    language: 'Romanian (Moldova)',
+  },
+  {
+    locale: 'ro-ro',
+    language: 'Romanian (Romania)',
+  },
+  {
+    locale: 'rm',
+    language: 'Romansh',
+  },
+  {
+    locale: 'rm-ch',
+    language: 'Romansh (Switzerland)',
+  },
+  {
+    locale: 'cgg',
+    language: 'Rukiga',
+  },
+  {
+    locale: 'cgg-ug',
+    language: 'Rukiga (Uganda)',
+  },
+  {
+    locale: 'nyn',
+    language: 'Runyankore',
+  },
+  {
+    locale: 'nyn-ug',
+    language: 'Runyankore (Uganda)',
+  },
+  {
+    locale: 'ru',
+    language: 'Russian',
+  },
+  {
+    locale: 'ru-md',
+    language: 'Russian (Moldova)',
+  },
+  {
+    locale: 'ru-ru',
+    language: 'Russian (Russia)',
+  },
+  {
+    locale: 'ssy',
+    language: 'Saho',
+  },
+  {
+    locale: 'ssy-er',
+    language: 'Saho (Eretria)',
+  },
+  {
+    locale: 'sah',
+    language: 'Sakha',
+  },
+  {
+    locale: 'sah-ru',
+    language: 'Sakha (Russia)',
+  },
+  {
+    locale: 'smn',
+    language: 'Sami (Inari)',
+  },
+  {
+    locale: 'smj',
+    language: 'Sami (Lule)',
+  },
+  {
+    locale: 'sms',
+    language: 'Sami (Skolt)',
+  },
+  {
+    locale: 'sma',
+    language: 'Sami (Southern)',
+  },
+  {
+    locale: 'smn-fi',
+    language: 'Sami, Inari (Finland)',
+  },
+  {
+    locale: 'smj-no',
+    language: 'Sami, Lule (Norway)',
+  },
+  {
+    locale: 'smj-se',
+    language: 'Sami, Lule (Sweden)',
+  },
+  {
+    locale: 'se-fi',
+    language: 'Sami, Northern (Finland)',
+  },
+  {
+    locale: 'se-no',
+    language: 'Sami, Northern (Norway)',
+  },
+  {
+    locale: 'se-se',
+    language: 'Sami, Northern (Sweden)',
+  },
+  {
+    locale: 'sms-fi',
+    language: 'Sami, Skolt (Finland)',
+  },
+  {
+    locale: 'sma-no',
+    language: 'Sami, Southern (Norway)',
+  },
+  {
+    locale: 'sma-se',
+    language: 'Sami, Southern (Sweden)',
+  },
+  {
+    locale: 'sa',
+    language: 'Sanskrit',
+  },
+  {
+    locale: 'sa-in',
+    language: 'Sanskrit (India)',
+  },
+  {
+    locale: 'gsw-li',
+    language: 'Schwiizertüütsch (Liächteschtäi)',
+  },
+  {
+    locale: 'gsw-ch',
+    language: 'Schwiizertüütsch (Schwiiz)',
+  },
+  {
+    locale: 'gd',
+    language: 'Scottish Gaelic',
+  },
+  {
+    locale: 'gd-gb',
+    language: 'Scottish Gaelic (United Kingdom)',
+  },
+  {
+    locale: 'sr',
+    language: 'Serbian',
+  },
+  {
+    locale: 'sr-cyrl',
+    language: 'Serbian (Cyrillic)',
+  },
+  {
+    locale: 'sr-cyrl-ba',
+    language: 'Serbian (Cyrillic, Bosnia and Herzegovina)',
+  },
+  {
+    locale: 'sr-cyrl-me',
+    language: 'Serbian (Cyrillic, Montenegro)',
+  },
+  {
+    locale: 'sr-cyrl-rs',
+    language: 'Serbian (Cyrillic, Serbia)',
+  },
+  {
+    locale: 'sr-latn',
+    language: 'Serbian (Latin)',
+  },
+  {
+    locale: 'sr-latn-ba',
+    language: 'Serbian (Latin, Bosnia and Herzegovina)',
+  },
+  {
+    locale: 'sr-latn-me',
+    language: 'Serbian (Latin, Montenegro)',
+  },
+  {
+    locale: 'sr-latn-rs',
+    language: 'Serbian (Latin, Serbia)',
+  },
+  {
+    locale: 'st',
+    language: 'Sesotho',
+  },
+  {
+    locale: 'st-ls',
+    language: 'Sesotho (Lesotho)',
+  },
+  {
+    locale: 'st-za',
+    language: 'Sesotho (South Africa)',
+  },
+  {
+    locale: 'nso',
+    language: 'Sesotho sa Leboa',
+  },
+  {
+    locale: 'nso-za',
+    language: 'Sesotho sa Leboa (South Africa)',
+  },
+  {
+    locale: 'tn',
+    language: 'Setswana',
+  },
+  {
+    locale: 'tn-bw',
+    language: 'Setswana (Botswana)',
+  },
+  {
+    locale: 'tn-za',
+    language: 'Setswana (South Africa)',
+  },
+  {
+    locale: 'nnh',
+    language: 'Shwóŋò ngiembɔɔn',
+  },
+  {
+    locale: 'nnh-cm',
+    language: 'Shwóŋò ngiembɔɔn (Kàmalûm)',
+  },
+  {
+    locale: 'sd',
+    language: 'Sindhi',
+  },
+  {
+    locale: 'sd-arab',
+    language: 'Sindhi',
+  },
+  {
+    locale: 'sd-deva-in',
+    language: 'Sindhi (Devanagari, India)',
+  },
+  {
+    locale: 'sd-arab-pk',
+    language: 'Sindhi (Pakistan)',
+  },
+  {
+    locale: 'si',
+    language: 'Sinhala',
+  },
+  {
+    locale: 'si-lk',
+    language: 'Sinhala (Sri Lanka)',
+  },
+  {
+    locale: 'ss',
+    language: 'Siswati',
+  },
+  {
+    locale: 'sk',
+    language: 'Slovak',
+  },
+  {
+    locale: 'sk-sk',
+    language: 'Slovak (Slovakia)',
+  },
+  {
+    locale: 'sl',
+    language: 'Slovenian',
+  },
+  {
+    locale: 'sl-si',
+    language: 'Slovenian (Slovenia)',
+  },
+  {
+    locale: 'so',
+    language: 'Somali',
+  },
+  {
+    locale: 'so-so',
+    language: 'Somali (Somalia)',
+  },
+  {
+    locale: 'so-et',
+    language: 'Soomaali (Itoobiya)',
+  },
+  {
+    locale: 'so-dj',
+    language: 'Soomaali (Jabuuti)',
+  },
+  {
+    locale: 'so-ke',
+    language: 'Soomaali (Kiiniya)',
+  },
+  {
+    locale: 'es',
+    language: 'Spanish',
+  },
+  {
+    locale: 'es-ar',
+    language: 'Spanish (Argentina)',
+  },
+  {
+    locale: 'es-bo',
+    language: 'Spanish (Bolivia)',
+  },
+  {
+    locale: 'es-cl',
+    language: 'Spanish (Chile)',
+  },
+  {
+    locale: 'es-co',
+    language: 'Spanish (Colombia)',
+  },
+  {
+    locale: 'es-cr',
+    language: 'Spanish (Costa Rica)',
+  },
+  {
+    locale: 'es-cu',
+    language: 'Spanish (Cuba)',
+  },
+  {
+    locale: 'es-do',
+    language: 'Spanish (Dominican Republic)',
+  },
+  {
+    locale: 'es-ec',
+    language: 'Spanish (Ecuador)',
+  },
+  {
+    locale: 'es-sv',
+    language: 'Spanish (El Salvador)',
+  },
+  {
+    locale: 'es-gt',
+    language: 'Spanish (Guatemala)',
+  },
+  {
+    locale: 'es-hn',
+    language: 'Spanish (Honduras)',
+  },
+  {
+    locale: 'es-419',
+    language: 'Spanish (Latin America)',
+  },
+  {
+    locale: 'es-mx',
+    language: 'Spanish (Mexico)',
+  },
+  {
+    locale: 'es-ni',
+    language: 'Spanish (Nicaragua)',
+  },
+  {
+    locale: 'es-pa',
+    language: 'Spanish (Panama)',
+  },
+  {
+    locale: 'es-py',
+    language: 'Spanish (Paraguay)',
+  },
+  {
+    locale: 'es-pe',
+    language: 'Spanish (Peru)',
+  },
+  {
+    locale: 'es-pr',
+    language: 'Spanish (Puerto Rico)',
+  },
+  {
+    locale: 'es-es',
+    language: 'Spanish (Spain, International Sort)',
+  },
+  {
+    locale: 'es-us',
+    language: 'Spanish (United States)',
+  },
+  {
+    locale: 'es-uy',
+    language: 'Spanish (Uruguay)',
+  },
+  {
+    locale: 'es-ve',
+    language: 'Spanish (Venezuela)',
+  },
+  {
+    locale: 'sv',
+    language: 'Swedish',
+  },
+  {
+    locale: 'sv-fi',
+    language: 'Swedish (Finland)',
+  },
+  {
+    locale: 'sv-se',
+    language: 'Swedish (Sweden)',
+  },
+  {
+    locale: 'gsw',
+    language: 'Swiss German',
+  },
+  {
+    locale: 'syr',
+    language: 'Syriac',
+  },
+  {
+    locale: 'syr-sy',
+    language: 'Syriac (Syria)',
+  },
+  {
+    locale: 'sg',
+    language: 'Sängö',
+  },
+  {
+    locale: 'sg-cf',
+    language: 'Sängö (Ködörösêse tî Bêafrîka)',
+  },
+  {
+    locale: 'tg',
+    language: 'Tajik',
+  },
+  {
+    locale: 'tg-cyrl',
+    language: 'Tajik (Cyrillic)',
+  },
+  {
+    locale: 'tg-cyrl-tj',
+    language: 'Tajik (Cyrillic, Tajikistan)',
+  },
+  {
+    locale: 'tzm-latn-ma',
+    language: 'Tamaziɣt n laṭlaṣ (Meṛṛuk)',
+  },
+  {
+    locale: 'ta',
+    language: 'Tamil',
+  },
+  {
+    locale: 'ta-in',
+    language: 'Tamil (India)',
+  },
+  {
+    locale: 'ta-lk',
+    language: 'Tamil (Sri Lanka)',
+  },
+  {
+    locale: 'kab',
+    language: 'Taqbaylit',
+  },
+  {
+    locale: 'kab-dz',
+    language: 'Taqbaylit (Lezzayer)',
+  },
+  {
+    locale: 'twq',
+    language: 'Tasawaq senni',
+  },
+  {
+    locale: 'twq-ne',
+    language: 'Tasawaq senni (Nižer)',
+  },
+  {
+    locale: 'shi-latn',
+    language: 'Tashelḥiyt',
+  },
+  {
+    locale: 'shi-latn-ma',
+    language: 'Tashelḥiyt (lmɣrib)',
+  },
+  {
+    locale: 'tt',
+    language: 'Tatar',
+  },
+  {
+    locale: 'tt-ru',
+    language: 'Tatar (Russia)',
+  },
+  {
+    locale: 'te',
+    language: 'Telugu',
+  },
+  {
+    locale: 'te-in',
+    language: 'Telugu (India)',
+  },
+  {
+    locale: 'th',
+    language: 'Thai',
+  },
+  {
+    locale: 'th-th',
+    language: 'Thai (Thailand)',
+  },
+  {
+    locale: 'nus',
+    language: 'Thok Nath',
+  },
+  {
+    locale: 'nus-ss',
+    language: 'Thok Nath (South Sudan)',
+  },
+  {
+    locale: 'bo',
+    language: 'Tibetan',
+  },
+  {
+    locale: 'bo-cn',
+    language: 'Tibetan (China)',
+  },
+  {
+    locale: 'ti',
+    language: 'Tigrinya',
+  },
+  {
+    locale: 'ti-er',
+    language: 'Tigrinya (Eritrea)',
+  },
+  {
+    locale: 'ti-et',
+    language: 'Tigrinya (Ethiopia)',
+  },
+  {
+    locale: 'lu',
+    language: 'Tshiluba',
+  },
+  {
+    locale: 'lu-cd',
+    language: 'Tshiluba (Ditunga wa Kongu)',
+  },
+  {
+    locale: 'ts',
+    language: 'Tsonga',
+  },
+  {
+    locale: 'tr',
+    language: 'Turkish',
+  },
+  {
+    locale: 'tr-tr',
+    language: 'Turkish (Turkey)',
+  },
+  {
+    locale: 'tk',
+    language: 'Turkmen',
+  },
+  {
+    locale: 'tk-tm',
+    language: 'Turkmen (Turkmenistan)',
+  },
+  {
+    locale: 'tr-cy',
+    language: 'Türkçe (Kıbrıs)',
+  },
+  {
+    locale: 'uk',
+    language: 'Ukrainian',
+  },
+  {
+    locale: 'uk-ua',
+    language: 'Ukrainian (Ukraine)',
+  },
+  {
+    locale: 'hsb',
+    language: 'Upper Sorbian',
+  },
+  {
+    locale: 'hsb-de',
+    language: 'Upper Sorbian (Germany)',
+  },
+  {
+    locale: 'ur',
+    language: 'Urdu',
+  },
+  {
+    locale: 'ur-in',
+    language: 'Urdu (India)',
+  },
+  {
+    locale: 'ur-pk',
+    language: 'Urdu (Pakistan)',
+  },
+  {
+    locale: 'ug',
+    language: 'Uyghur',
+  },
+  {
+    locale: 'ug-cn',
+    language: 'Uyghur (China)',
+  },
+  {
+    locale: 'uz',
+    language: 'Uzbek',
+  },
+  {
+    locale: 'uz-cyrl',
+    language: 'Uzbek (Cyrillic)',
+  },
+  {
+    locale: 'uz-cyrl-uz',
+    language: 'Uzbek (Cyrillic, Uzbekistan)',
+  },
+  {
+    locale: 'uz-latn',
+    language: 'Uzbek (Latin)',
+  },
+  {
+    locale: 'uz-latn-uz',
+    language: 'Uzbek (Latin, Uzbekistan)',
+  },
+  {
+    locale: 'vai-latn',
+    language: 'Vai',
+  },
+  {
+    locale: 'vai-latn-lr',
+    language: 'Vai (Laibhiya)',
+  },
+  {
+    locale: 'ca-es-valencia',
+    language: 'Valencian (Spain)',
+  },
+  {
+    locale: 've',
+    language: 'Venda',
+  },
+  {
+    locale: 've-za',
+    language: 'Venda (South Africa)',
+  },
+  {
+    locale: 'vi',
+    language: 'Vietnamese',
+  },
+  {
+    locale: 'vi-vn',
+    language: 'Vietnamese (Vietnam)',
+  },
+  {
+    locale: 'vo',
+    language: 'Volapük',
+  },
+  {
+    locale: 'vo-001',
+    language: 'Volapük (World)',
+  },
+  {
+    locale: 'wae',
+    language: 'Walser',
+  },
+  {
+    locale: 'wae-ch',
+    language: 'Walser (Schwiz)',
+  },
+  {
+    locale: 'cy',
+    language: 'Welsh',
+  },
+  {
+    locale: 'cy-gb',
+    language: 'Welsh (United Kingdom)',
+  },
+  {
+    locale: 'fy',
+    language: 'Western Frisian',
+  },
+  {
+    locale: 'fy-nl',
+    language: 'Western Frisian (Netherlands)',
+  },
+  {
+    locale: 'wo',
+    language: 'Wolof',
+  },
+  {
+    locale: 'wo-sn',
+    language: 'Wolof (Senegal)',
+  },
+  {
+    locale: 'ts-za',
+    language: 'Xitsonga (South Africa)',
+  },
+  {
+    locale: 'ii',
+    language: 'Yi',
+  },
+  {
+    locale: 'ii-cn',
+    language: 'Yi (China)',
+  },
+  {
+    locale: 'yi',
+    language: 'Yiddish',
+  },
+  {
+    locale: 'yi-001',
+    language: 'Yiddish (World)',
+  },
+  {
+    locale: 'yo',
+    language: 'Yoruba',
+  },
+  {
+    locale: 'yo-ng',
+    language: 'Yoruba (Nigeria)',
+  },
+  {
+    locale: 'dje',
+    language: 'Zarmaciine',
+  },
+  {
+    locale: 'dje-ne',
+    language: 'Zarmaciine (Nižer)',
+  },
+  {
+    locale: 'ast',
+    language: 'asturianu',
+  },
+  {
+    locale: 'ast-es',
+    language: 'asturianu (España)',
+  },
+  {
+    locale: 'bm',
+    language: 'bamanakan',
+  },
+  {
+    locale: 'bm-latn',
+    language: 'bamanakan',
+  },
+  {
+    locale: 'bm-latn-ml',
+    language: 'bamanakan (Mali)',
+  },
+  {
+    locale: 'ca-ad',
+    language: 'català (Andorra)',
+  },
+  {
+    locale: 'ca-fr',
+    language: 'català (França)',
+  },
+  {
+    locale: 'ca-it',
+    language: 'català (Itàlia)',
+  },
+  {
+    locale: 'sn',
+    language: 'chiShona',
+  },
+  {
+    locale: 'sn-latn',
+    language: 'chiShona (Latin)',
+  },
+  {
+    locale: 'sn-latn-zw',
+    language: 'chiShona (Zimbabwe)',
+  },
+  {
+    locale: 'da-gl',
+    language: 'dansk (Grønland)',
+  },
+  {
+    locale: 'dua',
+    language: 'duálá',
+  },
+  {
+    locale: 'dua-cm',
+    language: 'duálá (Cameroun)',
+  },
+  {
+    locale: 'es-bz',
+    language: 'español (Belice)',
+  },
+  {
+    locale: 'es-br',
+    language: 'español (Brasil)',
+  },
+  {
+    locale: 'es-ph',
+    language: 'español (Filipinas)',
+  },
+  {
+    locale: 'es-gq',
+    language: 'español (Guinea Ecuatorial)',
+  },
+  {
+    locale: 'eo',
+    language: 'esperanto',
+  },
+  {
+    locale: 'eo-001',
+    language: 'esperanto (World)',
+  },
+  {
+    locale: 'ewo',
+    language: 'ewondo',
+  },
+  {
+    locale: 'ewo-cm',
+    language: 'ewondo (Kamərún)',
+  },
+  {
+    locale: 'fr-dz',
+    language: 'français (Algérie)',
+  },
+  {
+    locale: 'fr-bf',
+    language: 'français (Burkina Faso)',
+  },
+  {
+    locale: 'fr-bi',
+    language: 'français (Burundi)',
+  },
+  {
+    locale: 'fr-bj',
+    language: 'français (Bénin)',
+  },
+  {
+    locale: 'fr-km',
+    language: 'français (Comores)',
+  },
+  {
+    locale: 'fr-cg',
+    language: 'français (Congo)',
+  },
+  {
+    locale: 'fr-dj',
+    language: 'français (Djibouti)',
+  },
+  {
+    locale: 'fr-ga',
+    language: 'français (Gabon)',
+  },
+  {
+    locale: 'fr-gp',
+    language: 'français (Guadeloupe)',
+  },
+  {
+    locale: 'fr-gq',
+    language: 'français (Guinée équatoriale)',
+  },
+  {
+    locale: 'fr-gn',
+    language: 'français (Guinée)',
+  },
+  {
+    locale: 'fr-gf',
+    language: 'français (Guyane française)',
+  },
+  {
+    locale: 'fr-mg',
+    language: 'français (Madagascar)',
+  },
+  {
+    locale: 'fr-mq',
+    language: 'français (Martinique)',
+  },
+  {
+    locale: 'fr-mu',
+    language: 'français (Maurice)',
+  },
+  {
+    locale: 'fr-mr',
+    language: 'français (Mauritanie)',
+  },
+  {
+    locale: 'fr-yt',
+    language: 'français (Mayotte)',
+  },
+  {
+    locale: 'fr-ne',
+    language: 'français (Niger)',
+  },
+  {
+    locale: 'fr-nc',
+    language: 'français (Nouvelle-Calédonie)',
+  },
+  {
+    locale: 'fr-pf',
+    language: 'français (Polynésie française)',
+  },
+  {
+    locale: 'fr-rw',
+    language: 'français (Rwanda)',
+  },
+  {
+    locale: 'fr-cf',
+    language: 'français (République centrafricaine)',
+  },
+  {
+    locale: 'fr-bl',
+    language: 'français (Saint-Barthélemy)',
+  },
+  {
+    locale: 'fr-mf',
+    language: 'français (Saint-Martin)',
+  },
+  {
+    locale: 'fr-pm',
+    language: 'français (Saint-Pierre-et-Miquelon)',
+  },
+  {
+    locale: 'fr-sc',
+    language: 'français (Seychelles)',
+  },
+  {
+    locale: 'fr-sy',
+    language: 'français (Syrie)',
+  },
+  {
+    locale: 'fr-td',
+    language: 'français (Tchad)',
+  },
+  {
+    locale: 'fr-tg',
+    language: 'français (Togo)',
+  },
+  {
+    locale: 'fr-tn',
+    language: 'français (Tunisie)',
+  },
+  {
+    locale: 'fr-vu',
+    language: 'français (Vanuatu)',
+  },
+  {
+    locale: 'fr-wf',
+    language: 'français (Wallis-et-Futuna)',
+  },
+  {
+    locale: 'fur',
+    language: 'furlan',
+  },
+  {
+    locale: 'fur-it',
+    language: 'furlan (Italie)',
+  },
+  {
+    locale: 'fo-dk',
+    language: 'føroyskt (Danmark)',
+  },
+  {
+    locale: 'ia',
+    language: 'interlingua',
+  },
+  {
+    locale: 'ia-fr',
+    language: 'interlingua (Francia)',
+  },
+  {
+    locale: 'ia-001',
+    language: 'interlingua (World)',
+  },
+  {
+    locale: 'nd',
+    language: 'isiNdebele',
+  },
+  {
+    locale: 'nr',
+    language: 'isiNdebele',
+  },
+  {
+    locale: 'nr-za',
+    language: 'isiNdebele (South Africa)',
+  },
+  {
+    locale: 'nd-zw',
+    language: 'isiNdebele (Zimbabwe)',
+  },
+  {
+    locale: 'xh',
+    language: 'isiXhosa',
+  },
+  {
+    locale: 'xh-za',
+    language: 'isiXhosa (South Africa)',
+  },
+  {
+    locale: 'zu',
+    language: 'isiZulu',
+  },
+  {
+    locale: 'zu-za',
+    language: 'isiZulu (South Africa)',
+  },
+  {
+    locale: 'it-va',
+    language: 'italiano (Città del Vaticano)',
+  },
+  {
+    locale: 'it-sm',
+    language: 'italiano (San Marino)',
+  },
+  {
+    locale: 'dyo',
+    language: 'joola',
+  },
+  {
+    locale: 'dyo-sn',
+    language: 'joola (Senegal)',
+  },
+  {
+    locale: 'kea',
+    language: 'kabuverdianu',
+  },
+  {
+    locale: 'kea-cv',
+    language: 'kabuverdianu (Kabu Verdi)',
+  },
+  {
+    locale: 'kkj',
+    language: 'kakɔ',
+  },
+  {
+    locale: 'kkj-cm',
+    language: 'kakɔ (Kamɛrun)',
+  },
+  {
+    locale: 'kw',
+    language: 'kernewek',
+  },
+  {
+    locale: 'kw-gb',
+    language: 'kernewek (Rywvaneth Unys)',
+  },
+  {
+    locale: 'mfe',
+    language: 'kreol morisien',
+  },
+  {
+    locale: 'mfe-mu',
+    language: 'kreol morisien (Moris)',
+  },
+  {
+    locale: 'to',
+    language: 'lea fakatonga',
+  },
+  {
+    locale: 'to-to',
+    language: 'lea fakatonga (Tonga)',
+  },
+  {
+    locale: 'ln',
+    language: 'lingála',
+  },
+  {
+    locale: 'ln-ao',
+    language: 'lingála (Angóla)',
+  },
+  {
+    locale: 'ln-cg',
+    language: 'lingála (Kongo)',
+  },
+  {
+    locale: 'ln-cf',
+    language: 'lingála (Repibiki ya Afríka ya Káti)',
+  },
+  {
+    locale: 'ln-cd',
+    language: 'lingála (Republíki ya Kongó Demokratíki)',
+  },
+  {
+    locale: 'mgo',
+    language: 'metaʼ',
+  },
+  {
+    locale: 'mgo-cm',
+    language: 'metaʼ (Kamalun)',
+  },
+  {
+    locale: 'nb-sj',
+    language: 'norsk bokmål (Svalbard og Jan Mayen)',
+  },
+  {
+    locale: 'yav',
+    language: 'nuasue',
+  },
+  {
+    locale: 'yav-cm',
+    language: 'nuasue (Kemelún)',
+  },
+  {
+    locale: 'pt-ao',
+    language: 'português (Angola)',
+  },
+  {
+    locale: 'pt-cv',
+    language: 'português (Cabo Verde)',
+  },
+  {
+    locale: 'pt-gq',
+    language: 'português (Guiné Equatorial)',
+  },
+  {
+    locale: 'pt-gw',
+    language: 'português (Guiné-Bissau)',
+  },
+  {
+    locale: 'pt-lu',
+    language: 'português (Luxemburgo)',
+  },
+  {
+    locale: 'pt-mz',
+    language: 'português (Moçambique)',
+  },
+  {
+    locale: 'pt-mo',
+    language: 'português (RAE de Macau)',
+  },
+  {
+    locale: 'pt-ch',
+    language: 'português (Suíça)',
+  },
+  {
+    locale: 'pt-st',
+    language: 'português (São Tomé e Príncipe)',
+  },
+  {
+    locale: 'pt-tl',
+    language: 'português (Timor-Leste)',
+  },
+  {
+    locale: 'prg',
+    language: 'prūsiskan',
+  },
+  {
+    locale: 'prg-001',
+    language: 'prūsiskan (swītai)',
+  },
+  {
+    locale: 'ksf',
+    language: 'rikpa',
+  },
+  {
+    locale: 'ksf-cm',
+    language: 'rikpa (kamɛrún)',
+  },
+  {
+    locale: 'seh',
+    language: 'sena',
+  },
+  {
+    locale: 'seh-mz',
+    language: 'sena (Moçambique)',
+  },
+  {
+    locale: 'sq-xk',
+    language: 'shqip (Kosovë)',
+  },
+  {
+    locale: 'sq-mk',
+    language: 'shqip (Republika e Maqedonisë)',
+  },
+  {
+    locale: 'ss-za',
+    language: 'siSwati (South Africa)',
+  },
+  {
+    locale: 'ss-sz',
+    language: 'siSwati (Swaziland)',
+  },
+  {
+    locale: 'sr-latn-xk',
+    language: 'srpski (Kosovo)',
+  },
+  {
+    locale: 'sv-ax',
+    language: 'svenska (Åland)',
+  },
+  {
+    locale: 'yo-bj',
+    language: 'Èdè Yorùbá (Orílɛ́ède Bɛ̀nɛ̀)',
+  },
+  {
+    locale: 'bas',
+    language: 'Ɓàsàa',
+  },
+  {
+    locale: 'bas-cm',
+    language: 'Ɓàsàa (Kàmɛ̀rûn)',
+  },
+  {
+    locale: 'el-cy',
+    language: 'Ελληνικά (Κύπρος)',
+  },
+  {
+    locale: 'os',
+    language: 'ирон',
+  },
+  {
+    locale: 'os-ge',
+    language: 'ирон (Гуырдзыстон)',
+  },
+  {
+    locale: 'os-ru',
+    language: 'ирон (Уӕрӕсе)',
+  },
+  {
+    locale: 'ce',
+    language: 'нохчийн',
+  },
+  {
+    locale: 'ce-ru',
+    language: 'нохчийн (Росси)',
+  },
+  {
+    locale: 'ru-by',
+    language: 'русский (Беларусь)',
+  },
+  {
+    locale: 'ru-kz',
+    language: 'русский (Казахстан)',
+  },
+  {
+    locale: 'ru-kg',
+    language: 'русский (Киргизия)',
+  },
+  {
+    locale: 'ru-ua',
+    language: 'русский (Украина)',
+  },
+  {
+    locale: 'sr-cyrl-xk',
+    language: 'српски (Косово)',
+  },
+  {
+    locale: 'cu',
+    language: 'церковнослове́нскїй',
+  },
+  {
+    locale: 'cu-ru',
+    language: 'церковнослове́нскїй (рѡссі́а)',
+  },
+  {
+    locale: 'tzm-arab',
+    language: 'أطلس المركزية التامازيتية',
+  },
+  {
+    locale: 'ar-er',
+    language: 'العربية (إريتريا)',
+  },
+  {
+    locale: 'ar-il',
+    language: 'العربية (إسرائيل)',
+  },
+  {
+    locale: 'ar-ps',
+    language: 'العربية (السلطة الفلسطينية)',
+  },
+  {
+    locale: 'ar-sd',
+    language: 'العربية (السودان)',
+  },
+  {
+    locale: 'ar-so',
+    language: 'العربية (الصومال)',
+  },
+  {
+    locale: 'ar-001',
+    language: 'العربية (العالم)',
+  },
+  {
+    locale: 'ar-td',
+    language: 'العربية (تشاد)',
+  },
+  {
+    locale: 'ar-km',
+    language: 'العربية (جزر القمر)',
+  },
+  {
+    locale: 'ar-ss',
+    language: 'العربية (جنوب السودان)',
+  },
+  {
+    locale: 'ar-dj',
+    language: 'العربية (جيبوتي)',
+  },
+  {
+    locale: 'ar-mr',
+    language: 'العربية (موريتانيا)',
+  },
+  {
+    locale: 'uz-arab',
+    language: 'اوزبیک',
+  },
+  {
+    locale: 'uz-arab-af',
+    language: 'اوزبیک (افغانستان)',
+  },
+  {
+    locale: 'lrc',
+    language: 'لۊری شومالی',
+  },
+  {
+    locale: 'lrc-ir',
+    language: 'لۊری شومالی (Iran)',
+  },
+  {
+    locale: 'lrc-iq',
+    language: 'لۊری شومالی (Iraq)',
+  },
+  {
+    locale: 'mzn',
+    language: 'مازرونی',
+  },
+  {
+    locale: 'mzn-ir',
+    language: 'مازرونی (ایران)',
+  },
+  {
+    locale: 'ku-arab-ir',
+    language: 'کوردی (ئێران)',
+  },
+  {
+    locale: 'ks-arab-in',
+    language: 'کٲشُر (اَربی)',
+  },
+  {
+    locale: 'nqo',
+    language: 'ߒߞߏ',
+  },
+  {
+    locale: 'nqo-gn',
+    language: 'ߒߞߏ (ߖߌ߬ߣߍ߬ ߞߊ߲ߓߍ߲)',
+  },
+  {
+    locale: 'ks-deva',
+    language: 'कॉशुर',
+  },
+  {
+    locale: 'brx',
+    language: 'बड़ो',
+  },
+  {
+    locale: 'brx-in',
+    language: 'बड़ो (भारत)',
+  },
+  {
+    locale: 'sd-deva',
+    language: 'सिन्धी',
+  },
+  {
+    locale: 'pa-guru',
+    language: 'ਪੰਜਾਬੀ',
+  },
+  {
+    locale: 'ta-sg',
+    language: 'தமிழ் (சிங்கப்பூர்)',
+  },
+  {
+    locale: 'ta-my',
+    language: 'தமிழ் (மலேசியா)',
+  },
+  {
+    locale: 'bo-in',
+    language: 'བོད་སྐད་ (རྒྱ་གར་)',
+  },
+  {
+    locale: 'dz',
+    language: 'རྫོང་ཁ',
+  },
+  {
+    locale: 'byn',
+    language: 'ብሊን',
+  },
+  {
+    locale: 'byn-er',
+    language: 'ብሊን (ኤርትራ)',
+  },
+  {
+    locale: 'tig',
+    language: 'ትግረ',
+  },
+  {
+    locale: 'tig-er',
+    language: 'ትግረ (ኤርትራ)',
+  },
+  {
+    locale: 'wal',
+    language: 'ወላይታቱ',
+  },
+  {
+    locale: 'wal-et',
+    language: 'ወላይታቱ (ኢትዮጵያ)',
+  },
+  {
+    locale: 'zgh',
+    language: 'ⵜⴰⵎⴰⵣⵉⵖⵜ',
+  },
+  {
+    locale: 'zgh-tfng',
+    language: 'ⵜⴰⵎⴰⵣⵉⵖⵜ',
+  },
+  {
+    locale: 'zgh-tfng-ma',
+    language: 'ⵜⴰⵎⴰⵣⵉⵖⵜ (ⵍⵎⵖⵔⵉⴱ)',
+  },
+  {
+    locale: 'shi',
+    language: 'ⵜⴰⵛⵍⵃⵉⵜ',
+  },
+  {
+    locale: 'shi-tfng',
+    language: 'ⵜⴰⵛⵍⵃⵉⵜ',
+  },
+  {
+    locale: 'shi-tfng-ma',
+    language: 'ⵜⴰⵛⵍⵃⵉⵜ (ⵍⵎⵖⵔⵉⴱ)',
+  },
+  {
+    locale: 'zh-hans-mo',
+    language: '中文 (澳门特别行政区)',
+  },
+  {
+    locale: 'zh-hans-hk',
+    language: '中文 (香港特别行政区)',
+  },
+  {
+    locale: 'vai',
+    language: 'ꕙꔤ',
+  },
+  {
+    locale: 'vai-vaii',
+    language: 'ꕙꔤ',
+  },
+  {
+    locale: 'vai-vaii-lr',
+    language: 'ꕙꔤ (ꕞꔤꔫꕩ)',
+  },
+  {
+    locale: 'jv-java',
+    language: 'ꦧꦱꦗꦮ',
+  },
+  {
+    locale: 'jv-java-id',
+    language: 'ꦧꦱꦗꦮ (Indonesia)',
+  },
+  {
+    locale: 'ko-kp',
+    language: '한국어 (조선민주주의인민공화국)',
+  },
+];

--- a/Composer/packages/client/src/pages/language-generation/LGPage.tsx
+++ b/Composer/packages/client/src/pages/language-generation/LGPage.tsx
@@ -34,11 +34,15 @@ const LGPage: React.FC<LGPageProps> = (props) => {
 
   const navLinks: INavTreeItem[] = useMemo(() => {
     const newDialogLinks: INavTreeItem[] = dialogs.map((dialog) => {
+      let url = `/bot/${projectId}/language-generation/${dialog.id}`;
+      if (edit) {
+        url += `/edit`;
+      }
       return {
         id: dialog.id,
         name: dialog.displayName,
         ariaLabel: formatMessage('language generation file'),
-        url: `/bot/${projectId}/language-generation/${dialog.id}`,
+        url,
       };
     });
     const mainDialogIndex = newDialogLinks.findIndex((link) => link.id === 'Main');
@@ -47,14 +51,19 @@ const LGPage: React.FC<LGPageProps> = (props) => {
       const mainDialog = newDialogLinks.splice(mainDialogIndex, 1)[0];
       newDialogLinks.splice(0, 0, mainDialog);
     }
+    let commonUrl = `/bot/${projectId}/language-generation/common`;
+    if (edit) {
+      commonUrl += '/edit';
+    }
+
     newDialogLinks.splice(0, 0, {
       id: 'common',
       name: 'All',
       ariaLabel: formatMessage('all language generation files'),
-      url: `/bot/${projectId}/language-generation/common`,
+      url: commonUrl,
     });
     return newDialogLinks;
-  }, [dialogs]);
+  }, [dialogs, edit]);
 
   useEffect(() => {
     const activeDialog = dialogs.find(({ id }) => id === dialogId);
@@ -86,7 +95,6 @@ const LGPage: React.FC<LGPageProps> = (props) => {
         checked={!!edit}
         className={'toggleEditMode'}
         css={actionButton}
-        defaultChecked={false}
         offText={formatMessage('Edit mode')}
         onChange={onToggleEditMode}
         onText={formatMessage('Edit mode')}

--- a/Composer/packages/client/src/pages/language-generation/code-editor.tsx
+++ b/Composer/packages/client/src/pages/language-generation/code-editor.tsx
@@ -2,11 +2,12 @@
 // Licensed under the MIT License.
 
 /* eslint-disable react/display-name */
-import React, { useState, useEffect, useMemo, useCallback } from 'react';
+/** @jsx jsx */
+import { jsx } from '@emotion/core';
+import React, { useState, useEffect, useMemo, useCallback, Fragment } from 'react';
 import { LgEditor, EditorDidMount } from '@bfc/code-editor';
 import get from 'lodash/get';
 import debounce from 'lodash/debounce';
-import isEmpty from 'lodash/isEmpty';
 import { filterTemplateDiagnostics } from '@bfc/indexers';
 import { RouteComponentProps } from '@reach/router';
 import querystring from 'query-string';
@@ -14,8 +15,9 @@ import { CodeEditorSettings } from '@bfc/shared';
 import { useRecoilValue } from 'recoil';
 import { LgFile } from '@bfc/shared/src/types/indexers';
 
-import { localeState, lgFilesState, projectIdState } from '../../recoilModel/atoms/botState';
+import { localeState, lgFilesState, projectIdState, settingsState } from '../../recoilModel/atoms/botState';
 import { userSettingsState, dispatcherState } from '../../recoilModel';
+import { DiffCodeEditor } from '../language-understanding/diff-editor';
 
 const lspServerPath = '/lg-language-server';
 
@@ -28,13 +30,20 @@ const CodeEditor: React.FC<CodeEditorProps> = (props) => {
   const projectId = useRecoilValue(projectIdState);
   const locale = useRecoilValue(localeState);
   const lgFiles = useRecoilValue(lgFilesState);
+  const settings = useRecoilValue(settingsState);
+
+  const { languages, defaultLanguage } = settings;
+
   const {
     updateLgTemplate: updateLgTemplateDispatcher,
     updateLgFile: updateLgFileDispatcher,
     updateUserSettings,
+    setLocale,
   } = useRecoilValue(dispatcherState);
   const { dialogId } = props;
   const file: LgFile | undefined = lgFiles.find(({ id }) => id === `${dialogId}.${locale}`);
+  const defaultLangFile = lgFiles.find(({ id }) => id === `${dialogId}.${defaultLanguage}`);
+
   const diagnostics = get(file, 'diagnostics', []);
   const [errorMsg, setErrorMsg] = useState('');
   const [lgEditor, setLgEditor] = useState<any>(null);
@@ -53,14 +62,10 @@ const CodeEditor: React.FC<CodeEditorProps> = (props) => {
   const line = Array.isArray(hashLine) ? +hashLine[0] : typeof hashLine === 'string' ? +hashLine : 0;
 
   const inlineMode = !!template;
-  const [content, setContent] = useState(template?.body || file?.content);
-
-  useEffect(() => {
-    // reset content with file.content's initial state
-    if (!file || isEmpty(file) || content) return;
-    const value = template ? template.body : file.content;
-    setContent(value);
-  }, [file, templateId, projectId]);
+  const content = template?.body || file?.content;
+  const defaultLangContent =
+    (inlineMode && defaultLangFile?.templates.find(({ name }) => name === templateId)?.body) ||
+    defaultLangFile?.content;
 
   const currentDiagnostics =
     inlineMode && file && template ? filterTemplateDiagnostics(file, template.name) : diagnostics;
@@ -141,21 +146,56 @@ const CodeEditor: React.FC<CodeEditorProps> = (props) => {
     templateId: template?.name,
   };
 
+  const currentLanguageFileEditor = useMemo(() => {
+    return (
+      <LgEditor
+        diagnostics={currentDiagnostics}
+        editorDidMount={editorDidMount}
+        editorSettings={userSettings.codeEditor}
+        errorMessage={errorMsg}
+        hidePlaceholder={inlineMode}
+        languageServer={{
+          path: lspServerPath,
+        }}
+        lgOption={lgOption}
+        value={content}
+        onChange={onChange}
+        onChangeSettings={handleSettingsChange}
+      />
+    );
+  }, [lgOption]);
+
+  const defaultLanguageFileEditor = useMemo(() => {
+    return (
+      <LgEditor
+        editorSettings={userSettings.codeEditor}
+        lgOption={{
+          fileId: dialogId,
+        }}
+        options={{
+          readOnly: true,
+        }}
+        value={defaultLangContent}
+        onChange={() => {}}
+      />
+    );
+  }, [dialogId]);
+
   return (
-    <LgEditor
-      diagnostics={currentDiagnostics}
-      editorDidMount={editorDidMount}
-      editorSettings={userSettings.codeEditor}
-      errorMessage={errorMsg}
-      hidePlaceholder={inlineMode}
-      languageServer={{
-        path: lspServerPath,
-      }}
-      lgOption={lgOption}
-      value={content}
-      onChange={onChange}
-      onChangeSettings={handleSettingsChange}
-    />
+    <Fragment>
+      {locale === defaultLanguage ? (
+        currentLanguageFileEditor
+      ) : (
+        <DiffCodeEditor
+          defaultLanguage={defaultLanguage}
+          languages={languages}
+          left={currentLanguageFileEditor}
+          locale={locale}
+          right={defaultLanguageFileEditor}
+          onLanguageChange={setLocale}
+        ></DiffCodeEditor>
+      )}
+    </Fragment>
   );
 };
 

--- a/Composer/packages/client/src/pages/language-generation/table-view.tsx
+++ b/Composer/packages/client/src/pages/language-generation/table-view.tsx
@@ -4,7 +4,6 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import React, { useRef, useEffect, useState, useCallback, useMemo } from 'react';
-import debounce from 'lodash/debounce';
 import isEmpty from 'lodash/isEmpty';
 import { DetailsList, DetailsListLayoutMode, SelectionMode } from 'office-ui-fabric-react/lib/DetailsList';
 import { ActionButton } from 'office-ui-fabric-react/lib/Button';
@@ -37,21 +36,19 @@ interface TableViewProps extends RouteComponentProps<{}> {
 }
 
 const TableView: React.FC<TableViewProps> = (props) => {
-  const actions = useRecoilValue(dispatcherState);
   const dialogs = useRecoilValue(dialogsState);
   const lgFiles = useRecoilValue(lgFilesState);
   const projectId = useRecoilValue(projectIdState);
   const locale = useRecoilValue(localeState);
   const settings = useRecoilValue(settingsState);
+  const { createLgTemplate, copyLgTemplate, removeLgTemplate, setMessage } = useRecoilValue(dispatcherState);
+
   const { languages, defaultLanguage } = settings;
 
   const { dialogId } = props;
   const file = lgFiles.find(({ id }) => id === `${dialogId}.${locale}`);
-  const createLgTemplate = useRef(debounce(actions.createLgTemplate, 500)).current;
-  const copyLgTemplate = useRef(debounce(actions.copyLgTemplate, 500)).current;
-  const removeLgTemplate = useRef(debounce(actions.removeLgTemplate, 500)).current;
+
   const [templates, setTemplates] = useState<LgTemplate[]>([]);
-  const { setMessage } = useRecoilValue(dispatcherState);
   const listRef = useRef(null);
 
   const activeDialog = dialogs.find(({ id }) => id === dialogId);

--- a/Composer/packages/client/src/pages/language-generation/table-view.tsx
+++ b/Composer/packages/client/src/pages/language-generation/table-view.tsx
@@ -3,7 +3,7 @@
 
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
-import React, { useContext, useRef, useEffect, useState, useCallback, useMemo } from 'react';
+import React, { useRef, useEffect, useState, useCallback, useMemo } from 'react';
 import debounce from 'lodash/debounce';
 import isEmpty from 'lodash/isEmpty';
 import { DetailsList, DetailsListLayoutMode, SelectionMode } from 'office-ui-fabric-react/lib/DetailsList';

--- a/Composer/packages/client/src/pages/language-understanding/LUPage.tsx
+++ b/Composer/packages/client/src/pages/language-understanding/LUPage.tsx
@@ -35,9 +35,13 @@ const LUPage: React.FC<LUPageProps> = (props) => {
 
   const navLinks: INavTreeItem[] = useMemo(() => {
     const newDialogLinks: INavTreeItem[] = dialogs.map((dialog) => {
+      let url = `/bot/${projectId}/language-understanding/${dialog.id}`;
+      if (edit) {
+        url += `/edit`;
+      }
       return {
         id: dialog.id,
-        url: `/bot/${projectId}/language-understanding/${dialog.id}`,
+        url: url,
         name: dialog.displayName,
         ariaLabel: formatMessage('language understanding file'),
       };
@@ -55,7 +59,7 @@ const LUPage: React.FC<LUPageProps> = (props) => {
       url: `/bot/${projectId}/language-understanding/all`,
     });
     return newDialogLinks;
-  }, [dialogs]);
+  }, [dialogs, edit]);
 
   useEffect(() => {
     const activeDialog = dialogs.find(({ id }) => id === dialogId);
@@ -88,7 +92,6 @@ const LUPage: React.FC<LUPageProps> = (props) => {
           checked={!!edit}
           className={'toggleEditMode'}
           css={actionButton}
-          defaultChecked={false}
           offText={formatMessage('Edit mode')}
           onChange={onToggleEditMode}
           onText={formatMessage('Edit mode')}

--- a/Composer/packages/client/src/pages/language-understanding/code-editor.tsx
+++ b/Composer/packages/client/src/pages/language-understanding/code-editor.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 /* eslint-disable react/display-name */
-import React, { useState, useEffect, useMemo, useContext, useCallback, Fragment } from 'react';
+import React, { useState, useEffect, useMemo, useCallback, Fragment } from 'react';
 import { LuEditor, EditorDidMount } from '@bfc/code-editor';
 import get from 'lodash/get';
 import debounce from 'lodash/debounce';
@@ -29,6 +29,7 @@ const CodeEditor: React.FC<CodeEditorProps> = (props) => {
     updateLuIntent: updateLuIntentDispatcher,
     updateLuFile: updateLuFileDispatcher,
     updateUserSettings,
+    setLocale,
   } = useRecoilValue(dispatcherState);
   const luFiles = useRecoilValue(luFilesState);
   const projectId = useRecoilValue(projectIdState);
@@ -177,7 +178,7 @@ const CodeEditor: React.FC<CodeEditorProps> = (props) => {
           left={currentLanguageFileEditor}
           locale={locale}
           right={defaultLanguageFileEditor}
-          onLanguageChange={actions.setLocale}
+          onLanguageChange={setLocale}
         ></DiffCodeEditor>
       )}
     </Fragment>

--- a/Composer/packages/client/src/pages/language-understanding/code-editor.tsx
+++ b/Composer/packages/client/src/pages/language-understanding/code-editor.tsx
@@ -2,19 +2,20 @@
 // Licensed under the MIT License.
 
 /* eslint-disable react/display-name */
-import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import React, { useState, useEffect, useMemo, useContext, useCallback, Fragment } from 'react';
 import { LuEditor, EditorDidMount } from '@bfc/code-editor';
 import get from 'lodash/get';
 import debounce from 'lodash/debounce';
-import isEmpty from 'lodash/isEmpty';
 import { filterSectionDiagnostics } from '@bfc/indexers';
 import { RouteComponentProps } from '@reach/router';
 import querystring from 'query-string';
 import { CodeEditorSettings } from '@bfc/shared';
 import { useRecoilValue } from 'recoil';
 
-import { luFilesState, projectIdState, localeState } from '../../recoilModel/atoms/botState';
+import { luFilesState, projectIdState, localeState, settingsState } from '../../recoilModel/atoms/botState';
 import { userSettingsState, dispatcherState } from '../../recoilModel';
+
+import { DiffCodeEditor } from './diff-editor';
 
 const lspServerPath = '/lu-language-server';
 
@@ -32,8 +33,14 @@ const CodeEditor: React.FC<CodeEditorProps> = (props) => {
   const luFiles = useRecoilValue(luFilesState);
   const projectId = useRecoilValue(projectIdState);
   const locale = useRecoilValue(localeState);
+  const settings = useRecoilValue(settingsState);
+
+  const { languages, defaultLanguage } = settings;
+
   const { dialogId } = props;
   const file = luFiles.find(({ id }) => id === `${dialogId}.${locale}`);
+  const defaultLangFile = luFiles.find(({ id }) => id === `${dialogId}.${defaultLanguage}`);
+
   const diagnostics = get(file, 'diagnostics', []);
   const [luEditor, setLuEditor] = useState<any>(null);
 
@@ -51,14 +58,9 @@ const CodeEditor: React.FC<CodeEditorProps> = (props) => {
   const line = Array.isArray(hashLine) ? +hashLine[0] : typeof hashLine === 'string' ? +hashLine : 0;
 
   const inlineMode = !!intent;
-  const [content, setContent] = useState(intent?.Body || file?.content);
-
-  useEffect(() => {
-    // reset content with file.content initial state
-    if (!file || isEmpty(file) || content) return;
-    const value = intent ? intent.Body : file.content;
-    setContent(value);
-  }, [file, sectionId, projectId]);
+  const content = intent?.Body || file?.content;
+  const defaultLangContent =
+    (inlineMode && defaultLangFile?.intents.find(({ Name }) => Name === sectionId)?.Body) || defaultLangFile?.content;
 
   const currentDiagnostics = inlineMode && file && sectionId ? filterSectionDiagnostics(file, sectionId) : diagnostics;
 
@@ -111,7 +113,6 @@ const CodeEditor: React.FC<CodeEditorProps> = (props) => {
 
   const onChange = useCallback(
     (value) => {
-      setContent(value);
       if (!file) return;
       if (inlineMode) {
         updateLuIntent(value);
@@ -132,19 +133,54 @@ const CodeEditor: React.FC<CodeEditorProps> = (props) => {
     updateUserSettings({ codeEditor: settings });
   };
 
+  const currentLanguageFileEditor = useMemo(() => {
+    return (
+      <LuEditor
+        diagnostics={currentDiagnostics}
+        editorDidMount={editorDidMount}
+        editorSettings={userSettings.codeEditor}
+        languageServer={{
+          path: lspServerPath,
+        }}
+        luOption={luOption}
+        value={content}
+        onChange={onChange}
+        onChangeSettings={handleSettingsChange}
+      />
+    );
+  }, [luOption]);
+
+  const defaultLanguageFileEditor = useMemo(() => {
+    return (
+      <LuEditor
+        editorSettings={userSettings.codeEditor}
+        luOption={{
+          fileId: dialogId,
+        }}
+        options={{
+          readOnly: true,
+        }}
+        value={defaultLangContent}
+        onChange={() => {}}
+      />
+    );
+  }, [dialogId]);
+
   return (
-    <LuEditor
-      diagnostics={currentDiagnostics}
-      editorDidMount={editorDidMount}
-      editorSettings={userSettings.codeEditor}
-      languageServer={{
-        path: lspServerPath,
-      }}
-      luOption={luOption}
-      value={content}
-      onChange={onChange}
-      onChangeSettings={handleSettingsChange}
-    />
+    <Fragment>
+      {locale === defaultLanguage ? (
+        currentLanguageFileEditor
+      ) : (
+        <DiffCodeEditor
+          defaultLanguage={defaultLanguage}
+          languages={languages}
+          left={currentLanguageFileEditor}
+          locale={locale}
+          right={defaultLanguageFileEditor}
+          onLanguageChange={actions.setLocale}
+        ></DiffCodeEditor>
+      )}
+    </Fragment>
   );
 };
 

--- a/Composer/packages/client/src/pages/language-understanding/diff-editor.tsx
+++ b/Composer/packages/client/src/pages/language-understanding/diff-editor.tsx
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/* eslint-disable react/display-name */
+/** @jsx jsx */
+import { jsx } from '@emotion/core';
+import React, { useMemo } from 'react';
+import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
+
+import { languageListTemplates } from '../../components/MultiLanguage';
+
+import { diffEditorContainer, diffEditorRight, editorToolbar, diffEditorContent, dropdown } from './styles';
+
+interface DiffCodeEditorProps {
+  locale: string;
+  defaultLanguage: string;
+  languages: string[];
+  left: JSX.Element;
+  right: JSX.Element;
+  onLanguageChange: (lang) => void;
+}
+
+const DiffCodeEditor: React.FC<DiffCodeEditorProps> = (props) => {
+  const { onLanguageChange, locale, defaultLanguage, languages, left: leftEditor, right: rightEditor } = props;
+
+  const languageList = languageListTemplates(languages, locale, defaultLanguage);
+
+  const onLanguageSelectChange = (event: React.FormEvent<HTMLDivElement>, option?: IDropdownOption, index?: number) => {
+    const selectedLang = option?.key;
+    if (selectedLang && selectedLang !== locale) {
+      onLanguageChange(selectedLang);
+    }
+  };
+
+  const languageListOptionsLeft: IDropdownOption[] = useMemo(() => {
+    const enableLanguages = languageList.filter(({ isDefault, isEnabled }) => !isDefault && isEnabled);
+    return enableLanguages.map((item) => {
+      const { language, locale } = item;
+      return {
+        key: locale,
+        text: language,
+      };
+    });
+  }, [languages]);
+
+  const languageListOptionsRight: IDropdownOption[] = useMemo(() => {
+    const enableLanguages = languageList.filter(({ isDefault }) => !!isDefault);
+    return enableLanguages.map((item) => {
+      const { language, locale } = item;
+      return {
+        key: locale,
+        text: language,
+      };
+    });
+  }, [languages]);
+
+  return (
+    <div css={diffEditorContainer}>
+      <div>
+        <div css={editorToolbar}>
+          <Dropdown
+            options={languageListOptionsLeft}
+            selectedKey={locale}
+            styles={dropdown}
+            onChange={onLanguageSelectChange}
+          />
+        </div>
+        <div css={diffEditorContent}>{leftEditor}</div>
+      </div>
+      <div css={diffEditorRight}>
+        <div css={editorToolbar}>
+          <Dropdown disabled options={languageListOptionsRight} selectedKey={defaultLanguage} styles={dropdown} />
+        </div>
+        <div css={diffEditorContent}>{rightEditor}</div>
+      </div>
+    </div>
+  );
+};
+
+export { DiffCodeEditor };

--- a/Composer/packages/client/src/pages/language-understanding/styles.ts
+++ b/Composer/packages/client/src/pages/language-understanding/styles.ts
@@ -79,3 +79,29 @@ export const tableCell = css`
 export const content = css`
   outline: none;
 `;
+
+export const diffEditorContainer = css`
+  min-width: 400px;
+  height: 100%;
+  > div {
+    width: calc(50% - 10px);
+    height: 100%;
+    float: left;
+  }
+`;
+
+export const editorToolbar = css`
+  height: 50px;
+`;
+
+export const diffEditorRight = css`
+  margin-left: 20px;
+`;
+
+export const diffEditorContent = css`
+  height: calc(100% - 50px);
+`;
+
+export const dropdown = {
+  dropdown: { width: '50%', maxWidth: 300, minWidth: 100 },
+};

--- a/Composer/packages/client/src/pages/language-understanding/table-view.tsx
+++ b/Composer/packages/client/src/pages/language-understanding/table-view.tsx
@@ -4,7 +4,7 @@
 /* eslint-disable react/display-name */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
-import { useContext, useRef, useEffect, useState, useMemo } from 'react';
+import { useRef, useEffect, useState, useMemo } from 'react';
 import isEmpty from 'lodash/isEmpty';
 import get from 'lodash/get';
 import { DetailsList, DetailsListLayoutMode, SelectionMode } from 'office-ui-fabric-react/lib/DetailsList';

--- a/Composer/packages/client/src/pages/language-understanding/table-view.tsx
+++ b/Composer/packages/client/src/pages/language-understanding/table-view.tsx
@@ -4,7 +4,7 @@
 /* eslint-disable react/display-name */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
-import { useRef, useEffect, useState } from 'react';
+import { useContext, useRef, useEffect, useState, useMemo } from 'react';
 import isEmpty from 'lodash/isEmpty';
 import get from 'lodash/get';
 import { DetailsList, DetailsListLayoutMode, SelectionMode } from 'office-ui-fabric-react/lib/DetailsList';
@@ -17,10 +17,18 @@ import { Sticky, StickyPositionType } from 'office-ui-fabric-react/lib/Sticky';
 import formatMessage from 'format-message';
 import { NeutralColors, FontSizes } from '@uifabric/fluent-theme';
 import { RouteComponentProps } from '@reach/router';
-import { LuFile } from '@bfc/shared';
 import { useRecoilValue } from 'recoil';
+import { LuFile, LuIntentSection } from '@bfc/shared';
 
-import { dialogsState, luFilesState, projectIdState, localeState } from '../../recoilModel/atoms/botState';
+import { getExtension } from '../../utils/fileUtil';
+import { languageListTemplates } from '../../components/MultiLanguage';
+import {
+  dialogsState,
+  luFilesState,
+  projectIdState,
+  localeState,
+  settingsState,
+} from '../../recoilModel/atoms/botState';
 import { navigateTo } from '../../utils/navigation';
 
 import { formCell, luPhraseCell, tableCell, content } from './styles';
@@ -42,6 +50,9 @@ const TableView: React.FC<TableViewProps> = (props) => {
   const luFiles = useRecoilValue(luFilesState);
   const projectId = useRecoilValue(projectIdState);
   const locale = useRecoilValue(localeState);
+  const settings = useRecoilValue(settingsState);
+
+  const { languages, defaultLanguage } = settings;
   const { dialogId } = props;
   const activeDialog = dialogs.find(({ id }) => id === dialogId);
 
@@ -65,23 +76,24 @@ const TableView: React.FC<TableViewProps> = (props) => {
   useEffect(() => {
     if (isEmpty(luFiles)) return;
 
-    const allIntents = luFiles.reduce((result: Intent[], luFile: LuFile) => {
-      const items: Intent[] = [];
-      const luDialog = dialogs.find((dialog) => luFile.id === `${dialog.id}.${locale}`);
-      get(luFile, 'intents', []).forEach(({ Name: name, Body: phrases }) => {
-        const state = getIntentState(luFile);
-
-        items.push({
-          name,
-          phrases,
-          fileId: luFile.id,
-          dialogId: luDialog?.id || '',
-          used: !!luDialog && luDialog.referredLuIntents.some((lu) => lu.name === name), // used by it's dialog or not
-          state,
+    const allIntents = luFiles
+      .filter(({ id }) => getExtension(id) === locale)
+      .reduce((result: Intent[], luFile: LuFile) => {
+        const items: Intent[] = [];
+        const luDialog = dialogs.find((dialog) => luFile.id === `${dialog.id}.${locale}`);
+        get(luFile, 'intents', []).forEach(({ Name: name, Body: phrases }) => {
+          const state = getIntentState(luFile);
+          items.push({
+            name,
+            phrases,
+            fileId: luFile.id,
+            dialogId: luDialog?.id || '',
+            used: !!luDialog && luDialog.referredLuIntents.some((lu) => lu.name === name), // used by it's dialog or not
+            state,
+          });
         });
-      });
-      return result.concat(items);
-    }, []);
+        return result.concat(items);
+      }, []);
 
     if (!activeDialog) {
       setIntents(allIntents);
@@ -106,7 +118,15 @@ const TableView: React.FC<TableViewProps> = (props) => {
   };
 
   const getTableColums = () => {
-    const tableColums = [
+    const languagesList = languageListTemplates(languages, locale, defaultLanguage);
+    const defaultLangTeamplate = languagesList.find((item) => item.locale === defaultLanguage);
+    const currentLangTeamplate = languagesList.find((item) => item.locale === locale);
+    // eslint-disable-next-line format-message/literal-pattern
+    const currentLangResponsesHeader = formatMessage(`Sample Phrases - ${currentLangTeamplate?.language}`);
+    // eslint-disable-next-line format-message/literal-pattern
+    const defaultLangResponsesHeader = formatMessage(`Sample Phrases - ${defaultLangTeamplate?.language} (default)`);
+
+    let tableColums = [
       {
         key: 'name',
         name: formatMessage('Intent'),
@@ -146,6 +166,52 @@ const TableView: React.FC<TableViewProps> = (props) => {
                 tabIndex={-1}
               >
                 {item.phrases}
+              </div>
+            </div>
+          );
+        },
+      },
+      {
+        key: 'phrases-lang',
+        name: currentLangResponsesHeader,
+        fieldName: 'phrases',
+        minWidth: 100,
+        maxWidth: 500,
+        isResizable: true,
+        data: 'string',
+        onRender: (item) => {
+          const text = item.phrases;
+          return (
+            <div data-is-focusable css={luPhraseCell}>
+              <div
+                aria-label={formatMessage(`Sample Phrases are {phrases}`, { phrases: text })}
+                css={content}
+                tabIndex={-1}
+              >
+                {text}
+              </div>
+            </div>
+          );
+        },
+      },
+      {
+        key: 'phrases-default-lang',
+        name: defaultLangResponsesHeader,
+        fieldName: 'phrases-default-lang',
+        minWidth: 100,
+        maxWidth: 500,
+        isResizable: true,
+        data: 'string',
+        onRender: (item) => {
+          const text = item[`body-${defaultLanguage}`];
+          return (
+            <div data-is-focusable css={luPhraseCell}>
+              <div
+                aria-label={formatMessage(`Sample Phrases are {phrases}`, { phrases: text })}
+                css={content}
+                tabIndex={-1}
+              >
+                {text}
               </div>
             </div>
           );
@@ -236,9 +302,16 @@ const TableView: React.FC<TableViewProps> = (props) => {
       },
     ];
 
+    // show compairable column when current lang is not default lang
+    if (locale === defaultLanguage) {
+      tableColums = tableColums.filter(({ key }) => ['phrases-default-lang', 'phrases-lang'].includes(key) === false);
+    } else {
+      tableColums = tableColums.filter(({ key }) => ['phrases'].includes(key) === false);
+    }
+
     // all view, hide defineIn column
-    if (activeDialog) {
-      tableColums.splice(2, 1);
+    if (!activeDialog) {
+      tableColums = tableColums.filter(({ key }) => ['definedIn'].includes(key) === false);
     }
 
     return tableColums;
@@ -257,6 +330,30 @@ const TableView: React.FC<TableViewProps> = (props) => {
     );
   }
 
+  const intentsToRender = useMemo(() => {
+    if (locale !== defaultLanguage) {
+      let defaultLangTeamplates;
+      if (activeDialog) {
+        defaultLangTeamplates = luFiles.find(({ id }) => id === `${dialogId}.${defaultLanguage}`)?.intents;
+      } else {
+        defaultLangTeamplates = luFiles
+          .filter(({ id }) => getExtension(id) === defaultLanguage)
+          .reduce((result: LuIntentSection[], luFile: LuFile) => {
+            return result.concat(luFile.intents);
+          }, []);
+      }
+
+      return intents.map((item) => {
+        const itemInDefaultLang = defaultLangTeamplates?.find(({ Name }) => Name === item.name);
+        return {
+          ...item,
+          [`body-${defaultLanguage}`]: itemInDefaultLang?.Body || '',
+        };
+      });
+    }
+    return intents;
+  }, [intents]);
+
   return (
     <div className={'table-view'} data-testid={'table-view'}>
       <ScrollablePane scrollbarVisibility={ScrollbarVisibility.auto}>
@@ -265,7 +362,7 @@ const TableView: React.FC<TableViewProps> = (props) => {
           columns={getTableColums()}
           componentRef={listRef}
           getKey={(item) => item.Name}
-          items={intents}
+          items={intentsToRender}
           layoutMode={DetailsListLayoutMode.justified}
           selectionMode={SelectionMode.none}
           styles={{

--- a/Composer/packages/client/src/pages/setting/SettingsPage.tsx
+++ b/Composer/packages/client/src/pages/setting/SettingsPage.tsx
@@ -10,7 +10,13 @@ import { FontIcon } from 'office-ui-fabric-react/lib/Icon';
 import { Text } from 'office-ui-fabric-react/lib/Text';
 import { useRecoilValue } from 'recoil';
 
-import { projectIdState } from '../../recoilModel/atoms/botState';
+import {
+  projectIdState,
+  localeState,
+  showAddLanguageModalState,
+  showDelLanguageModalState,
+  settingsState,
+} from '../../recoilModel/atoms/botState';
 import { dispatcherState } from '../../recoilModel';
 import { TestController } from '../../components/TestController/TestController';
 import { OpenConfirmModal } from '../../components/Modal/ConfirmDialog';
@@ -18,6 +24,8 @@ import { navigateTo } from '../../utils/navigation';
 import { Page } from '../../components/Page';
 import { INavTreeItem } from '../../components/NavTree';
 import { useLocation } from '../../utils/hooks';
+import { IToolBarItem } from '../../components/ToolBar';
+import { AddLanguageModal, DeleteLanguageModal } from '../../components/MultiLanguage/index';
 
 import { SettingsRoutes } from './router';
 
@@ -26,8 +34,20 @@ const getProjectLink = (path: string, id?: string) => {
 };
 
 const SettingPage: React.FC<RouteComponentProps<{ '*': string }>> = () => {
-  const { deleteBotProject } = useRecoilValue(dispatcherState);
+  const {
+    deleteBotProject,
+    addLanguageDialogBegin,
+    addLanguageDialogCancel,
+    delLanguageDialogBegin,
+    delLanguageDialogCancel,
+    addLanguages,
+    deleteLanguages,
+  } = useRecoilValue(dispatcherState);
   const projectId = useRecoilValue(projectIdState);
+  const locale = useRecoilValue(localeState);
+  const showAddLanguageModal = useRecoilValue(showAddLanguageModalState);
+  const showDelLanguageModal = useRecoilValue(showDelLanguageModalState);
+  const { defaultLanguage, languages } = useRecoilValue(settingsState);
   const { navigate } = useLocation();
 
   // If no project is open and user tries to access a bot-scoped settings (e.g., browser history, deep link)
@@ -129,18 +149,56 @@ const SettingPage: React.FC<RouteComponentProps<{ '*': string }>> = () => {
     }
   };
 
-  const toolbarItems = [
+  const onAddLangModalSubmit = async (formData) => {
+    await addLanguages({
+      ...formData,
+      projectId,
+    });
+  };
+
+  const onDeleteLangModalSubmit = async (formData) => {
+    await deleteLanguages({
+      ...formData,
+      projectId,
+    });
+  };
+
+  const toolbarItems: IToolBarItem[] = [
     {
-      type: 'action',
-      text: formatMessage('Delete'),
-      buttonProps: {
-        iconProps: {
-          iconName: 'Delete',
-        },
-        onClick: openDeleteBotModal,
-      },
+      type: 'dropdown',
+      text: formatMessage('Edit'),
       align: 'left',
+      dataTestid: 'EditFlyout',
+      buttonProps: {
+        iconProps: { iconName: 'Edit' },
+      },
+      menuProps: {
+        items: [
+          {
+            key: 'edit.deleteBot',
+            text: formatMessage('Delete Bot'),
+            onClick: openDeleteBotModal,
+          },
+          {
+            key: 'edit.addLanguage',
+            text: formatMessage('Add language'),
+            onClick: () => {
+              addLanguageDialogBegin((newLanguages) => {
+                console.log(newLanguages);
+              });
+            },
+          },
+          {
+            key: 'edit.deleteLanguage',
+            text: formatMessage('Delete language'),
+            onClick: () => {
+              delLanguageDialogBegin(() => {});
+            },
+          },
+        ],
+      },
     },
+
     {
       type: 'element',
       element: <TestController />,
@@ -165,6 +223,22 @@ const SettingPage: React.FC<RouteComponentProps<{ '*': string }>> = () => {
       title={title}
       toolbarItems={toolbarItems}
     >
+      <AddLanguageModal
+        defaultLanguage={defaultLanguage}
+        isOpen={showAddLanguageModal}
+        languages={languages}
+        locale={locale}
+        onDismiss={addLanguageDialogCancel}
+        onSubmit={onAddLangModalSubmit}
+      ></AddLanguageModal>
+      <DeleteLanguageModal
+        defaultLanguage={defaultLanguage}
+        isOpen={showDelLanguageModal}
+        languages={languages}
+        locale={locale}
+        onDismiss={delLanguageDialogCancel}
+        onSubmit={onDeleteLangModalSubmit}
+      ></DeleteLanguageModal>
       <SettingsRoutes projectId={projectId} />
     </Page>
   );

--- a/Composer/packages/client/src/pages/setting/SettingsPage.tsx
+++ b/Composer/packages/client/src/pages/setting/SettingsPage.tsx
@@ -183,9 +183,7 @@ const SettingPage: React.FC<RouteComponentProps<{ '*': string }>> = () => {
             key: 'edit.addLanguage',
             text: formatMessage('Add language'),
             onClick: () => {
-              addLanguageDialogBegin((newLanguages) => {
-                console.log(newLanguages);
-              });
+              addLanguageDialogBegin(() => {});
             },
           },
           {

--- a/Composer/packages/client/src/pages/setting/dialog-settings/DialogSettings.tsx
+++ b/Composer/packages/client/src/pages/setting/dialog-settings/DialogSettings.tsx
@@ -87,6 +87,7 @@ export const DialogSettings: React.FC<RouteComponentProps> = () => {
       const { language, locale } = item;
       return {
         key: locale,
+        title: locale,
         text: language,
       };
     });

--- a/Composer/packages/client/src/pages/setting/dialog-settings/DialogSettings.tsx
+++ b/Composer/packages/client/src/pages/setting/dialog-settings/DialogSettings.tsx
@@ -8,28 +8,38 @@ import formatMessage from 'format-message';
 import { Link } from 'office-ui-fabric-react/lib/Link';
 import { RouteComponentProps } from '@reach/router';
 import { useRecoilValue } from 'recoil';
+import React, { useMemo, useEffect } from 'react';
+import { Stack, StackItem } from 'office-ui-fabric-react/lib/Stack';
+import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
+import cloneDeep from 'lodash/cloneDeep';
+import { Label } from 'office-ui-fabric-react/lib/Label';
 
-import { botNameState, settingsState, projectIdState, dispatcherState, userSettingsState } from '../../../recoilModel';
+import {
+  botNameState,
+  settingsState,
+  projectIdState,
+  dispatcherState,
+  userSettingsState,
+  localeState,
+} from '../../../recoilModel';
+import { languageListTemplates } from '../../../components/MultiLanguage';
+import { navigateTo } from '../../../utils/navigation';
 
-import { hostedSettings, hostedControls, settingsEditor } from './style';
-
-const hostControlLabels = {
-  showKeys: formatMessage('Show keys'),
-  productionSlot: formatMessage('In production'),
-  integrationSlot: formatMessage('In test'),
-  botSettings: formatMessage('Settings'),
-  botSettingDescription: formatMessage(
-    'Settings contains detailed information about your bot. For security reasons, they are hidden by default. To test your bot or publish to Azure, you may need to provide these settings.'
-  ),
-  learnMore: formatMessage('Learn more.'),
-};
+import { hostedControls, settingsEditor, toolbar } from './style';
+import { BotSettings } from './constants';
 
 export const DialogSettings: React.FC<RouteComponentProps> = () => {
   const botName = useRecoilValue(botNameState);
+  const locale = useRecoilValue(localeState);
   const settings = useRecoilValue(settingsState);
   const projectId = useRecoilValue(projectIdState);
   const userSettings = useRecoilValue(userSettingsState);
-  const { setSettings } = useRecoilValue(dispatcherState);
+  const { setSettings, setLocale, addLanguageDialogBegin } = useRecoilValue(dispatcherState);
+
+  const { languages, defaultLanguage } = settings;
+  useEffect(() => {
+    if (!botName) navigateTo('/home');
+  }, [botName]);
 
   const saveChangeResult = (result) => {
     try {
@@ -47,25 +57,92 @@ export const DialogSettings: React.FC<RouteComponentProps> = () => {
     }
   };
 
-  const hostedControl = () => (
-    <div css={hostedControls}>
-      <p>
-        {hostControlLabels.botSettingDescription}
-        &nbsp;
-        <Link href={'https://aka.ms/bf-composer-docs-publish-bot'} target="_blank">
-          {hostControlLabels.learnMore}
-        </Link>
-      </p>
-    </div>
-  );
+  const onDefaultLanguageChange = (
+    _event: React.FormEvent<HTMLDivElement>,
+    option?: IDropdownOption,
+    _index?: number
+  ) => {
+    const selectedLang = option?.key as string;
+    if (selectedLang && selectedLang !== defaultLanguage) {
+      setLocale(selectedLang);
+      const updatedSetting = { ...cloneDeep(settings), defaultLanguage: selectedLang };
+      if (updatedSetting?.luis?.defaultLanguage) {
+        updatedSetting.luis.defaultLanguage = selectedLang;
+      }
+      saveChangeResult(updatedSetting);
+    }
+  };
+
+  const onLanguageChange = (_event: React.FormEvent<HTMLDivElement>, option?: IDropdownOption, _index?: number) => {
+    const selectedLang = option?.key as string;
+    if (selectedLang && selectedLang !== locale) {
+      setLocale(selectedLang);
+    }
+  };
+
+  const languageListOptions = useMemo(() => {
+    const languageList = languageListTemplates(languages, locale, defaultLanguage);
+    const enableLanguages = languageList.filter(({ isEnabled }) => !!isEnabled);
+    return enableLanguages.map((item) => {
+      const { language, locale } = item;
+      return {
+        key: locale,
+        text: language,
+      };
+    });
+  }, [languages]);
+
+  const editorId = [defaultLanguage, ...languages].join('-');
 
   return botName ? (
-    <div css={hostedSettings}>
-      {hostedControl()}
-      <div css={settingsEditor}>
-        <JsonEditor editorSettings={userSettings.codeEditor} value={settings} onChange={handleChange} />
-      </div>
-    </div>
+    <Stack tokens={{ childrenGap: '3rem' }}>
+      <StackItem grow={0}>
+        <div css={hostedControls}>
+          <Label>{BotSettings.generalTitle}</Label>
+          <p>
+            {BotSettings.botSettingDescription}
+            &nbsp;
+            <Link href={'https://aka.ms/bf-composer-docs-publish-bot'} target="_blank">
+              {BotSettings.learnMore}
+            </Link>
+          </p>
+        </div>
+      </StackItem>
+      <StackItem>
+        <Label>{BotSettings.languageTitle}</Label>
+        <p>{BotSettings.languagesubTitle}</p>
+        <section style={{ padding: '0 50px' }}>
+          <div css={toolbar}>
+            <Dropdown
+              disabled={languageListOptions.length === 1}
+              label={BotSettings.languageBotLanauge}
+              options={languageListOptions}
+              placeholder="Select an option"
+              selectedKey={locale}
+              styles={{ dropdown: { width: 300 } }}
+              onChange={onLanguageChange}
+            />
+
+            <Link onClick={addLanguageDialogBegin}>{BotSettings.languageAddLanauge}</Link>
+          </div>
+
+          <Dropdown
+            disabled={languageListOptions.length === 1}
+            label={BotSettings.languageDefaultLanauge}
+            options={languageListOptions}
+            placeholder="Select an option"
+            selectedKey={defaultLanguage}
+            styles={{ dropdown: { width: 300 } }}
+            onChange={onDefaultLanguageChange}
+          />
+        </section>
+      </StackItem>
+      <StackItem>
+        <div css={settingsEditor}>
+          <JsonEditor editorSettings={userSettings.codeEditor} id={editorId} value={settings} onChange={handleChange} />
+        </div>
+      </StackItem>
+    </Stack>
   ) : (
     <div>{formatMessage('Data loading...')}</div>
   );

--- a/Composer/packages/client/src/pages/setting/dialog-settings/DialogSettings.tsx
+++ b/Composer/packages/client/src/pages/setting/dialog-settings/DialogSettings.tsx
@@ -123,7 +123,13 @@ export const DialogSettings: React.FC<RouteComponentProps> = () => {
               onChange={onLanguageChange}
             />
 
-            <Link onClick={addLanguageDialogBegin}>{BotSettings.languageAddLanauge}</Link>
+            <Link
+              onClick={() => {
+                addLanguageDialogBegin(() => {});
+              }}
+            >
+              {BotSettings.languageAddLanauge}
+            </Link>
           </div>
 
           <Dropdown

--- a/Composer/packages/client/src/pages/setting/dialog-settings/constants.ts
+++ b/Composer/packages/client/src/pages/setting/dialog-settings/constants.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import formatMessage from 'format-message';
+
+export const BotSettings = {
+  showKeys: formatMessage('Show keys'),
+  productionSlot: formatMessage('In production'),
+  integrationSlot: formatMessage('In test'),
+  botSettings: formatMessage('Settings'),
+  generalTitle: formatMessage('General'),
+  botSettingDescription: formatMessage(
+    'Settings contains detailed information about your bot. For security reasons, they are hidden by default. To test your bot or publish to Azure, you may need to provide these settings.'
+  ),
+  languageTitle: formatMessage('Bot language'),
+  languagesubTitle: formatMessage(`Select the language that bot will be able to understand (User input) and respond to (Bot responses).
+    To make this bot available in other languages, click “Add’ to create a copy of the default language, and translate the content into the new language.`),
+  languageBotLanauge: formatMessage('Bot language (active)'),
+  languageDefaultLanauge: formatMessage('Default language'),
+  languageAddLanauge: formatMessage('Create copy to translate bot content'),
+  learnMore: formatMessage('Learn more.'),
+  settingsTitle: formatMessage('Bot settings'),
+};

--- a/Composer/packages/client/src/pages/setting/dialog-settings/style.ts
+++ b/Composer/packages/client/src/pages/setting/dialog-settings/style.ts
@@ -25,10 +25,19 @@ export const hostedControls = css`
 
 export const settingsEditor = css`
   flex: 1;
-  max-height: 70%;
+  height: 500px;
 `;
 
 export const hostedControlsTitle = css`
   font-size: ${FontSizes.xLarge};
   font-weight: ${FontWeights.semibold};
+`;
+
+export const toolbar = css`
+  margin-bottom: 10px;
+  display: flex;
+  > button {
+    margin-left: 20px;
+    margin-top: 20px;
+  }
 `;

--- a/Composer/packages/client/src/recoilModel/atoms/botState.ts
+++ b/Composer/packages/client/src/recoilModel/atoms/botState.ts
@@ -38,6 +38,7 @@ export const botEnvironmentState = atom<string>({
   default: 'production',
 });
 
+// current bot authoring language
 export const localeState = atom<string>({
   key: getFullyQualifiedKey('locale'),
   default: 'en-us',
@@ -115,7 +116,7 @@ export const showAddSkillDialogModalState = atom<boolean>({
 
 export const settingsState = atom<DialogSetting>({
   key: getFullyQualifiedKey('settings'),
-  default: {} as DialogSetting,
+  default: { defaultLanguage: 'en-us', languages: ['en-us'], luis: {} } as DialogSetting,
 });
 
 export const publishVersionsState = atom<any>({
@@ -168,4 +169,24 @@ export const onAddSkillDialogCompleteState = atom<any>({
 export const displaySkillManifestState = atom<any>({
   key: getFullyQualifiedKey('displaySkillManifest'),
   default: undefined,
+});
+
+export const showAddLanguageModalState = atom<boolean>({
+  key: getFullyQualifiedKey('showAddLanguageModal'),
+  default: false,
+});
+
+export const showDelLanguageModalState = atom<boolean>({
+  key: getFullyQualifiedKey('showDelLanguageModal'),
+  default: false,
+});
+
+export const onAddLanguageDialogCompleteState = atom<any>({
+  key: getFullyQualifiedKey('onAddLanguageDialogComplete'),
+  default: { func: undefined },
+});
+
+export const onDelLanguageDialogCompleteState = atom<any>({
+  key: getFullyQualifiedKey('onDelLanguageDialogComplete'),
+  default: { func: undefined },
 });

--- a/Composer/packages/client/src/recoilModel/dispatchers/__tests__/dialog.test.tsx
+++ b/Composer/packages/client/src/recoilModel/dispatchers/__tests__/dialog.test.tsx
@@ -43,6 +43,29 @@ jest.mock('@bfc/indexers', () => {
   };
 });
 
+jest.mock('../../parsers/luWorker', () => {
+  return {
+    parse: (id, content) => ({ id, content }),
+    addIntent: require('@bfc/indexers/lib/utils/luUtil').addIntent,
+    addIntents: require('@bfc/indexers/lib/utils/luUtil').addIntents,
+    updateIntent: require('@bfc/indexers/lib/utils/luUtil').updateIntent,
+    removeIntent: require('@bfc/indexers/lib/utils/luUtil').removeIntent,
+    removeIntents: require('@bfc/indexers/lib/utils/luUtil').removeIntents,
+  };
+});
+
+jest.mock('../../parsers/lgWorker', () => {
+  return {
+    parse: (id, content) => ({ id, content }),
+    addTemplate: require('../../../utils/lgUtil').addTemplate,
+    addTemplates: require('../../../utils/lgUtil').addTemplates,
+    updateTemplate: require('../../../utils/lgUtil').updateTemplate,
+    removeTemplate: require('../../../utils/lgUtil').removeTemplate,
+    removeAllTemplates: require('../../../utils/lgUtil').removeTemplates,
+    copyTemplate: require('../../../utils/lgUtil').copyTemplate,
+  };
+});
+
 describe('dialog dispatcher', () => {
   let renderedComponent, dispatcher;
   beforeEach(() => {

--- a/Composer/packages/client/src/recoilModel/dispatchers/__tests__/lg.test.tsx
+++ b/Composer/packages/client/src/recoilModel/dispatchers/__tests__/lg.test.tsx
@@ -16,6 +16,7 @@ jest.mock('../../parsers/lgWorker', () => {
   return {
     parse: (id, content) => ({ id, content }),
     addTemplate: require('../../../utils/lgUtil').addTemplate,
+    addTemplates: require('../../../utils/lgUtil').addTemplates,
     updateTemplate: require('../../../utils/lgUtil').updateTemplate,
     removeTemplate: require('../../../utils/lgUtil').removeTemplate,
     removeAllTemplates: require('../../../utils/lgUtil').removeTemplates,

--- a/Composer/packages/client/src/recoilModel/dispatchers/__tests__/lu.test.tsx
+++ b/Composer/packages/client/src/recoilModel/dispatchers/__tests__/lu.test.tsx
@@ -16,8 +16,10 @@ jest.mock('../../parsers/luWorker', () => {
   return {
     parse: (id, content) => ({ id, content }),
     addIntent: require('@bfc/indexers/lib/utils/luUtil').addIntent,
+    addIntents: require('@bfc/indexers/lib/utils/luUtil').addIntents,
     updateIntent: require('@bfc/indexers/lib/utils/luUtil').updateIntent,
     removeIntent: require('@bfc/indexers/lib/utils/luUtil').removeIntent,
+    removeIntents: require('@bfc/indexers/lib/utils/luUtil').removeIntents,
   };
 });
 const luFiles = [

--- a/Composer/packages/client/src/recoilModel/dispatchers/__tests__/mocks/mockProjectResponse.json
+++ b/Composer/packages/client/src/recoilModel/dispatchers/__tests__/mocks/mockProjectResponse.json
@@ -1,7 +1,6 @@
 {
   "id": "30876.502871204648",
   "botName": "EmptyBot-1",
-  "locale": "en-us",
   "botEnvironment": "test",
   "files": [
     {
@@ -8647,6 +8646,8 @@
       "connectionString": "",
       "container": "transcripts"
     },
+    "defaultLanguage": "en-us",
+    "languages": ["en-us"],
     "luis": {
       "name": "",
       "authoringKey": "",

--- a/Composer/packages/client/src/recoilModel/dispatchers/__tests__/multilang.test.tsx
+++ b/Composer/packages/client/src/recoilModel/dispatchers/__tests__/multilang.test.tsx
@@ -1,0 +1,118 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { useRecoilValue } from 'recoil';
+import { act } from '@bfc/test-utils/lib/hooks';
+
+import { renderRecoilHook } from '../../../../__tests__/testUtils';
+import {
+  luFilesState,
+  lgFilesState,
+  settingsState,
+  dialogsState,
+  localeState,
+  onAddLanguageDialogCompleteState,
+  onDelLanguageDialogCompleteState,
+  actionsSeedState,
+} from '../../atoms';
+import { dispatcherState } from '../../../recoilModel/DispatcherWrapper';
+import { Dispatcher } from '..';
+import { multilangDispatcher } from '../multilang';
+
+const state = {
+  dialogs: [{ id: '1' }, { id: '2' }],
+  locale: 'en-us',
+  lgFiles: [
+    { id: 'a.en-us', content: 'hi' },
+    { id: 'a.fr-fr', content: 'hi' },
+  ],
+  luFiles: [
+    { id: 'a.en-us', content: 'hi' },
+    { id: 'a.fr-fr', content: 'hi' },
+  ],
+  settings: {
+    defaultLanguage: 'en-us',
+    languages: ['en-us', 'fr-fr'],
+  },
+};
+
+describe('Multilang dispatcher', () => {
+  let renderedComponent, dispatcher: Dispatcher;
+  beforeEach(() => {
+    const useRecoilTestHook = () => {
+      const dialogs = useRecoilValue(dialogsState);
+      const locale = useRecoilValue(localeState);
+      const settings = useRecoilValue(settingsState);
+      const luFiles = useRecoilValue(luFilesState);
+      const lgFiles = useRecoilValue(lgFilesState);
+      const currentDispatcher = useRecoilValue(dispatcherState);
+      const actionsSeed = useRecoilValue(actionsSeedState);
+      const onAddLanguageDialogComplete = useRecoilValue(onAddLanguageDialogCompleteState);
+      const onDelLanguageDialogComplete = useRecoilValue(onDelLanguageDialogCompleteState);
+
+      return {
+        dialogs,
+        locale,
+        settings,
+        luFiles,
+        lgFiles,
+        currentDispatcher,
+        actionsSeed,
+        onAddLanguageDialogComplete,
+        onDelLanguageDialogComplete,
+      };
+    };
+
+    const { result } = renderRecoilHook(useRecoilTestHook, {
+      states: [
+        { recoilState: dialogsState, initialValue: state.dialogs },
+        { recoilState: localeState, initialValue: state.locale },
+        { recoilState: lgFilesState, initialValue: state.lgFiles },
+        { recoilState: luFilesState, initialValue: state.luFiles },
+        { recoilState: settingsState, initialValue: state.settings },
+      ],
+      dispatcher: {
+        recoilState: dispatcherState,
+        initialValue: {
+          multilangDispatcher,
+        },
+      },
+    });
+    renderedComponent = result;
+    dispatcher = renderedComponent.current.currentDispatcher;
+  });
+
+  it('add language', async () => {
+    await act(async () => {
+      await dispatcher.addLanguages({
+        languages: ['zh-cn'],
+        defaultLang: 'en-us',
+        switchTo: true,
+      });
+    });
+    expect(renderedComponent.current.settings.languages).toEqual(['en-us', 'fr-fr', 'zh-cn']);
+    expect(renderedComponent.current.lgFiles.length).toEqual(3);
+    expect(renderedComponent.current.lgFiles[2]).toEqual({ id: 'a.zh-cn', content: 'hi' });
+    expect(renderedComponent.current.luFiles.length).toEqual(3);
+    expect(renderedComponent.current.luFiles[2]).toEqual({ id: 'a.zh-cn', content: 'hi' });
+    expect(renderedComponent.current.locale).toEqual('zh-cn');
+  });
+
+  it('delete language', async () => {
+    await act(async () => {
+      await dispatcher.deleteLanguages({
+        languages: ['fr-fr'],
+      });
+    });
+    expect(renderedComponent.current.settings.languages).toEqual(['en-us']);
+    expect(renderedComponent.current.lgFiles.length).toEqual(1);
+    expect(renderedComponent.current.luFiles.length).toEqual(1);
+  });
+
+  it('set locale', async () => {
+    await act(async () => {
+      await dispatcher.setLocale('fr-fr');
+    });
+    expect(renderedComponent.current.locale).toEqual('fr-fr');
+  });
+});

--- a/Composer/packages/client/src/recoilModel/dispatchers/__tests__/project.test.tsx
+++ b/Composer/packages/client/src/recoilModel/dispatchers/__tests__/project.test.tsx
@@ -153,7 +153,6 @@ describe('Project dispatcher', () => {
     });
     expect(renderedComponent.current.projectId).toBe(mockProjectResponse.id);
     expect(renderedComponent.current.botName).toBe(mockProjectResponse.botName);
-    expect(renderedComponent.current.locale).toBe(mockProjectResponse.locale);
     expect(renderedComponent.current.settings).toStrictEqual(mockProjectResponse.settings);
     expect(renderedComponent.current.lgFiles.length).toBe(1);
     expect(renderedComponent.current.luFiles.length).toBe(1);

--- a/Composer/packages/client/src/recoilModel/dispatchers/__tests__/setting.test.tsx
+++ b/Composer/packages/client/src/recoilModel/dispatchers/__tests__/setting.test.tsx
@@ -31,6 +31,8 @@ const settings = {
     connectionString: '',
     container: 'transcripts',
   },
+  defaultLanguage: 'en-us',
+  languages: ['en-us'],
   luis: {
     name: '',
     authoringKey: '',

--- a/Composer/packages/client/src/recoilModel/dispatchers/dialogs.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/dialogs.ts
@@ -2,88 +2,30 @@
 // Licensed under the MIT License.
 /* eslint-disable react-hooks/rules-of-hooks */
 import { useRecoilCallback, CallbackInterface } from 'recoil';
-import { LuFile, importResolverGenerator } from '@bfc/shared';
-import { dialogIndexer, autofixReferInDialog, luIndexer, lgIndexer, validateDialog } from '@bfc/indexers';
+import { dialogIndexer, autofixReferInDialog, validateDialog } from '@bfc/indexers';
 
-import luFileStatusStorage from '../../utils/luFileStatusStorage';
-import { getBaseName } from '../../utils/fileUtil';
 import {
   dialogsState,
   lgFilesState,
   luFilesState,
-  projectIdState,
   schemasState,
   onCreateDialogCompleteState,
   actionsSeedState,
   showCreateDialogModalState,
-  localeState,
 } from '../atoms/botState';
 
+import { createLgFileState, removeLgFileState } from './lg';
+import { createLuFileState, removeLuFileState } from './lu';
+
 export const dialogsDispatcher = () => {
-  const createLgFile = async (callbackHelpers: CallbackInterface, id: string, content: string) => {
-    const { set, snapshot } = callbackHelpers;
-    const lgFiles = await snapshot.getPromise(lgFilesState);
-    const locale = await snapshot.getPromise(localeState);
-
-    id = `${id}.${locale}`;
-
-    // slot with common.lg import
-    let lgInitialContent = '';
-    const lgCommonFile = lgFiles.find(({ id }) => id === `common.${locale}`);
-    if (lgCommonFile) {
-      lgInitialContent = `[import](common.lg)`;
-    }
-    content = [lgInitialContent, content].join('\n');
-
-    const { parse } = lgIndexer;
-    const lgImportresolver = importResolverGenerator(lgFiles, '.lg');
-    const lgFile = parse(content, id, lgImportresolver);
-    set(lgFilesState, [...lgFiles, lgFile]);
-  };
-
-  const removeLgFile = async (callbackHelpers: CallbackInterface, id: string) => {
-    const { set, snapshot } = callbackHelpers;
-    let lgFiles = await snapshot.getPromise(lgFilesState);
-    lgFiles = lgFiles.filter((file) => getBaseName(file.id) !== id && file.id !== id);
-    set(lgFilesState, lgFiles);
-  };
-
-  const createLuFile = async (callbackHelpers: CallbackInterface, id: string, content: string) => {
-    const { set, snapshot } = callbackHelpers;
-    const luFiles = await snapshot.getPromise(luFilesState);
-    const locale = await snapshot.getPromise(localeState);
-    const projectId = await snapshot.getPromise(projectIdState);
-
-    id = `${id}.${locale}`;
-    const { parse } = luIndexer;
-    const luFile = { id, content, ...parse(content, id) };
-    luFileStatusStorage.updateFileStatus(projectId, id);
-    set(luFilesState, [...luFiles, luFile]);
-  };
-
-  const removeLuFile = async (callbackHelpers: CallbackInterface, id: string) => {
-    const { set, snapshot } = callbackHelpers;
-    let luFiles = await snapshot.getPromise(luFilesState);
-    const projectId = await snapshot.getPromise(projectIdState);
-    luFiles = luFiles.reduce((result: LuFile[], file) => {
-      if (getBaseName(file.id) === id || file.id === id) {
-        luFileStatusStorage.removeFileStatus(projectId, id);
-      } else {
-        result.push(file);
-      }
-      return result;
-    }, []);
-    set(luFilesState, luFiles);
-  };
-
   const removeDialog = useRecoilCallback((callbackHelpers: CallbackInterface) => async (id: string) => {
     const { set, snapshot } = callbackHelpers;
     let dialogs = await snapshot.getPromise(dialogsState);
     dialogs = dialogs.filter((dialog) => dialog.id !== id);
     set(dialogsState, dialogs);
     //remove dialog should remove all locales lu and lg files
-    await removeLgFile(callbackHelpers, id);
-    await removeLuFile(callbackHelpers, id);
+    await removeLgFileState(callbackHelpers, { id });
+    await removeLuFileState(callbackHelpers, { id });
   });
 
   const updateDialog = useRecoilCallback((callbackHelpers: CallbackInterface) => async ({ id, content }) => {
@@ -128,8 +70,8 @@ export const dialogsDispatcher = () => {
     const luFiles = await snapshot.getPromise(luFilesState);
     const dialog = { isRoot: false, displayName: id, ...dialogIndexer.parse(id, fixedContent) };
     dialog.diagnostics = validateDialog(dialog, schemas.sdk.content, lgFiles, luFiles);
-    await createLgFile(callbackHelpers, id, '');
-    await createLuFile(callbackHelpers, id, '');
+    await createLgFileState(callbackHelpers, { id });
+    await createLuFileState(callbackHelpers, { id });
 
     set(dialogsState, (dialogs) => [...dialogs, dialog]);
     set(actionsSeedState, []);

--- a/Composer/packages/client/src/recoilModel/dispatchers/dialogs.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/dialogs.ts
@@ -70,8 +70,8 @@ export const dialogsDispatcher = () => {
     const luFiles = await snapshot.getPromise(luFilesState);
     const dialog = { isRoot: false, displayName: id, ...dialogIndexer.parse(id, fixedContent) };
     dialog.diagnostics = validateDialog(dialog, schemas.sdk.content, lgFiles, luFiles);
-    await createLgFileState(callbackHelpers, { id });
-    await createLuFileState(callbackHelpers, { id });
+    await createLgFileState(callbackHelpers, { id, content: '' });
+    await createLuFileState(callbackHelpers, { id, content: '' });
 
     set(dialogsState, (dialogs) => [...dialogs, dialog]);
     set(actionsSeedState, []);

--- a/Composer/packages/client/src/recoilModel/dispatchers/index.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/index.ts
@@ -14,6 +14,7 @@ import { publisherDispatcher } from './publisher';
 import { settingsDispatcher } from './setting';
 import { skillDispatcher } from './skill';
 import { userDispatcher } from './user';
+import { multilangDispatcher } from './multilang';
 
 const createDispatchers = () => {
   return {
@@ -30,6 +31,7 @@ const createDispatchers = () => {
     ...settingsDispatcher(),
     ...skillDispatcher(),
     ...userDispatcher(),
+    ...multilangDispatcher(),
   };
 };
 

--- a/Composer/packages/client/src/recoilModel/dispatchers/lg.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/lg.ts
@@ -142,7 +142,7 @@ export const lgDispatcher = () => {
   };
 
   const updateLgTemplate = useRecoilCallback(
-    ({ set }: CallbackInterface) => async ({
+    (callbackHelpers: CallbackInterface) => async ({
       id,
       templateName,
       template,
@@ -151,49 +151,46 @@ export const lgDispatcher = () => {
       templateName: string;
       template: LgTemplate;
     }) => {
-      set(lgFilesState, (lgFiles) => {
-        const content = lgFiles.find((file) => file.id === id)?.content ?? '';
-        const result = lgUtil.updateTemplate(id, content, templateName, template, lgFileResolver(lgFiles));
-        return lgFiles.map((file) => (file.id === id ? result : file));
-      });
+      const { snapshot } = callbackHelpers;
+      const lgFiles = await snapshot.getPromise(lgFilesState);
+      let content = lgFiles.find((file) => file.id === id)?.content ?? '';
+      content = lgUtil.updateTemplate(id, content, templateName, template, lgFileResolver(lgFiles)).content;
+      await updateLgFileState(callbackHelpers, { id, content });
     }
   );
 
   const createLgTemplate = useRecoilCallback(
-    ({ set }: CallbackInterface) => async ({ id, template }: { id: string; template: LgTemplate }) => {
-      set(lgFilesState, (lgFiles) => {
-        const content = lgFiles.find((file) => file.id === id)?.content ?? '';
-        const result = lgUtil.addTemplate(id, content, template, lgFileResolver(lgFiles));
-
-        return lgFiles.map((file) => (file.id === id ? result : file));
-      });
+    (callbackHelpers: CallbackInterface) => async ({ id, template }: { id: string; template: LgTemplate }) => {
+      const { snapshot } = callbackHelpers;
+      const lgFiles = await snapshot.getPromise(lgFilesState);
+      let content = lgFiles.find((file) => file.id === id)?.content ?? '';
+      content = lgUtil.addTemplate(id, content, template, lgFileResolver(lgFiles)).content;
+      await updateLgFileState(callbackHelpers, { id, content });
     }
   );
 
   const removeLgTemplate = useRecoilCallback(
-    ({ set }: CallbackInterface) => async ({ id, templateName }: { id: string; templateName: string }) => {
-      set(lgFilesState, (lgFiles) => {
-        const content = lgFiles.find((file) => file.id === id)?.content ?? '';
-        const result = lgUtil.removeTemplate(id, content, templateName, lgFileResolver(lgFiles));
-
-        return lgFiles.map((file) => (file.id === id ? result : file));
-      });
+    (callbackHelpers: CallbackInterface) => async ({ id, templateName }: { id: string; templateName: string }) => {
+      const { snapshot } = callbackHelpers;
+      const lgFiles = await snapshot.getPromise(lgFilesState);
+      let content = lgFiles.find((file) => file.id === id)?.content ?? '';
+      content = lgUtil.removeTemplate(id, content, templateName, lgFileResolver(lgFiles)).content;
+      await updateLgFileState(callbackHelpers, { id, content });
     }
   );
 
   const removeLgTemplates = useRecoilCallback(
-    ({ set }: CallbackInterface) => async ({ id, templateNames }: { id: string; templateNames: string[] }) => {
-      set(lgFilesState, (lgFiles) => {
-        const content = lgFiles.find((file) => file.id === id)?.content ?? '';
-        const result = lgUtil.removeTemplates(id, content, templateNames, lgFileResolver(lgFiles));
-
-        return lgFiles.map((file) => (file.id === id ? result : file));
-      });
+    (callbackHelpers: CallbackInterface) => async ({ id, templateNames }: { id: string; templateNames: string[] }) => {
+      const { snapshot } = callbackHelpers;
+      const lgFiles = await snapshot.getPromise(lgFilesState);
+      let content = lgFiles.find((file) => file.id === id)?.content ?? '';
+      content = lgUtil.removeTemplates(id, content, templateNames, lgFileResolver(lgFiles)).content;
+      await updateLgFileState(callbackHelpers, { id, content });
     }
   );
 
   const copyLgTemplate = useRecoilCallback(
-    ({ set }: CallbackInterface) => async ({
+    (callbackHelpers: CallbackInterface) => async ({
       id,
       fromTemplateName,
       toTemplateName,
@@ -202,12 +199,11 @@ export const lgDispatcher = () => {
       fromTemplateName: string;
       toTemplateName: string;
     }) => {
-      set(lgFilesState, (lgFiles) => {
-        const content = lgFiles.find((file) => file.id === id)?.content ?? '';
-        const result = lgUtil.copyTemplate(id, content, fromTemplateName, toTemplateName, lgFileResolver(lgFiles));
-
-        return lgFiles.map((file) => (file.id === id ? result : file));
-      });
+      const { snapshot } = callbackHelpers;
+      const lgFiles = await snapshot.getPromise(lgFilesState);
+      let content = lgFiles.find((file) => file.id === id)?.content ?? '';
+      content = lgUtil.copyTemplate(id, content, fromTemplateName, toTemplateName, lgFileResolver(lgFiles)).content;
+      await updateLgFileState(callbackHelpers, { id, content });
     }
   );
 

--- a/Composer/packages/client/src/recoilModel/dispatchers/lg.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/lg.ts
@@ -56,8 +56,9 @@ export const updateLgFileState = async (
   // sync add/remove templates
   if (onlyAdds || onlyDeletes) {
     for (const { id, content } of sameIdOtherLocaleFiles) {
-      let newContent: string = (await LgWorker.addTemplates(content, addedTemplates)) as string;
+      let newContent: string = (await LgWorker.addTemplates(id, content, addedTemplates)) as string;
       newContent = (await LgWorker.removeTemplates(
+        id,
         newContent,
         deletedTemplates.map(({ name }) => name)
       )) as string;

--- a/Composer/packages/client/src/recoilModel/dispatchers/lg.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/lg.ts
@@ -3,17 +3,137 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import { LgTemplate, LgFile, importResolverGenerator } from '@bfc/shared';
 import { useRecoilCallback, CallbackInterface } from 'recoil';
+import differenceBy from 'lodash/differenceBy';
+
+import { getBaseName, getExtension } from '../../utils/fileUtil';
 
 import LgWorker from './../parsers/lgWorker';
-import { lgFilesState } from './../atoms/botState';
+import { lgFilesState, localeState, settingsState } from './../atoms/botState';
 import * as lgUtil from './../../utils/lgUtil';
 
+const templateIsNotEmpty = ({ name, body }) => {
+  return !!name && !!body;
+};
+
+// fill other locale lgFile new added template with '- '
+const initialBody = '- ';
+
+export const updateLgFileState = async (
+  callbackHelpers: CallbackInterface,
+  { id, content }: { id: string; content: string }
+) => {
+  const { set, snapshot } = callbackHelpers;
+  const lgFiles = await snapshot.getPromise(lgFilesState);
+  const dialogId = getBaseName(id);
+  const locale = getExtension(id);
+  const updatedLgFile = (await LgWorker.parse(id, content, lgFiles)) as LgFile;
+  const originLgFile = lgFiles.find((file) => id === file.id);
+  const sameIdOtherLocaleFiles = lgFiles.filter((file) => {
+    const fileDialogId = getBaseName(file.id);
+    const fileLocale = getExtension(file.id);
+    return fileDialogId === dialogId && locale !== fileLocale;
+  });
+
+  if (!originLgFile) {
+    throw new Error('origin lg file not found in store');
+  }
+
+  const changes: LgFile[] = [updatedLgFile];
+
+  const addedTemplates = differenceBy(updatedLgFile.templates, originLgFile.templates, 'name')
+    .filter(templateIsNotEmpty)
+    .map((t) => {
+      return {
+        ...t,
+        body: initialBody,
+      };
+    });
+  const deletedTemplates = differenceBy(originLgFile.templates, updatedLgFile.templates, 'name').filter(
+    templateIsNotEmpty
+  );
+  const onlyAdds = addedTemplates.length && !deletedTemplates.length;
+  const onlyDeletes = !addedTemplates.length && deletedTemplates.length;
+  // sync add/remove templates
+  if (onlyAdds || onlyDeletes) {
+    for (const { id, content } of sameIdOtherLocaleFiles) {
+      let newContent: string = (await LgWorker.addTemplates(content, addedTemplates)) as string;
+      newContent = (await LgWorker.removeTemplates(
+        newContent,
+        deletedTemplates.map(({ name }) => name)
+      )) as string;
+      const newLgFile = (await LgWorker.parse(id, newContent, lgFiles)) as LgFile;
+      changes.push(newLgFile);
+    }
+  }
+
+  const newlgFiles = lgFiles.map((file) => {
+    const changedFile = changes.find(({ id }) => id === file.id);
+    if (changedFile) {
+      return changedFile;
+    }
+    return file;
+  });
+
+  set(lgFilesState, newlgFiles);
+};
+
+// when do create, passed id do not carried with locale
+export const createLgFileState = async (
+  callbackHelpers: CallbackInterface,
+  { id, content = '' }: { id: string; content: string }
+) => {
+  const { set, snapshot } = callbackHelpers;
+  const lgFiles = await snapshot.getPromise(lgFilesState);
+  const locale = await snapshot.getPromise(localeState);
+  const { languages } = await snapshot.getPromise(settingsState);
+  const createdLgId = `${id}.${locale}`;
+  if (lgFiles.find((lg) => lg.id === createdLgId)) {
+    throw new Error('lg file already exist');
+  }
+  // slot with common.lg import
+  let lgInitialContent = '';
+  const lgCommonFile = lgFiles.find(({ id }) => id === `common.${locale}`);
+  if (lgCommonFile) {
+    lgInitialContent = `[import](common.lg)`;
+  }
+  content = [lgInitialContent, content].join('\n');
+  const createdLgFile = (await LgWorker.parse(createdLgId, content, lgFiles)) as LgFile;
+  const changes: LgFile[] = [];
+
+  // copy to other locales
+  languages.forEach((lang) => {
+    changes.push({
+      ...createdLgFile,
+      id: `${id}.${lang}`,
+    });
+  });
+
+  set(lgFilesState, [...lgFiles, ...changes]);
+};
+
+export const removeLgFileState = async (callbackHelpers: CallbackInterface, { id }: { id: string }) => {
+  const { set, snapshot } = callbackHelpers;
+  let lgFiles = await snapshot.getPromise(lgFilesState);
+  lgFiles = lgFiles.filter((file) => getBaseName(file.id) !== id);
+  set(lgFilesState, lgFiles);
+};
+
 export const lgDispatcher = () => {
-  const updateLgFile = useRecoilCallback<[{ id: string; content: any }], Promise<void>>(
-    ({ set, snapshot }: CallbackInterface) => async ({ id, content }) => {
-      const lgFiles = await snapshot.getPromise(lgFilesState);
-      const result = (await LgWorker.parse(id, content, lgFiles)) as LgFile;
-      set(lgFilesState, (lgFiles) => lgFiles.map((file) => (file.id === id ? result : file)));
+  const createLgFile = useRecoilCallback(
+    (callbackHelpers: CallbackInterface) => async ({ id, content }: { id: string; content: string }) => {
+      await createLgFileState(callbackHelpers, { id, content });
+    }
+  );
+
+  const removeLgFile = useRecoilCallback(
+    (callbackHelpers: CallbackInterface) => async ({ id, content }: { id: string; content: string }) => {
+      await createLgFileState(callbackHelpers, { id, content });
+    }
+  );
+
+  const updateLgFile = useRecoilCallback(
+    (callbackHelpers: CallbackInterface) => async ({ id, content }: { id: string; content: string }) => {
+      await updateLgFileState(callbackHelpers, { id, content });
     }
   );
 
@@ -93,6 +213,8 @@ export const lgDispatcher = () => {
 
   return {
     updateLgFile,
+    createLgFile,
+    removeLgFile,
     updateLgTemplate,
     createLgTemplate,
     removeLgTemplate,

--- a/Composer/packages/client/src/recoilModel/dispatchers/lg.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/lg.ts
@@ -56,13 +56,12 @@ export const updateLgFileState = async (
   // sync add/remove templates
   if (onlyAdds || onlyDeletes) {
     for (const { id, content } of sameIdOtherLocaleFiles) {
-      let newContent: string = (await LgWorker.addTemplates(id, content, addedTemplates)) as string;
-      newContent = (await LgWorker.removeTemplates(
+      let newLgFile = (await LgWorker.addTemplates(id, content, addedTemplates)) as LgFile;
+      newLgFile = (await LgWorker.removeTemplates(
         id,
-        newContent,
+        newLgFile.content,
         deletedTemplates.map(({ name }) => name)
-      )) as string;
-      const newLgFile = (await LgWorker.parse(id, newContent, lgFiles)) as LgFile;
+      )) as LgFile;
       changes.push(newLgFile);
     }
   }

--- a/Composer/packages/client/src/recoilModel/dispatchers/lg.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/lg.ts
@@ -80,7 +80,7 @@ export const updateLgFileState = async (
 // when do create, passed id do not carried with locale
 export const createLgFileState = async (
   callbackHelpers: CallbackInterface,
-  { id, content = '' }: { id: string; content: string }
+  { id, content }: { id: string; content: string }
 ) => {
   const { set, snapshot } = callbackHelpers;
   const lgFiles = await snapshot.getPromise(lgFilesState);

--- a/Composer/packages/client/src/recoilModel/dispatchers/lu.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/lu.ts
@@ -3,43 +3,149 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import { LuFile, LuIntentSection } from '@bfc/shared';
 import { useRecoilCallback, CallbackInterface } from 'recoil';
+import differenceBy from 'lodash/differenceBy';
 
+import { getBaseName, getExtension } from '../../utils/fileUtil';
 import * as luUtil from '../../utils/luUtil';
 import luFileStatusStorage from '../../utils/luFileStatusStorage';
-import LuWorker from '../parsers/luWorker';
-import { luFilesState, botLoadErrorState } from '../atoms/botState';
 import luWorker from '../parsers/luWorker';
+import {
+  luFilesState,
+  botLoadErrorState,
+  projectIdState,
+  botStatusState,
+  dialogsState,
+  localeState,
+  settingsState,
+} from '../atoms/botState';
 
-import { projectIdState } from './../atoms/botState';
-import { Text } from './../../constants';
-import { botStatusState } from './../atoms/botState';
-import { dialogsState } from './../atoms/botState';
 import httpClient from './../../utils/httpUtil';
-import { BotStatus } from './../../constants';
+import { Text, BotStatus } from './../../constants';
+
+const intentIsNotEmpty = ({ Name, Body }) => {
+  return !!Name && !!Body;
+};
+// fill other locale luFile new added intent with '- '
+const initialBody = '- ';
+
+export const updateLuFileState = async (
+  callbackHelpers: CallbackInterface,
+  { id, content }: { id: string; content: string }
+) => {
+  const { set, snapshot } = callbackHelpers;
+  const luFiles = await snapshot.getPromise(luFilesState);
+  const projectId = await snapshot.getPromise(projectIdState);
+
+  const dialogId = getBaseName(id);
+  const locale = getExtension(id);
+  const updatedLuFile = (await luWorker.parse(id, content)) as LuFile;
+  const originLuFile = luFiles.find((file) => id === file.id);
+  const sameIdOtherLocaleFiles = luFiles.filter((file) => {
+    const fileDialogId = getBaseName(file.id);
+    const fileLocale = getExtension(file.id);
+    return fileDialogId === dialogId && locale !== fileLocale;
+  });
+
+  if (!originLuFile) {
+    throw new Error('origin lu file not found in store');
+  }
+
+  const changes: LuFile[] = [updatedLuFile];
+
+  const addedIntents = differenceBy(updatedLuFile.intents, originLuFile.intents, 'Name')
+    .filter(intentIsNotEmpty)
+    .map((t) => {
+      return {
+        ...t,
+        Body: initialBody,
+      };
+    });
+  const deletedIntents = differenceBy(originLuFile.intents, updatedLuFile.intents, 'Name').filter(intentIsNotEmpty);
+  const onlyAdds = addedIntents.length && !deletedIntents.length;
+  const onlyDeletes = !addedIntents.length && deletedIntents.length;
+  // sync add/remove intents
+  if (onlyAdds || onlyDeletes) {
+    for (const { id, content } of sameIdOtherLocaleFiles) {
+      let newContent: string = (await luWorker.addIntents(content, addedIntents)) as string;
+      newContent = (await luWorker.removeIntents(
+        newContent,
+        deletedIntents.map(({ Name }) => Name)
+      )) as string;
+      const newLuFile = (await luWorker.parse(id, newContent)) as LuFile;
+      changes.push(newLuFile);
+    }
+  }
+
+  changes.forEach(({ id }) => {
+    luFileStatusStorage.updateFileStatus(projectId, id);
+  });
+
+  const newluFiles = luFiles.map((file) => {
+    const changedFile = changes.find(({ id }) => id === file.id);
+    if (changedFile) {
+      return changedFile;
+    }
+    return file;
+  });
+
+  set(luFilesState, newluFiles);
+};
+
+export const createLuFileState = async (
+  callbackHelpers: CallbackInterface,
+  { id, content }: { id: string; content: string }
+) => {
+  const { set, snapshot } = callbackHelpers;
+  const luFiles = await snapshot.getPromise(luFilesState);
+  const projectId = await snapshot.getPromise(projectIdState);
+  const locale = await snapshot.getPromise(localeState);
+  const { languages } = await snapshot.getPromise(settingsState);
+  const createdLuId = `${id}.${locale}`;
+  const createdLuFile = (await luWorker.parse(id, content)) as LuFile;
+  if (luFiles.find((lg) => lg.id === createdLuId)) {
+    throw new Error('lu file already exist');
+  }
+  const changes: LuFile[] = [];
+
+  // copy to other locales
+  languages.forEach((lang) => {
+    const fileId = `${id}.${lang}`;
+    luFileStatusStorage.updateFileStatus(projectId, fileId);
+    changes.push({
+      ...createdLuFile,
+      id: fileId,
+    });
+  });
+
+  set(luFilesState, [...luFiles, ...changes]);
+};
+
+export const removeLuFileState = async (callbackHelpers: CallbackInterface, { id }: { id: string }) => {
+  const { set, snapshot } = callbackHelpers;
+  let luFiles = await snapshot.getPromise(luFilesState);
+  const projectId = await snapshot.getPromise(projectIdState);
+
+  luFiles.forEach((file) => {
+    if (getBaseName(file.id) === getBaseName(id)) {
+      luFileStatusStorage.removeFileStatus(projectId, id);
+    }
+  });
+
+  luFiles = luFiles.filter((file) => getBaseName(file.id) !== id);
+  set(luFilesState, luFiles);
+};
 
 export const luDispatcher = () => {
-  const updateFile = async (
-    { set, snapshot }: CallbackInterface,
-    { id, content, projectId }: { id: string; content: string; projectId: string }
-  ) => {
-    let luFiles = await snapshot.getPromise(luFilesState);
-    const result = (await LuWorker.parse(id, content)) as LuFile;
-    luFiles = luFiles.map((file) => (file.id === id ? result : file));
-    luFileStatusStorage.updateFileStatus(projectId, id);
-    set(luFilesState, luFiles);
-  };
-
   const updateLuFile = useRecoilCallback(
     (callbackHelpers: CallbackInterface) => async ({
       id,
       content,
-      projectId,
     }: {
       id: string;
       content: string;
       projectId: string;
     }) => {
-      await updateFile(callbackHelpers, { id, content, projectId });
+      await updateLuFileState(callbackHelpers, { id, content });
     }
   );
 
@@ -54,33 +160,30 @@ export const luDispatcher = () => {
       intent: LuIntentSection;
     }) => {
       const luFiles = await callbackHelpers.snapshot.getPromise(luFilesState);
-      const projectId = await callbackHelpers.snapshot.getPromise(projectIdState);
       const file = luFiles.find((temp) => temp.id === id);
       if (!file) return;
       const content = (await luWorker.updateIntent(file.content, intentName, intent)) as string;
-      await updateFile(callbackHelpers, { id: file.id, projectId, content });
+      await updateLuFileState(callbackHelpers, { id: file.id, content });
     }
   );
 
   const createLuIntent = useRecoilCallback(
     (callbackHelpers: CallbackInterface) => async ({ id, intent }: { id: string; intent: LuIntentSection }) => {
       const luFiles = await callbackHelpers.snapshot.getPromise(luFilesState);
-      const projectId = await callbackHelpers.snapshot.getPromise(projectIdState);
       const file = luFiles.find((temp) => temp.id === id);
       if (!file) return;
       const content = (await luWorker.addIntent(file.content, intent)) as string;
-      await updateFile(callbackHelpers, { id: file.id, projectId, content });
+      await updateLuFileState(callbackHelpers, { id: file.id, content });
     }
   );
 
   const removeLuIntent = useRecoilCallback(
     (callbackHelpers: CallbackInterface) => async ({ id, intentName }: { id: string; intentName: string }) => {
       const luFiles = await callbackHelpers.snapshot.getPromise(luFilesState);
-      const projectId = await callbackHelpers.snapshot.getPromise(projectIdState);
       const file = luFiles.find((temp) => temp.id === id);
       if (!file) return;
       const content = (await luWorker.removeIntent(file.content, intentName)) as string;
-      await updateFile(callbackHelpers, { id: file.id, projectId, content });
+      await updateLuFileState(callbackHelpers, { id: file.id, content });
     }
   );
 

--- a/Composer/packages/client/src/recoilModel/dispatchers/multilang.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/multilang.ts
@@ -1,0 +1,153 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+/* eslint-disable react-hooks/rules-of-hooks */
+
+import { useRecoilCallback, CallbackInterface } from 'recoil';
+import cloneDeep from 'lodash/cloneDeep';
+import difference from 'lodash/difference';
+
+import languageStorage from '../../utils/languageStorage';
+import { getExtension } from '../../utils/fileUtil';
+
+import {
+  lgFilesState,
+  luFilesState,
+  localeState,
+  settingsState,
+  showAddLanguageModalState,
+  onAddLanguageDialogCompleteState,
+  onDelLanguageDialogCompleteState,
+  showDelLanguageModalState,
+  botNameState,
+} from './../atoms/botState';
+
+const copyLanguageResources = (files: any[], fromLanguage: string, toLanguages: string[]): any[] => {
+  const copiedFiles: any = [];
+  const copyOriginFiles = files.filter(({ id }) => getExtension(id) === fromLanguage);
+
+  for (const file of copyOriginFiles) {
+    for (const toLanguage of toLanguages) {
+      // eslint-disable-next-line security/detect-non-literal-regexp
+      const id = file.id.replace(new RegExp(`${fromLanguage}$`), toLanguage);
+      copiedFiles.push({
+        ...file,
+        id,
+      });
+    }
+  }
+
+  return copiedFiles;
+};
+
+// pull out target language file
+const deleteLanguageResources = (
+  files: any[],
+  languages: string[]
+): {
+  left: any[];
+  deletes: any[];
+} => {
+  const left = files.filter(({ id }) => !languages.includes(getExtension(id)));
+  const deletes = files.filter(({ id }) => languages.includes(getExtension(id)));
+  return {
+    left,
+    deletes,
+  };
+};
+
+export const multilangDispatcher = () => {
+  const setLocale = useRecoilCallback(({ set, snapshot }: CallbackInterface) => async (locale: string) => {
+    const botName = await snapshot.getPromise(botNameState);
+
+    set(localeState, locale);
+    languageStorage.setLocale(botName, locale);
+  });
+
+  const addLanguages = useRecoilCallback(
+    (callbackHelpers: CallbackInterface) => async ({ languages, defaultLang, switchTo = false }) => {
+      const { set, snapshot } = callbackHelpers;
+      const botName = await snapshot.getPromise(botNameState);
+      const prevlgFiles = await snapshot.getPromise(lgFilesState);
+      const prevluFiles = await snapshot.getPromise(luFilesState);
+      const prevSettings = await snapshot.getPromise(settingsState);
+
+      // copy files from default language
+      const lgFiles = copyLanguageResources(prevlgFiles, defaultLang, languages);
+      const luFiles = copyLanguageResources(prevluFiles, defaultLang, languages);
+
+      const settings: any = cloneDeep(prevSettings);
+      if (Array.isArray(settings.languages)) {
+        settings.languages.push(...languages);
+      } else {
+        settings.languages = languages;
+      }
+
+      if (switchTo) {
+        const switchToLocale = languages[0];
+        set(localeState, switchToLocale);
+        languageStorage.setLocale(botName, switchToLocale);
+      }
+
+      set(lgFilesState, [...prevlgFiles, ...lgFiles]);
+      set(luFilesState, [...prevluFiles, ...luFiles]);
+      set(settingsState, settings);
+
+      // better way?
+      set(showAddLanguageModalState, false);
+      set(onAddLanguageDialogCompleteState, { func: undefined });
+    }
+  );
+
+  const deleteLanguages = useRecoilCallback((callbackHelpers: CallbackInterface) => async ({ languages }) => {
+    const { set, snapshot } = callbackHelpers;
+    const prevlgFiles = await snapshot.getPromise(lgFilesState);
+    const prevluFiles = await snapshot.getPromise(luFilesState);
+    const prevSettings = await snapshot.getPromise(settingsState);
+
+    // copy files from default language
+    const { left: leftLgFiles } = deleteLanguageResources(prevlgFiles, languages);
+    const { left: leftLuFiles } = deleteLanguageResources(prevluFiles, languages);
+
+    const settings: any = cloneDeep(prevSettings);
+
+    const leftLanguages = difference(settings.languages, languages);
+    settings.languages = leftLanguages;
+
+    set(lgFilesState, leftLgFiles);
+    set(luFilesState, leftLuFiles);
+    set(settingsState, settings);
+
+    set(showDelLanguageModalState, false);
+    set(onDelLanguageDialogCompleteState, { func: undefined });
+  });
+
+  const addLanguageDialogBegin = useRecoilCallback(({ set }: CallbackInterface) => async (onComplete) => {
+    set(showAddLanguageModalState, true);
+    set(onAddLanguageDialogCompleteState, { func: onComplete });
+  });
+
+  const addLanguageDialogCancel = useRecoilCallback(({ set }: CallbackInterface) => async () => {
+    set(showAddLanguageModalState, false);
+    set(onAddLanguageDialogCompleteState, { func: undefined });
+  });
+
+  const delLanguageDialogBegin = useRecoilCallback(({ set }: CallbackInterface) => async (onComplete) => {
+    set(showDelLanguageModalState, true);
+    set(onDelLanguageDialogCompleteState, { func: onComplete });
+  });
+
+  const delLanguageDialogCancel = useRecoilCallback(({ set }: CallbackInterface) => async () => {
+    set(showDelLanguageModalState, false);
+    set(onDelLanguageDialogCompleteState, { func: undefined });
+  });
+
+  return {
+    setLocale,
+    addLanguages,
+    deleteLanguages,
+    addLanguageDialogBegin,
+    addLanguageDialogCancel,
+    delLanguageDialogBegin,
+    delLanguageDialogCancel,
+  };
+};

--- a/Composer/packages/client/src/recoilModel/dispatchers/multilang.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/multilang.ts
@@ -70,6 +70,7 @@ export const multilangDispatcher = () => {
       const prevlgFiles = await snapshot.getPromise(lgFilesState);
       const prevluFiles = await snapshot.getPromise(luFilesState);
       const prevSettings = await snapshot.getPromise(settingsState);
+      const onAddLanguageDialogComplete = (await snapshot.getPromise(onAddLanguageDialogCompleteState)).func;
 
       // copy files from default language
       const lgFiles = copyLanguageResources(prevlgFiles, defaultLang, languages);
@@ -92,7 +93,10 @@ export const multilangDispatcher = () => {
       set(luFilesState, [...prevluFiles, ...luFiles]);
       set(settingsState, settings);
 
-      // better way?
+      if (typeof onAddLanguageDialogComplete === 'function') {
+        onAddLanguageDialogComplete(languages);
+      }
+
       set(showAddLanguageModalState, false);
       set(onAddLanguageDialogCompleteState, { func: undefined });
     }
@@ -103,6 +107,7 @@ export const multilangDispatcher = () => {
     const prevlgFiles = await snapshot.getPromise(lgFilesState);
     const prevluFiles = await snapshot.getPromise(luFilesState);
     const prevSettings = await snapshot.getPromise(settingsState);
+    const onDelLanguageDialogComplete = (await snapshot.getPromise(onDelLanguageDialogCompleteState)).func;
 
     // copy files from default language
     const { left: leftLgFiles } = deleteLanguageResources(prevlgFiles, languages);
@@ -116,6 +121,10 @@ export const multilangDispatcher = () => {
     set(lgFilesState, leftLgFiles);
     set(luFilesState, leftLuFiles);
     set(settingsState, settings);
+
+    if (typeof onDelLanguageDialogComplete === 'function') {
+      onDelLanguageDialogComplete(leftLanguages);
+    }
 
     set(showDelLanguageModalState, false);
     set(onDelLanguageDialogCompleteState, { func: undefined });

--- a/Composer/packages/client/src/recoilModel/dispatchers/project.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/project.ts
@@ -19,6 +19,7 @@ import { DialogSetting } from '../../recoilModel/types';
 import settingStorage from '../../utils/dialogSettingStorage';
 import filePersistence from '../persistence/FilePersistence';
 import { navigateTo } from '../../utils/navigation';
+import languageStorage from '../../utils/languageStorage';
 
 import {
   skillManifestsState,
@@ -112,18 +113,10 @@ export const projectDispatcher = () => {
   const initBotState = async (callbackHelpers: CallbackInterface, data: any, jumpToMain: boolean) => {
     const { snapshot, gotoSnapshot } = callbackHelpers;
     const curLocation = await snapshot.getPromise(locationState);
-    const {
-      files,
-      botName,
-      botEnvironment,
-      location,
-      schemas,
-      settings,
-      id: projectId,
-      locale,
-      diagnostics,
-      skills,
-    } = data;
+    const { files, botName, botEnvironment, location, schemas, settings, id: projectId, diagnostics, skills } = data;
+    const storedLocale = languageStorage.get(botName)?.locale;
+    const locale = settings.languages.includes(storedLocale) ? storedLocale : settings.defaultLanguage;
+
     try {
       schemas.sdk.content = processSchema(projectId, schemas.sdk.content);
     } catch (err) {

--- a/Composer/packages/client/src/recoilModel/parsers/lgWorker.ts
+++ b/Composer/packages/client/src/recoilModel/parsers/lgWorker.ts
@@ -17,32 +17,33 @@ import {
 
 // Wrapper class
 class LgWorker extends BaseWorker<LgActionType> {
-  parse(targetId: string, content: string, lgFiles: LgFile[]) {
-    return this.sendMsg<LgParsePayload>(LgActionType.Parse, { targetId, content, lgFiles: lgFiles });
+  parse(id: string, content: string, lgFiles: LgFile[]) {
+    return this.sendMsg<LgParsePayload>(LgActionType.Parse, { id, content, lgFiles: lgFiles });
   }
 
-  addTemplate(content: string, template: LgTemplate) {
-    return this.sendMsg<LgCreateTemplatePayload>(LgActionType.AddTemplate, { content, template });
+  addTemplate(id: string, content: string, template: LgTemplate) {
+    return this.sendMsg<LgCreateTemplatePayload>(LgActionType.AddTemplate, { id, content, template });
   }
 
-  addTemplates(content: string, templates: LgTemplate[]) {
-    return this.sendMsg<LgCreateTemplatesPayload>(LgActionType.AddTemplates, { content, templates });
+  addTemplates(id: string, content: string, templates: LgTemplate[]) {
+    return this.sendMsg<LgCreateTemplatesPayload>(LgActionType.AddTemplates, { id, content, templates });
   }
 
-  updateTemplate(content: string, templateName: string, template: LgTemplate) {
-    return this.sendMsg<LgUpdateTemplatePayload>(LgActionType.UpdateTemplate, { content, templateName, template });
+  updateTemplate(id: string, content: string, templateName: string, template: LgTemplate) {
+    return this.sendMsg<LgUpdateTemplatePayload>(LgActionType.UpdateTemplate, { id, content, templateName, template });
   }
 
-  removeTemplate(content: string, templateName: string) {
-    return this.sendMsg<LgRemoveTemplatePayload>(LgActionType.RemoveTemplate, { content, templateName });
+  removeTemplate(id: string, content: string, templateName: string) {
+    return this.sendMsg<LgRemoveTemplatePayload>(LgActionType.RemoveTemplate, { id, content, templateName });
   }
 
-  removeTemplates(content: string, templateNames: string[]) {
-    return this.sendMsg<LgRemoveAllTemplatesPayload>(LgActionType.RemoveAllTemplates, { content, templateNames });
+  removeTemplates(id: string, content: string, templateNames: string[]) {
+    return this.sendMsg<LgRemoveAllTemplatesPayload>(LgActionType.RemoveAllTemplates, { id, content, templateNames });
   }
 
-  copyTemplate(content: string, fromTemplateName: string, toTemplateName: string) {
+  copyTemplate(id: string, content: string, fromTemplateName: string, toTemplateName: string) {
     return this.sendMsg<LgCopyTemplatePayload>(LgActionType.CopyTemplate, {
+      id,
       content,
       fromTemplateName,
       toTemplateName,

--- a/Composer/packages/client/src/recoilModel/parsers/lgWorker.ts
+++ b/Composer/packages/client/src/recoilModel/parsers/lgWorker.ts
@@ -1,15 +1,52 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-import { LgFile } from '@bfc/shared';
+import { LgFile, LgTemplate } from '@bfc/shared';
 
 import Worker from './workers/lgParser.worker.ts';
 import { BaseWorker } from './baseWorker';
-import { LgActionType, LgParsePayload } from './types';
+import {
+  LgActionType,
+  LgParsePayload,
+  LgUpdateTemplatePayload,
+  LgCreateTemplatePayload,
+  LgCreateTemplatesPayload,
+  LgRemoveTemplatePayload,
+  LgRemoveAllTemplatesPayload,
+  LgCopyTemplatePayload,
+} from './types';
 
 // Wrapper class
 class LgWorker extends BaseWorker<LgActionType> {
   parse(targetId: string, content: string, lgFiles: LgFile[]) {
     return this.sendMsg<LgParsePayload>(LgActionType.Parse, { targetId, content, lgFiles: lgFiles });
+  }
+
+  addTemplate(content: string, template: LgTemplate) {
+    return this.sendMsg<LgCreateTemplatePayload>(LgActionType.AddTemplate, { content, template });
+  }
+
+  addTemplates(content: string, templates: LgTemplate[]) {
+    return this.sendMsg<LgCreateTemplatesPayload>(LgActionType.AddTemplates, { content, templates });
+  }
+
+  updateTemplate(content: string, templateName: string, template: LgTemplate) {
+    return this.sendMsg<LgUpdateTemplatePayload>(LgActionType.UpdateTemplate, { content, templateName, template });
+  }
+
+  removeTemplate(content: string, templateName: string) {
+    return this.sendMsg<LgRemoveTemplatePayload>(LgActionType.RemoveTemplate, { content, templateName });
+  }
+
+  removeTemplates(content: string, templateNames: string[]) {
+    return this.sendMsg<LgRemoveAllTemplatesPayload>(LgActionType.RemoveAllTemplates, { content, templateNames });
+  }
+
+  copyTemplate(content: string, fromTemplateName: string, toTemplateName: string) {
+    return this.sendMsg<LgCopyTemplatePayload>(LgActionType.CopyTemplate, {
+      content,
+      fromTemplateName,
+      toTemplateName,
+    });
   }
 }
 

--- a/Composer/packages/client/src/recoilModel/parsers/luWorker.ts
+++ b/Composer/packages/client/src/recoilModel/parsers/luWorker.ts
@@ -27,6 +27,16 @@ class LuWorker extends BaseWorker<LuActionType> {
     const payload = { content, intentName };
     return this.sendMsg<LuPayload>(LuActionType.RemoveIntent, payload);
   }
+
+  addIntents(content: string, intents: LuIntentSection[]) {
+    const payload = { content, intents };
+    return this.sendMsg<LuPayload>(LuActionType.AddIntents, payload);
+  }
+
+  removeIntents(content: string, intentNames: string[]) {
+    const payload = { content, intentNames };
+    return this.sendMsg<LuPayload>(LuActionType.RemoveIntents, payload);
+  }
 }
 
 export default new LuWorker(new Worker());

--- a/Composer/packages/client/src/recoilModel/parsers/types.ts
+++ b/Composer/packages/client/src/recoilModel/parsers/types.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-import { LuIntentSection, LgFile, FileInfo } from '@bfc/shared';
+import { LuIntentSection, LgFile, FileInfo, LgTemplate } from '@bfc/shared';
 
 export type LuPayload = {
   content: string;
@@ -15,6 +15,37 @@ export type LgParsePayload = {
   lgFiles: LgFile[];
 };
 
+export interface LgCreateTemplatePayload {
+  content: string;
+  template: LgTemplate;
+}
+
+export interface LgCreateTemplatesPayload {
+  content: string;
+  templates: LgTemplate[];
+}
+
+export interface LgUpdateTemplatePayload {
+  content: string;
+  templateName: string;
+  template: LgTemplate;
+}
+
+export interface LgRemoveTemplatePayload {
+  content: string;
+  templateName: string;
+}
+
+export interface LgRemoveAllTemplatesPayload {
+  content: string;
+  templateNames: string[];
+}
+
+export interface LgCopyTemplatePayload {
+  content: string;
+  fromTemplateName: string;
+  toTemplateName: string;
+}
 export type IndexPayload = {
   files: FileInfo;
   botName: string;
@@ -27,10 +58,18 @@ export enum LuActionType {
   AddIntent = 'add-intent',
   UpdateIntent = 'update-intent',
   RemoveIntent = 'remove-intent',
+  AddIntents = 'add-intents',
+  RemoveIntents = 'remove-intents',
 }
 
 export enum LgActionType {
   Parse = 'parse',
+  AddTemplate = 'add-template',
+  AddTemplates = 'add-templates',
+  UpdateTemplate = 'update-template',
+  RemoveTemplate = 'remove-template',
+  RemoveAllTemplates = 'remove-all-templates',
+  CopyTemplate = 'copy-template',
 }
 
 export enum IndexerActionType {

--- a/Composer/packages/client/src/recoilModel/parsers/types.ts
+++ b/Composer/packages/client/src/recoilModel/parsers/types.ts
@@ -10,38 +10,44 @@ export type LuPayload = {
 };
 
 export type LgParsePayload = {
-  targetId: string;
+  id: string;
   content: string;
   lgFiles: LgFile[];
 };
 
 export interface LgCreateTemplatePayload {
+  id: string;
   content: string;
   template: LgTemplate;
 }
 
 export interface LgCreateTemplatesPayload {
+  id: string;
   content: string;
   templates: LgTemplate[];
 }
 
 export interface LgUpdateTemplatePayload {
+  id: string;
   content: string;
   templateName: string;
   template: LgTemplate;
 }
 
 export interface LgRemoveTemplatePayload {
+  id: string;
   content: string;
   templateName: string;
 }
 
 export interface LgRemoveAllTemplatesPayload {
+  id: string;
   content: string;
   templateNames: string[];
 }
 
 export interface LgCopyTemplatePayload {
+  id: string;
   content: string;
   fromTemplateName: string;
   toTemplateName: string;

--- a/Composer/packages/client/src/recoilModel/parsers/workers/lgParser.worker.ts
+++ b/Composer/packages/client/src/recoilModel/parsers/workers/lgParser.worker.ts
@@ -1,9 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-import { importResolverGenerator } from '@bfc/shared';
-import { lgIndexer } from '@bfc/indexers';
+import { lgUtil } from '@bfc/indexers';
 
-import { LgActionType, LgParsePayload } from '../types';
+import {
+  LgActionType,
+  LgParsePayload,
+  LgUpdateTemplatePayload,
+  LgCreateTemplatePayload,
+  LgCreateTemplatesPayload,
+  LgRemoveTemplatePayload,
+  LgRemoveAllTemplatesPayload,
+  LgCopyTemplatePayload,
+} from '../types';
 
 const ctx: Worker = self as any;
 
@@ -13,19 +21,90 @@ interface ParseMessage {
   payload: LgParsePayload;
 }
 
-type LgMessageEvent = ParseMessage;
+interface AddMessage {
+  id: string;
+  type: LgActionType.AddTemplate;
+  payload: LgCreateTemplatePayload;
+}
+
+interface AddsMessage {
+  id: string;
+  type: LgActionType.AddTemplates;
+  payload: LgCreateTemplatesPayload;
+}
+
+interface UpdateMessage {
+  id: string;
+  type: LgActionType.UpdateTemplate;
+  payload: LgUpdateTemplatePayload;
+}
+
+interface RemoveMessage {
+  id: string;
+  type: LgActionType.RemoveTemplate;
+  payload: LgRemoveTemplatePayload;
+}
+
+interface RemoveAllMessage {
+  id: string;
+  type: LgActionType.RemoveAllTemplates;
+  payload: LgRemoveAllTemplatesPayload;
+}
+
+interface CopyMessage {
+  id: string;
+  type: LgActionType.CopyTemplate;
+  payload: LgCopyTemplatePayload;
+}
+
+type LgMessageEvent =
+  | ParseMessage
+  | AddMessage
+  | AddsMessage
+  | UpdateMessage
+  | RemoveMessage
+  | RemoveAllMessage
+  | CopyMessage;
 
 export const handleMessage = (msg: LgMessageEvent) => {
   let payload: any = null;
   switch (msg.type) {
     case LgActionType.Parse: {
-      const { targetId, content, lgFiles } = msg.payload;
-      const { parse } = lgIndexer;
+      const { id, content, lgFiles } = msg.payload;
 
-      const lgImportResolver = importResolverGenerator(lgFiles, '.lg');
-
-      const { templates, diagnostics } = parse(content, targetId, lgImportResolver);
-      payload = { id: targetId, content, templates, diagnostics };
+      const { templates, diagnostics } = lgUtil.parse(id, content, lgFiles);
+      payload = { id, content, templates, diagnostics };
+      break;
+    }
+    case LgActionType.AddTemplate: {
+      const { id, content, template } = msg.payload;
+      payload = lgUtil.addTemplate(id, content, template);
+      break;
+    }
+    case LgActionType.AddTemplates: {
+      const { id, content, templates } = msg.payload;
+      payload = lgUtil.addTemplates(id, content, templates);
+      break;
+    }
+    case LgActionType.UpdateTemplate: {
+      const { id, content, templateName, template } = msg.payload;
+      lgUtil.checkSingleLgTemplate(template);
+      payload = lgUtil.updateTemplate(id, content, templateName, template);
+      break;
+    }
+    case LgActionType.RemoveTemplate: {
+      const { id, content, templateName } = msg.payload;
+      payload = lgUtil.removeTemplate(id, content, templateName);
+      break;
+    }
+    case LgActionType.RemoveAllTemplates: {
+      const { id, content, templateNames } = msg.payload;
+      payload = lgUtil.removeTemplates(id, content, templateNames);
+      break;
+    }
+    case LgActionType.CopyTemplate: {
+      const { id, content, toTemplateName, fromTemplateName } = msg.payload;
+      payload = lgUtil.copyTemplate(id, content, fromTemplateName, toTemplateName);
       break;
     }
   }

--- a/Composer/packages/client/src/recoilModel/parsers/workers/luParser.worker.ts
+++ b/Composer/packages/client/src/recoilModel/parsers/workers/luParser.worker.ts
@@ -1,44 +1,51 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-import { luUtil } from '@bfc/indexers';
+
+import * as luUtil from '@bfc/indexers/lib/utils/luUtil';
 
 import { LuActionType } from '../types';
 const ctx: Worker = self as any;
 
-ctx.onmessage = function (msg) {
-  const { id: msgId, type, payload } = msg.data;
+export const handleMessage = (msg) => {
+  const { type, payload } = msg.data;
   const { content, id, intentName, intentNames, intent, intents } = payload;
   let result: any = null;
-  try {
-    switch (type) {
-      case LuActionType.Parse: {
-        result = luUtil.parse(id, content);
-        break;
-      }
-      case LuActionType.AddIntent: {
-        result = luUtil.addIntent(content, intent);
-        break;
-      }
-      case LuActionType.AddIntents: {
-        result = luUtil.addIntents(content, intents);
-        break;
-      }
-      case LuActionType.UpdateIntent: {
-        result = luUtil.updateIntent(content, intentName, intent || null);
-        break;
-      }
-      case LuActionType.RemoveIntent: {
-        result = luUtil.removeIntent(content, intentName);
-        break;
-      }
-      case LuActionType.RemoveIntents: {
-        result = luUtil.removeIntents(content, intentNames);
-        break;
-      }
+  switch (type) {
+    case LuActionType.Parse: {
+      result = luUtil.parse(id, content);
+      break;
     }
+    case LuActionType.AddIntent: {
+      result = luUtil.addIntent(content, intent);
+      break;
+    }
+    case LuActionType.AddIntents: {
+      result = luUtil.addIntents(content, intents);
+      break;
+    }
+    case LuActionType.UpdateIntent: {
+      result = luUtil.updateIntent(content, intentName, intent || null);
+      break;
+    }
+    case LuActionType.RemoveIntent: {
+      result = luUtil.removeIntent(content, intentName);
+      break;
+    }
+    case LuActionType.RemoveIntents: {
+      result = luUtil.removeIntents(content, intentNames);
+      break;
+    }
+  }
+  return result;
+};
 
-    ctx.postMessage({ id: msgId, payload: result });
+ctx.onmessage = function (msg) {
+  const { id } = msg.data;
+  try {
+    const payload = handleMessage(msg);
+
+    ctx.postMessage({ id, payload });
   } catch (error) {
-    ctx.postMessage({ id: msgId, error });
+    ctx.postMessage({ id, error });
   }
 };

--- a/Composer/packages/client/src/recoilModel/parsers/workers/luParser.worker.ts
+++ b/Composer/packages/client/src/recoilModel/parsers/workers/luParser.worker.ts
@@ -1,47 +1,44 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-import { luIndexer } from '@bfc/indexers';
-import * as luUtil from '@bfc/indexers/lib/utils/luUtil';
+import { luUtil } from '@bfc/indexers';
 
 import { LuActionType } from '../types';
 const ctx: Worker = self as any;
 
-const parse = (id: string, content: string) => {
-  return { id, content, ...luIndexer.parse(content, id) };
-};
-
-export const handleMessage = (msg) => {
-  const { type, payload } = msg.data;
-  const { content, id, intentName, intent } = payload;
-  let result: any = null;
-  switch (type) {
-    case LuActionType.Parse: {
-      result = parse(id, content);
-      break;
-    }
-    case LuActionType.AddIntent: {
-      result = luUtil.addIntent(content, intent);
-      break;
-    }
-    case LuActionType.UpdateIntent: {
-      result = luUtil.updateIntent(content, intentName, intent || null);
-      break;
-    }
-    case LuActionType.RemoveIntent: {
-      result = luUtil.removeIntent(content, intentName);
-      break;
-    }
-  }
-  return result;
-};
-
 ctx.onmessage = function (msg) {
-  const { id } = msg.data;
+  const { id: msgId, type, payload } = msg.data;
+  const { content, id, intentName, intentNames, intent, intents } = payload;
+  let result: any = null;
   try {
-    const payload = handleMessage(msg);
+    switch (type) {
+      case LuActionType.Parse: {
+        result = luUtil.parse(id, content);
+        break;
+      }
+      case LuActionType.AddIntent: {
+        result = luUtil.addIntent(content, intent);
+        break;
+      }
+      case LuActionType.AddIntents: {
+        result = luUtil.addIntents(content, intents);
+        break;
+      }
+      case LuActionType.UpdateIntent: {
+        result = luUtil.updateIntent(content, intentName, intent || null);
+        break;
+      }
+      case LuActionType.RemoveIntent: {
+        result = luUtil.removeIntent(content, intentName);
+        break;
+      }
+      case LuActionType.RemoveIntents: {
+        result = luUtil.removeIntents(content, intentNames);
+        break;
+      }
+    }
 
-    ctx.postMessage({ id, payload });
+    ctx.postMessage({ id: msgId, payload: result });
   } catch (error) {
-    ctx.postMessage({ id, error });
+    ctx.postMessage({ id: msgId, error });
   }
 };

--- a/Composer/packages/client/src/recoilModel/types.ts
+++ b/Composer/packages/client/src/recoilModel/types.ts
@@ -109,6 +109,8 @@ export interface DialogSetting {
     path: string;
     command: string;
   };
+  defaultLanguage: string;
+  languages: string[];
   [key: string]: unknown;
 }
 

--- a/Composer/packages/client/src/utils/languageStorage.ts
+++ b/Composer/packages/client/src/utils/languageStorage.ts
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import set from 'lodash/set';
+
+import storage from './storage';
+
+const KEY = 'LanguageSettings';
+
+class LanguageStorage {
+  private storage;
+  private _all;
+  constructor() {
+    this.storage = storage;
+    this._all = this.storage.get(KEY, {});
+  }
+  get(botName: string) {
+    return this._all[botName] || {};
+  }
+  setField(botName: string, field: string, value: any) {
+    let current = this._all[botName];
+    if (!current) {
+      current = {};
+    }
+    set(current, field, value);
+    this._all[botName] = current;
+    this.storage.set(KEY, this._all);
+  }
+  remove(botName: string) {
+    delete this._all[botName];
+    this.storage.set(KEY, this._all);
+  }
+
+  setLocale(botName: string, locale: string) {
+    this.setField(botName, 'locale', locale);
+  }
+}
+
+export default new LanguageStorage();

--- a/Composer/packages/extensions/adaptive-form/package.json
+++ b/Composer/packages/extensions/adaptive-form/package.json
@@ -13,6 +13,7 @@
     "build:ts": "tsc --build ./tsconfig.build.json",
     "clean": "rimraf lib demo/dist",
     "lint": "eslint --quiet src",
+    "lint:fix": "yarn lint --fix",
     "prepare": "yarn build"
   },
   "license": "MIT",

--- a/Composer/packages/lib/code-editor/src/BaseEditor.tsx
+++ b/Composer/packages/lib/code-editor/src/BaseEditor.tsx
@@ -35,7 +35,7 @@ const defaultOptions = {
 };
 
 const styles = {
-  container: ({ hovered, focused, error, warning, height }) => {
+  container: ({ hovered, focused, error, warning, height, editorOptions }) => {
     let borderColor = NeutralColors.gray120;
 
     if (hovered) {
@@ -68,7 +68,9 @@ const styles = {
       transition: border-color 0.1s linear;
       box-sizing: border-box;
       height: calc(${typeof height === 'string' ? height : `${height}px`} - ${heightAdj}px);
-
+      > * {
+        opacity: ${editorOptions?.readOnly ? 0.4 : 1};
+      }
       label: BaseEditor;
     `;
   },
@@ -218,7 +220,9 @@ const BaseEditor: React.FC<BaseEditorProps> = (props) => {
           error: hasError,
           warning: hasWarning,
           height,
+          editorOptions,
         })}
+        data-testid="BaseEditor"
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
       >

--- a/Composer/packages/lib/code-editor/src/languages/lg.ts
+++ b/Composer/packages/lib/code-editor/src/languages/lg.ts
@@ -147,11 +147,11 @@ export function registerLGLanguage(monaco: Monaco) {
       { token: 'template-name', foreground: 'CA5010' },
       { token: 'function-name', foreground: 'CA5010' },
       { token: 'keywords', foreground: '0078D7' },
-      { token: 'comments', foreground: '7A7574' },
+      { token: 'comments', foreground: '656565' },
       { token: 'parameter', foreground: '004E8C' },
       { token: 'fence-block', foreground: '038387' },
-      { token: 'string', foreground: 'DF2C2C' },
-      { token: 'structure-name', foreground: '00B7C3' },
+      { token: 'string', foreground: '393939' },
+      { token: 'structure-name', foreground: '038387' },
     ],
   });
 

--- a/Composer/packages/lib/code-editor/src/languages/lu.ts
+++ b/Composer/packages/lib/code-editor/src/languages/lu.ts
@@ -79,11 +79,11 @@ export function registerLULanguage(monaco: Monaco) {
       { token: 'intent', foreground: '0000FF' },
       { token: 'pattern', foreground: '00B7C3' },
       { token: 'entity-name', foreground: '038387' },
-      { token: 'comments', foreground: '7A7A7A' },
+      { token: 'comments', foreground: '656565' },
       { token: 'import-desc', foreground: '00A32B' },
       { token: 'entity-type', foreground: 'DF2C2C' },
-      { token: 'prebult-type', foreground: 'DF2C2C' },
-      { token: 'keywords', foreground: '0078D7' },
+      { token: 'prebult-type', foreground: '393939' },
+      { token: 'keywords', foreground: '038387' },
     ],
   });
 }

--- a/Composer/packages/lib/indexers/src/utils/index.ts
+++ b/Composer/packages/lib/indexers/src/utils/index.ts
@@ -4,3 +4,5 @@
 export * from './diagnosticUtil';
 export * from './jsonWalk';
 export * from './dialogCheckUtil';
+export * as lgUtil from './lgUtil';
+export * as luUtil from './luUtil';

--- a/Composer/packages/lib/indexers/src/utils/luUtil.ts
+++ b/Composer/packages/lib/indexers/src/utils/luUtil.ts
@@ -15,8 +15,6 @@ import { luIndexer } from '../luIndexer';
 
 import { buildNewlineText, splitNewlineText } from './help';
 
-const { parse } = luIndexer;
-
 const { luParser, sectionOperator } = sectionHandler;
 
 const NEWLINE = '\r\n';
@@ -71,7 +69,7 @@ export function textFromIntents(intents: LuIntentSection[], nestedLevel = 1): st
 
 export function checkSection(intent: LuIntentSection, enableSections = true): Diagnostic[] {
   const text = textFromIntent(intent, 1, enableSections);
-  return parse(text).diagnostics;
+  return luIndexer.parse(text).diagnostics;
 }
 
 export function checkIsSingleSection(intent: LuIntentSection, enableSections = true): boolean {
@@ -175,6 +173,14 @@ export function addIntent(content: string, { Name, Body, Entities }: LuIntentSec
   return updateIntent(content, intentName, { Name, Body, Entities });
 }
 
+export function addIntents(content: string, intents: LuIntentSection[]): string {
+  let result = content;
+  for (const intent of intents) {
+    result = addIntent(result, intent);
+  }
+  return result;
+}
+
 /**
  *
  * @param content origin lu file content
@@ -191,4 +197,15 @@ export function removeIntent(content: string, intentName: string): string {
     return new sectionOperator(resource).deleteSection(targetSection.Id).Content;
   }
   return content;
+}
+export function removeIntents(content: string, intentNames: string[]): string {
+  let result = content;
+  for (const intentName of intentNames) {
+    result = removeIntent(result, intentName);
+  }
+  return result;
+}
+
+export function parse(id: string, content: string) {
+  return { id, content, ...luIndexer.parse(content, id) };
 }

--- a/Composer/packages/lib/shared/src/types/indexers.ts
+++ b/Composer/packages/lib/shared/src/types/indexers.ts
@@ -4,6 +4,14 @@
 import { Diagnostic } from './diagnostic';
 import { IIntentTrigger } from './dialogUtils';
 
+export enum FileExtensions {
+  Dialog = '.dialog',
+  Manifest = '.json',
+  Lu = '.lu',
+  Lg = '.lg',
+  Setting = 'appsettings.json',
+}
+
 export interface FileInfo {
   name: string;
   content: string;

--- a/Composer/packages/server/__tests__/controllers/project.test.ts
+++ b/Composer/packages/server/__tests__/controllers/project.test.ts
@@ -303,7 +303,7 @@ describe('skill operation', () => {
     } as Request;
     await ProjectController.getSkill(mockReq, mockRes);
     expect(mockRes.status).toHaveBeenCalledWith(200);
-  });
+  }, 5000);
 
   it('should update skill', async () => {
     const mockReq = {
@@ -319,9 +319,9 @@ describe('skill operation', () => {
     } as Request;
     await ProjectController.updateSkill(mockReq, mockRes);
     expect(mockRes.status).toHaveBeenCalledWith(200);
-  });
+  }, 5000);
 
-  it('should update skill', async () => {
+  it('should update skill, remove', async () => {
     const mockReq = {
       params: { projectId },
       query: {},

--- a/Composer/packages/server/__tests__/controllers/project.test.ts
+++ b/Composer/packages/server/__tests__/controllers/project.test.ts
@@ -233,7 +233,7 @@ describe('lg operation', () => {
     const mockReq = {
       params: { projectId },
       query: {},
-      body: { name: 'test1.lg', content: '' },
+      body: { name: 'test1.en-us.lg', content: '' },
     } as Request;
     await ProjectController.createFile(mockReq, mockRes);
     expect(mockRes.status).toHaveBeenCalledWith(200);
@@ -241,7 +241,7 @@ describe('lg operation', () => {
 
   it('should remove lg file', async () => {
     const mockReq = {
-      params: { name: 'test1.lg', projectId },
+      params: { name: 'test1.en-us.lg', projectId },
       query: {},
       body: {},
     } as Request;
@@ -270,7 +270,7 @@ describe('lu operation', () => {
     const mockReq = {
       params: { projectId },
       query: {},
-      body: { name: 'c.lu', content: '' },
+      body: { name: 'c.en-us.lu', content: '' },
     } as Request;
     await ProjectController.createFile(mockReq, mockRes);
     expect(mockRes.status).toHaveBeenCalledWith(200);
@@ -278,7 +278,7 @@ describe('lu operation', () => {
 
   it('should remove lu file', async () => {
     const mockReq = {
-      params: { name: 'c.lu', projectId },
+      params: { name: 'c.en-us.lu', projectId },
       query: {},
       body: {},
     } as Request;

--- a/Composer/packages/server/__tests__/models/bot/botProject.test.ts
+++ b/Composer/packages/server/__tests__/models/bot/botProject.test.ts
@@ -135,7 +135,7 @@ describe('lg operations', () => {
     await proj.init();
     const filesCount = proj.files.length;
     const lgFilesCount = lgFileLength(proj.files);
-    const id = 'root.lg';
+    const id = 'root.en-us.lg';
     const content = '# hello \n - hello';
     const file = await proj.createFile(id, content);
 
@@ -153,7 +153,7 @@ describe('lg operations', () => {
     const filesCount = proj.files.length;
     const lgFilesCount = lgFileLength(proj.files);
 
-    const id = 'root.lg';
+    const id = 'root.en-us.lg';
     let content = '# hello \n - hello';
     await proj.createFile(id, content);
 
@@ -171,7 +171,7 @@ describe('lg operations', () => {
   });
 
   it('should delete lg file and update index', async () => {
-    const id = 'root.lg';
+    const id = 'root.en-us.lg';
     const content = '# hello \n - hello';
     await proj.createFile(id, content);
 
@@ -203,7 +203,7 @@ describe('lu operations', () => {
     const filesCount = proj.files.length;
     const luFilesCount = luFileLength(proj.files);
 
-    const id = 'root.lu';
+    const id = 'root.en-us.lu';
     const content = '# hello \n - hello';
     const file = await proj.createFile(id, content);
 
@@ -221,7 +221,7 @@ describe('lu operations', () => {
     const filesCount = proj.files.length;
     const luFilesCount = luFileLength(proj.files);
 
-    const id = 'root.lu';
+    const id = 'root.en-us.lu';
     let content = '## hello \n - hello';
     await proj.createFile(id, content);
     content = '## hello \n - hello2';
@@ -237,7 +237,7 @@ describe('lu operations', () => {
   });
 
   it('should delete lu file and update index', async () => {
-    const id = 'root.lu';
+    const id = 'root.en-us.lu';
     const content = '## hello \n - hello2';
     await proj.createFile(id, content);
     const filesCount = proj.files.length;

--- a/Composer/packages/server/__tests__/models/bot/botStructure.test.ts
+++ b/Composer/packages/server/__tests__/models/bot/botStructure.test.ts
@@ -1,0 +1,119 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { defaultFilePath, parseFileName } from '../../../src/models/bot/botStructure';
+
+const botName = 'Mybot';
+const defaultLocale = 'en-us';
+
+describe('Bot structure file path', () => {
+  // entry dialog
+  it('should get entry dialog file path', async () => {
+    const targetPath = defaultFilePath(botName, defaultLocale, 'mybot.dialog');
+    expect(targetPath).toEqual('mybot.dialog');
+  });
+
+  // common.lg
+  it('should get common lg file path', async () => {
+    const targetPath = defaultFilePath(botName, defaultLocale, 'common.en-us.lg');
+    expect(targetPath).toEqual('language-generation/en-us/common.en-us.lg');
+  });
+
+  // common.zh-cn.lg
+  it('should get common lg file path', async () => {
+    const targetPath = defaultFilePath(botName, defaultLocale, 'common.zh-cn.lg');
+    expect(targetPath).toEqual('language-generation/zh-cn/common.zh-cn.lg');
+  });
+
+  // skill manifest
+  it('should get exported skill manifest file path', async () => {
+    const targetPath = defaultFilePath(botName, defaultLocale, 'EchoBot-4-2-1-preview-1-manifest.json');
+    expect(targetPath).toEqual('manifests/EchoBot-4-2-1-preview-1-manifest.json');
+  });
+
+  // mybot.en-us.lg
+  it('should get entry dialog-lg file path', async () => {
+    const targetPath = defaultFilePath(botName, defaultLocale, 'mybot.en-us.lg');
+    expect(targetPath).toEqual('language-generation/en-us/mybot.en-us.lg');
+  });
+
+  // mybot.zh-cn.lg
+  it('should get entry dialog-lg file path', async () => {
+    const targetPath = defaultFilePath('my-bot', defaultLocale, 'my-bot.zh-cn.lg');
+    expect(targetPath).toEqual('language-generation/zh-cn/my-bot.zh-cn.lg');
+  });
+
+  // entry dialog's lu
+  it('should get entry dialog-lu file path', async () => {
+    const targetPath = defaultFilePath(botName, defaultLocale, 'mybot.en-us.lu');
+    expect(targetPath).toEqual('language-understanding/en-us/mybot.en-us.lu');
+  });
+
+  // child dialog's entry
+  it('should get child dialog file path', async () => {
+    const targetPath = defaultFilePath(botName, defaultLocale, 'greeting.dialog');
+    expect(targetPath).toEqual('dialogs/greeting/greeting.dialog');
+  });
+
+  // child dialog's lg
+  it('should get child dialog-lg file path', async () => {
+    const targetPath = defaultFilePath(botName, defaultLocale, 'greeting.en-us.lg');
+    expect(targetPath).toEqual('dialogs/greeting/language-generation/en-us/greeting.en-us.lg');
+  });
+
+  // child dialog's lu
+  it('should get child dialog-lu file path', async () => {
+    const targetPath = defaultFilePath(botName, defaultLocale, 'greeting.en-us.lu');
+    expect(targetPath).toEqual('dialogs/greeting/language-understanding/en-us/greeting.en-us.lu');
+  });
+});
+
+describe('Parse file name', () => {
+  // entry dialog
+  it('should parse entry dialog file name', async () => {
+    const { fileId, locale, fileType } = parseFileName('mybot.dialog', defaultLocale);
+    expect(fileId).toEqual('mybot');
+    expect(locale).toEqual(defaultLocale);
+    expect(fileType).toEqual('.dialog');
+  });
+
+  // entry dialog's lg
+  it('should parse entry dialog-lg file name', async () => {
+    const { fileId, locale, fileType } = parseFileName('mybot.en-us.lg', defaultLocale);
+    expect(fileId).toEqual('mybot');
+    expect(locale).toEqual('en-us');
+    expect(fileType).toEqual('.lg');
+  });
+
+  // entry dialog's lu
+  it('should parse entry dialog-lu file name', async () => {
+    const { fileId, locale, fileType } = parseFileName('mybot.en-us.lu', defaultLocale);
+    expect(fileId).toEqual('mybot');
+    expect(locale).toEqual('en-us');
+    expect(fileType).toEqual('.lu');
+  });
+
+  // child dialog
+  it('should parse child dialog file name', async () => {
+    const { fileId, locale, fileType } = parseFileName('greeting.dialog', defaultLocale);
+    expect(fileId).toEqual('greeting');
+    expect(locale).toEqual('en-us');
+    expect(fileType).toEqual('.dialog');
+  });
+
+  // child dialog's lg
+  it('should parse entry dialog-lg file name', async () => {
+    const { fileId, locale, fileType } = parseFileName('greeting.zh-cn.lg', defaultLocale);
+    expect(fileId).toEqual('greeting');
+    expect(locale).toEqual('zh-cn');
+    expect(fileType).toEqual('.lg');
+  });
+
+  // child dialog's lu
+  it('should parse entry dialog-lu file name', async () => {
+    const { fileId, locale, fileType } = parseFileName('greeting.en-us.lu', defaultLocale);
+    expect(fileId).toEqual('greeting');
+    expect(locale).toEqual('en-us');
+    expect(fileType).toEqual('.lu');
+  });
+});

--- a/Composer/packages/server/src/models/bot/botProject.ts
+++ b/Composer/packages/server/src/models/bot/botProject.ts
@@ -24,6 +24,7 @@ import { LocationRef } from './interface';
 import { LuPublisher } from './luPublisher';
 import { extractSkillManifestUrl } from './skillManager';
 import { DialogSetting } from './interface';
+import { defaultFilePath, serializeFiles } from './botStructure';
 
 const debug = log.extend('bot-project');
 const mkDirAsync = promisify(fs.mkdir);
@@ -33,30 +34,10 @@ const oauthInput = () => ({
   MicrosoftAppPassword: process.env.MicrosoftAppPassword || '',
 });
 
-// Define the project structure
-const BotStructureTemplate = {
-  folder: '',
-  entry: '${BOTNAME}.dialog',
-  schema: '${FILENAME}',
-  settings: 'settings/${FILENAME}',
-  common: {
-    lg: 'language-generation/${LOCALE}/common.${LOCALE}.lg',
-  },
-  dialogs: {
-    folder: 'dialogs/${DIALOGNAME}',
-    entry: '${DIALOGNAME}.dialog',
-    lg: 'language-generation/${LOCALE}/${DIALOGNAME}.${LOCALE}.lg',
-    lu: 'language-understanding/${LOCALE}/${DIALOGNAME}.${LOCALE}.lu',
-  },
-  skillManifests: 'manifests/${MANIFESTNAME}.json',
-};
-
-const templateInterpolate = (str: string, obj: { [key: string]: string }) =>
-  str.replace(/\${([^}]+)}/g, (_, prop) => obj[prop]);
+const defaultLanguage = 'en-us'; // default value for settings.defaultLanguage
 
 export class BotProject {
   public ref: LocationRef;
-  public locale: string;
   // TODO: address need to instantiate id - perhaps do so in constructor based on Store.get(projectLocationMap)
   public id: string | undefined;
   public name: string;
@@ -74,7 +55,6 @@ export class BotProject {
   public settings: DialogSetting | null = null;
   constructor(ref: LocationRef, user?: UserIdentity) {
     this.ref = ref;
-    this.locale = 'en-us'; // default to en-us
     this.dir = Path.resolve(this.ref.path); // make sure we swtich to posix style after here
     this.dataDir = this.dir;
     this.name = Path.basename(this.dir);
@@ -83,7 +63,7 @@ export class BotProject {
 
     this.settingManager = new DefaultSettingManager(this.dir);
     this.fileStorage = StorageService.getStorageClient(this.ref.storageId, user);
-    this.luPublisher = new LuPublisher(this.dir, this.fileStorage, this.locale);
+    this.luPublisher = new LuPublisher(this.dir, this.fileStorage, defaultLanguage);
   }
 
   public init = async () => {
@@ -98,7 +78,6 @@ export class BotProject {
   public getProject = () => {
     return {
       botName: this.name,
-      locale: this.locale,
       files: this.files,
       location: this.dir,
       schemas: this.getSchemas(),
@@ -119,6 +98,14 @@ export class BotProject {
     }
     if (settings && oauthInput().MicrosoftAppPassword && oauthInput().MicrosoftAppPassword !== OBFUSCATED_VALUE) {
       settings.MicrosoftAppPassword = oauthInput().MicrosoftAppPassword;
+    }
+
+    // fix old bot have no language settings
+    if (!settings?.defaultLanguage) {
+      settings.defaultLanguage = defaultLanguage;
+    }
+    if (!settings?.languages) {
+      settings.languages = [defaultLanguage];
     }
     return settings;
   };
@@ -215,7 +202,7 @@ export class BotProject {
   public updateBotInfo = async (name: string, description: string) => {
     const mainDialogFile = this.files.find((file) => !file.relativePath.includes('/') && file.name.endsWith('.dialog'));
     if (!mainDialogFile) return;
-    const entryDialogId = name.trim().toLowerCase();
+    const botName = name.trim().toLowerCase();
     const { relativePath } = mainDialogFile;
     const content = JSON.parse(mainDialogFile.content);
     if (!content.$designer) return;
@@ -231,26 +218,9 @@ export class BotProject {
       newDesigner = getNewDesigner(name, description);
     }
     content.$designer = newDesigner;
-    const updatedContent = autofixReferInDialog(entryDialogId, JSON.stringify(content, null, 2));
+    const updatedContent = autofixReferInDialog(botName, JSON.stringify(content, null, 2));
     await this._updateFile(relativePath, updatedContent);
-    // when create/saveAs bot, serialize entry dialog/lg/lu
-    const entryPatterns = [
-      templateInterpolate(BotStructureTemplate.entry, { BOTNAME: '*' }),
-      templateInterpolate(BotStructureTemplate.dialogs.lg, { LOCALE: '*', DIALOGNAME: '*' }),
-      templateInterpolate(BotStructureTemplate.dialogs.lu, { LOCALE: '*', DIALOGNAME: '*' }),
-    ];
-    for (const pattern of entryPatterns) {
-      const root = this.dataDir;
-      const paths = await this.fileStorage.glob(pattern, root);
-      for (const filePath of paths.sort()) {
-        const realFilePath = Path.join(root, filePath);
-        // skip common file, do not rename.
-        if (Path.basename(realFilePath).startsWith('common.')) continue;
-        // rename file to new botname
-        const targetFilePath = realFilePath.replace(/(.*)\/[^.]*(\..*$)/i, `$1/${entryDialogId}$2`);
-        await this.fileStorage.rename(realFilePath, targetFilePath);
-      }
-    }
+    await serializeFiles(this.fileStorage, this.dataDir, botName);
   };
 
   public updateFile = async (name: string, content: string): Promise<string> => {
@@ -281,13 +251,31 @@ export class BotProject {
     await this._cleanUp(file.relativePath);
   };
 
-  public createFile = async (name: string, content = '', dir: string = this.defaultDir(name)) => {
-    const file = this.files.find((d) => d.name === name);
-    if (file) {
-      throw new Error(`${name} dialog already exist`);
+  public deleteFiles = async (files) => {
+    for (const { name } of files) {
+      await this.deleteFile(name);
     }
-    const relativePath = Path.join(dir, name.trim());
+  };
+
+  public createFile = async (name: string, content = '') => {
+    const filename = name.trim();
+    const botName = this.name;
+    const defaultLocale = this.settings?.defaultLanguage || defaultLanguage;
+    const relativePath = defaultFilePath(botName, defaultLocale, filename);
+    const file = this.files.find((d) => d.name === filename);
+    if (file) {
+      throw new Error(`${filename} dialog already exist`);
+    }
     return await this._createFile(relativePath, content);
+  };
+
+  public createFiles = async (files) => {
+    const createdFiles: any = [];
+    for (const { name, content } of files) {
+      const file = await this.createFile(name, content);
+      createdFiles.push(file);
+    }
+    return createdFiles;
   };
 
   public publishLuis = async (luisConfig: ILuisConfig, fileIds: string[] = [], crossTrainConfig: ICrossTrainConfig) => {
@@ -382,46 +370,6 @@ export class BotProject {
         // pass
       }
     }
-  };
-
-  private getLocale(id: string): string {
-    const index = id.lastIndexOf('.');
-    if (index >= 0) return '';
-    return id.substring(index + 1);
-  }
-
-  private defaultDir = (name: string) => {
-    const fileType = Path.extname(name);
-    const id = Path.basename(name, fileType);
-    const idWithoutLocale = Path.basename(id, `.${this.locale}`);
-    const DIALOGNAME = idWithoutLocale;
-    const LOCALE = this.getLocale(id) || this.locale;
-    const folder = BotStructureTemplate.dialogs.folder;
-    let dir = BotStructureTemplate.folder;
-    if (fileType === '.dialog') {
-      dir = templateInterpolate(Path.dirname(Path.join(folder, BotStructureTemplate.dialogs.entry)), {
-        DIALOGNAME,
-        LOCALE,
-      });
-    } else if (fileType === '.lg') {
-      dir = templateInterpolate(Path.dirname(Path.join(folder, BotStructureTemplate.dialogs.lg)), {
-        DIALOGNAME,
-        LOCALE,
-      });
-    } else if (fileType === '.lu') {
-      dir = templateInterpolate(Path.dirname(Path.join(folder, BotStructureTemplate.dialogs.lu)), {
-        DIALOGNAME,
-        LOCALE,
-      });
-    } else if (fileType === '.json') {
-      dir = templateInterpolate(
-        Path.dirname(Path.join(BotStructureTemplate.folder, BotStructureTemplate.skillManifests)),
-        {
-          MANIFESTNAME: id,
-        }
-      );
-    }
-    return dir;
   };
 
   // create a file with relativePath and content relativePath is a path relative

--- a/Composer/packages/server/src/models/bot/botStructure.ts
+++ b/Composer/packages/server/src/models/bot/botStructure.ts
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Define the project structure
+import { FileExtensions } from '@bfc/shared';
+
+import { Path } from '../../utility/path';
+
+const BotStructureTemplate = {
+  entry: '${BOTNAME}.dialog',
+  lg: 'language-generation/${LOCALE}/${BOTNAME}.${LOCALE}.lg',
+  lu: 'language-understanding/${LOCALE}/${BOTNAME}.${LOCALE}.lu',
+  schema: '${FILENAME}',
+  settings: 'settings/${FILENAME}',
+  common: {
+    lg: 'language-generation/${LOCALE}/common.${LOCALE}.lg',
+  },
+  dialogs: {
+    entry: 'dialogs/${DIALOGNAME}/${DIALOGNAME}.dialog',
+    lg: 'dialogs/${DIALOGNAME}/language-generation/${LOCALE}/${DIALOGNAME}.${LOCALE}.lg',
+    lu: 'dialogs/${DIALOGNAME}/language-understanding/${LOCALE}/${DIALOGNAME}.${LOCALE}.lu',
+  },
+  skillManifests: 'manifests/${MANIFESTFILENAME}',
+};
+
+const templateInterpolate = (str: string, obj: { [key: string]: string }) =>
+  str.replace(/\${([^}]+)}/g, (_, prop) => obj[prop]);
+
+export const parseFileName = (name: string, defaultLocale: string) => {
+  const fileType = Path.extname(name);
+  const id = Path.basename(name, fileType);
+
+  let fileId = id;
+  let locale = defaultLocale;
+  const index = id.lastIndexOf('.');
+  if (index !== -1) {
+    fileId = id.slice(0, index);
+    locale = id.slice(index + 1);
+  }
+  return { fileId, locale, fileType };
+};
+
+// only
+export const defaultFilePath = (botName: string, defaultLocale: string, filename: string): string => {
+  const { fileId, locale, fileType } = parseFileName(filename, defaultLocale);
+  const BOTNAME = botName.toLowerCase();
+  const CommonFileId = 'common';
+  const LOCALE = locale;
+
+  // 1. Even appsettings.json hit FileExtensions.Manifest, but it never use this do created.
+  // 2. When exprot bot as a skill, name is `EchoBot-4-2-1-preview-1-manifest.json`
+  if (fileType === FileExtensions.Manifest) {
+    return templateInterpolate(BotStructureTemplate.skillManifests, {
+      MANIFESTFILENAME: filename,
+    });
+  }
+
+  // common.lg
+  if (fileId === CommonFileId && fileType === FileExtensions.Lg) {
+    return templateInterpolate(BotStructureTemplate.common.lg, {
+      LOCALE,
+    });
+  }
+
+  const DIALOGNAME = fileId.toLowerCase();
+  const isRootFile = BOTNAME === DIALOGNAME;
+
+  let TemplatePath = '';
+  if (fileType === FileExtensions.Dialog) {
+    TemplatePath = isRootFile ? BotStructureTemplate.entry : BotStructureTemplate.dialogs.entry;
+  } else if (fileType === FileExtensions.Lg) {
+    TemplatePath = isRootFile ? BotStructureTemplate.lg : BotStructureTemplate.dialogs.lg;
+  }
+  if (fileType === FileExtensions.Lu) {
+    TemplatePath = isRootFile ? BotStructureTemplate.lu : BotStructureTemplate.dialogs.lu;
+  }
+  return templateInterpolate(TemplatePath, {
+    BOTNAME,
+    DIALOGNAME,
+    LOCALE,
+  });
+};
+
+// when create/saveAs bot, serialize entry dialog/lg/lu
+export const serializeFiles = async (fileStorage, rootPath, botName) => {
+  const entryPatterns = [
+    templateInterpolate(BotStructureTemplate.entry, { BOTNAME: '*' }),
+    templateInterpolate(BotStructureTemplate.lg, { LOCALE: '*', BOTNAME: '*' }),
+    templateInterpolate(BotStructureTemplate.lu, { LOCALE: '*', BOTNAME: '*' }),
+  ];
+  for (const pattern of entryPatterns) {
+    const paths = await fileStorage.glob(pattern, rootPath);
+    for (const filePath of paths.sort()) {
+      const realFilePath = Path.join(rootPath, filePath);
+      // skip common file, do not rename.
+      if (Path.basename(realFilePath).startsWith('common.')) continue;
+      // rename file to new botname
+      const targetFilePath = realFilePath.replace(/(.*)\/[^.]*(\..*$)/i, `$1/${botName}$2`);
+      await fileStorage.rename(realFilePath, targetFilePath);
+    }
+  }
+};

--- a/Composer/packages/server/src/models/bot/interface.ts
+++ b/Composer/packages/server/src/models/bot/interface.ts
@@ -49,5 +49,7 @@ export interface DialogSetting {
   MicrosoftAppPassword: string;
   luis: ILuisConfig;
   skill: { manifestUrl: string; name: string }[];
+  defaultLanguage: string;
+  languages: string[];
   [key: string]: any;
 }

--- a/Composer/packages/server/src/models/bot/luPublisher.ts
+++ b/Composer/packages/server/src/models/bot/luPublisher.ts
@@ -175,7 +175,7 @@ export class LuPublisher {
       config.botName,
       config.suffix,
       config.fallbackLocal,
-      true,
+      false,
       loadResult.multiRecognizers,
       loadResult.settings
     );

--- a/Composer/packages/server/src/models/settings/defaultSettingManager.ts
+++ b/Composer/packages/server/src/models/settings/defaultSettingManager.ts
@@ -68,6 +68,8 @@ export class DefaultSettingManager extends FileSettingManager {
         maxImbalanceRatio: 10,
         maxUtteranceAllowed: 15000,
       },
+      defaultLanguage: 'en-us',
+      languages: ['en-us'],
     };
   };
 

--- a/Composer/packages/ui-plugins/lg/package.json
+++ b/Composer/packages/ui-plugins/lg/package.json
@@ -11,6 +11,7 @@
     "start": "tsc --watch --preserveWatchOutput",
     "build": "tsc --build ./tsconfig.build.json",
     "lint": "eslint --quiet src",
+    "lint:fix": "yarn lint --fix",
     "prepare": "yarn build"
   },
   "keywords": [

--- a/Composer/packages/ui-plugins/lg/src/LgWidget/useLgTemplate.ts
+++ b/Composer/packages/ui-plugins/lg/src/LgWidget/useLgTemplate.ts
@@ -1,28 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { Template } from 'botbuilder-lg';
-import { LgTemplateRef } from '@bfc/shared';
-import get from 'lodash/get';
+import { LgTemplateRef, LgFile, LgTemplate } from '@bfc/shared';
 import { useShellApi } from '@bfc/extension';
 
-export const queryLgTemplateFromFiles = (lgTemplateName: string, lgFiles: any): Template | undefined => {
-  if (!Array.isArray(lgFiles)) return;
-
-  const allTemplates: Template[] = [];
-  for (const file of lgFiles) {
-    const templates = get(file, 'templates');
-    if (Array.isArray(templates)) {
-      allTemplates.push(...templates);
-    }
-  }
-
-  const result = allTemplates.find((x) => get(x, 'name') === lgTemplateName);
-  return result;
+export const queryLgTemplate = (templateId: string, lgFileId: string, lgFiles: LgFile[]): LgTemplate | undefined => {
+  return lgFiles.find(({ id }) => id === lgFileId)?.templates?.find(({ name }) => name === templateId);
 };
 
 export const useLgTemplate = (str?: string) => {
-  const { lgFiles } = useShellApi();
+  const { currentDialog, lgFiles, locale } = useShellApi();
+  const lgFileId = `${currentDialog.lgFile}.${locale}`;
 
   const lgTemplateRef = LgTemplateRef.parse(str || '');
   const templateId = lgTemplateRef ? lgTemplateRef.name : '';
@@ -30,6 +18,6 @@ export const useLgTemplate = (str?: string) => {
   // fallback to input string
   if (!templateId) return str || '';
 
-  const lgTemplate = queryLgTemplateFromFiles(templateId, lgFiles);
+  const lgTemplate = queryLgTemplate(templateId, lgFileId, lgFiles);
   return lgTemplate ? lgTemplate.body : '';
 };

--- a/Composer/packages/ui-plugins/luis/package.json
+++ b/Composer/packages/ui-plugins/luis/package.json
@@ -11,6 +11,7 @@
     "start": "tsc --watch --preserveWatchOutput",
     "build": "tsc --build ./tsconfig.build.json",
     "lint": "eslint --quiet src",
+    "lint:fix": "yarn lint --fix",
     "prepare": "yarn build"
   },
   "keywords": [

--- a/runtime/dotnet/azurefunctions/Startup.cs
+++ b/runtime/dotnet/azurefunctions/Startup.cs
@@ -177,7 +177,7 @@ namespace Microsoft.BotFramework.Composer.Functions
                 return adapter;
             });
 
-            var defaultLocale = rootConfiguration.GetValue<string>("defaultLocale") ?? "en-us";
+            var defaultLocale = rootConfiguration.GetValue<string>("defaultLanguage") ?? "en-us";
 
             var removeRecipientMention = settings?.Feature?.RemoveRecipientMention ?? false;
 

--- a/runtime/dotnet/azurewebapp/Startup.cs
+++ b/runtime/dotnet/azurewebapp/Startup.cs
@@ -43,7 +43,7 @@ namespace Microsoft.BotFramework.Composer.WebAppTemplates
         public IWebHostEnvironment HostingEnvironment { get; }
 
         public IConfiguration Configuration { get; }
-        
+
         public void ConfigureTranscriptLoggerMiddleware(BotFrameworkHttpAdapter adapter, BotSettings settings)
         {
             if (ConfigSectionValid(settings.BlobStorage.ConnectionString) && ConfigSectionValid(settings.BlobStorage.Container))
@@ -132,7 +132,7 @@ namespace Microsoft.BotFramework.Composer.WebAppTemplates
             ComponentRegistration.Add(new LanguageGenerationComponentRegistration());
             ComponentRegistration.Add(new QnAMakerComponentRegistration());
             ComponentRegistration.Add(new LuisComponentRegistration());
-            
+
             // This is for custom action component registration.
             //ComponentRegistration.Add(new CustomActionComponentRegistration());
 
@@ -171,7 +171,7 @@ namespace Microsoft.BotFramework.Composer.WebAppTemplates
             var resourceExplorer = new ResourceExplorer().AddFolder(botDir);
             var rootDialog = GetRootDialog(botDir);
 
-            var defaultLocale = Configuration.GetValue<string>("defaultLocale") ?? "en-us";
+            var defaultLocale = Configuration.GetValue<string>("defaultLanguage") ?? "en-us";
 
             services.AddSingleton(resourceExplorer);
 


### PR DESCRIPTION
## Description

### Multiple language bot file structure 
```
/coolbot
  coolbot.dialog          
  /language-generation
    /en-us
      common.en-us.lg
      coolbot.en-us.lg
    /fr-fr
      common.fr-fr.lg
      coolbot.fr-fr.lg 
  /language-understanding
    /en-us
      coolbot.en-us.lu 
    /fr-fr
      coolbot.fr-fr.lu 
  /dialogs
    /foo
      foo.dialog
      /language-generation
        /en-us
          foo.en-us.lg
        /fr-fr
          foo.fr-fr.lg
      /language-understanding
        /en-us
          foo.en-us.lu
        /fr-fr
          foo.fr-fr.lu
```

### appsettings.json adds
```
{
  ...
  defaultLanguage: string,  // default bot language
  languages: string[], // bot added languages
}
```

### client state
```
{
  locale: string; // current bot authoring language, one of `settings.languages`
}
```

### Check behaviors:
1. when add a language, lg/lu would be copied from `defaultLanuage` files.
2. when delete a language, all this language lg/lu would be delete.
3. when create/delete a dialog, all `languages` lg/lu would be created/deleted.
4. when create/delete/copy a template, this template in all `languages` lg would be create/delete/copy. (also for lu)
5. when update a template, only current authoring language lg `would not` be updated. ( also for lu ).
6. publish would publish all language Luis file.
7. `defaultLanguage`/`languages` can be modified through `app settings.json`
8. current language(bot authoring language) can be switch through setting page.
9. user can't delete default/current language.
10. user add more than one language at one time, and checked `switch to newly add ` would switch to first one of newly adds

### Recap 
CRUD would only ensure file structure align cross multilang lg/lu.
means file exist, lgTemplate exist, intent exist.

But update inside one lg template or lu intent or editing in all up view edit mode, changes would not be sync to other language files.

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item

refs #3348 
close #1726
close #3426 
close #2443 
close #1979
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

#### Supported locale list
![Untitled5](https://user-images.githubusercontent.com/49866537/86438550-64ca8180-bd39-11ea-9a75-14b5b3a1225d.gif)



#### Select language
![Untitled2](https://user-images.githubusercontent.com/49866537/87918439-04fa0780-caa9-11ea-9ae2-fac4246a450b.gif)



#### Add languages
![Untitled5](https://user-images.githubusercontent.com/49866537/87918179-a59bf780-caa8-11ea-9b08-5a4b3ee53e20.gif)
![Untitled4](https://user-images.githubusercontent.com/49866537/87918198-ac2a6f00-caa8-11ea-82dd-b4186ac3316e.gif)
#### Delete languages
![Untitled3](https://user-images.githubusercontent.com/49866537/87918261-c401f300-caa8-11ea-8f62-ed783c803746.gif)


#### All up view
![Untitled5](https://user-images.githubusercontent.com/49866537/84886196-aa931300-b0c6-11ea-8fbd-2eb870b07ef1.gif)
<img width="1258" alt="image" src="https://user-images.githubusercontent.com/49866537/87394173-f8296f80-c5e1-11ea-94df-0c0c13533702.png">


<!---
Please include screenshots or gifs if your PR include UX changes.
--->
