### PR TITLE
fix: a broken link in CardSample

### DIFF
--- a/Composer/plugins/samples/assets/projects/RespondingWithCardsSample/language-generation/en-us/common.en-us.lg
+++ b/Composer/plugins/samples/assets/projects/RespondingWithCardsSample/language-generation/en-us/common.en-us.lg
@@ -85,7 +85,7 @@
     subtitle = Star Wars: Episode V - The Empire Strikes Back
     text = The Empire Strikes Back (also known as Star Wars: Episode V – The Empire Strikes Back)
     image = https://upload.wikimedia.org/wikipedia/en/3/3c/SW_-_Empire_Strikes_Back.jpg
-    media = http://www.wavlist.com/movies/004/father.wav
+    media = https://wavlist.com/wav/father.wav
     buttons = Read More
 ]
 


### PR DESCRIPTION
## Description
Fixed [audio card link](http://www.wavlist.com/movies/004/father.wav) in RespondWithCardSample. 
Should point to https://wavlist.com/wav/father.wav

#minor

## Task Item
#3698 
