### PR TITLE
feat: 'Ctrl + Click', 'Shift + Click' behaviors in Flow Editor

### DIFF
--- a/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-editor/constants/ScreenReaderMessage.ts
+++ b/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-editor/constants/ScreenReaderMessage.ts
@@ -5,6 +5,7 @@ export enum ScreenReaderMessage {
   EventFocused = 'Event focused',
   ActionFocused = 'Action focused',
   ActionUnfocused = 'Action unfocused',
+  RangeSelection = 'Range Selection',
   DialogOpened = 'Dialog opened',
   ActionDeleted = 'Action deleted',
   ActionsDeleted = 'Actions deleted',

--- a/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-editor/constants/ScreenReaderMessage.ts
+++ b/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-editor/constants/ScreenReaderMessage.ts
@@ -4,6 +4,7 @@
 export enum ScreenReaderMessage {
   EventFocused = 'Event focused',
   ActionFocused = 'Action focused',
+  ActionUnfocused = 'Action unfocused',
   DialogOpened = 'Dialog opened',
   ActionDeleted = 'Action deleted',
   ActionsDeleted = 'Actions deleted',

--- a/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-editor/contexts/SelectionContext.ts
+++ b/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-editor/contexts/SelectionContext.ts
@@ -7,6 +7,7 @@ import { SelectorElement } from '../utils/cursorTracker';
 
 export interface SelectionContextData {
   getNodeIndex: (id: string) => number;
+  getSelectableIds: () => string[];
   selectedIds: string[];
   setSelectedIds: (ids: string[]) => any;
   selectableElements: SelectorElement[];
@@ -14,6 +15,7 @@ export interface SelectionContextData {
 
 export const SelectionContext = React.createContext<SelectionContextData>({
   getNodeIndex: (_: string): number => 0,
+  getSelectableIds: () => [],
   selectedIds: [] as string[],
   setSelectedIds: () => null,
   selectableElements: [],

--- a/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-editor/hooks/useEditorEventApi.ts
+++ b/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-editor/hooks/useEditorEventApi.ts
@@ -81,16 +81,24 @@ export const useEditorEventApi = (
         };
         break;
       case NodeEventTypes.CtrlClick:
-        handler = (e: { id: string }) => {
+        handler = (e: { id: string; tab?: string }) => {
+          if (!focusedId && !selectedIds.length) {
+            return handleEditorEvent(NodeEventTypes.Focus, e);
+          }
+
           // Toggle the selection state of clicked id
           const alreadySelected = selectedIds.some((x) => x === e.id);
           if (alreadySelected) {
             const shrinkedSelection = selectedIds.filter((x) => x !== e.id);
             setSelectedIds(shrinkedSelection);
+            if (focusedId === e.id) {
+              onFocusSteps([shrinkedSelection[0] || '']);
+            }
             announce(ScreenReaderMessage.ActionUnfocused);
           } else {
             const expandedSelection = [...selectedIds, e.id];
             setSelectedIds(expandedSelection);
+            onFocusSteps([e.id], e.tab);
             announce(ScreenReaderMessage.ActionFocused);
           }
         };

--- a/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-editor/hooks/useEditorEventApi.ts
+++ b/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-editor/hooks/useEditorEventApi.ts
@@ -16,6 +16,7 @@ import { moveCursor } from '../utils/cursorTracker';
 import { AttrNames } from '../constants/ElementAttributes';
 import { NodeRendererContextValue } from '../contexts/NodeRendererContext';
 import { SelectionContextData } from '../contexts/SelectionContext';
+import { calculateRangeSelection } from '../utils/calculateRangeSelection';
 
 export const useEditorEventApi = (
   state: { path: string; data: any; nodeContext: NodeRendererContextValue; selectionContext: SelectionContextData },
@@ -101,6 +102,22 @@ export const useEditorEventApi = (
             onFocusSteps([e.id], e.tab);
             announce(ScreenReaderMessage.ActionFocused);
           }
+        };
+        break;
+      case NodeEventTypes.ShiftClick:
+        handler = (e: { id: string; tab?: string }) => {
+          if (!focusedId && !selectedIds.length) {
+            return handleEditorEvent(NodeEventTypes.Focus, e);
+          }
+
+          if (!focusedId) {
+            return handleEditorEvent(NodeEventTypes.CtrlClick, e);
+          }
+
+          // Range selection from 'focusedId' to Shift-Clicked id.
+          const newSelectedIds = calculateRangeSelection(focusedId, e.id, data);
+          setSelectedIds(newSelectedIds);
+          announce(ScreenReaderMessage.RangeSelection);
         };
         break;
       case NodeEventTypes.FocusEvent:

--- a/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-editor/hooks/useEditorEventApi.ts
+++ b/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-editor/hooks/useEditorEventApi.ts
@@ -114,8 +114,10 @@ export const useEditorEventApi = (
             return handleEditorEvent(NodeEventTypes.CtrlClick, e);
           }
 
+          // Maintained by NodeIndexGenerator, `selectableIds` is in pre-order natively.
+          const selectableIds = selectionContext.getSelectableIds();
           // Range selection from 'focusedId' to Shift-Clicked id.
-          const newSelectedIds = calculateRangeSelection(focusedId, e.id, data);
+          const newSelectedIds = calculateRangeSelection(focusedId, e.id, selectableIds);
           setSelectedIds(newSelectedIds);
           announce(ScreenReaderMessage.RangeSelection);
         };

--- a/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-editor/hooks/useEditorEventApi.ts
+++ b/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-editor/hooks/useEditorEventApi.ts
@@ -80,6 +80,21 @@ export const useEditorEventApi = (
           announce(ScreenReaderMessage.ActionFocused);
         };
         break;
+      case NodeEventTypes.CtrlClick:
+        handler = (e: { id: string }) => {
+          // Toggle the selection state of clicked id
+          const alreadySelected = selectedIds.some((x) => x === e.id);
+          if (alreadySelected) {
+            const shrinkedSelection = selectedIds.filter((x) => x !== e.id);
+            setSelectedIds(shrinkedSelection);
+            announce(ScreenReaderMessage.ActionUnfocused);
+          } else {
+            const expandedSelection = [...selectedIds, e.id];
+            setSelectedIds(expandedSelection);
+            announce(ScreenReaderMessage.ActionFocused);
+          }
+        };
+        break;
       case NodeEventTypes.FocusEvent:
         handler = (eventData) => {
           onFocusEvent(eventData);

--- a/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-editor/hooks/useSelectionEffect.ts
+++ b/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-editor/hooks/useSelectionEffect.ts
@@ -17,6 +17,7 @@ export const useSelectionEffect = (state: { data: any; nodeContext: NodeRenderer
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [selectableElements, setSelectableElements] = useState<SelectorElement[]>(querySelectableElements());
   const nodeIndexGenerator = useRef(new NodeIndexGenerator());
+  const getSelectableIds = () => nodeIndexGenerator.current.getItemList().map((x) => x.key as string);
 
   useEffect((): void => {
     // Notify container at every selection change.
@@ -60,5 +61,6 @@ export const useSelectionEffect = (state: { data: any; nodeContext: NodeRenderer
     setSelectedIds,
     selectableElements,
     getNodeIndex,
+    getSelectableIds,
   };
 };

--- a/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-editor/renderers/NodeWrapper.tsx
+++ b/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-editor/renderers/NodeWrapper.tsx
@@ -81,7 +81,7 @@ export const ActionNodeWrapper: FC<NodeWrapperProps> = ({ id, tab, data, onEvent
         e.preventDefault();
 
         const payload = { id, tab };
-        if (e.ctrlKey) {
+        if (e.ctrlKey || e.metaKey) {
           return onEvent(NodeEventTypes.CtrlClick, payload);
         }
         if (e.shiftKey) {

--- a/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-editor/renderers/NodeWrapper.tsx
+++ b/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-editor/renderers/NodeWrapper.tsx
@@ -75,6 +75,9 @@ export const ActionNodeWrapper: FC<NodeWrapperProps> = ({ id, tab, data, onEvent
       aria-label={generateSDKTitle(data, '', tab)}
       onClick={(e) => {
         e.stopPropagation();
+        if (e.ctrlKey) {
+          return onEvent(NodeEventTypes.CtrlClick, { id, tab });
+        }
         onEvent(NodeEventTypes.Focus, { id, tab });
       }}
     >

--- a/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-editor/renderers/NodeWrapper.tsx
+++ b/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-editor/renderers/NodeWrapper.tsx
@@ -58,10 +58,13 @@ export const ActionNodeWrapper: FC<NodeWrapperProps> = ({ id, tab, data, onEvent
     addCoachMarkRef({ action });
   }, []);
 
+  // Set 'use-select' to none to disable browser's default
+  // text selection effect when pressing Shift + Click.
   return (
     <div
       ref={actionRef}
       css={css`
+        user-select: none;
         position: relative;
         border-radius: 2px 2px 0 0;
         ${nodeSelected && nodeBorderSelectedStyle};
@@ -75,10 +78,16 @@ export const ActionNodeWrapper: FC<NodeWrapperProps> = ({ id, tab, data, onEvent
       aria-label={generateSDKTitle(data, '', tab)}
       onClick={(e) => {
         e.stopPropagation();
+        e.preventDefault();
+
+        const payload = { id, tab };
         if (e.ctrlKey) {
-          return onEvent(NodeEventTypes.CtrlClick, { id, tab });
+          return onEvent(NodeEventTypes.CtrlClick, payload);
         }
-        onEvent(NodeEventTypes.Focus, { id, tab });
+        if (e.shiftKey) {
+          return onEvent(NodeEventTypes.ShiftClick, payload);
+        }
+        onEvent(NodeEventTypes.Focus, payload);
       }}
     >
       {children}

--- a/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-editor/utils/calculateRangeSelection.ts
+++ b/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-editor/utils/calculateRangeSelection.ts
@@ -1,6 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export const calculateRangeSelection = (fromId: string, toId: string, adaptiveJson: any): string[] => {
-  return [fromId, toId];
+export const calculateRangeSelection = (
+  focusedId: string,
+  clickedId: string,
+  orderedSelectableIds: string[]
+): string[] => {
+  const range = [focusedId, clickedId].map((id) => orderedSelectableIds.findIndex((x) => x === id));
+  const [fromIndex, toIndex] = range.sort();
+  return orderedSelectableIds.slice(fromIndex, toIndex + 1);
 };

--- a/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-editor/utils/calculateRangeSelection.ts
+++ b/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-editor/utils/calculateRangeSelection.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export const calculateRangeSelection = (fromId: string, toId: string, adaptiveJson: any): string[] => {
+  return [fromId, toId];
+};

--- a/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-renderer/constants/NodeEventTypes.ts
+++ b/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-renderer/constants/NodeEventTypes.ts
@@ -3,6 +3,7 @@
 
 export enum NodeEventTypes {
   Focus = 'event.view.focus',
+  CtrlClick = 'event.view.ctrl-click',
   FocusEvent = 'event.view.focus-event',
   MoveCursor = 'event.view.move-cursor',
   OpenDialog = 'event.nav.opendialog',

--- a/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-renderer/constants/NodeEventTypes.ts
+++ b/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-renderer/constants/NodeEventTypes.ts
@@ -4,6 +4,7 @@
 export enum NodeEventTypes {
   Focus = 'event.view.focus',
   CtrlClick = 'event.view.ctrl-click',
+  ShiftClick = 'event.view.shift-click',
   FocusEvent = 'event.view.focus-event',
   MoveCursor = 'event.view.move-cursor',
   OpenDialog = 'event.nav.opendialog',


### PR DESCRIPTION
## Description

Closes #3249 
1. [Ctrl + Click] - Toggle selection
  ![ctrl-click](https://user-images.githubusercontent.com/8528761/85260176-d6cedb00-b49c-11ea-8146-5a2c1e5b31d5.gif)
2. [Shift + Click] - Range Selection
  ![shift-click](https://user-images.githubusercontent.com/8528761/85273946-db04f380-b4b0-11ea-8b7f-c33e35373134.gif)

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
