### PR TITLE
fix: use different shellData in Form and Flow's ExtensionContext

### DIFF
--- a/Composer/packages/client/src/pages/design/DesignPage.tsx
+++ b/Composer/packages/client/src/pages/design/DesignPage.tsx
@@ -143,7 +143,9 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
   const [dialogJsonVisible, setDialogJsonVisibility] = useState(false);
   const [currentDialog, setCurrentDialog] = useState<DialogInfo>(dialogs[0]);
   const [exportSkillModalVisible, setExportSkillModalVisible] = useState(false);
-  const shell = useShell('ProjectTree');
+  const shell = useShell('DesignPage');
+  const shellForFlowEditor = useShell('FlowEditor');
+  const shellForPropertyEditor = useShell('PropertyEditor');
   const triggerApi = useTriggerApi(shell.api);
 
   useEffect(() => {
@@ -543,30 +545,32 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
             />
             <Toolbar toolbarItems={toolbarItems} />
           </div>
-          <Extension plugins={pluginConfig} shell={shell.api} shellData={shell.data}>
-            <Conversation css={editorContainer}>
-              <div css={editorWrapper}>
-                <div aria-label={formatMessage('Authoring canvas')} css={visualPanel} role="region">
-                  {breadcrumbItems}
-                  {dialogJsonVisible ? (
-                    <JsonEditor
-                      key="dialogjson"
-                      editorSettings={userSettings.codeEditor}
-                      id={currentDialog.id}
-                      schema={schemas.sdk.content}
-                      value={currentDialog.content || undefined}
-                      onChange={(data) => {
-                        updateDialog({ id: currentDialog.id, content: data });
-                      }}
-                    />
-                  ) : (
+          <Conversation css={editorContainer}>
+            <div css={editorWrapper}>
+              <div aria-label={formatMessage('Authoring canvas')} css={visualPanel} role="region">
+                {breadcrumbItems}
+                {dialogJsonVisible ? (
+                  <JsonEditor
+                    key="dialogjson"
+                    editorSettings={userSettings.codeEditor}
+                    id={currentDialog.id}
+                    schema={schemas.sdk.content}
+                    value={currentDialog.content || undefined}
+                    onChange={(data) => {
+                      updateDialog({ id: currentDialog.id, content: data });
+                    }}
+                  />
+                ) : (
+                  <Extension plugins={pluginConfig} shell={shellForFlowEditor}>
                     <VisualEditor openNewTriggerModal={openNewTriggerModal} />
-                  )}
-                </div>
-                <PropertyEditor key={focusPath} />
+                  </Extension>
+                )}
               </div>
-            </Conversation>
-          </Extension>
+              <Extension plugins={pluginConfig} shell={shellForPropertyEditor}>
+                <PropertyEditor key={focusPath} />
+              </Extension>
+            </div>
+          </Conversation>
         </div>
       </div>
       <Suspense fallback={<LoadingSpinner />}>

--- a/Composer/packages/client/src/shell/useShell.ts
+++ b/Composer/packages/client/src/shell/useShell.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { useMemo, useRef } from 'react';
-import { ShellApi, ShellData } from '@bfc/shared';
+import { ShellApi, ShellData, Shell } from '@bfc/shared';
 import isEqual from 'lodash/isEqual';
 import { useRecoilValue } from 'recoil';
 import formatMessage from 'format-message';
@@ -33,9 +33,9 @@ import { useLuApi } from './luApi';
 
 const FORM_EDITOR = 'PropertyEditor';
 
-type EventSource = 'VisualEditor' | 'PropertyEditor' | 'ProjectTree';
+type EventSource = 'FlowEditor' | 'PropertyEditor' | 'DesignPage';
 
-export function useShell(source: EventSource): { api: ShellApi; data: ShellData } {
+export function useShell(source: EventSource): Shell {
   const dialogMapRef = useRef({});
   const botName = useRecoilValue(botNameState);
   const dialogs = useRecoilValue(dialogsState);

--- a/Composer/packages/extensions/extension/src/components/Extension.tsx
+++ b/Composer/packages/extensions/extension/src/components/Extension.tsx
@@ -1,25 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 import React, { useMemo } from 'react';
-import { ShellApi, ShellData } from '@bfc/shared';
+import { Shell } from '@bfc/shared';
 
 import ExtensionContext from '../extensionContext';
 import { PluginConfig } from '../types';
 
 interface ExtensionProps {
-  shell: ShellApi;
-  shellData: ShellData;
+  shell: Shell;
   plugins: PluginConfig;
 }
 
-export const Extension: React.FC<ExtensionProps> = function Extension(props) {
-  const { shell, shellData, plugins } = props;
-
+export const Extension: React.FC<ExtensionProps> = ({ shell, plugins, children }) => {
   const context = useMemo(() => {
-    return { shellApi: shell, shellData, plugins };
-  }, [shell, shellData, plugins]);
+    return { shellApi: shell.api, shellData: shell.data, plugins };
+  }, [shell.api, shell.data, plugins]);
 
-  return <ExtensionContext.Provider value={context}>{props.children}</ExtensionContext.Provider>;
+  return <ExtensionContext.Provider value={context}>{children}</ExtensionContext.Provider>;
 };
 
 export default Extension;

--- a/Composer/packages/lib/shared/src/types/shell.ts
+++ b/Composer/packages/lib/shared/src/types/shell.ts
@@ -90,3 +90,8 @@ export interface ShellApi {
   announce: (message: string) => void;
   displayManifestModal: (manifestId: string) => void;
 }
+
+export interface Shell {
+  api: ShellApi;
+  data: ShellData;
+}

--- a/Composer/packages/ui-plugins/select-dialog/src/__tests__/selectDialog.test.tsx
+++ b/Composer/packages/ui-plugins/select-dialog/src/__tests__/selectDialog.test.tsx
@@ -33,7 +33,7 @@ const renderSelectDialog = ({ createDialog, navTo, onChange } = {}) => {
     ],
   };
   return render(
-    <Extension shell={shell} shellData={shellData}>
+    <Extension shell={{ api: shell, data: shellData }}>
       <SelectDialog {...props} />
     </Extension>
   );

--- a/Composer/packages/ui-plugins/select-skill-dialog/src/__tests__/BeginSkillDialogField.test.tsx
+++ b/Composer/packages/ui-plugins/select-skill-dialog/src/__tests__/BeginSkillDialogField.test.tsx
@@ -35,7 +35,7 @@ const renderBeginSkillDialog = ({ value = {}, onChange = jest.fn() } = {}) => {
   };
 
   return render(
-    <Extension plugins={{}} shell={shell} shellData={shellData}>
+    <Extension plugins={{}} shell={{ api: shell, data: shellData }}>
       <BeginSkillDialogField {...props} />
     </Extension>
   );

--- a/Composer/packages/ui-plugins/select-skill-dialog/src/__tests__/SelectSkillDialog.test.tsx
+++ b/Composer/packages/ui-plugins/select-skill-dialog/src/__tests__/SelectSkillDialog.test.tsx
@@ -55,7 +55,7 @@ const renderSelectSkillDialog = ({ addSkillDialog, onChange } = {}) => {
   };
 
   return render(
-    <Extension shell={shell} shellData={shellData}>
+    <Extension shell={{ api: shell, data: shellData }}>
       <SelectSkillDialog {...props} />
     </Extension>
   );


### PR DESCRIPTION
## Description

fixes #3783 
refs #3721 

Let Flow Editor consumes shellData from `useShell('FlowEditor')`;
let Property Editor consumes shellData from `useShell('PropertyEditor')`

The difference is when an Action is selected, Property Editor's shellData should be the Action json, compared with Flow's data is whole dialog json.

![image](https://user-images.githubusercontent.com/8528761/89372527-f4889480-d718-11ea-96d8-63ff2711655c.png)

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
