### PR TITLE
feature: show 'AutoEndDialog' from Adaptive Dialog Property Editor

### DIFF
--- a/Composer/packages/extensions/adaptive-form/src/defaultUiSchema.ts
+++ b/Composer/packages/extensions/adaptive-form/src/defaultUiSchema.ts
@@ -17,7 +17,7 @@ const DefaultUISchema: UISchema = {
     description: () => formatMessage('This configures a data driven dialog via a collection of events and actions.'),
     helpLink: 'https://aka.ms/bf-composer-docs-dialog',
     order: ['recognizer', '*'],
-    hidden: ['triggers', 'autoEndDialog', 'generator', 'selector', 'schema'],
+    hidden: ['triggers', 'generator', 'selector', 'schema'],
     properties: {
       recognizer: {
         label: () => formatMessage('Language Understanding'),


### PR DESCRIPTION
## Description
Removed 'AutoEndDialog' from hidden properties in the default ui schema.

## Task Item
Closes #3492

## Screenshots
![image](https://user-images.githubusercontent.com/17039790/85763731-2fd38480-b6d2-11ea-853d-822f5ba81bd5.png)

