### PR TITLE
fix: fix get history before file persistence

### DIFF
--- a/Composer/packages/client/src/pages/publish/createPublishTarget.tsx
+++ b/Composer/packages/client/src/pages/publish/createPublishTarget.tsx
@@ -11,6 +11,7 @@ import { Fragment, useState, useMemo } from 'react';
 import { PrimaryButton, DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { JsonEditor } from '@bfc/code-editor';
 
+import filePersistence from '../../store/persistence/FilePersistence';
 import { PublishTarget, PublishType } from '../../store/types';
 
 import { label } from './styles';
@@ -83,6 +84,7 @@ const CreatePublishTarget: React.FC<CreatePublishTargetProps> = (props) => {
     if (targetType) {
       await props.updateSettings(name, targetType, JSON.stringify(config) || '{}');
       props.closeDialog();
+      await filePersistence.flush();
     }
   };
 

--- a/Composer/packages/client/src/pages/publish/createPublishTarget.tsx
+++ b/Composer/packages/client/src/pages/publish/createPublishTarget.tsx
@@ -11,7 +11,6 @@ import { Fragment, useState, useMemo } from 'react';
 import { PrimaryButton, DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { JsonEditor } from '@bfc/code-editor';
 
-import filePersistence from '../../store/persistence/FilePersistence';
 import { PublishTarget, PublishType } from '../../store/types';
 
 import { label } from './styles';
@@ -84,7 +83,6 @@ const CreatePublishTarget: React.FC<CreatePublishTargetProps> = (props) => {
     if (targetType) {
       await props.updateSettings(name, targetType, JSON.stringify(config) || '{}');
       props.closeDialog();
-      await filePersistence.flush();
     }
   };
 

--- a/Composer/packages/client/src/pages/publish/index.tsx
+++ b/Composer/packages/client/src/pages/publish/index.tsx
@@ -142,6 +142,14 @@ const Publish: React.FC<PublishPageProps> = (props) => {
   };
 
   useEffect(() => {
+    // if url was wrong, redirect to all profiles page
+    const activeDialog = settings.publishTargets?.find(({ name }) => name === selectedTargetName);
+    if (!activeDialog && selectedTargetName !== 'all') {
+      navigateTo(`/bot/${projectId}/publish/all`);
+    }
+  }, [selectedTargetName, projectId, settings.publishTargets]);
+
+  useEffect(() => {
     if (projectId) {
       actions.getPublishTargetTypes();
       // init selected status

--- a/Composer/packages/client/src/store/action/publisher.ts
+++ b/Composer/packages/client/src/store/action/publisher.ts
@@ -4,10 +4,10 @@
 import formatMessage from 'format-message';
 
 import { ActionCreator } from '../types';
+import filePersistence from '../persistence/FilePersistence';
 
 import { ActionTypes } from './../../constants/index';
 import httpClient from './../../utils/httpUtil';
-
 export const getPublishTargetTypes: ActionCreator = async ({ dispatch }) => {
   try {
     const response = await httpClient.get(`/publish/types`);
@@ -121,6 +121,7 @@ export const getPublishStatus: ActionCreator = async ({ dispatch }, projectId, t
 
 export const getPublishHistory: ActionCreator = async ({ dispatch }, projectId, target) => {
   try {
+    await filePersistence.flush();
     const response = await httpClient.get(`/publish/${projectId}/history/${target.name}`);
     dispatch({
       type: ActionTypes.GET_PUBLISH_HISTORY,

--- a/Composer/packages/client/src/store/persistence/FilePersistence.ts
+++ b/Composer/packages/client/src/store/persistence/FilePersistence.ts
@@ -93,7 +93,7 @@ class FilePersistence {
       if (this._isFlushing) {
         return new Promise((resolve) => {
           const timer = setInterval(() => {
-            if (!this.isEmpty()) {
+            if (this.isEmpty()) {
               clearInterval(timer);
               resolve(true);
             }


### PR DESCRIPTION
## Description

Fix missing plugin issue when creating a new publish profile, and make url redirect to all profile when url error.

Cause: get publish history before settings file persisted to server.
Solution: Add filePersistence.flush after clicking the save button.

## Task Item

close #3300 

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
