### PR TITLE
ci: allow dependabot PRs to skip checks

### DIFF
--- a/.github/actions/conventional-pr/src/conventional-pr.ts
+++ b/.github/actions/conventional-pr/src/conventional-pr.ts
@@ -20,6 +20,9 @@ const prQuery = `
   query PRInfo($owner: String!, $repo: String!, $prNumber: Int!) {
     repository(owner: $owner, name: $repo) {
       pullRequest(number: $prNumber) {
+        author {
+          login
+        }
         title
         body
         baseRefName
@@ -48,6 +51,11 @@ async function run() {
 
     if (!pr) {
       core.setFailed('Not in a Pull Request context.');
+      return;
+    }
+
+    if (pr.author?.login === 'dependabot') {
+      core.info('This is a Dependabot PR; no verification needed.')
       return;
     }
 

--- a/.github/actions/conventional-pr/src/utils.ts
+++ b/.github/actions/conventional-pr/src/utils.ts
@@ -4,6 +4,7 @@ export interface PullRequestInfo {
   title: string;
   body: string;
   baseRefName: string;
+  author: {login: string};
 }
 type ValidationResult = string[];
 


### PR DESCRIPTION
## Description

Dependabot is a useful tool, but the PRs it autogenerates don't match the format we restrict our PRs to. This change will detect if a PR's author is Dependabot and, if so, let it skip the usual checks.

## Task Item

#minor