### PR TITLE
fix: yarn start:dev app crashed

### DIFF
--- a/Composer/packages/tools/language-servers/language-generation/src/lgParser.ts
+++ b/Composer/packages/tools/language-servers/language-generation/src/lgParser.ts
@@ -48,7 +48,8 @@ class LgParserWithWorker {
 
   constructor() {
     const workerScriptPath = path.join(__dirname, 'lgWorker.js');
-    this.worker = fork(workerScriptPath, []);
+    // set exec arguments to empty, avoid fork nodemon `--inspect` error
+    this.worker = fork(workerScriptPath, [], { execArgv: [] });
     this.worker.on('message', this.handleMsg.bind(this));
   }
 


### PR DESCRIPTION
## Description

lgWorker fork process re-exec nodemon run arguments `--inspect=9228` , which caused an app crashed error
<img width="1775" alt="image" src="https://user-images.githubusercontent.com/49866537/86866648-f6543d80-c103-11ea-9658-ddeb41c429c3.png">

Fix this by reset forked process `execArgv: []`, but not sure it's the best solution or not.

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item

#minor 
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots



<!---
Please include screenshots or gifs if your PR include UX changes.
--->
