### PR TITLE
release: 1.0.2

### DIFF
--- a/Composer/packages/client/config/env.js
+++ b/Composer/packages/client/config/env.js
@@ -88,7 +88,7 @@ function getClientEnvironment(publicUrl) {
         PUBLIC_URL: publicUrl,
         GIT_SHA: getGitSha().toString().replace('\n', ''),
         SDK_PACKAGE_VERSION: '4.9.3', // TODO: change this when Composer supports custom schema/custom runtime
-        COMPOSER_VERSION: '1.0.1',
+        COMPOSER_VERSION: '1.0.2',
         LOCAL_PUBLISH_PATH:
           process.env.LOCAL_PUBLISH_PATH || path.resolve(process.cwd(), '../../plugins/localPublish/hostedBots'),
       }

--- a/Composer/packages/electron-server/package.json
+++ b/Composer/packages/electron-server/package.json
@@ -2,7 +2,7 @@
   "name": "@bfc/electron-server",
   "license": "MIT",
   "author": "Microsoft Corporation",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Electron wrapper around Composer that launches Composer as a desktop application.",
   "main": "./build/main.js",
   "engines": {

--- a/releases/1.0.2.md
+++ b/releases/1.0.2.md
@@ -1,0 +1,92 @@
+### 07-08-2020
+
+#### Added
+
+- feat: Disable / Enable actions ([#3416](https://github.com/microsoft/BotFramework-Composer/pull/3416)) ([@yeze322](https://github.com/yeze322))
+- feat: allow inputting path ([#3302](https://github.com/microsoft/BotFramework-Composer/pull/3302)) ([@liweitian](https://github.com/liweitian))
+- feat: add loading indicator when waiting on form data or schema to load ([#3523](https://github.com/microsoft/BotFramework-Composer/pull/3523)) ([@a-b-r-o-w-n](https://github.com/a-b-r-o-w-n))
+- feat: support validate lg custom functions ([#3273](https://github.com/microsoft/BotFramework-Composer/pull/3273)) ([@lei9444](https://github.com/lei9444))
+- feat: show 'AutoEndDialog' from Adaptive Dialog Property Editor ([#3498](https://github.com/microsoft/BotFramework-Composer/pull/3498)) ([@tdurnford](https://github.com/tdurnford))
+- feat: 'Ctrl + Click', 'Shift + Click' behaviors in Flow Editor ([#3448](https://github.com/microsoft/BotFramework-Composer/pull/3448)) ([@yeze322](https://github.com/yeze322))
+
+#### Fixed
+
+- fix: deploy issue while zipping the folder ([#3557](https://github.com/microsoft/BotFramework-Composer/pull/3557)) ([@lei9444](https://github.com/lei9444))
+- fix: location initialization ([#3549](https://github.com/microsoft/BotFramework-Composer/pull/3549)) ([@liweitian](https://github.com/liweitian))
+- fix: composer will crashed when add a new publish profile ([#3550](https://github.com/microsoft/BotFramework-Composer/pull/3550)) ([@lei9444](https://github.com/lei9444))
+- fix: Dialog validate throw error when delete an action ([#3537](https://github.com/microsoft/BotFramework-Composer/pull/3537)) ([@lei9444](https://github.com/lei9444))
+- fix: replace the endpoint to authoringEndpoint when publishing luis ([#3517](https://github.com/microsoft/BotFramework-Composer/pull/3517)) ([@lei9444](https://github.com/lei9444))
+- fix: inline editing LU mess up whole file ([#3478](https://github.com/microsoft/BotFramework-Composer/pull/3478)) ([@zhixzhan](https://github.com/zhixzhan))
+- fix: add logo-clicking to tests ([#3500](https://github.com/microsoft/BotFramework-Composer/pull/3500)) ([@beyackle](https://github.com/beyackle))
+- fix: revert plugins out of workspace ([#3479](https://github.com/microsoft/BotFramework-Composer/pull/3479)) ([@VanyLaw](https://github.com/VanyLaw))
+- fix: #2692 Tabbing / clicking / returning out of a number field round your input ([#3427](https://github.com/microsoft/BotFramework-Composer/pull/3427)) LouisEugeneMSFT
+- fix: fix get history before file persistence ([#3440](https://github.com/microsoft/BotFramework-Composer/pull/3440)) ([@VanyLaw](https://github.com/VanyLaw))
+- fix: typo ([#3474](https://github.com/microsoft/BotFramework-Composer/pull/3474)) ([@zxyanliu](https://github.com/zxyanliu))
+- fix: fix relative path of runtime folder in eject customized ([#3434](https://github.com/microsoft/BotFramework-Composer/pull/3434)) ([@VanyLaw](https://github.com/VanyLaw))
+- fix: #3309 Allow configuring app settings without opening a bot project ([#3454](https://github.com/microsoft/BotFramework-Composer/pull/3454)) Soroush
+- a11y: reapply tooltip additions ([#3362](https://github.com/microsoft/BotFramework-Composer/pull/3362)) ([@beyackle](https://github.com/beyackle))
+- fix: improve the user experience about lg editor ([#3337](https://github.com/microsoft/BotFramework-Composer/pull/3337)) ([@lei9444](https://github.com/lei9444))
+- fix: add untracked settings to composer default settings ([#3397](https://github.com/microsoft/BotFramework-Composer/pull/3397)) ([@zidaneymar](https://github.com/zidaneymar))
+- fix: endpoint, authoringEndpoint missing after publishing luis ([#3396](https://github.com/microsoft/BotFramework-Composer/pull/3396)) ([@VanyLaw](https://github.com/VanyLaw))
+- fix: relabel "End Dialog Turn" to "End Turn" for clarity ([#3382](https://github.com/microsoft/BotFramework-Composer/pull/3382)) ([@benbrown](https://github.com/benbrown))
+- fix: change local storage key ([#3119](https://github.com/microsoft/BotFramework-Composer/pull/3119)) ([@liweitian](https://github.com/liweitian))
+- fix: add authoring endpoint for luis setting. ([#3364](https://github.com/microsoft/BotFramework-Composer/pull/3364)) ([@lei9444](https://github.com/lei9444))
+- fix: sort custom action menu by $kind ([#3368](https://github.com/microsoft/BotFramework-Composer/pull/3368)) ([@yeze322](https://github.com/yeze322))
+- fix: reload schema when fetching project in electron ([#3365](https://github.com/microsoft/BotFramework-Composer/pull/3365)) ([@yeze322](https://github.com/yeze322))
+- fix: only identify files that end with .dialog as dialog files ([#3360](https://github.com/microsoft/BotFramework-Composer/pull/3360)) ([@liweitian](https://github.com/liweitian))
+- fix: More security vulnerability fixes ([#3347](https://github.com/microsoft/BotFramework-Composer/pull/3347)) ([@srinaath](https://github.com/srinaath))
+- fix: Cleaned up handling of external links in Electron. ([#3326](https://github.com/microsoft/BotFramework-Composer/pull/3326)) ([@tonyanziano](https://github.com/tonyanziano))
+- fix: validate new trigger form inline ([#3152](https://github.com/microsoft/BotFramework-Composer/pull/3152)) ([@liweitian](https://github.com/liweitian))
+- fix: update lg format link ([#3289](https://github.com/microsoft/BotFramework-Composer/pull/3289)) ([@liweitian](https://github.com/liweitian))
+
+#### Changed
+
+- refactor: split some actions off setSettings ([#3525](https://github.com/microsoft/BotFramework-Composer/pull/3525)) ([@beyackle](https://github.com/beyackle))
+- refactor: change term primary key to authoring key ([#3516](https://github.com/microsoft/BotFramework-Composer/pull/3516)) ([@liweitian](https://github.com/liweitian))
+- refactor: add rule and remove dangling underscores ([#3496](https://github.com/microsoft/BotFramework-Composer/pull/3496)) ([@beyackle](https://github.com/beyackle))
+- refactor: update more components ([#3383](https://github.com/microsoft/BotFramework-Composer/pull/3383)) ([@beyackle](https://github.com/beyackle))
+- refactor: split types.ts for clarity ([#3423](https://github.com/microsoft/BotFramework-Composer/pull/3423)) ([@beyackle](https://github.com/beyackle))
+- refactor: remove tildes ([#3266](https://github.com/microsoft/BotFramework-Composer/pull/3266)) ([@beyackle](https://github.com/beyackle))
+- style: Changed Next to OK in buttons that close dialogs ([#3411](https://github.com/microsoft/BotFramework-Composer/pull/3411)) ([@GeoffCoxMSFT](https://github.com/GeoffCoxMSFT))
+- refactor: add typing to toolbar items ([#3374](https://github.com/microsoft/BotFramework-Composer/pull/3374)) ([@beyackle](https://github.com/beyackle))
+- refactor: code cleanup phase 1 ([#3327](https://github.com/microsoft/BotFramework-Composer/pull/3327)) ([@beyackle](https://github.com/beyackle))
+- refactor: Visual Editor - be pluggable & reorganize folder tree & adaptive-flow-renderer lib ([#3143](https://github.com/microsoft/BotFramework-Composer/pull/3143)) ([@yeze322](https://github.com/yeze322))
+
+#### Other
+
+- doc: add some missing details to plugin readme ([#3585](https://github.com/microsoft/BotFramework-Composer/pull/3585)) ([@benbrown](https://github.com/benbrown))
+- docs: archive old docs ([#3572](https://github.com/microsoft/BotFramework-Composer/pull/3572)) ([@zxyanliu](https://github.com/zxyanliu))
+- chore: Index file renames part 2 ([#3546](https://github.com/microsoft/BotFramework-Composer/pull/3546)) ([@GeoffCoxMSFT](https://github.com/GeoffCoxMSFT))
+- chore: adds webpack bundle analyzer ([#3542](https://github.com/microsoft/BotFramework-Composer/pull/3542)) Soroush
+- test: increase 'adaptive-flow' test coverage to 77% ([#3530](https://github.com/microsoft/BotFramework-Composer/pull/3530)) ([@yeze322](https://github.com/yeze322))
+- chore: Index file renames part 1 ([#3519](https://github.com/microsoft/BotFramework-Composer/pull/3519)) ([@GeoffCoxMSFT](https://github.com/GeoffCoxMSFT))
+- chore: added config to debug Electron main process. ([#3501](https://github.com/microsoft/BotFramework-Composer/pull/3501)) ([@tonyanziano](https://github.com/tonyanziano))
+- chore: Hide ignored folders in vscode, update prettier config ([#3493](https://github.com/microsoft/BotFramework-Composer/pull/3493)) Soroush
+- chore: move plugins inside of yarn workspace ([#3322](https://github.com/microsoft/BotFramework-Composer/pull/3322)) ([@VanyLaw](https://github.com/VanyLaw))
+- docs: Update download links to match latest version ([#3375](https://github.com/microsoft/BotFramework-Composer/pull/3375)) Bart Billiet
+- test: add unit test coverage for adaptive-form ([#3371](https://github.com/microsoft/BotFramework-Composer/pull/3371)) ([@a-b-r-o-w-n](https://github.com/a-b-r-o-w-n))
+- security: add CodeQL security scanning ([#3332](https://github.com/microsoft/BotFramework-Composer/pull/3332)) Justin Hutchings
+- test: increase test coverage on server ([#3291](https://github.com/microsoft/BotFramework-Composer/pull/3291)) ([@zhixzhan](https://github.com/zhixzhan))
+- docs: help links ([#3341](https://github.com/microsoft/BotFramework-Composer/pull/3341)) ([@zxyanliu](https://github.com/zxyanliu))
+- test: add unit tests for custom hooks ([#3303](https://github.com/microsoft/BotFramework-Composer/pull/3303)) ([@lei9444](https://github.com/lei9444))
+
+ Uncategorized
+
+- fix nodemon `--inspect` error in lgWorker ([#3590](https://github.com/microsoft/BotFramework-Composer/pull/3590)) ([@zhixzhan](https://github.com/zhixzhan))
+- handle schema parsing error better ([#3586](https://github.com/microsoft/BotFramework-Composer/pull/3586)) ([@a-b-r-o-w-n](https://github.com/a-b-r-o-w-n))
+- Bumped electron-builder config to correct electron version. ([#3584](https://github.com/microsoft/BotFramework-Composer/pull/3584)) ([@tonyanziano](https://github.com/tonyanziano))
+- chore(deps-dev): bump electron from 8.0.2 to 8.2.4 in /Composer ([#3577](https://github.com/microsoft/BotFramework-Composer/pull/3577)) dependabot[bot]
+- replace function callbacks with arrows ([#3545](https://github.com/microsoft/BotFramework-Composer/pull/3545)) ([@beyackle](https://github.com/beyackle))
+- fix lgWorker test failure ([#3529](https://github.com/microsoft/BotFramework-Composer/pull/3529)) ([@zhixzhan](https://github.com/zhixzhan))
+- update a test case ([#3531](https://github.com/microsoft/BotFramework-Composer/pull/3531)) ([@liweitian](https://github.com/liweitian))
+- run coverage on all source files ([#3522](https://github.com/microsoft/BotFramework-Composer/pull/3522)) ([@a-b-r-o-w-n](https://github.com/a-b-r-o-w-n))
+- propagate code editor settings to all editor surfaces ([#3520](https://github.com/microsoft/BotFramework-Composer/pull/3520)) ([@a-b-r-o-w-n](https://github.com/a-b-r-o-w-n))
+- Merge pull request #3502 from hatpick/master Soroush
+- link the application keys with bot service in provision script ([#3425](https://github.com/microsoft/BotFramework-Composer/pull/3425)) ([@zidaneymar](https://github.com/zidaneymar))
+- Updated copy plugins script to point to new plugin dir. ([#3437](https://github.com/microsoft/BotFramework-Composer/pull/3437)) ([@tonyanziano](https://github.com/tonyanziano))
+- convert stuff to TSX and clean up casing ([#3342](https://github.com/microsoft/BotFramework-Composer/pull/3342)) ([@beyackle](https://github.com/beyackle))
+- use subscription api for tenant id retrieving ([#3359](https://github.com/microsoft/BotFramework-Composer/pull/3359)) ([@zidaneymar](https://github.com/zidaneymar))
+- watch editor avoid re-render ([#3334](https://github.com/microsoft/BotFramework-Composer/pull/3334)) ([@zhixzhan](https://github.com/zhixzhan))
+- Upgrade dependancies ([#3336](https://github.com/microsoft/BotFramework-Composer/pull/3336)) ([@srinaath](https://github.com/srinaath))
+- bump versions of things ([#3329](https://github.com/microsoft/BotFramework-Composer/pull/3329)) ([@beyackle](https://github.com/beyackle))
+- polish dotnet error message replaced in client ([#3293](https://github.com/microsoft/BotFramework-Composer/pull/3293)) ([@VanyLaw](https://github.com/VanyLaw))

--- a/releases/1.0.2.md
+++ b/releases/1.0.2.md
@@ -8,6 +8,9 @@
 - feat: support validate lg custom functions ([#3273](https://github.com/microsoft/BotFramework-Composer/pull/3273)) ([@lei9444](https://github.com/lei9444))
 - feat: show 'AutoEndDialog' from Adaptive Dialog Property Editor ([#3498](https://github.com/microsoft/BotFramework-Composer/pull/3498)) ([@tdurnford](https://github.com/tdurnford))
 - feat: 'Ctrl + Click', 'Shift + Click' behaviors in Flow Editor ([#3448](https://github.com/microsoft/BotFramework-Composer/pull/3448)) ([@yeze322](https://github.com/yeze322))
+- feat: handle schema parsing error better ([#3586](https://github.com/microsoft/BotFramework-Composer/pull/3586)) ([@a-b-r-o-w-n](https://github.com/a-b-r-o-w-n))
+- feat: link the application keys with bot service in provision script ([#3425](https://github.com/microsoft/BotFramework-Composer/pull/3425)) ([@zidaneymar](https://github.com/zidaneymar))
+- feat: propagate code editor settings to all editor surfaces ([#3520](https://github.com/microsoft/BotFramework-Composer/pull/3520)) ([@a-b-r-o-w-n](https://github.com/a-b-r-o-w-n))
 
 #### Fixed
 
@@ -31,13 +34,16 @@
 - fix: relabel "End Dialog Turn" to "End Turn" for clarity ([#3382](https://github.com/microsoft/BotFramework-Composer/pull/3382)) ([@benbrown](https://github.com/benbrown))
 - fix: change local storage key ([#3119](https://github.com/microsoft/BotFramework-Composer/pull/3119)) ([@liweitian](https://github.com/liweitian))
 - fix: add authoring endpoint for luis setting. ([#3364](https://github.com/microsoft/BotFramework-Composer/pull/3364)) ([@lei9444](https://github.com/lei9444))
-- fix: sort custom action menu by $kind ([#3368](https://github.com/microsoft/BotFramework-Composer/pull/3368)) ([@yeze322](https://github.com/yeze322))
+- fix: sort custom action menu by \$kind ([#3368](https://github.com/microsoft/BotFramework-Composer/pull/3368)) ([@yeze322](https://github.com/yeze322))
 - fix: reload schema when fetching project in electron ([#3365](https://github.com/microsoft/BotFramework-Composer/pull/3365)) ([@yeze322](https://github.com/yeze322))
 - fix: only identify files that end with .dialog as dialog files ([#3360](https://github.com/microsoft/BotFramework-Composer/pull/3360)) ([@liweitian](https://github.com/liweitian))
 - fix: More security vulnerability fixes ([#3347](https://github.com/microsoft/BotFramework-Composer/pull/3347)) ([@srinaath](https://github.com/srinaath))
 - fix: Cleaned up handling of external links in Electron. ([#3326](https://github.com/microsoft/BotFramework-Composer/pull/3326)) ([@tonyanziano](https://github.com/tonyanziano))
 - fix: validate new trigger form inline ([#3152](https://github.com/microsoft/BotFramework-Composer/pull/3152)) ([@liweitian](https://github.com/liweitian))
 - fix: update lg format link ([#3289](https://github.com/microsoft/BotFramework-Composer/pull/3289)) ([@liweitian](https://github.com/liweitian))
+- fix: LU inline editor suggestion not work ([#3334](https://github.com/microsoft/BotFramework-Composer/pull/3334)) ([@zhixzhan](https://github.com/zhixzhan))
+- fix: polish dotnet error message shown in client ([#3293](https://github.com/microsoft/BotFramework-Composer/pull/3293)) ([@VanyLaw](https://github.com/VanyLaw))
+- fix: use subscription api for tenant id retrieving ([#3359](https://github.com/microsoft/BotFramework-Composer/pull/3359)) ([@zidaneymar](https://github.com/zidaneymar))
 
 #### Changed
 
@@ -69,24 +75,14 @@
 - test: increase test coverage on server ([#3291](https://github.com/microsoft/BotFramework-Composer/pull/3291)) ([@zhixzhan](https://github.com/zhixzhan))
 - docs: help links ([#3341](https://github.com/microsoft/BotFramework-Composer/pull/3341)) ([@zxyanliu](https://github.com/zxyanliu))
 - test: add unit tests for custom hooks ([#3303](https://github.com/microsoft/BotFramework-Composer/pull/3303)) ([@lei9444](https://github.com/lei9444))
-
- Uncategorized
-
-- fix nodemon `--inspect` error in lgWorker ([#3590](https://github.com/microsoft/BotFramework-Composer/pull/3590)) ([@zhixzhan](https://github.com/zhixzhan))
-- handle schema parsing error better ([#3586](https://github.com/microsoft/BotFramework-Composer/pull/3586)) ([@a-b-r-o-w-n](https://github.com/a-b-r-o-w-n))
-- Bumped electron-builder config to correct electron version. ([#3584](https://github.com/microsoft/BotFramework-Composer/pull/3584)) ([@tonyanziano](https://github.com/tonyanziano))
-- chore(deps-dev): bump electron from 8.0.2 to 8.2.4 in /Composer ([#3577](https://github.com/microsoft/BotFramework-Composer/pull/3577)) dependabot[bot]
-- replace function callbacks with arrows ([#3545](https://github.com/microsoft/BotFramework-Composer/pull/3545)) ([@beyackle](https://github.com/beyackle))
-- fix lgWorker test failure ([#3529](https://github.com/microsoft/BotFramework-Composer/pull/3529)) ([@zhixzhan](https://github.com/zhixzhan))
-- update a test case ([#3531](https://github.com/microsoft/BotFramework-Composer/pull/3531)) ([@liweitian](https://github.com/liweitian))
-- run coverage on all source files ([#3522](https://github.com/microsoft/BotFramework-Composer/pull/3522)) ([@a-b-r-o-w-n](https://github.com/a-b-r-o-w-n))
-- propagate code editor settings to all editor surfaces ([#3520](https://github.com/microsoft/BotFramework-Composer/pull/3520)) ([@a-b-r-o-w-n](https://github.com/a-b-r-o-w-n))
-- Merge pull request #3502 from hatpick/master Soroush
-- link the application keys with bot service in provision script ([#3425](https://github.com/microsoft/BotFramework-Composer/pull/3425)) ([@zidaneymar](https://github.com/zidaneymar))
-- Updated copy plugins script to point to new plugin dir. ([#3437](https://github.com/microsoft/BotFramework-Composer/pull/3437)) ([@tonyanziano](https://github.com/tonyanziano))
-- convert stuff to TSX and clean up casing ([#3342](https://github.com/microsoft/BotFramework-Composer/pull/3342)) ([@beyackle](https://github.com/beyackle))
-- use subscription api for tenant id retrieving ([#3359](https://github.com/microsoft/BotFramework-Composer/pull/3359)) ([@zidaneymar](https://github.com/zidaneymar))
-- watch editor avoid re-render ([#3334](https://github.com/microsoft/BotFramework-Composer/pull/3334)) ([@zhixzhan](https://github.com/zhixzhan))
-- Upgrade dependancies ([#3336](https://github.com/microsoft/BotFramework-Composer/pull/3336)) ([@srinaath](https://github.com/srinaath))
-- bump versions of things ([#3329](https://github.com/microsoft/BotFramework-Composer/pull/3329)) ([@beyackle](https://github.com/beyackle))
-- polish dotnet error message replaced in client ([#3293](https://github.com/microsoft/BotFramework-Composer/pull/3293)) ([@VanyLaw](https://github.com/VanyLaw))
+- build: fix nodemon `--inspect` error in lgWorker ([#3590](https://github.com/microsoft/BotFramework-Composer/pull/3590)) ([@zhixzhan](https://github.com/zhixzhan))
+- build: updated copy plugins script to point to new plugin dir. ([#3437](https://github.com/microsoft/BotFramework-Composer/pull/3437)) ([@tonyanziano](https://github.com/tonyanziano))
+- chore: bump electron from 8.0.2 to 8.2.4 in /Composer ([#3577](https://github.com/microsoft/BotFramework-Composer/pull/3577))
+- chore: bump version of serialize-javascript to help tests pass ([#3329](https://github.com/microsoft/BotFramework-Composer/pull/3329)) ([@beyackle](https://github.com/beyackle))
+- chore: Bumped electron-builder config to correct electron version. ([#3584](https://github.com/microsoft/BotFramework-Composer/pull/3584)) ([@tonyanziano](https://github.com/tonyanziano))
+- chore: convert stuff to TSX and clean up casing ([#3342](https://github.com/microsoft/BotFramework-Composer/pull/3342)) ([@beyackle](https://github.com/beyackle))
+- chore: replace function callbacks with arrows ([#3545](https://github.com/microsoft/BotFramework-Composer/pull/3545)) ([@beyackle](https://github.com/beyackle))
+- chore: Upgrade dependencies to avoid security warnings ([#3336](https://github.com/microsoft/BotFramework-Composer/pull/3336)) ([@srinaath](https://github.com/srinaath))
+- test: fix lgWorker test failure ([#3529](https://github.com/microsoft/BotFramework-Composer/pull/3529)) ([@zhixzhan](https://github.com/zhixzhan))
+- test: run coverage on all source files ([#3522](https://github.com/microsoft/BotFramework-Composer/pull/3522)) ([@a-b-r-o-w-n](https://github.com/a-b-r-o-w-n))
+- test: update a test case ([#3531](https://github.com/microsoft/BotFramework-Composer/pull/3531)) ([@liweitian](https://github.com/liweitian))


### PR DESCRIPTION
### 07-08-2020

#### Added

- feat: Disable / Enable actions ([#3416](https://github.com/microsoft/BotFramework-Composer/pull/3416)) ([@yeze322](https://github.com/yeze322))
- feat: allow inputting path ([#3302](https://github.com/microsoft/BotFramework-Composer/pull/3302)) ([@liweitian](https://github.com/liweitian))
- feat: add loading indicator when waiting on form data or schema to load ([#3523](https://github.com/microsoft/BotFramework-Composer/pull/3523)) ([@a-b-r-o-w-n](https://github.com/a-b-r-o-w-n))
- feat: support validate lg custom functions ([#3273](https://github.com/microsoft/BotFramework-Composer/pull/3273)) ([@lei9444](https://github.com/lei9444))
- feat: show 'AutoEndDialog' from Adaptive Dialog Property Editor ([#3498](https://github.com/microsoft/BotFramework-Composer/pull/3498)) ([@tdurnford](https://github.com/tdurnford))
- feat: 'Ctrl + Click', 'Shift + Click' behaviors in Flow Editor ([#3448](https://github.com/microsoft/BotFramework-Composer/pull/3448)) ([@yeze322](https://github.com/yeze322))
- feat: handle schema parsing error better ([#3586](https://github.com/microsoft/BotFramework-Composer/pull/3586)) ([@a-b-r-o-w-n](https://github.com/a-b-r-o-w-n))
- feat: link the application keys with bot service in provision script ([#3425](https://github.com/microsoft/BotFramework-Composer/pull/3425)) ([@zidaneymar](https://github.com/zidaneymar))
- feat: propagate code editor settings to all editor surfaces ([#3520](https://github.com/microsoft/BotFramework-Composer/pull/3520)) ([@a-b-r-o-w-n](https://github.com/a-b-r-o-w-n))

#### Fixed

- fix: deploy issue while zipping the folder ([#3557](https://github.com/microsoft/BotFramework-Composer/pull/3557)) ([@lei9444](https://github.com/lei9444))
- fix: location initialization ([#3549](https://github.com/microsoft/BotFramework-Composer/pull/3549)) ([@liweitian](https://github.com/liweitian))
- fix: composer will crashed when add a new publish profile ([#3550](https://github.com/microsoft/BotFramework-Composer/pull/3550)) ([@lei9444](https://github.com/lei9444))
- fix: Dialog validate throw error when delete an action ([#3537](https://github.com/microsoft/BotFramework-Composer/pull/3537)) ([@lei9444](https://github.com/lei9444))
- fix: replace the endpoint to authoringEndpoint when publishing luis ([#3517](https://github.com/microsoft/BotFramework-Composer/pull/3517)) ([@lei9444](https://github.com/lei9444))
- fix: inline editing LU mess up whole file ([#3478](https://github.com/microsoft/BotFramework-Composer/pull/3478)) ([@zhixzhan](https://github.com/zhixzhan))
- fix: add logo-clicking to tests ([#3500](https://github.com/microsoft/BotFramework-Composer/pull/3500)) ([@beyackle](https://github.com/beyackle))
- fix: revert plugins out of workspace ([#3479](https://github.com/microsoft/BotFramework-Composer/pull/3479)) ([@VanyLaw](https://github.com/VanyLaw))
- fix: #2692 Tabbing / clicking / returning out of a number field round your input ([#3427](https://github.com/microsoft/BotFramework-Composer/pull/3427)) LouisEugeneMSFT
- fix: fix get history before file persistence ([#3440](https://github.com/microsoft/BotFramework-Composer/pull/3440)) ([@VanyLaw](https://github.com/VanyLaw))
- fix: typo ([#3474](https://github.com/microsoft/BotFramework-Composer/pull/3474)) ([@zxyanliu](https://github.com/zxyanliu))
- fix: fix relative path of runtime folder in eject customized ([#3434](https://github.com/microsoft/BotFramework-Composer/pull/3434)) ([@VanyLaw](https://github.com/VanyLaw))
- fix: #3309 Allow configuring app settings without opening a bot project ([#3454](https://github.com/microsoft/BotFramework-Composer/pull/3454)) Soroush
- a11y: reapply tooltip additions ([#3362](https://github.com/microsoft/BotFramework-Composer/pull/3362)) ([@beyackle](https://github.com/beyackle))
- fix: improve the user experience about lg editor ([#3337](https://github.com/microsoft/BotFramework-Composer/pull/3337)) ([@lei9444](https://github.com/lei9444))
- fix: add untracked settings to composer default settings ([#3397](https://github.com/microsoft/BotFramework-Composer/pull/3397)) ([@zidaneymar](https://github.com/zidaneymar))
- fix: endpoint, authoringEndpoint missing after publishing luis ([#3396](https://github.com/microsoft/BotFramework-Composer/pull/3396)) ([@VanyLaw](https://github.com/VanyLaw))
- fix: relabel "End Dialog Turn" to "End Turn" for clarity ([#3382](https://github.com/microsoft/BotFramework-Composer/pull/3382)) ([@benbrown](https://github.com/benbrown))
- fix: change local storage key ([#3119](https://github.com/microsoft/BotFramework-Composer/pull/3119)) ([@liweitian](https://github.com/liweitian))
- fix: add authoring endpoint for luis setting. ([#3364](https://github.com/microsoft/BotFramework-Composer/pull/3364)) ([@lei9444](https://github.com/lei9444))
- fix: sort custom action menu by \$kind ([#3368](https://github.com/microsoft/BotFramework-Composer/pull/3368)) ([@yeze322](https://github.com/yeze322))
- fix: reload schema when fetching project in electron ([#3365](https://github.com/microsoft/BotFramework-Composer/pull/3365)) ([@yeze322](https://github.com/yeze322))
- fix: only identify files that end with .dialog as dialog files ([#3360](https://github.com/microsoft/BotFramework-Composer/pull/3360)) ([@liweitian](https://github.com/liweitian))
- fix: More security vulnerability fixes ([#3347](https://github.com/microsoft/BotFramework-Composer/pull/3347)) ([@srinaath](https://github.com/srinaath))
- fix: Cleaned up handling of external links in Electron. ([#3326](https://github.com/microsoft/BotFramework-Composer/pull/3326)) ([@tonyanziano](https://github.com/tonyanziano))
- fix: validate new trigger form inline ([#3152](https://github.com/microsoft/BotFramework-Composer/pull/3152)) ([@liweitian](https://github.com/liweitian))
- fix: update lg format link ([#3289](https://github.com/microsoft/BotFramework-Composer/pull/3289)) ([@liweitian](https://github.com/liweitian))
- fix: LU inline editor suggestion not work ([#3334](https://github.com/microsoft/BotFramework-Composer/pull/3334)) ([@zhixzhan](https://github.com/zhixzhan))
- fix: polish dotnet error message shown in client ([#3293](https://github.com/microsoft/BotFramework-Composer/pull/3293)) ([@VanyLaw](https://github.com/VanyLaw))
- fix: use subscription api for tenant id retrieving ([#3359](https://github.com/microsoft/BotFramework-Composer/pull/3359)) ([@zidaneymar](https://github.com/zidaneymar))

#### Changed

- refactor: split some actions off setSettings ([#3525](https://github.com/microsoft/BotFramework-Composer/pull/3525)) ([@beyackle](https://github.com/beyackle))
- refactor: change term primary key to authoring key ([#3516](https://github.com/microsoft/BotFramework-Composer/pull/3516)) ([@liweitian](https://github.com/liweitian))
- refactor: add rule and remove dangling underscores ([#3496](https://github.com/microsoft/BotFramework-Composer/pull/3496)) ([@beyackle](https://github.com/beyackle))
- refactor: update more components ([#3383](https://github.com/microsoft/BotFramework-Composer/pull/3383)) ([@beyackle](https://github.com/beyackle))
- refactor: split types.ts for clarity ([#3423](https://github.com/microsoft/BotFramework-Composer/pull/3423)) ([@beyackle](https://github.com/beyackle))
- refactor: remove tildes ([#3266](https://github.com/microsoft/BotFramework-Composer/pull/3266)) ([@beyackle](https://github.com/beyackle))
- style: Changed Next to OK in buttons that close dialogs ([#3411](https://github.com/microsoft/BotFramework-Composer/pull/3411)) ([@GeoffCoxMSFT](https://github.com/GeoffCoxMSFT))
- refactor: add typing to toolbar items ([#3374](https://github.com/microsoft/BotFramework-Composer/pull/3374)) ([@beyackle](https://github.com/beyackle))
- refactor: code cleanup phase 1 ([#3327](https://github.com/microsoft/BotFramework-Composer/pull/3327)) ([@beyackle](https://github.com/beyackle))
- refactor: Visual Editor - be pluggable & reorganize folder tree & adaptive-flow-renderer lib ([#3143](https://github.com/microsoft/BotFramework-Composer/pull/3143)) ([@yeze322](https://github.com/yeze322))

#### Other

- doc: add some missing details to plugin readme ([#3585](https://github.com/microsoft/BotFramework-Composer/pull/3585)) ([@benbrown](https://github.com/benbrown))
- docs: archive old docs ([#3572](https://github.com/microsoft/BotFramework-Composer/pull/3572)) ([@zxyanliu](https://github.com/zxyanliu))
- chore: Index file renames part 2 ([#3546](https://github.com/microsoft/BotFramework-Composer/pull/3546)) ([@GeoffCoxMSFT](https://github.com/GeoffCoxMSFT))
- chore: adds webpack bundle analyzer ([#3542](https://github.com/microsoft/BotFramework-Composer/pull/3542)) Soroush
- test: increase 'adaptive-flow' test coverage to 77% ([#3530](https://github.com/microsoft/BotFramework-Composer/pull/3530)) ([@yeze322](https://github.com/yeze322))
- chore: Index file renames part 1 ([#3519](https://github.com/microsoft/BotFramework-Composer/pull/3519)) ([@GeoffCoxMSFT](https://github.com/GeoffCoxMSFT))
- chore: added config to debug Electron main process. ([#3501](https://github.com/microsoft/BotFramework-Composer/pull/3501)) ([@tonyanziano](https://github.com/tonyanziano))
- chore: Hide ignored folders in vscode, update prettier config ([#3493](https://github.com/microsoft/BotFramework-Composer/pull/3493)) Soroush
- chore: move plugins inside of yarn workspace ([#3322](https://github.com/microsoft/BotFramework-Composer/pull/3322)) ([@VanyLaw](https://github.com/VanyLaw))
- docs: Update download links to match latest version ([#3375](https://github.com/microsoft/BotFramework-Composer/pull/3375)) Bart Billiet
- test: add unit test coverage for adaptive-form ([#3371](https://github.com/microsoft/BotFramework-Composer/pull/3371)) ([@a-b-r-o-w-n](https://github.com/a-b-r-o-w-n))
- security: add CodeQL security scanning ([#3332](https://github.com/microsoft/BotFramework-Composer/pull/3332)) Justin Hutchings
- test: increase test coverage on server ([#3291](https://github.com/microsoft/BotFramework-Composer/pull/3291)) ([@zhixzhan](https://github.com/zhixzhan))
- docs: help links ([#3341](https://github.com/microsoft/BotFramework-Composer/pull/3341)) ([@zxyanliu](https://github.com/zxyanliu))
- test: add unit tests for custom hooks ([#3303](https://github.com/microsoft/BotFramework-Composer/pull/3303)) ([@lei9444](https://github.com/lei9444))
- build: fix nodemon `--inspect` error in lgWorker ([#3590](https://github.com/microsoft/BotFramework-Composer/pull/3590)) ([@zhixzhan](https://github.com/zhixzhan))
- build: updated copy plugins script to point to new plugin dir. ([#3437](https://github.com/microsoft/BotFramework-Composer/pull/3437)) ([@tonyanziano](https://github.com/tonyanziano))
- chore: bump electron from 8.0.2 to 8.2.4 in /Composer ([#3577](https://github.com/microsoft/BotFramework-Composer/pull/3577))
- chore: bump version of serialize-javascript to help tests pass ([#3329](https://github.com/microsoft/BotFramework-Composer/pull/3329)) ([@beyackle](https://github.com/beyackle))
- chore: Bumped electron-builder config to correct electron version. ([#3584](https://github.com/microsoft/BotFramework-Composer/pull/3584)) ([@tonyanziano](https://github.com/tonyanziano))
- chore: convert stuff to TSX and clean up casing ([#3342](https://github.com/microsoft/BotFramework-Composer/pull/3342)) ([@beyackle](https://github.com/beyackle))
- chore: replace function callbacks with arrows ([#3545](https://github.com/microsoft/BotFramework-Composer/pull/3545)) ([@beyackle](https://github.com/beyackle))
- chore: Upgrade dependencies to avoid security warnings ([#3336](https://github.com/microsoft/BotFramework-Composer/pull/3336)) ([@srinaath](https://github.com/srinaath))
- test: fix lgWorker test failure ([#3529](https://github.com/microsoft/BotFramework-Composer/pull/3529)) ([@zhixzhan](https://github.com/zhixzhan))
- test: run coverage on all source files ([#3522](https://github.com/microsoft/BotFramework-Composer/pull/3522)) ([@a-b-r-o-w-n](https://github.com/a-b-r-o-w-n))
- test: update a test case ([#3531](https://github.com/microsoft/BotFramework-Composer/pull/3531)) ([@liweitian](https://github.com/liweitian))