### PR TITLE
fix: 3354 Changed Next to OK in buttons that close dialogs

### DIFF
--- a/Composer/packages/client/__tests__/components/CreationFlow/DefineConversation/index.test.tsx
+++ b/Composer/packages/client/__tests__/components/CreationFlow/DefineConversation/index.test.tsx
@@ -69,7 +69,7 @@ describe('<DefineConversation/>', () => {
         'schemaUrl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fmicrosoft%2Fbotframework-sdk%2Fmaster%2Fschemas%2Fcomponent%2Fcomponent.schema%26name%3DEchoBot-11299%26description%3DTest%20Echo',
     };
     const component = renderComponent();
-    const node = await component.findByText('Next');
+    const node = await component.findByText('OK');
     fireEvent.click(node);
     expect(onSubmitMock).toHaveBeenCalledWith({
       description: 'Test Echo',

--- a/Composer/packages/client/__tests__/components/CreationFlow/index.test.tsx
+++ b/Composer/packages/client/__tests__/components/CreationFlow/index.test.tsx
@@ -92,7 +92,7 @@ describe('<CreationFlow/>', () => {
 
     const component = renderComponent();
     await navigate('create/Emptybot');
-    const node = await component.findByText('Next');
+    const node = await component.findByText('OK');
     fireEvent.click(node);
   });
 });

--- a/Composer/packages/client/src/components/CreationFlow/DefineConversation/index.tsx
+++ b/Composer/packages/client/src/components/CreationFlow/DefineConversation/index.tsx
@@ -183,7 +183,7 @@ const DefineConversation: React.FC<DefineConversationProps> = (props) => {
             <PrimaryButton
               data-testid="SubmitNewBotBtn"
               disabled={hasErrors}
-              text={formatMessage('Next')}
+              text={formatMessage('OK')}
               onClick={handleSubmit}
             />
           </DialogFooter>

--- a/Composer/packages/client/src/pages/design/createDialogModal.tsx
+++ b/Composer/packages/client/src/pages/design/createDialogModal.tsx
@@ -105,7 +105,7 @@ export const CreateDialogModal: React.FC<CreateDialogModalProps> = (props) => {
           <PrimaryButton
             data-testid="SubmitNewDialogBtn"
             disabled={hasErrors}
-            text={formatMessage('Next')}
+            text={formatMessage('OK')}
             onClick={handleSubmit}
           />
         </DialogFooter>


### PR DESCRIPTION
## Description
Changed button text from Next to OK per request from design.

## Task Item
[fixes #3354](https://github.com/microsoft/BotFramework-Composer/issues/3354)