### PR TITLE
fix: composer will crashed when add a new publish profile

### DIFF
--- a/Composer/packages/client/src/store/action/setting.ts
+++ b/Composer/packages/client/src/store/action/setting.ts
@@ -14,7 +14,7 @@ export const setSettings: ActionCreator = async ({ dispatch }, projectId: string
   });
 };
 
-export const setPublishTarget: ActionCreator = async ({ dispatch }, _, publishTarget) => {
+export const setPublishTargets: ActionCreator = async ({ dispatch }, publishTarget) => {
   dispatch({
     type: ActionTypes.SET_PUBLISH_TARGETS,
     payload: {

--- a/Composer/packages/client/src/store/persistence/FilePersistence.ts
+++ b/Composer/packages/client/src/store/persistence/FilePersistence.ts
@@ -238,13 +238,13 @@ class FilePersistence {
     return fileChanges;
   }
 
-  private getSettingsChanges(previousState: State, currentState: State, projectId: string) {
+  private getSettingsChanges(previousState: State, currentState: State) {
     return [
       {
         id: `${FileExtensions.Setting}`,
         change: JSON.stringify(currentState.settings, null, 2),
         type: ChangeType.UPDATE,
-        projectId,
+        projectId: this._projectId,
       },
     ];
   }
@@ -288,7 +288,7 @@ class FilePersistence {
         break;
       }
       case FileExtensions.Setting: {
-        fileChanges = this.getSettingsChanges(previousState, currentState, action.payload.projectId);
+        fileChanges = this.getSettingsChanges(previousState, currentState);
       }
     }
     return fileChanges;


### PR DESCRIPTION
## Description
action function call error.
the setting update in file persistence lost projectId

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
#minor
refs #3525
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots
![image](https://user-images.githubusercontent.com/39758135/86362693-41a3c180-bca8-11ea-9c41-fd886dbe0e48.png)

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
