### PR TITLE
build: use importHelpers compiler option

### DIFF
--- a/Composer/package.json
+++ b/Composer/package.json
@@ -89,6 +89,7 @@
     "chalk": "^4.0.0",
     "concurrently": "^4.1.0",
     "coveralls": "^3.1.0",
+    "cross-env": "^6.0.3",
     "cypress": "^4.5.0",
     "cypress-plugin-tab": "^1.0.5",
     "eslint": "7.0.0",
@@ -109,11 +110,10 @@
     "lint-staged": "^8.1.0",
     "prettier": "2.0.5",
     "rimraf": "^2.6.3",
+    "tslib": "^2.0.0",
     "ts-loader": "7.0.4",
     "typescript": "3.9.2",
     "wsrun": "^5.2.0"
   },
-  "dependencies": {
-    "cross-env": "^6.0.3"
-  }
+  "dependencies": {}
 }

--- a/Composer/tsconfig.base.json
+++ b/Composer/tsconfig.base.json
@@ -5,6 +5,7 @@
     "declarationMap": true,
     "esModuleInterop": true,
     "jsx": "react",
+    "importHelpers": true,
     "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitAny": false,

--- a/Composer/yarn.lock
+++ b/Composer/yarn.lock
@@ -18203,6 +18203,11 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
 
+tslib@^2.0.0:
+  version "2.0.0"
+  resolved "https://botbuilder.myget.org/F/botframework-cli/npm/tslib/-/tslib-2.0.0.tgz#18d13fc2dce04051e20f074cc8387fd8089ce4f3"
+  integrity sha1-GNE/wtzgQFHiDwdMyDh/2Aic5PM=
+
 tsutils@^3.17.1:
   version "3.17.1"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"


### PR DESCRIPTION
## Description

Uses `importHelpers` compiler option which imports various helper methods from `tslib` instead of inlining them. Reduces bundle size slightly.

## Task Item

#minor
