### PR TITLE
fix: file persistence's flush method should wait for all tasks finish

### DIFF
--- a/Composer/packages/client/src/recoilModel/persistence/FilePersistence.ts
+++ b/Composer/packages/client/src/recoilModel/persistence/FilePersistence.ts
@@ -74,7 +74,7 @@ class FilePersistence {
       if (this._isFlushing) {
         return new Promise((resolve) => {
           const timer = setInterval(() => {
-            if (this.isEmpty()) {
+            if (this.isEmpty() && !this._isFlushing) {
               clearInterval(timer);
               resolve(true);
             }


### PR DESCRIPTION
## Description
The flush method will be resolved when the queue is empty. But the asynchronous tasks may be not finished. 

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
#minor
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
