### PR TITLE
fix: numbers in ExpressionField now recognized as such

### DIFF
--- a/Composer/packages/extensions/adaptive-form/src/components/SchemaField.tsx
+++ b/Composer/packages/extensions/adaptive-form/src/components/SchemaField.tsx
@@ -62,6 +62,7 @@ const SchemaField: React.FC<FieldProps> = (props) => {
   const handleChange = (newValue: any) => {
     const serializedValue =
       typeof uiOptions?.serializer?.set === 'function' ? uiOptions.serializer.set(newValue) : newValue;
+
     onChange(serializedValue);
   };
 

--- a/Composer/packages/ui-plugins/expressions/src/__tests__/utils.test.ts
+++ b/Composer/packages/ui-plugins/expressions/src/__tests__/utils.test.ts
@@ -132,11 +132,11 @@ describe('getSelectedOption', () => {
       },
     },
     {
-      key: 'integer',
-      text: 'integer',
+      key: 'number',
+      text: 'number',
       data: {
         schema: {
-          type: 'integer' as const,
+          type: 'number' as const,
         },
       },
     },

--- a/Composer/packages/ui-plugins/expressions/src/utils.ts
+++ b/Composer/packages/ui-plugins/expressions/src/utils.ts
@@ -112,10 +112,14 @@ export function getOptions(schema: JSONSchema7, definitions): SchemaOption[] {
 
 export function getSelectedOption(value: any | undefined, options: SchemaOption[]): SchemaOption | undefined {
   const expressionOption = options.find(({ key }) => key === 'expression');
-  const valueType = getValueType(value);
+  let valueType = getValueType(value);
 
   // if its an array, we know it's not an expression
-  if (valueType === 'array') {
+
+  if (valueType === 'integer') {
+    // integer-type values should also count as numbers as far as the schema goes
+    valueType = 'number';
+  } else if (valueType === 'array') {
     const item = value[0];
     const firstArrayOption = options.find((o) => o.data.schema.type === 'array');
 
@@ -135,10 +139,8 @@ export function getSelectedOption(value: any | undefined, options: SchemaOption[
         return typeof itemSchema === 'object' && getValueType(item) === itemSchema.type;
       }) || firstArrayOption
     );
-  }
-
-  // if the value if undefined, either default to expression or the first option
-  if (typeof value === 'undefined' || value === null) {
+  } else if (typeof value === 'undefined' || value === null) {
+    // if the value if undefined, either default to expression or the first option
     return options.length > 2 ? expressionOption : options[0];
     // else if the value is a string and starts with '=' it is an expression
   } else if (


### PR DESCRIPTION
## Description

Numbers in expression fields were getting recognized with a valueType of "integer", which didn't match the expected type of "number", leading to numbers getting turned into generic blank objects.

## Task Item

fixes #3366 

## Screenshots
![image](https://user-images.githubusercontent.com/61990921/87730402-85083080-c77c-11ea-8f39-25f27f85137d.png)
