### PR TITLE
fix: validate skill empty & add duplicate dialog

### DIFF
--- a/Composer/packages/client/__tests__/pages/notifications/useNotifications.test.tsx
+++ b/Composer/packages/client/__tests__/pages/notifications/useNotifications.test.tsx
@@ -30,6 +30,7 @@ const state = {
           source: 'test',
         },
       ],
+      skills: ['https://yuesuemailskill0207-gjvga67.azurewebsites.net/manifest/manifest-1.0.json'],
     },
   ],
   luFiles: [
@@ -91,6 +92,14 @@ const state = {
       source: 'server',
     },
   ],
+  settings: {
+    skill: [
+      {
+        manifestUrl: 'https://yuesuemailskill0207-gjvga67.azurewebsites.net/manifest/manifest-1.0.json',
+        name: 'Email Skill',
+      },
+    ],
+  },
 };
 
 const initRecoilState = ({ set }) => {
@@ -116,7 +125,7 @@ describe('useNotification hooks', () => {
   });
 
   it('should return notifications', () => {
-    expect(renderedResult.current.length).toBe(4);
+    expect(renderedResult.current.length).toBe(5);
   });
 
   it('should return filtered notifications', () => {

--- a/Composer/packages/client/src/components/TestController/TestController.tsx
+++ b/Composer/packages/client/src/components/TestController/TestController.tsx
@@ -33,6 +33,7 @@ import { ErrorCallout } from './errorCallout';
 import { EmulatorOpenButton } from './emulatorOpenButton';
 import { Loading } from './loading';
 import { ErrorInfo } from './errorInfo';
+import { WarningInfo } from './warningInfo';
 
 // -------------------- Styles -------------------- //
 
@@ -76,6 +77,8 @@ export const TestController: React.FC = () => {
   const addRef = useCallback((startBot) => onboardingAddCoachMarkRef({ startBot }), []);
   const errorLength = notifications.filter((n) => n.severity === 'Error').length;
   const showError = errorLength > 0;
+  const warningLength = notifications.filter((n) => n.severity === 'Warning').length;
+  const showWarning = !showError && warningLength > 0;
 
   useEffect(() => {
     if (projectId) {
@@ -181,6 +184,7 @@ export const TestController: React.FC = () => {
         <Loading botStatus={botStatus} />
         <div ref={addRef}>
           <ErrorInfo count={errorLength} hidden={!showError} onClick={handleErrorButtonClick} />
+          <WarningInfo count={warningLength} hidden={!showWarning} onClick={handleErrorButtonClick} />
           <PrimaryButton
             css={botButton}
             disabled={showError || publishing || reloading}

--- a/Composer/packages/client/src/components/TestController/warningInfo.tsx
+++ b/Composer/packages/client/src/components/TestController/warningInfo.tsx
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/** @jsx jsx */
+import { jsx, css } from '@emotion/core';
+import { IconButton } from 'office-ui-fabric-react/lib/Button';
+import { SharedColors } from '@uifabric/fluent-theme';
+
+// -------------------- Styles -------------------- //
+
+const warningInfo = css`
+  float: left;
+  display: flex;
+`;
+
+const warningButton = css`
+  color: ${SharedColors.yellow10};
+  &:hover {
+    color: ${SharedColors.yellow10};
+  }
+`;
+
+const warningCount = css`
+  height: 32px;
+  line-height: 32px;
+  font-size 16px;
+  cursor: pointer;
+  display:inline-block;
+`;
+
+// -------------------- warningInfo -------------------- //
+
+interface IwarningInfoProps {
+  hidden: boolean;
+  count: number;
+  onClick: () => void;
+}
+
+export const WarningInfo: React.FC<IwarningInfoProps> = (props) => {
+  const { hidden, count, onClick } = props;
+
+  if (hidden) return null;
+
+  return (
+    <div css={warningInfo} data-testid="notifications-info-button" onClick={onClick}>
+      <span css={warningCount}>{count}</span>
+      <IconButton ariaLabel="warning" css={warningButton} iconProps={{ iconName: 'Error' }} title="warning" />
+    </div>
+  );
+};

--- a/Composer/packages/client/src/pages/design/createDialogModal.tsx
+++ b/Composer/packages/client/src/pages/design/createDialogModal.tsx
@@ -39,7 +39,7 @@ export const CreateDialogModal: React.FC<CreateDialogModalProps> = (props) => {
         if (!nameRegex.test(value)) {
           return formatMessage('Spaces and special characters are not allowed. Use letters, numbers, -, or _.');
         }
-        if (dialogs.some((dialog) => dialog.id === value)) {
+        if (dialogs.some((dialog) => dialog.id.toLowerCase() === value.toLowerCase())) {
           return formatMessage('Duplicate dialog name');
         }
       },

--- a/Composer/packages/client/src/pages/notifications/Notifications.tsx
+++ b/Composer/packages/client/src/pages/notifications/Notifications.tsx
@@ -44,6 +44,10 @@ const Notifications: React.FC<RouteComponentProps> = () => {
       const uri = convertPathToUrl(projectId, id, dialogPath);
       navigateTo(uri);
     },
+    [NotificationType.SKILL]: (item: INotification) => {
+      const { projectId } = item;
+      navigateTo(`/bot/${projectId}/skills`);
+    },
   };
   const handleItemClick = (item: INotification) => {
     navigations[item.type](item);

--- a/Composer/packages/client/src/pages/notifications/types.ts
+++ b/Composer/packages/client/src/pages/notifications/types.ts
@@ -12,6 +12,7 @@ export enum NotificationType {
   DIALOG,
   LG,
   LU,
+  SKILL,
   GENERAL,
 }
 
@@ -60,6 +61,15 @@ export class DialogNotification extends Notification {
   constructor(projectId: string, id: string, location: string, diagnostic: Diagnostic) {
     super(projectId, id, location, diagnostic);
     this.message = `In ${replaceDialogDiagnosticLabel(diagnostic.path)} ${diagnostic.message}`;
+    this.dialogPath = diagnostic.path;
+  }
+}
+
+export class SkillNotification extends Notification {
+  type = NotificationType.SKILL;
+  constructor(projectId: string, id: string, location: string, diagnostic: Diagnostic) {
+    super(projectId, id, location, diagnostic);
+    this.message = `${replaceDialogDiagnosticLabel(diagnostic.path)} ${diagnostic.message}`;
     this.dialogPath = diagnostic.path;
   }
 }

--- a/Composer/packages/client/src/pages/notifications/useNotifications.tsx
+++ b/Composer/packages/client/src/pages/notifications/useNotifications.tsx
@@ -3,6 +3,7 @@
 
 import { useMemo } from 'react';
 import { useRecoilValue } from 'recoil';
+import { Diagnostic, DiagnosticSeverity } from '@bfc/shared';
 
 import {
   dialogsState,
@@ -10,9 +11,17 @@ import {
   lgFilesState,
   projectIdState,
   BotDiagnosticsState,
+  settingsState,
 } from '../../recoilModel/atoms/botState';
 
-import { Notification, DialogNotification, LuNotification, LgNotification, ServerNotification } from './types';
+import {
+  Notification,
+  DialogNotification,
+  LuNotification,
+  LgNotification,
+  ServerNotification,
+  SkillNotification,
+} from './types';
 import { getReferredFiles } from './../../utils/luUtil';
 export default function useNotifications(filter?: string) {
   const dialogs = useRecoilValue(dialogsState);
@@ -20,12 +29,37 @@ export default function useNotifications(filter?: string) {
   const projectId = useRecoilValue(projectIdState);
   const lgFiles = useRecoilValue(lgFilesState);
   const diagnostics = useRecoilValue(BotDiagnosticsState);
+  const settings = useRecoilValue(settingsState);
   const memoized = useMemo(() => {
     const notifactions: Notification[] = [];
     diagnostics.forEach((d) => {
       notifactions.push(new ServerNotification(projectId, '', d.source, d));
     });
     dialogs.forEach((dialog) => {
+      // used skill not existed in setting
+      dialog.skills.forEach((skillId) => {
+        if (settings.skill?.findIndex(({ manifestUrl }) => manifestUrl === skillId) === -1) {
+          const diagnostic = new Diagnostic(
+            `skill '${skillId}' is not existed in appsettings.json`,
+            dialog.id,
+            DiagnosticSeverity.Error
+          );
+          const location = `${dialog.id}.dialog`;
+          notifactions.push(new DialogNotification(projectId, dialog.id, location, diagnostic));
+        }
+      });
+      // use skill but not fill bot endpoint in skill page.
+      if (dialog.skills.length) {
+        if (!settings.botId || !settings.skillHostEndpoint) {
+          const diagnostic = new Diagnostic(
+            'appsettings.json Microsoft App Id or Skill Host Endpoint are empty',
+            dialog.id,
+            DiagnosticSeverity.Warning
+          );
+          const location = `${dialog.id}.dialog`;
+          notifactions.push(new SkillNotification(projectId, dialog.id, location, diagnostic));
+        }
+      }
       dialog.diagnostics.map((diagnostic) => {
         const location = `${dialog.id}.dialog`;
         notifactions.push(new DialogNotification(projectId, dialog.id, location, diagnostic));
@@ -44,7 +78,7 @@ export default function useNotifications(filter?: string) {
       });
     });
     return notifactions;
-  }, [dialogs, luFiles, lgFiles, projectId, diagnostics]);
+  }, [dialogs, luFiles, lgFiles, projectId, diagnostics, settings]);
 
   const notifications: Notification[] = filter ? memoized.filter((x) => x.severity === filter) : memoized;
   return notifications;

--- a/Composer/packages/client/src/recoilModel/types.ts
+++ b/Composer/packages/client/src/recoilModel/types.ts
@@ -111,6 +111,12 @@ export interface DialogSetting {
   };
   defaultLanguage: string;
   languages: string[];
+  skill?: {
+    name: string;
+    manifestUrl: string;
+  }[];
+  botId?: string;
+  skillHostEndpoint?: string;
   [key: string]: unknown;
 }
 

--- a/Composer/packages/lib/indexers/src/dialogIndexer.ts
+++ b/Composer/packages/lib/indexers/src/dialogIndexer.ts
@@ -155,6 +155,26 @@ function extractReferredDialogs(dialog): string[] {
   return uniq(dialogs);
 }
 
+// find out all skill
+function extractReferredSkills(dialog): string[] {
+  const skills: string[] = [];
+  /**    *
+   * @param path , jsonPath string
+   * @param value , current node value    *
+   * @return boolean, true to stop walk
+   * */
+  const visitor: VisitorFunc = (path: string, value: any): boolean => {
+    // it's a valid schema dialog node.
+    if (has(value, '$kind') && value.$kind === SDKKinds.BeginSkill) {
+      const skillId = value.id;
+      skills.push(skillId);
+    }
+    return false;
+  };
+  JsonWalk('$', dialog, visitor);
+  return uniq(skills);
+}
+
 function parse(id: string, content: any) {
   const luFile = typeof content.recognizer === 'string' ? content.recognizer : '';
   const lgFile = typeof content.generator === 'string' ? content.generator : '';
@@ -170,6 +190,7 @@ function parse(id: string, content: any) {
     lgFile: getBaseName(lgFile, '.lg'),
     triggers: extractTriggers(content),
     intentTriggers: extractIntentTriggers(content),
+    skills: extractReferredSkills(content),
   };
 }
 

--- a/Composer/packages/lib/shared/src/types/indexers.ts
+++ b/Composer/packages/lib/shared/src/types/indexers.ts
@@ -45,6 +45,7 @@ export interface DialogInfo {
   referredDialogs: string[];
   triggers: ITrigger[];
   intentTriggers: IIntentTrigger[];
+  skills: string[];
 }
 
 export interface LgTemplateJsonPath {


### PR DESCRIPTION
## Description

#### Warning style beside Start Bot button
Show warning in toolbar, if both has error and warning, will show error at first priority. 
<img width="188" alt="image" src="https://user-images.githubusercontent.com/49866537/88262664-3407b780-ccfb-11ea-86b1-b16f56200973.png"><img width="188" alt="image" src="https://user-images.githubusercontent.com/49866537/88262692-408c1000-ccfb-11ea-8a37-7d01f5370811.png">

#### When bot call a skill
1. check dialog used skills exist (Error)
2. check skill required info (Warning)
<img width="600" alt="image" src="https://user-images.githubusercontent.com/49866537/88262274-7381d400-ccfa-11ea-829e-7b6eb61b1218.png">. 

#### When add a dialog
Prevent create same id dialog, ignore case


<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item

close #3284 
close #3401 
close #3687 
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots
![Untitled2](https://user-images.githubusercontent.com/49866537/88261999-ecccf700-ccf9-11ea-98b8-57d473d65623.gif)

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
