### PR TITLE
test: run coverage on all source files

### DIFF
--- a/Composer/packages/test-utils/src/base/jest.config.ts
+++ b/Composer/packages/test-utils/src/base/jest.config.ts
@@ -6,6 +6,8 @@ import path from 'path';
 import { JestOverrides } from '../types';
 
 const base: Partial<JestOverrides> = {
+  collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}'],
+
   testPathIgnorePatterns: [
     '/node_modules/',
     '/mocks/',


### PR DESCRIPTION
## Description

Jest needs to be told to collect coverage from all files. Without this config, jest would only collect coverage on files that were imported in a test.

## Task Item

refs #3456
