### PR TITLE
chore: Bumped electron-builder config to correct electron version.

### DIFF
--- a/Composer/packages/electron-server/electron-builder-config.json
+++ b/Composer/packages/electron-server/electron-builder-config.json
@@ -4,7 +4,7 @@
   "appId": "com.microsoft.botframework.composer",
   "copyright": "Copyright © 2020 Microsoft Corporation",
   "electronDownload": {
-    "version": "8.0.2"
+    "version": "8.2.4"
   },
   "directories": {
     "buildResources": "resources",


### PR DESCRIPTION
## Description

The electron version specified in the electron-builder config needs to be updated to match the current version or else the build process will fail to download the correct binary.


#minor

