### PR TITLE
fix: Update banner with the right location to resolve 404 error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ![Microsoft Bot Framework Composer](./docs/media/gh-banner.png)
+# ![Microsoft Bot Framework Composer](./docs/Assets/gh-banner.png)
 
 # Microsoft Bot Framework Composer
 


### PR DESCRIPTION
## Description

The path `./docs/media/` is broken, thus, I updated it with the right path to align with the rest of the [README](https://github.com/microsoft/BotFramework-Composer/blob/master/README.md) file to be `./docs/Assets/` to fix the visual aspect of the repo.

## Task Item

closes #3611 

## Screenshots

Before this PR:
![banner-404](https://user-images.githubusercontent.com/53379183/87078132-7a054b80-c224-11ea-9e2b-15e75f876a9c.jpg)

After this PR:
![banner-working](https://user-images.githubusercontent.com/53379183/87078164-84274a00-c224-11ea-95be-692cc88c3158.jpg)

