### PR TITLE
fix: composer loading bot forever due to unexpected main dialog

### DIFF
--- a/Composer/packages/client/src/pages/design/createDialogModal.tsx
+++ b/Composer/packages/client/src/pages/design/createDialogModal.tsx
@@ -43,9 +43,11 @@ export const CreateDialogModal: React.FC<CreateDialogModalProps> = (props) => {
           return formatMessage('Duplicate dialog name');
         }
       },
+      defaultValue: '',
     },
     description: {
       required: false,
+      defaultValue: '',
     },
   };
 
@@ -103,7 +105,7 @@ export const CreateDialogModal: React.FC<CreateDialogModalProps> = (props) => {
           <DefaultButton text={formatMessage('Cancel')} onClick={onDismiss} />
           <PrimaryButton
             data-testid="SubmitNewDialogBtn"
-            disabled={hasErrors}
+            disabled={hasErrors || formData.name === ''}
             text={formatMessage('OK')}
             onClick={handleSubmit}
           />

--- a/Composer/packages/server/__tests__/models/bot/botProject.test.ts
+++ b/Composer/packages/server/__tests__/models/bot/botProject.test.ts
@@ -254,6 +254,44 @@ describe('dialog operations', () => {
   });
 });
 
+describe('should validate the file name when create a new one', () => {
+  it('validate the empty dialog name', () => {
+    expect(() => {
+      proj.validateFileName('.dialog');
+    }).toThrowError('The file name can not be empty');
+  });
+
+  it('validate the illegal dialog name', async () => {
+    expect(() => {
+      proj.validateFileName('a.b.dialog');
+    }).toThrowError('Spaces and special characters are not allowed. Use letters, numbers, -, or _.');
+  });
+
+  it('validate the empty lu file name', () => {
+    expect(() => {
+      proj.validateFileName('.en-us.lu');
+    }).toThrowError('The file name can not be empty');
+  });
+
+  it('validate the illegal lu file name', async () => {
+    expect(() => {
+      proj.validateFileName('a.b.en-us.lu');
+    }).toThrowError('Spaces and special characters are not allowed. Use letters, numbers, -, or _.');
+  });
+
+  it('validate the empty lg file name', () => {
+    expect(() => {
+      proj.validateFileName('.en-us.lg');
+    }).toThrowError('The file name can not be empty');
+  });
+
+  it('validate the illegal lu file name', async () => {
+    expect(() => {
+      proj.validateFileName('a.b.en-us.lg');
+    }).toThrowError('Spaces and special characters are not allowed. Use letters, numbers, -, or _.');
+  });
+});
+
 describe('deleteAllFiles', () => {
   const locationRef: LocationRef = {
     storageId: 'default',

--- a/Composer/packages/server/src/models/bot/botProject.ts
+++ b/Composer/packages/server/src/models/bot/botProject.ts
@@ -22,7 +22,7 @@ import { IFileStorage } from './../storage/interface';
 import { LocationRef } from './interface';
 import { LuPublisher } from './luPublisher';
 import { extractSkillManifestUrl } from './skillManager';
-import { defaultFilePath, serializeFiles } from './botStructure';
+import { defaultFilePath, serializeFiles, parseFileName } from './botStructure';
 
 const debug = log.extend('bot-project');
 const mkDirAsync = promisify(fs.mkdir);
@@ -341,8 +341,27 @@ export class BotProject implements IBotProject {
     }
   };
 
+  public validateFileName = (name: string) => {
+    const nameRegex = /^[a-zA-Z0-9-_]+$/;
+    const { fileId, fileType } = parseFileName(name, '');
+
+    let fileName = fileId;
+    if (fileType === '.dialog') {
+      fileName = Path.basename(name, fileType);
+    }
+
+    if (!fileName) {
+      throw new Error('The file name can not be empty');
+    }
+
+    if (!nameRegex.test(fileName)) {
+      throw new Error('Spaces and special characters are not allowed. Use letters, numbers, -, or _.');
+    }
+  };
+
   public createFile = async (name: string, content = '') => {
     const filename = name.trim();
+    this.validateFileName(filename);
     const botName = this.name;
     const defaultLocale = this.settings?.defaultLanguage || defaultLanguage;
     const relativePath = defaultFilePath(botName, defaultLocale, filename);


### PR DESCRIPTION
## Description
![newdialog](https://user-images.githubusercontent.com/39758135/88921621-67b98300-d2a1-11ea-90e5-a03c97cae3e4.gif)

In this PR if the name is empty, disable the "OK" button

Do we need to use { validateOnMount: true }? This will show error message when we open the dialog first time
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
closes #3428
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
