### PR TITLE
test: add toDispatch to expect and runMinorTests

### DIFF
--- a/Composer/packages/client/__tests__/jest.d.ts
+++ b/Composer/packages/client/__tests__/jest.d.ts
@@ -7,6 +7,7 @@ declare global {
   namespace jest {
     interface Matchers<R> {
       toBeDispatchedWith(type: ActionTypes, payload?: any, error?: any);
+      toDispatch(actionType: ActionTypes, payload: {}, output?: {});
     }
   }
 }

--- a/Composer/packages/client/__tests__/store/actions/dialog.test.ts
+++ b/Composer/packages/client/__tests__/store/actions/dialog.test.ts
@@ -1,10 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { removeDialog, updateDialogBase, createDialogBegin } from '../../../src/store/action/dialog';
+import {
+  removeDialog,
+  updateDialogBase,
+  createDialogBegin,
+  createDialog,
+  createDialogCancel,
+} from '../../../src/store/action/dialog';
 import { ActionTypes } from '../../../src/constants';
 
 import { runMinorTests } from './testUtils';
+
+jest.useFakeTimers();
 
 const ACTION_TESTS = [
   { action: removeDialog, actionType: ActionTypes.REMOVE_DIALOG, payload: {}, output: { id: {} } },
@@ -18,3 +26,36 @@ const ACTION_TESTS = [
 ];
 
 describe('simple actions', () => runMinorTests(ACTION_TESTS));
+
+describe('the createDialog actions', () => {
+  const mockStore = {
+    getState: jest.fn(),
+    dispatch: jest.fn(),
+  };
+  const dialogCompleteCallback = jest.fn();
+
+  mockStore.getState.mockReturnValue({ onCreateDialogComplete: dialogCompleteCallback });
+
+  it('dispatches createDialog', async () => {
+    const id = '1234';
+    const payload = { id, content: 'content' };
+    await createDialog(mockStore, payload);
+
+    expect(mockStore.dispatch).toHaveBeenCalledWith({
+      type: ActionTypes.CREATE_DIALOG,
+      payload,
+    });
+    jest.runAllTimers();
+    expect(dialogCompleteCallback).toHaveBeenCalledWith(id);
+  });
+
+  it('dispatches createDialogCancel', () => {
+    createDialogCancel(mockStore);
+
+    expect(mockStore.dispatch).toHaveBeenCalledWith({
+      type: ActionTypes.CREATE_DIALOG_CANCEL,
+    });
+    jest.runAllTimers();
+    expect(dialogCompleteCallback).toHaveBeenCalledWith(null);
+  });
+});

--- a/Composer/packages/client/__tests__/store/actions/dialog.test.ts
+++ b/Composer/packages/client/__tests__/store/actions/dialog.test.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { removeDialog, updateDialogBase, createDialogBegin } from '../../../src/store/action/dialog';
+import { ActionTypes } from '../../../src/constants';
+
+import { runMinorTests } from './testUtils';
+
+const ACTION_TESTS = [
+  { action: removeDialog, actionType: ActionTypes.REMOVE_DIALOG, payload: {}, output: { id: {} } },
+  { action: updateDialogBase, actionType: ActionTypes.UPDATE_DIALOG, payload: { id: {}, content: {} } },
+  {
+    action: createDialogBegin,
+    actionType: ActionTypes.CREATE_DIALOG_BEGIN,
+    payload: 123,
+    output: { actionsSeed: 123, onComplete: {} },
+  },
+];
+
+describe('simple actions', () => runMinorTests(ACTION_TESTS));

--- a/Composer/packages/client/__tests__/store/actions/dialog.test.ts
+++ b/Composer/packages/client/__tests__/store/actions/dialog.test.ts
@@ -28,34 +28,65 @@ const ACTION_TESTS = [
 describe('simple actions', () => runMinorTests(ACTION_TESTS));
 
 describe('the createDialog actions', () => {
-  const mockStore = {
-    getState: jest.fn(),
-    dispatch: jest.fn(),
-  };
-  const dialogCompleteCallback = jest.fn();
+  describe('with a function in the dialogCompleteCallback', () => {
+    const mockStore = {
+      getState: jest.fn(),
+      dispatch: jest.fn(),
+    };
+    const dialogCompleteCallback = jest.fn();
 
-  mockStore.getState.mockReturnValue({ onCreateDialogComplete: dialogCompleteCallback });
+    mockStore.getState.mockReturnValue({ onCreateDialogComplete: dialogCompleteCallback });
 
-  it('dispatches createDialog', async () => {
-    const id = '1234';
-    const payload = { id, content: 'content' };
-    await createDialog(mockStore, payload);
+    it('dispatches createDialog', async () => {
+      const id = '1234';
+      const payload = { id, content: 'content' };
+      await createDialog(mockStore, payload);
 
-    expect(mockStore.dispatch).toHaveBeenCalledWith({
-      type: ActionTypes.CREATE_DIALOG,
-      payload,
+      expect(mockStore.dispatch).toHaveBeenCalledWith({
+        type: ActionTypes.CREATE_DIALOG,
+        payload,
+      });
+      jest.runAllTimers();
+      expect(dialogCompleteCallback).toHaveBeenCalledWith(id);
     });
-    jest.runAllTimers();
-    expect(dialogCompleteCallback).toHaveBeenCalledWith(id);
+
+    it('dispatches createDialogCancel', () => {
+      createDialogCancel(mockStore);
+
+      expect(mockStore.dispatch).toHaveBeenCalledWith({
+        type: ActionTypes.CREATE_DIALOG_CANCEL,
+      });
+      jest.runAllTimers();
+      expect(dialogCompleteCallback).toHaveBeenCalledWith(null);
+    });
   });
 
-  it('dispatches createDialogCancel', () => {
-    createDialogCancel(mockStore);
+  describe('with nothing in the dialogCompleteCallback', () => {
+    const mockStore = {
+      getState: jest.fn(),
+      dispatch: jest.fn(),
+    };
+    mockStore.getState.mockReturnValue({ onCreateDialogComplete: null });
 
-    expect(mockStore.dispatch).toHaveBeenCalledWith({
-      type: ActionTypes.CREATE_DIALOG_CANCEL,
+    it('dispatches createDialog', async () => {
+      const id = '1234';
+      const payload = { id, content: 'content' };
+      await createDialog(mockStore, payload);
+
+      expect(mockStore.dispatch).toHaveBeenCalledWith({
+        type: ActionTypes.CREATE_DIALOG,
+        payload,
+      });
+      jest.runAllTimers();
     });
-    jest.runAllTimers();
-    expect(dialogCompleteCallback).toHaveBeenCalledWith(null);
+
+    it('dispatches createDialogCancel', () => {
+      createDialogCancel(mockStore);
+
+      expect(mockStore.dispatch).toHaveBeenCalledWith({
+        type: ActionTypes.CREATE_DIALOG_CANCEL,
+      });
+      jest.runAllTimers();
+    });
   });
 });

--- a/Composer/packages/client/__tests__/store/actions/testUtils.ts
+++ b/Composer/packages/client/__tests__/store/actions/testUtils.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { ActionTypes } from '../../../src/constants';
+import { ActionCreator } from '../../../src/store/types';
+
+type SimpleTest = {
+  action: ActionCreator;
+  actionType: ActionTypes;
+  payload: {};
+  output?: {};
+};
+
+export function runMinorTests(tests: SimpleTest[]) {
+  for (const { action, actionType, payload, output } of tests) {
+    it(`dispatches the ${actionType} action`, () => expect(action).toDispatch(actionType, payload, output));
+  }
+}

--- a/Composer/packages/client/setupTests.ts
+++ b/Composer/packages/client/setupTests.ts
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { ActionCreator } from './src/store/types';
+import { ActionTypes } from './src/constants';
+import isEqual from 'lodash/isEqual';
+
 expect.extend({
   toBeDispatchedWith(dispatch: jest.Mock, type: string, payload: any, error?: any) {
     if (this.isNot) {
@@ -21,6 +25,42 @@ expect.extend({
       pass: !this.isNot,
       message: () => 'dispatch called with correct type and payload',
     };
+  },
+
+  // runs a simple test for ActionCreators that just take in an argument and dispatch an action with that as its payload;
+  // omit the testPayload argument to test actions that just pass the arguments through intact
+  async toDispatch(actionCreator: ActionCreator, actionType: ActionTypes, testArguments: {}, testPayload?: {}) {
+    const dispatch: jest.Mock = jest.fn();
+    const error = {};
+
+    await actionCreator({ dispatch, getState: jest.fn() }, testArguments, error);
+
+    if (dispatch.mock.calls.length !== 1) {
+      return { pass: false, message: () => `expected the dispatch function to be called` };
+    }
+
+    const call = dispatch.mock.calls[0][0];
+
+    if (testPayload == null) testPayload = testArguments;
+
+    if (call.type !== actionType) {
+      return {
+        pass: false,
+        message: () =>
+          `expected the action ${actionType} to be dispatched; was ${dispatch.mock.calls[0][0].type} instead`,
+      };
+    } else if (!isEqual(call.payload, testPayload)) {
+      return {
+        pass: false,
+        message: () =>
+          `expected ${actionType} to be dispatched with ${JSON.stringify(testPayload)};` +
+          ` received ${JSON.stringify(call.payload)}`,
+      };
+    } else
+      return {
+        pass: true,
+        message: () => `${actionType} dispatched with ${JSON.stringify(testPayload)}`,
+      };
   },
 });
 

--- a/Composer/packages/client/src/store/action/dialog.ts
+++ b/Composer/packages/client/src/store/action/dialog.ts
@@ -6,8 +6,8 @@ import { ActionTypes } from '../../constants';
 
 import { Store } from './../types';
 
-export const removeDialog: ActionCreator = (store, id) => {
-  store.dispatch({
+export const removeDialog: ActionCreator = ({ dispatch }, id) => {
+  dispatch({
     type: ActionTypes.REMOVE_DIALOG,
     payload: { id },
   });
@@ -24,8 +24,8 @@ export const createDialog: ActionCreator = async (store, { id, content }) => {
   });
 };
 
-export const updateDialogBase: ActionCreator = async (store, { id, content }) => {
-  store.dispatch({
+export const updateDialogBase: ActionCreator = async ({ dispatch }, { id, content }) => {
+  dispatch({
     type: ActionTypes.UPDATE_DIALOG,
     payload: { id, content },
   });

--- a/Composer/yarn.lock
+++ b/Composer/yarn.lock
@@ -8475,10 +8475,10 @@ elegant-spinner@^1.0.1:
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
   integrity sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=
 
-elliptic@^6.0.0:
+elliptic@^6.0.0, elliptic@^6.5.3:
   version "6.5.3"
-  resolved "https://botbuilder.myget.org/F/botframework-cli/npm/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
-  integrity sha1-y1nrLv2vc6C9eMzXAVpirW4Pk9Y=
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
+  integrity sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==
   dependencies:
     bn.js "^4.4.0"
     brorand "^1.0.1"
@@ -11016,11 +11016,6 @@ is-binary-path@~2.1.0:
   dependencies:
     binary-extensions "^2.0.0"
 
-is-buffer@^1.0.2, is-buffer@^1.1.5:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
-  integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
-
 is-buffer@^2.0.0, is-buffer@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.3.tgz#4ecf3fcf749cbd1e472689e109ac66261a25e725"
@@ -11258,7 +11253,7 @@ is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
 
-is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
+is-plain-object@^2.0.1, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
   integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
@@ -12176,36 +12171,10 @@ killable@^1.0.1:
   resolved "https://registry.yarnpkg.com/killable/-/killable-1.0.1.tgz#4c8ce441187a061c7474fb87ca08e2a638194892"
   integrity sha512-LzqtLKlUwirEUyl/nicirVmNiPvYs7l5n8wOPP7fyJVpUPkvCnW/vuiXGpylGUlnPDnB7311rARzAt3Mhswpjg==
 
-kind-of@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-2.0.1.tgz#018ec7a4ce7e3a86cb9141be519d24c8faa981b5"
-  integrity sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=
-  dependencies:
-    is-buffer "^1.0.2"
-
-kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
-  integrity sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=
-  dependencies:
-    is-buffer "^1.1.5"
-
-kind-of@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
-  integrity sha1-IIE989cSkosgc3hpGkUGb65y3Vc=
-  dependencies:
-    is-buffer "^1.1.5"
-
-kind-of@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
-  integrity sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==
-
-kind-of@^6.0.0, kind-of@^6.0.2:
+kind-of@^2.0.1, kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0, kind-of@^4.0.0, kind-of@^5.0.0, kind-of@^6.0.0, kind-of@^6.0.2, kind-of@^6.0.3:
   version "6.0.3"
-  resolved "https://botbuilder.myget.org/F/botframework-cli/npm/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
-  integrity sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0=
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
+  integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
 kleur@^3.0.2:
   version "3.0.2"
@@ -12627,10 +12596,10 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.15, "lodash@>=3.5 <5", lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5:
+lodash@4.17.15, "lodash@>=3.5 <5", lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.15"
-  resolved "https://botbuilder.myget.org/F/botframework-cli/npm/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg=
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
 log-driver@^1.2.7:
   version "1.2.7"
@@ -13068,11 +13037,6 @@ minimatch@3.0.4, minimatch@^3.0.3, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
-
 minimist@1.2.5, minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
@@ -13153,17 +13117,10 @@ mixin-object@^2.0.1:
     for-in "^0.1.3"
     is-extendable "^0.1.1"
 
-mkdirp@0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
-  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
-  dependencies:
-    minimist "0.0.8"
-
-mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.4, mkdirp@~0.5.1:
+mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.2, mkdirp@^0.5.3, mkdirp@^0.5.4, mkdirp@~0.5.1:
   version "0.5.5"
-  resolved "https://botbuilder.myget.org/F/botframework-cli/npm/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
-  integrity sha1-2Rzv1i0UNsoPQWIOJRKI1CAJne8=
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
+  integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
 
@@ -16542,17 +16499,7 @@ serialize-error@^5.0.0:
   dependencies:
     type-fest "^0.8.0"
 
-serialize-javascript@^1.7.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.9.1.tgz#cfc200aef77b600c47da9bb8149c943e798c2fdb"
-  integrity sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==
-
-serialize-javascript@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
-  integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
-
-serialize-javascript@^3.1.0:
+serialize-javascript@^1.7.0, serialize-javascript@^2.1.2, serialize-javascript@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-3.1.0.tgz#8bf3a9170712664ef2561b44b691eafe399214ea"
   integrity sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==
@@ -16597,25 +16544,12 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
 
-set-value@^0.4.3:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/set-value/-/set-value-0.4.3.tgz#7db08f9d3d22dc7f78e53af3c3bf4666ecdfccf1"
-  integrity sha1-fbCPnT0i3H945Trzw79GZuzfzPE=
+set-value@^0.4.3, set-value@^2.0.0, set-value@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-3.0.2.tgz#74e8ecd023c33d0f77199d415409a40f21e61b90"
+  integrity sha512-npjkVoz+ank0zjlV9F47Fdbjfj/PfXyVhZvGALWsyIYU/qrMzpi6avjKW3/7KeSU2Df3I46BrN1xOI1+6vW0hA==
   dependencies:
-    extend-shallow "^2.0.1"
-    is-extendable "^0.1.1"
-    is-plain-object "^2.0.1"
-    to-object-path "^0.3.0"
-
-set-value@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.1.tgz#a18d40530e6f07de4228c7defe4227af8cad005b"
-  integrity sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==
-  dependencies:
-    extend-shallow "^2.0.1"
-    is-extendable "^0.1.1"
-    is-plain-object "^2.0.3"
-    split-string "^3.0.1"
+    is-plain-object "^2.0.4"
 
 setimmediate@^1.0.4, setimmediate@^1.0.5:
   version "1.0.5"
@@ -17011,7 +16945,7 @@ split-on-first@^1.0.0:
   resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
   integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
 
-split-string@^3.0.1, split-string@^3.0.2:
+split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
   integrity sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==


### PR DESCRIPTION
## Description

This adds an "expect.toDispatch" custom matcher, which we can use to test all of the actions that just take in arguments and pass them along into a dispatch. This also adds the `dialog.test.ts` file to demonstrate how these are intended to work.

## Task Item

refs #3456 