### PR TITLE
fix: do not strict new created dialog name to be lowercase

### DIFF
--- a/Composer/packages/lib/indexers/src/utils/dialogCheckUtil.ts
+++ b/Composer/packages/lib/indexers/src/utils/dialogCheckUtil.ts
@@ -1,37 +1,19 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import has from 'lodash/has';
-import { SDKKinds } from '@bfc/shared';
-
-import { VisitorFunc, JsonWalk } from './jsonWalk';
-
 /**
- * fix dialog referrence.
- * - "dialog": 'AddTodos'
- * + "dialog": 'addtodos'
+ * fix dialog's lg/lu referrence, use dialog's lg/lu file
  */
 export function autofixReferInDialog(dialogId: string, content: string): string {
   try {
     const dialogJson = JSON.parse(content);
 
-    // fix dialog referrence
-    const visitor: VisitorFunc = (_path: string, value: any) => {
-      if (has(value, '$type') && value.$type === SDKKinds.BeginDialog) {
-        const dialogName = value.dialog;
-        value.dialog = dialogName.toLowerCase();
-      }
-      return false;
-    };
-
-    JsonWalk('/', dialogJson, visitor);
-
     // fix lg referrence
-    dialogJson.generator = `${dialogId.toLowerCase()}.lg`;
+    dialogJson.generator = `${dialogId}.lg`;
 
     // fix lu referrence
     if (typeof dialogJson.recognizer === 'string') {
-      dialogJson.recognizer = `${dialogId.toLowerCase()}.lu`;
+      dialogJson.recognizer = `${dialogId}.lu`;
     }
     return JSON.stringify(dialogJson, null, 2);
   } catch (_error) {

--- a/Composer/packages/server/src/models/bot/botStructure.ts
+++ b/Composer/packages/server/src/models/bot/botStructure.ts
@@ -64,8 +64,8 @@ export const defaultFilePath = (botName: string, defaultLocale: string, filename
     });
   }
 
-  const DIALOGNAME = fileId.toLowerCase();
-  const isRootFile = BOTNAME === DIALOGNAME;
+  const DIALOGNAME = fileId;
+  const isRootFile = BOTNAME === DIALOGNAME.toLowerCase();
 
   let TemplatePath = '';
   if (fileType === FileExtensions.Dialog) {


### PR DESCRIPTION
## Description
1. When create a dialog `Hello` now will create same case sensitive files:
```
dialogs/Hello/{Hello.dialog, Hello.lg, Hello.lu}
```

previous will created files:
```
dialogs/hello/{hello.dialog, hello.lg, hello.lu}
```

2. Validation is case insensitive (addressed via #3686 )

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
close #3814 
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
