### PR TITLE
fix: yarn build will run yarn build:plugin twice

### DIFF
--- a/Composer/package.json
+++ b/Composer/package.json
@@ -30,7 +30,7 @@
     "packages/ui-plugins/*"
   ],
   "scripts": {
-    "build": "node scripts/begin.js && yarn build:prod && yarn build:plugins",
+    "build": "node scripts/begin.js && yarn build:prod",
     "build:prod": "yarn build:dev && yarn build:server && yarn build:client && yarn build:electron",
     "build:dev": "yarn build:test && yarn build:lib && yarn build:tools && yarn build:extensions && yarn build:plugins",
     "build:test": "yarn workspace @bfc/test-utils build",


### PR DESCRIPTION
## Description
clean the yarn build:plugin script in yarn build.
![image](https://user-images.githubusercontent.com/39758135/89381228-65d14300-d72b-11ea-9229-c9d7bffa04e1.png)

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
#minor
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
