### PR TITLE
fix: set deleteOldVersion to true when publishing luis

### DIFF
--- a/Composer/packages/server/src/models/bot/luPublisher.ts
+++ b/Composer/packages/server/src/models/bot/luPublisher.ts
@@ -175,7 +175,7 @@ export class LuPublisher {
       config.botName,
       config.suffix,
       config.fallbackLocal,
-      false,
+      true,
       loadResult.multiRecognizers,
       loadResult.settings
     );


### PR DESCRIPTION
## Description
delete old version when publishing luis.
The lubuild support this feature. 
composer set deleteOldVersion to true.

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
closes #3640
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
