### PR TITLE
fix: differentiate Action / Trigger / Recognizer from custom schema

### DIFF
--- a/Composer/packages/extensions/adaptive-flow/__tests__/adaptive-flow-editor/utils/getCustomSchema.test.ts
+++ b/Composer/packages/extensions/adaptive-flow/__tests__/adaptive-flow-editor/utils/getCustomSchema.test.ts
@@ -7,32 +7,95 @@ import { getCustomSchema } from '../../../src/adaptive-flow-editor/utils/getCust
 
 describe('getCustomSchema', () => {
   it('can handle invalid input', () => {
-    expect(getCustomSchema()).toBeUndefined();
-    expect(getCustomSchema({}, undefined)).toBeUndefined();
-    expect(getCustomSchema(undefined, undefined)).toBeUndefined();
+    expect(getCustomSchema()).toEqual({});
+    expect(getCustomSchema({}, undefined)).toEqual({});
+    expect(getCustomSchema(undefined, undefined)).toEqual({});
 
-    expect(getCustomSchema({}, {})).toBeUndefined();
+    expect(getCustomSchema({}, {})).toEqual({});
   });
 
-  it('can genreate diff schema', () => {
+  it('can genreate diff action schema', () => {
     const ejected = {
       definitions: {
         'Microsoft.SendActivity': {
+          $role: 'implements(Microsoft.IDialog)',
           title: 'SendActivity Title',
           description: 'Send an activity.',
         },
       },
     } as OBISchema;
     expect(getCustomSchema({ oneOf: [], definitions: {} }, ejected)).toEqual({
-      oneOf: [
-        {
+      actions: {
+        oneOf: [
+          {
+            title: 'SendActivity Title',
+            description: 'Send an activity.',
+            $ref: '#/definitions/Microsoft.SendActivity',
+          },
+        ],
+        definitions: {
+          'Microsoft.SendActivity': ejected.definitions['Microsoft.SendActivity'],
+        },
+      },
+    });
+  });
+
+  it('can genreate diff synthesized schema', () => {
+    const ejected = {
+      definitions: {
+        'Microsoft.SendActivity': {
+          $role: 'implements(Microsoft.IDialog)',
           title: 'SendActivity Title',
           description: 'Send an activity.',
-          $ref: '#/definitions/Microsoft.SendActivity',
         },
-      ],
-      definitions: {
-        'Microsoft.SendActivity': ejected.definitions['Microsoft.SendActivity'],
+        'Microsoft.MyRecognizer': {
+          $role: 'implements(Microsoft.IRecognizer)',
+          title: 'My Recognizer Title',
+          description: 'My Recognizer.',
+        },
+        'Microsoft.MyTrigger': {
+          $role: 'implements(Microsoft.ITrigger)',
+          title: 'My Trigger Title',
+          description: 'My Trigger.',
+        },
+      },
+    } as OBISchema;
+    expect(getCustomSchema({ oneOf: [], definitions: {} }, ejected)).toEqual({
+      actions: {
+        oneOf: [
+          {
+            title: 'SendActivity Title',
+            description: 'Send an activity.',
+            $ref: '#/definitions/Microsoft.SendActivity',
+          },
+        ],
+        definitions: {
+          'Microsoft.SendActivity': ejected.definitions['Microsoft.SendActivity'],
+        },
+      },
+      recognizers: {
+        oneOf: [
+          {
+            title: 'My Recognizer Title',
+            description: 'My Recognizer.',
+            $ref: '#/definitions/Microsoft.MyRecognizer',
+          },
+        ],
+        definitions: {
+          'Microsoft.MyRecognizer': ejected.definitions['Microsoft.MyRecognizer'],
+        },
+      },
+      triggers: {
+        oneOf: [
+          {
+            title: 'My Trigger Title',
+            description: 'My Trigger.',
+            $ref: '#/definitions/Microsoft.MyTrigger',
+          },
+        ],
+        definitions: {
+          'Microsoft.MyTrigger': ejected.definitions['Microsoft.MyTrigger'],
+        },
       },
     });
   });

--- a/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-editor/AdaptiveFlowEditor.tsx
+++ b/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-editor/AdaptiveFlowEditor.tsx
@@ -89,7 +89,7 @@ const VisualDesigner: React.FC<VisualDesignerProps> = ({ schema }): JSX.Element 
   const focusedId = Array.isArray(focusedActions) && focusedActions[0] ? focusedActions[0] : '';
 
   // Compute schema diff
-  const customSchema = useMemo(() => getCustomSchema(schemas?.default, schemas?.sdk?.content), [
+  const customActionSchema = useMemo(() => getCustomSchema(schemas?.default, schemas?.sdk?.content).actions, [
     schemas?.sdk?.content,
     schemas?.default,
   ]);
@@ -100,7 +100,7 @@ const VisualDesigner: React.FC<VisualDesignerProps> = ({ schema }): JSX.Element 
     focusedTab,
     clipboardActions: clipboardActions || [],
     dialogFactory: new DialogFactory(schema),
-    customSchemas: customSchema ? [customSchema] : [],
+    customSchemas: customActionSchema ? [customActionSchema] : [],
   };
 
   const customFlowSchema: FlowSchema = nodeContext.customSchemas.reduce((result, s) => {

--- a/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-editor/utils/getCustomSchema.ts
+++ b/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-editor/utils/getCustomSchema.ts
@@ -1,25 +1,24 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { OBISchema } from '@bfc/shared';
+import { OBISchema, SDKKinds } from '@bfc/shared';
+import pickBy from 'lodash/pickBy';
 
-export const getCustomSchema = (baseSchema?: OBISchema, ejectedSchema?: OBISchema): OBISchema | undefined => {
-  if (!baseSchema || !ejectedSchema) return;
-  if (typeof baseSchema.definitions !== 'object' || typeof ejectedSchema.definitions !== 'object') return;
+interface CustomSchemaSet {
+  actions?: OBISchema;
+  triggers?: OBISchema;
+  recognizers?: OBISchema;
+}
 
-  const baseDefinitions = baseSchema.definitions;
-  const baseKindHash = Object.keys(baseDefinitions).reduce((hash, $kind) => {
-    hash[$kind] = true;
-    return hash;
-  }, {});
+const pickSchema = (
+  picked$kinds: SDKKinds[],
+  sourceSchema: { [key in SDKKinds]: OBISchema }
+): OBISchema | undefined => {
+  if (!Array.isArray(picked$kinds) || picked$kinds.length === 0) return undefined;
 
-  const ejectedDefinitions = ejectedSchema.definitions;
-  const diffKinds = Object.keys(ejectedDefinitions).filter(($kind) => !baseKindHash[$kind]);
-  if (diffKinds.length === 0) return;
-
-  const diffSchema = diffKinds.reduce(
+  const pickedSchema = picked$kinds.reduce(
     (schema, $kind) => {
-      const definition = ejectedDefinitions[$kind];
+      const definition = sourceSchema[$kind];
       schema.definitions[$kind] = definition;
       schema.oneOf?.push({
         title: definition.title || $kind,
@@ -34,8 +33,52 @@ export const getCustomSchema = (baseSchema?: OBISchema, ejectedSchema?: OBISchem
     } as OBISchema
   );
 
-  // Sort `oneOf` list by $kind to keep custom menu ordered
-  diffSchema.oneOf?.sort((a, b) => (a.$ref < b.$ref ? -1 : 1));
+  // Sort `oneOf` list alphabetically
+  pickedSchema.oneOf?.sort((a, b) => (a.$ref < b.$ref ? -1 : 1));
 
-  return diffSchema;
+  return pickedSchema;
+};
+
+type SchemaRole = string | string[];
+
+const roleImplementsInterface = (interfaceName: SDKKinds, $role?: SchemaRole): boolean => {
+  if (typeof $role === 'string') return $role === `implements(${interfaceName})`;
+  else if (Array.isArray($role)) return $role.some((x) => x === `implements(${interfaceName})`);
+  return false;
+};
+
+const isActionSchema = (schema: OBISchema) => roleImplementsInterface(SDKKinds.IDialog, schema.$role);
+const isTriggerSchema = (schema: OBISchema) => roleImplementsInterface(SDKKinds.ITrigger, schema.$role);
+const isRecognizerSchema = (schema: OBISchema) =>
+  roleImplementsInterface(SDKKinds.IRecognizer, schema.$role) ||
+  roleImplementsInterface(SDKKinds.IEntityRecognizer, schema.$role);
+
+export const getCustomSchema = (baseSchema?: OBISchema, ejectedSchema?: OBISchema): CustomSchemaSet => {
+  if (!baseSchema || !ejectedSchema) return {};
+  if (typeof baseSchema.definitions !== 'object' || typeof ejectedSchema.definitions !== 'object') return {};
+
+  const baseDefinitions = baseSchema.definitions;
+  const ejectedDefinitions = ejectedSchema.definitions;
+
+  const baseKindHash = Object.keys(baseDefinitions).reduce((hash, $kind) => {
+    hash[$kind] = true;
+    return hash;
+  }, {});
+
+  const diffKinds = Object.keys(ejectedDefinitions).filter(($kind) => !baseKindHash[$kind]) as SDKKinds[];
+  if (diffKinds.length === 0) return {};
+
+  // Differentiate 'trigger' / 'recognizer' / 'action'
+  const actionKinds = diffKinds.filter(($kind) => isActionSchema(ejectedDefinitions[$kind]));
+  const triggerKinds = diffKinds.filter(($kind) => isTriggerSchema(ejectedDefinitions[$kind]));
+  const recognizerKinds = diffKinds.filter(($kind) => isRecognizerSchema(ejectedDefinitions[$kind]));
+
+  return pickBy(
+    {
+      actions: pickSchema(actionKinds, ejectedDefinitions),
+      triggers: pickSchema(triggerKinds, ejectedDefinitions),
+      recognizers: pickSchema(recognizerKinds, ejectedDefinitions),
+    },
+    (v) => v !== undefined
+  );
 };


### PR DESCRIPTION
## Description

fixes #2946 

Previously, custom Triggers / Recognizers were incorrectly grouped as `Custom actions`.
This PR implements a stricter schema $role filter to differentiate Adatpive Action / Trigger / Recognizer.

As an example, I have a custom $kind `Microsoft.CustomResource`.
- When it's declared as `IDialog`, it appears under the 'Custom actions' label.
  ![image](https://user-images.githubusercontent.com/8528761/89258760-5edaff80-d65b-11ea-9c8e-1347d673dd06.png)
- When it's declared as `ITrigger` or other type, it won't be recognized as a custom action.
  ![image](https://user-images.githubusercontent.com/8528761/89258857-98ac0600-d65b-11ea-88c9-c69c02c8c844.png)


<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
