### PR TITLE
feat: grouping Toolbar buttons under the 'Edit' dropdown button

### DIFF
--- a/Composer/packages/client/src/components/ToolBar/ToolBar.tsx
+++ b/Composer/packages/client/src/components/ToolBar/ToolBar.tsx
@@ -3,11 +3,9 @@
 
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
-import { useCallback, Fragment } from 'react';
+import { Fragment } from 'react';
 import formatMessage from 'format-message';
 import { ActionButton, CommandButton } from 'office-ui-fabric-react/lib/Button';
-
-import { useStoreContext } from '../../hooks/useStoreContext';
 
 import { IToolBarItem } from './ToolBar.types';
 import { actionButton, leftActions, rightActions, headerSub } from './ToolBarStyles';
@@ -53,9 +51,6 @@ function itemList(item: IToolBarItem, index: number) {
 // fabric-ui IButtonProps interface}
 export function ToolBar(props: ToolbarProps) {
   const { toolbarItems = [], ...rest } = props;
-  const {
-    actions: { onboardingAddCoachMarkRef },
-  } = useStoreContext();
 
   const left: IToolBarItem[] = [];
   const right: IToolBarItem[] = [];
@@ -70,16 +65,9 @@ export function ToolBar(props: ToolbarProps) {
     }
   }
 
-  const addNewRef = useCallback((addNew) => {
-    onboardingAddCoachMarkRef({ addNew });
-  }, []);
-
   return (
     <div aria-label={formatMessage('toolbar')} css={headerSub} role="region" {...rest}>
-      <div css={leftActions}>
-        {window.location.href.includes('/dialogs/') && <div ref={addNewRef}></div>}
-        {left.map(itemList)}{' '}
-      </div>
+      <div css={leftActions}>{left.map(itemList)} </div>
       <div css={rightActions}>{right.map(itemList)}</div>
     </div>
   );

--- a/Composer/packages/client/src/components/ToolBar/ToolBar.tsx
+++ b/Composer/packages/client/src/components/ToolBar/ToolBar.tsx
@@ -2,62 +2,18 @@
 // Licensed under the MIT License.
 
 /** @jsx jsx */
-import { jsx, css } from '@emotion/core';
+import { jsx } from '@emotion/core';
 import { useCallback, Fragment, useMemo } from 'react';
 import formatMessage from 'format-message';
 import { ActionButton, CommandButton } from 'office-ui-fabric-react/lib/Button';
 import { DialogInfo } from '@bfc/shared';
 import get from 'lodash/get';
-import { NeutralColors } from '@uifabric/fluent-theme';
 
-import { useStoreContext } from '../hooks/useStoreContext';
-import { VisualEditorAPI } from '../pages/design/FrameAPI';
+import { VisualEditorAPI } from '../../pages/design/FrameAPI';
+import { useStoreContext } from '../../hooks/useStoreContext';
 
-// -------------------- Styles -------------------- //
-
-const headerSub = css`
-  height: 44px;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  border-bottom: 1px solid ${NeutralColors.gray30};
-`;
-
-const leftActions = css`
-  position: relative;
-  display: flex;
-  align-items: stretch;
-  height: 44px;
-`;
-
-const rightActions = css`
-  position: relative;
-  height: 44px;
-  margin-right: 20px;
-`;
-
-const actionButton = css`
-  font-size: 16px;
-  margin-top: 2px;
-  margin-left: 15px;
-`;
-
-// -------------------- ToolBar -------------------- //
-
-export type IToolBarItem = {
-  type: string;
-  element?: any;
-  text?: string;
-  buttonProps?: {
-    iconProps: {
-      iconName: string;
-    };
-    onClick: () => void;
-  };
-  align?: string;
-  dataTestid?: string;
-  disabled?: boolean;
-};
+import { IToolBarItem } from './ToolBar.types';
+import { actionButton, leftActions, rightActions, headerSub } from './ToolBarStyles';
 
 type ToolbarProps = {
   toolbarItems?: Array<IToolBarItem>;
@@ -67,21 +23,35 @@ type ToolbarProps = {
   showSkillManifestModal?: () => void;
 };
 
-function itemList(action: IToolBarItem, index: number) {
-  if (action.type === 'element') {
-    return <Fragment key={index}>{action.element}</Fragment>;
-  } else {
+function itemList(item: IToolBarItem, index: number) {
+  if (item.type === 'element') {
+    return <Fragment key={index}>{item.element}</Fragment>;
+  } else if (item.type === 'action') {
     return (
       <ActionButton
         key={index}
         css={actionButton}
-        {...action.buttonProps}
-        data-testid={action.dataTestid}
-        disabled={action.disabled}
+        {...item.buttonProps}
+        data-testid={item.dataTestid}
+        disabled={item.disabled}
       >
-        {action.text}
+        {item.text}
       </ActionButton>
     );
+  } else if (item.type === 'dropdown') {
+    return (
+      <CommandButton
+        key={index}
+        css={actionButton}
+        data-testid={item.dataTestid}
+        disabled={item.disabled}
+        iconProps={item.buttonProps?.iconProps}
+        menuProps={item.menuProps}
+        text={item.text}
+      />
+    );
+  } else {
+    return null;
   }
 }
 

--- a/Composer/packages/client/src/components/ToolBar/ToolBar.tsx
+++ b/Composer/packages/client/src/components/ToolBar/ToolBar.tsx
@@ -3,13 +3,10 @@
 
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
-import { useCallback, Fragment, useMemo } from 'react';
+import { useCallback, Fragment } from 'react';
 import formatMessage from 'format-message';
 import { ActionButton, CommandButton } from 'office-ui-fabric-react/lib/Button';
-import { DialogInfo } from '@bfc/shared';
-import get from 'lodash/get';
 
-import { VisualEditorAPI } from '../../pages/design/FrameAPI';
 import { useStoreContext } from '../../hooks/useStoreContext';
 
 import { IToolBarItem } from './ToolBar.types';
@@ -17,10 +14,6 @@ import { actionButton, leftActions, rightActions, headerSub } from './ToolBarSty
 
 type ToolbarProps = {
   toolbarItems?: Array<IToolBarItem>;
-  currentDialog?: DialogInfo;
-  onCreateDialogComplete?: (...args: any[]) => void;
-  openNewTriggerModal?: () => void;
-  showSkillManifestModal?: () => void;
 };
 
 function itemList(item: IToolBarItem, index: number) {
@@ -59,29 +52,10 @@ function itemList(item: IToolBarItem, index: number) {
 // action = {type:action/element, text, align, element, buttonProps: use
 // fabric-ui IButtonProps interface}
 export function ToolBar(props: ToolbarProps) {
+  const { toolbarItems = [], ...rest } = props;
   const {
-    toolbarItems = [],
-    currentDialog,
-    onCreateDialogComplete,
-    openNewTriggerModal,
-    showSkillManifestModal,
-    ...rest
-  } = props;
-  const {
-    actions: { onboardingAddCoachMarkRef, createDialogBegin, exportToZip },
-    state: { projectId, visualEditorSelection },
+    actions: { onboardingAddCoachMarkRef },
   } = useStoreContext();
-
-  const { actionSelected, showDisableBtn, showEnableBtn } = useMemo(() => {
-    const actionSelected = Array.isArray(visualEditorSelection) && visualEditorSelection.length > 0;
-    if (!actionSelected) {
-      return {};
-    }
-    const selectedActions = visualEditorSelection.map((id) => get(currentDialog?.content, id));
-    const showDisableBtn = selectedActions.some((x) => get(x, 'disabled') !== true);
-    const showEnableBtn = selectedActions.some((x) => get(x, 'disabled') === true);
-    return { actionSelected, showDisableBtn, showEnableBtn };
-  }, [visualEditorSelection]);
 
   const left: IToolBarItem[] = [];
   const right: IToolBarItem[] = [];
@@ -103,92 +77,8 @@ export function ToolBar(props: ToolbarProps) {
   return (
     <div aria-label={formatMessage('toolbar')} css={headerSub} role="region" {...rest}>
       <div css={leftActions}>
-        {window.location.href.includes('/dialogs/') && (
-          <div ref={addNewRef}>
-            <CommandButton
-              css={actionButton}
-              data-testid="AddFlyout"
-              iconProps={{ iconName: 'Add' }}
-              menuProps={{
-                items: [
-                  {
-                    'data-testid': 'FlyoutNewDialog',
-                    key: 'adddialog',
-                    text: formatMessage('Add new dialog'),
-                    onClick: () => {
-                      createDialogBegin([], onCreateDialogComplete);
-                    },
-                  },
-                  {
-                    'data-testid': 'FlyoutNewTrigger',
-                    key: 'addtrigger',
-                    text: formatMessage(`Add new trigger on {displayName}`, {
-                      displayName: currentDialog?.displayName ?? '',
-                    }),
-                    onClick: () => {
-                      openNewTriggerModal?.();
-                    },
-                  },
-                ],
-              }}
-              text={formatMessage('Add')}
-            />
-          </div>
-        )}
+        {window.location.href.includes('/dialogs/') && <div ref={addNewRef}></div>}
         {left.map(itemList)}{' '}
-        {window.location.href.includes('/dialogs/') && (
-          <CommandButton
-            css={actionButton}
-            disabled={!actionSelected}
-            iconProps={{ iconName: 'RemoveOccurrence' }}
-            menuProps={{
-              items: [
-                {
-                  key: 'disable',
-                  text: formatMessage('Disable'),
-                  disabled: !showDisableBtn,
-                  onClick: () => {
-                    VisualEditorAPI.disableSelection();
-                  },
-                },
-                {
-                  key: 'enable',
-                  text: formatMessage('Enable'),
-                  disabled: !showEnableBtn,
-                  onClick: () => {
-                    VisualEditorAPI.enableSelection();
-                  },
-                },
-              ],
-            }}
-            text={formatMessage('Disable')}
-          />
-        )}
-        {window.location.href.includes('/dialogs/') && (
-          <CommandButton
-            css={actionButton}
-            iconProps={{ iconName: 'OpenInNewWindow' }}
-            menuProps={{
-              items: [
-                {
-                  key: 'zipexport',
-                  text: formatMessage('Export assets to .zip'),
-                  onClick: () => {
-                    exportToZip({ projectId });
-                  },
-                },
-                {
-                  key: 'exportAsSkill',
-                  text: formatMessage('Export as skill'),
-                  onClick: () => {
-                    showSkillManifestModal?.();
-                  },
-                },
-              ],
-            }}
-            text={formatMessage('Export')}
-          />
-        )}
       </div>
       <div css={rightActions}>{right.map(itemList)}</div>
     </div>

--- a/Composer/packages/client/src/components/ToolBar/ToolBar.types.ts
+++ b/Composer/packages/client/src/components/ToolBar/ToolBar.types.ts
@@ -4,7 +4,7 @@
 import { IContextualMenuProps, IIconProps } from 'office-ui-fabric-react/lib';
 
 export type IToolBarItem = {
-  type: 'element' | 'action' | 'dropdown';
+  type: string;
   element?: any;
   text?: string;
   buttonProps?: {

--- a/Composer/packages/client/src/components/ToolBar/ToolBar.types.ts
+++ b/Composer/packages/client/src/components/ToolBar/ToolBar.types.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { IContextualMenuProps, IIconProps } from 'office-ui-fabric-react/lib';
+
+export type IToolBarItem = {
+  type: 'element' | 'action' | 'dropdown';
+  element?: any;
+  text?: string;
+  buttonProps?: {
+    iconProps?: IIconProps;
+    onClick?: () => void;
+  };
+  menuProps?: IContextualMenuProps;
+  align?: string;
+  dataTestid?: string;
+  disabled?: boolean;
+};

--- a/Composer/packages/client/src/components/ToolBar/ToolBarStyles.ts
+++ b/Composer/packages/client/src/components/ToolBar/ToolBarStyles.ts
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { css } from '@emotion/core';
+import { NeutralColors } from '@uifabric/fluent-theme';
+
+export const headerSub = css`
+  height: 44px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid ${NeutralColors.gray30};
+`;
+
+export const leftActions = css`
+  position: relative;
+  display: flex;
+  align-items: stretch;
+  height: 44px;
+`;
+
+export const rightActions = css`
+  position: relative;
+  height: 44px;
+  margin-right: 20px;
+`;
+
+export const actionButton = css`
+  font-size: 16px;
+  margin-top: 2px;
+  margin-left: 15px;
+`;

--- a/Composer/packages/client/src/components/ToolBar/index.ts
+++ b/Composer/packages/client/src/components/ToolBar/index.ts
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export { ToolBar } from './ToolBar';
+export { IToolBarItem } from './ToolBar.types';

--- a/Composer/packages/client/src/pages/design/DesignPage.tsx
+++ b/Composer/packages/client/src/pages/design/DesignPage.tsx
@@ -203,7 +203,7 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
     }
   };
 
-  const { actionSelected: nodeOperationAvailable, showDisableBtn, showEnableBtn } = useMemo(() => {
+  const { actionSelected, showDisableBtn, showEnableBtn } = useMemo(() => {
     const actionSelected = Array.isArray(visualEditorSelection) && visualEditorSelection.length > 0;
     if (!actionSelected) {
       return {};
@@ -218,6 +218,7 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
     {
       type: 'dropdown',
       text: formatMessage('Add'),
+      align: 'left',
       dataTestid: 'AddFlyout',
       buttonProps: {
         iconProps: { iconName: 'Add' },
@@ -244,85 +245,73 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
           },
         ],
       },
-      align: 'left',
     },
     {
-      type: 'action',
-      text: formatMessage('Undo'),
-      buttonProps: {
-        iconProps: {
-          iconName: 'Undo',
-        },
-        onClick: () => actions.undo(),
-      },
+      type: 'dropdown',
+      text: formatMessage('Edit'),
       align: 'left',
-      disabled: !undoHistory.canUndo(),
-    },
-    {
-      type: 'action',
-      text: formatMessage('Redo'),
+      dataTestid: 'EditFlyout',
       buttonProps: {
-        iconProps: {
-          iconName: 'Redo',
-        },
-        onClick: () => actions.redo(),
+        iconProps: { iconName: 'Edit' },
       },
-      align: 'left',
-      disabled: !undoHistory.canRedo(),
-    },
-    {
-      type: 'action',
-      text: formatMessage('Cut'),
-      buttonProps: {
-        iconProps: {
-          iconName: 'Cut',
-        },
-        onClick: () => VisualEditorAPI.cutSelection(),
+      menuProps: {
+        items: [
+          {
+            key: 'edit.undo',
+            text: formatMessage('Undo'),
+            disabled: !undoHistory.canUndo(),
+            onClick: () => {
+              actions.undo();
+            },
+          },
+          {
+            key: 'edit.redo',
+            text: formatMessage('Redo'),
+            disabled: !undoHistory.canRedo(),
+            onClick: () => {
+              actions.redo();
+            },
+          },
+          {
+            key: 'edit.cut',
+            text: formatMessage('Cut'),
+            disabled: !actionSelected,
+            onClick: () => {
+              VisualEditorAPI.cutSelection();
+            },
+          },
+          {
+            key: 'edit.copy',
+            text: formatMessage('Copy'),
+            disabled: !actionSelected,
+            onClick: () => {
+              VisualEditorAPI.copySelection();
+            },
+          },
+          {
+            key: 'edit.move',
+            text: formatMessage('Move'),
+            disabled: !actionSelected,
+            onClick: () => {
+              VisualEditorAPI.moveSelection();
+            },
+          },
+          {
+            key: 'edit.delete',
+            text: formatMessage('Delete'),
+            disabled: !actionSelected,
+            onClick: () => {
+              VisualEditorAPI.deleteSelection();
+            },
+          },
+        ],
       },
-      align: 'left',
-      disabled: !nodeOperationAvailable,
-    },
-    {
-      type: 'action',
-      text: formatMessage('Copy'),
-      buttonProps: {
-        iconProps: {
-          iconName: 'Copy',
-        },
-        onClick: () => VisualEditorAPI.copySelection(),
-      },
-      align: 'left',
-      disabled: !nodeOperationAvailable,
-    },
-    {
-      type: 'action',
-      text: formatMessage('Move'),
-      buttonProps: {
-        iconProps: {
-          iconName: 'Share',
-        },
-        onClick: () => VisualEditorAPI.moveSelection(),
-      },
-      align: 'left',
-      disabled: !nodeOperationAvailable,
-    },
-    {
-      type: 'action',
-      text: formatMessage('Delete'),
-      buttonProps: {
-        iconProps: {
-          iconName: 'Delete',
-        },
-        onClick: () => VisualEditorAPI.deleteSelection(),
-      },
-      align: 'left',
-      disabled: !nodeOperationAvailable,
     },
     {
       type: 'dropdown',
       text: formatMessage('Disable'),
       align: 'left',
-      disabled: !nodeOperationAvailable,
+      disabled: !actionSelected,
       buttonProps: {
         iconProps: { iconName: 'RemoveOccurrence' },
       },

--- a/Composer/packages/client/src/pages/design/DesignPage.tsx
+++ b/Composer/packages/client/src/pages/design/DesignPage.tsx
@@ -3,7 +3,7 @@
 
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
-import React, { Suspense, useEffect, useMemo, useState } from 'react';
+import React, { Suspense, useEffect, useMemo, useState, useCallback } from 'react';
 import { Breadcrumb, IBreadcrumbItem } from 'office-ui-fabric-react/lib/Breadcrumb';
 import formatMessage from 'format-message';
 import { globalHistory, RouteComponentProps } from '@reach/router';
@@ -106,6 +106,7 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
     clearUndoHistory,
     createDialogBegin,
     exportToZip,
+    onboardingAddCoachMarkRef,
   } = actions;
   const { location, dialogId } = props;
   const params = new URLSearchParams(location?.search);
@@ -493,6 +494,9 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
       }
     }
   }
+  const addNewBtnRef = useCallback((addNew) => {
+    onboardingAddCoachMarkRef({ addNew });
+  }, []);
 
   if (!dialogId) {
     return <LoadingSpinner />;
@@ -510,13 +514,14 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
           onSelect={handleSelect}
         />
         <div css={contentWrapper} role="main">
-          <ToolBar
-            currentDialog={currentDialog}
-            openNewTriggerModal={openNewTriggerModal}
-            showSkillManifestModal={() => setExportSkillModalVisible(true)}
-            toolbarItems={toolbarItems}
-            onCreateDialogComplete={onCreateDialogComplete}
-          />
+          <div css={{ position: 'relative' }} data-testid="DesignPage-ToolBar">
+            <span
+              ref={addNewBtnRef}
+              css={{ width: 120, height: '100%', position: 'absolute', left: 0, visibility: 'hidden' }}
+              data-testid="CoachmarkRef-AddNew"
+            />
+            <ToolBar toolbarItems={toolbarItems} />
+          </div>
           <Conversation css={editorContainer}>
             <div css={editorWrapper}>
               <div aria-label={formatMessage('Authoring canvas')} css={visualPanel} role="region">


### PR DESCRIPTION
## Description
closes #3591 
Follow the newest design in [Figma](https://www.figma.com/file/LlTlh5vXwq91zjGnFtrUUR6l/Composer-main-design-spec-%2F-UI-library?node-id=2968%3A26994).
![image](https://user-images.githubusercontent.com/8528761/87048301-213ab080-c22e-11ea-9a0f-872e79ca1c1a.png)


**Changes**
1. Refactor the 'ToolBar' component which was coupled with design page buttons.
2. Grouping 'undo' / 'redo' / 'copy' / 'cut' / 'move' / 'delete' together as a dropdown button.

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
