### PR TITLE
fix: loop infinitely on publish page when get publish status

### DIFF
--- a/Composer/packages/client/src/recoilModel/dispatchers/publisher.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/publisher.ts
@@ -68,7 +68,7 @@ export const publisherDispatcher = () => {
     if (status !== 404) {
       set(publishHistoryState, (publishHistory) => {
         const currentHistory = { ...data, target: target };
-        let targetHistories = publishHistory[target.name];
+        let targetHistories = publishHistory[target.name] ? [...publishHistory[target.name]] : [];
         // if no history exists, create one with the latest status
         // otherwise, replace the latest publish history with this one
         if (!targetHistories) {
@@ -82,8 +82,7 @@ export const publisherDispatcher = () => {
             targetHistories.unshift(currentHistory);
           }
         }
-        publishHistory[target.name] = targetHistories;
-        return publishHistory;
+        return { ...publishHistory, [target.name]: targetHistories };
       });
     }
   };
@@ -155,6 +154,7 @@ export const publisherDispatcher = () => {
         const response = await httpClient.get(`/publish/${projectId}/status/${target.name}`);
         updatePublishStatus(callbackHelpers, projectId, target, response.data);
       } catch (err) {
+        console.log(err);
         updatePublishStatus(callbackHelpers, projectId, target, err.response.data);
       }
     }

--- a/Composer/packages/client/src/recoilModel/dispatchers/publisher.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/publisher.ts
@@ -68,20 +68,21 @@ export const publisherDispatcher = () => {
     if (status !== 404) {
       set(publishHistoryState, (publishHistory) => {
         const currentHistory = { ...data, target: target };
-        const targetHistories = publishHistory[target.name];
+        let targetHistories = publishHistory[target.name];
         // if no history exists, create one with the latest status
         // otherwise, replace the latest publish history with this one
         if (!targetHistories) {
-          publishHistory[target.name] = [currentHistory];
+          targetHistories = [currentHistory];
         } else {
           // make sure this status payload represents the same item as item 0 (most of the time)
           // otherwise, prepend it to the list to indicate a NEW publish has occurred since last loading history
           if (targetHistories.length && targetHistories[0].id === id) {
-            publishHistory[target.name][0] = currentHistory;
+            targetHistories[0] = currentHistory;
           } else {
-            publishHistory[target.name].unshift(currentHistory);
+            targetHistories.unshift(currentHistory);
           }
         }
+        publishHistory[target.name] = targetHistories;
         return publishHistory;
       });
     }


### PR DESCRIPTION
## Description
Recoil state is immutable. If we set the value but the value hasn't changed, the component will re-render.
In publish page useEffect will called every time the history changed. 
![image](https://user-images.githubusercontent.com/39758135/88517633-ba850780-d021-11ea-9344-aac702990609.png)
So there will be a loop infinitely

In this PR, if the status is 404, do nothing.
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
closes #3705 
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
