### PR TITLE
fix: #3309 Allow configuring app settings without opening a bot project

### DIFF
--- a/Composer/cypress/integration/Onboarding.spec.ts
+++ b/Composer/cypress/integration/Onboarding.spec.ts
@@ -8,7 +8,7 @@ context('Onboarding', () => {
 
     //enable onboarding setting
     cy.visitPage('Settings');
-    cy.findByText('App Settings').click();
+    cy.findByText('Application Settings').click();
     cy.findByLabelText('Onboarding').click();
     cy.visitPage('Design');
   });

--- a/Composer/packages/client/src/components/NavTree/index.tsx
+++ b/Composer/packages/client/src/components/NavTree/index.tsx
@@ -55,10 +55,10 @@ const NavTree: React.FC<INavTreeProps> = (props) => {
           return (
             <DefaultButton
               key={item.id}
+              disabled={item.disabled}
               href={item.url}
               styles={isSelected ? itemSelected : itemNotSelected}
               text={item.name}
-              disabled={item.disabled}
               onClick={(e) => {
                 e.preventDefault();
                 navigateTo(item.url);

--- a/Composer/packages/client/src/components/NavTree/index.tsx
+++ b/Composer/packages/client/src/components/NavTree/index.tsx
@@ -17,6 +17,7 @@ export interface INavTreeItem {
   name: string;
   ariaLabel?: string;
   url: string;
+  disabled?: boolean;
 }
 
 interface INavTreeProps {
@@ -57,6 +58,7 @@ const NavTree: React.FC<INavTreeProps> = (props) => {
               href={item.url}
               styles={isSelected ? itemSelected : itemNotSelected}
               text={item.name}
+              disabled={item.disabled}
               onClick={(e) => {
                 e.preventDefault();
                 navigateTo(item.url);

--- a/Composer/packages/client/src/pages/setting/index.tsx
+++ b/Composer/packages/client/src/pages/setting/index.tsx
@@ -3,7 +3,7 @@
 
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
-import { useContext, useMemo } from 'react';
+import { useContext, useMemo, useEffect } from 'react';
 import formatMessage from 'format-message';
 import { RouteComponentProps } from '@reach/router';
 import { FontIcon } from 'office-ui-fabric-react/lib/Icon';
@@ -16,25 +16,44 @@ import { navigateTo } from '../../utils';
 import { Page } from '../../components/Page';
 import { INavTreeItem } from '../../components/NavTree';
 
-import Routes from './router';
+import { SettingsRoutes } from './router';
+import { useLocation } from '../../utils/hooks';
 
 const SettingPage: React.FC<RouteComponentProps<{ '*': string }>> = () => {
   const { state, actions } = useContext(StoreContext);
   const { projectId } = state;
-  const makeProjectLink = (id: string, path: string) => {
-    return `/bot/${id}/settings/${path}`;
+
+  const { navigate } = useLocation();
+
+  // If no project is open and user tries to access a bot-scoped settings (e.g., browser history, deep link)
+  // Redirect them to the default settings route that is not bot-scoped
+  useEffect(() => {
+    if (!projectId && location.pathname.indexOf('/settings/bot/') !== -1) {
+      navigate('/settings/application');
+    }
+  }, [projectId]);
+
+  const makeProjectLink = (path: string, id?: string) => {
+    return id ? `/settings/bot/${id}/${path}` : `/settings/${path}`;
   };
 
   const settingLabels = {
     botSettings: formatMessage('Bot Settings'),
     appSettings: formatMessage('App Settings'),
     runtime: formatMessage('Runtime Config'),
+    about: formatMessage('About'),
   };
 
   const links: INavTreeItem[] = [
-    { id: 'dialog-settings', name: settingLabels.botSettings, url: makeProjectLink(projectId, 'dialog-settings') },
-    { id: 'preferences', name: settingLabels.appSettings, url: makeProjectLink(projectId, 'preferences') },
-    { id: 'runtime', name: settingLabels.runtime, url: makeProjectLink(projectId, 'runtime') },
+    {
+      id: 'dialog-settings',
+      name: settingLabels.botSettings,
+      url: makeProjectLink('dialog-settings', projectId),
+      disabled: !projectId,
+    },
+    { id: 'application', name: settingLabels.appSettings, url: makeProjectLink('application') },
+    { id: 'runtime', name: settingLabels.runtime, url: makeProjectLink('runtime', projectId), disabled: !projectId },
+    { id: 'about', name: settingLabels.about, url: makeProjectLink('about') },
 
     // { key: '/settings/publish', name: settingLabels.publish, url: '' },
 
@@ -134,7 +153,7 @@ const SettingPage: React.FC<RouteComponentProps<{ '*': string }>> = () => {
       return page.name;
     }
 
-    return settingLabels.botSettings;
+    return settingLabels.appSettings;
   }, [location.pathname]);
 
   return (
@@ -145,7 +164,7 @@ const SettingPage: React.FC<RouteComponentProps<{ '*': string }>> = () => {
       title={title}
       toolbarItems={toolbarItems}
     >
-      <Routes />
+      <SettingsRoutes />
     </Page>
   );
 };

--- a/Composer/packages/client/src/pages/setting/index.tsx
+++ b/Composer/packages/client/src/pages/setting/index.tsx
@@ -15,9 +15,9 @@ import { OpenConfirmModal } from '../../components/Modal/Confirm';
 import { navigateTo } from '../../utils';
 import { Page } from '../../components/Page';
 import { INavTreeItem } from '../../components/NavTree';
+import { useLocation } from '../../utils/hooks';
 
 import { SettingsRoutes } from './router';
-import { useLocation } from '../../utils/hooks';
 
 const SettingPage: React.FC<RouteComponentProps<{ '*': string }>> = () => {
   const { state, actions } = useContext(StoreContext);

--- a/Composer/packages/client/src/pages/setting/index.tsx
+++ b/Composer/packages/client/src/pages/setting/index.tsx
@@ -19,6 +19,10 @@ import { useLocation } from '../../utils/hooks';
 
 import { SettingsRoutes } from './router';
 
+const getProjectLink = (path: string, id?: string) => {
+  return id ? `/settings/bot/${id}/${path}` : `/settings/${path}`;
+};
+
 const SettingPage: React.FC<RouteComponentProps<{ '*': string }>> = () => {
   const { state, actions } = useContext(StoreContext);
   const { projectId } = state;
@@ -33,13 +37,9 @@ const SettingPage: React.FC<RouteComponentProps<{ '*': string }>> = () => {
     }
   }, [projectId]);
 
-  const makeProjectLink = (path: string, id?: string) => {
-    return id ? `/settings/bot/${id}/${path}` : `/settings/${path}`;
-  };
-
   const settingLabels = {
     botSettings: formatMessage('Bot Settings'),
-    appSettings: formatMessage('App Settings'),
+    appSettings: formatMessage('Application Settings'),
     runtime: formatMessage('Runtime Config'),
     about: formatMessage('About'),
   };
@@ -48,12 +48,12 @@ const SettingPage: React.FC<RouteComponentProps<{ '*': string }>> = () => {
     {
       id: 'dialog-settings',
       name: settingLabels.botSettings,
-      url: makeProjectLink('dialog-settings', projectId),
+      url: getProjectLink('dialog-settings', projectId),
       disabled: !projectId,
     },
-    { id: 'application', name: settingLabels.appSettings, url: makeProjectLink('application') },
-    { id: 'runtime', name: settingLabels.runtime, url: makeProjectLink('runtime', projectId), disabled: !projectId },
-    { id: 'about', name: settingLabels.about, url: makeProjectLink('about') },
+    { id: 'application', name: settingLabels.appSettings, url: getProjectLink('application') },
+    { id: 'runtime', name: settingLabels.runtime, url: getProjectLink('runtime', projectId), disabled: !projectId },
+    { id: 'about', name: settingLabels.about, url: getProjectLink('about') },
 
     // { key: '/settings/publish', name: settingLabels.publish, url: '' },
 
@@ -164,7 +164,7 @@ const SettingPage: React.FC<RouteComponentProps<{ '*': string }>> = () => {
       title={title}
       toolbarItems={toolbarItems}
     >
-      <SettingsRoutes />
+      <SettingsRoutes projectId={projectId} />
     </Page>
   );
 };

--- a/Composer/packages/client/src/pages/setting/router.tsx
+++ b/Composer/packages/client/src/pages/setting/router.tsx
@@ -5,11 +5,11 @@ import * as React from 'react';
 import { Router, Redirect } from '@reach/router';
 
 import { ErrorBoundary } from '../../components/ErrorBoundary';
+import { About } from '../about';
 
 import { DialogSettings } from './dialog-settings';
 import { AppSettings } from './app-settings';
 import { RuntimeSettings } from './runtime-settings';
-import { About } from '../about';
 
 export const SettingsRoutes = () => (
   <ErrorBoundary>

--- a/Composer/packages/client/src/pages/setting/router.tsx
+++ b/Composer/packages/client/src/pages/setting/router.tsx
@@ -11,14 +11,18 @@ import { DialogSettings } from './dialog-settings';
 import { AppSettings } from './app-settings';
 import { RuntimeSettings } from './runtime-settings';
 
-export const SettingsRoutes = () => (
+export const SettingsRoutes = React.memo(({ projectId }: { projectId: string }) => (
   <ErrorBoundary>
     <Router>
-      <Redirect noThrow from="/" to="/settings/application" />
+      <Redirect
+        noThrow
+        from="/"
+        to={projectId ? `/settings/bot/${projectId}/dialog-settings` : '/settings/application'}
+      />
       <AppSettings default path="application" />
       <About path="about" />
       <DialogSettings path="/bot/:projectId/dialog-settings" />
       <RuntimeSettings path="/bot/:projectId/runtime" />
     </Router>
   </ErrorBoundary>
-);
+));

--- a/Composer/packages/client/src/pages/setting/router.tsx
+++ b/Composer/packages/client/src/pages/setting/router.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import React from 'react';
+import * as React from 'react';
 import { Router, Redirect } from '@reach/router';
 
 import { ErrorBoundary } from '../../components/ErrorBoundary';
@@ -9,25 +9,16 @@ import { ErrorBoundary } from '../../components/ErrorBoundary';
 import { DialogSettings } from './dialog-settings';
 import { AppSettings } from './app-settings';
 import { RuntimeSettings } from './runtime-settings';
+import { About } from '../about';
 
-const getRedirect = () => {
-  const { pathname } = location;
-
-  const path = pathname.endsWith('/') ? pathname.substring(0, pathname.length - 1) : pathname;
-  return `${path}/dialog-settings`;
-};
-
-const Routes = () => {
-  return (
-    <ErrorBoundary>
-      <Router>
-        <Redirect noThrow from="/" to={getRedirect()} />
-        <DialogSettings default path="dialog-settings" />
-        <AppSettings path="preferences" />
-        <RuntimeSettings path="runtime" />
-      </Router>
-    </ErrorBoundary>
-  );
-};
-
-export default Routes;
+export const SettingsRoutes = () => (
+  <ErrorBoundary>
+    <Router>
+      <Redirect noThrow from="/" to="/settings/application" />
+      <AppSettings default path="application" />
+      <About path="about" />
+      <DialogSettings path="/bot/:projectId/dialog-settings" />
+      <RuntimeSettings path="/bot/:projectId/runtime" />
+    </Router>
+  </ErrorBoundary>
+);

--- a/Composer/packages/client/src/router.tsx
+++ b/Composer/packages/client/src/router.tsx
@@ -5,9 +5,7 @@
 import { jsx, css } from '@emotion/core';
 import React, { useContext, useEffect, Suspense } from 'react';
 import { Router, Redirect, RouteComponentProps } from '@reach/router';
-
 import { resolveToBasePath } from './utils/fileUtil';
-import { About } from './pages/about';
 import { data } from './styles';
 import { NotFound } from './components/NotFound';
 import { BASEPATH } from './constants';
@@ -45,7 +43,6 @@ const Routes = (props) => {
           <Redirect noThrow from="/" to={resolveToBasePath(BASEPATH, 'home')} />
           <ProjectRouter path="/bot/:projectId">
             <DesignPage path="dialogs/:dialogId/*" />
-            <SettingPage path="settings/*" />
             <LUPage path="language-understanding/:dialogId/*" />
             <LGPage path="language-generation/:dialogId/*" />
             <Notifications path="notifications" />
@@ -53,9 +50,9 @@ const Routes = (props) => {
             <Skills path="skills/*" />
             <DesignPage path="*" />
           </ProjectRouter>
+          <SettingPage path="settings/*" />
           <BotCreationFlowRouter path="projects/*" />
           <BotCreationFlowRouter path="home" />
-          <About path="about" />
           <NotFound default />
         </Router>
       </Suspense>

--- a/Composer/packages/client/src/router.tsx
+++ b/Composer/packages/client/src/router.tsx
@@ -5,6 +5,7 @@
 import { jsx, css } from '@emotion/core';
 import React, { useContext, useEffect, Suspense } from 'react';
 import { Router, Redirect, RouteComponentProps } from '@reach/router';
+
 import { resolveToBasePath } from './utils/fileUtil';
 import { data } from './styles';
 import { NotFound } from './components/NotFound';

--- a/Composer/packages/client/src/utils/pageLinks.ts
+++ b/Composer/packages/client/src/utils/pageLinks.ts
@@ -54,13 +54,6 @@ export const topLinks = (projectId: string, openedDialogId: string) => {
       exact: true,
       disabled: !botLoaded,
     },
-    {
-      to: `/bot/${projectId}/settings/`,
-      iconName: 'Settings',
-      labelName: formatMessage('Settings'),
-      exact: false,
-      disabled: !botLoaded,
-    },
   ];
 
   if (process.env.COMPOSER_AUTH_PROVIDER === 'abs-h') {
@@ -72,10 +65,10 @@ export const topLinks = (projectId: string, openedDialogId: string) => {
 
 export const bottomLinks = [
   {
-    to: '/about',
-    iconName: 'info',
-    labelName: formatMessage('About'),
-    exact: true,
+    to: `/settings`,
+    iconName: 'Settings',
+    labelName: formatMessage('Settings'),
+    exact: false,
     disabled: false,
   },
 ];

--- a/Composer/packages/electron-server/scripts/copy-plugins.js
+++ b/Composer/packages/electron-server/scripts/copy-plugins.js
@@ -5,7 +5,7 @@ const fs = require('fs-extra');
 const { resolve } = require('path');
 const electronBuildConfig = require('../electron-builder-config.json');
 
-const source = resolve(__dirname, '../../../plugins');
+const source = resolve(__dirname, '../../plugins');
 console.log('[copy-plugins.js] Copying plugins from: ', source);
 
 let destination;
@@ -34,8 +34,13 @@ switch (process.platform) {
     process.exit(1);
 }
 
+const filterOutTS = (src) => {
+  // true keeps the file, false omits it
+  return !src.endsWith('.ts');
+};
+
 // copy plugins from /Composer/plugins/ to pre-packaged electron app
-fs.copy(source, destination, err => {
+fs.copy(source, destination, { filter: filterOutTS }, (err) => {
   if (err) {
     console.err('[copy-plugins.js] Error while copying plugins: ', err);
     return;


### PR DESCRIPTION
## Description

1. Move Info page into Settings page
2. Remove/replace Info icon/location with Settings cog (move to bottom left)
3. Settings cog is always enabled and interactable
4. Bot settings & Runtime config in subnav of Settings page are disabled if no bot is currently loaded.

fixes #3309 

## Task Item

https://github.com/microsoft/BotFramework-Composer/issues/3309

## Screenshots

![image](https://user-images.githubusercontent.com/1483492/85339018-25c64180-b498-11ea-984b-33e113adc491.png)
