### PR TITLE
fix: Open a new bot after delete a bot will nagivate to the old bot

### DIFF
--- a/Composer/packages/client/src/recoilModel/dispatchers/project.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/project.ts
@@ -19,6 +19,7 @@ import { DialogSetting } from '../../recoilModel/types';
 import settingStorage from '../../utils/dialogSettingStorage';
 import filePersistence from '../persistence/FilePersistence';
 import { navigateTo } from '../../utils/navigation';
+import { designPageLocationState } from '../atoms/botState';
 
 import {
   skillManifestsState,
@@ -269,6 +270,7 @@ export const projectDispatcher = () => {
       reset(settingsState);
       reset(localeState);
       reset(skillManifestsState);
+      reset(designPageLocationState);
     } catch (e) {
       logMessage(callbackHelpers, e.message);
     }


### PR DESCRIPTION
## Description
Open a new bot after delete a bot will navigate to the old bot

The reason is the design page will use the location state to navigate to the begin dialog action. The location is not reset in dispatcher.

In this PR, reset the location when deleting a bot.

![DELETEFILE](https://user-images.githubusercontent.com/39758135/88152348-79ae7c80-cc36-11ea-98d8-9f0c1d145f60.gif)

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
#minor
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
