### PR TITLE
fix: keep user settings in localStorage as well as recoil

### DIFF
--- a/Composer/packages/client/src/recoilModel/dispatchers/user.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/user.ts
@@ -7,6 +7,7 @@ import jwtDecode from 'jwt-decode';
 
 import { userSettingsState, currentUserState, CurrentUser } from '../atoms/appState';
 import { getUserTokenFromCache, loginPopup, refreshToken } from '../../utils/auth';
+import storage from '../../utils/storage';
 import { UserSettingsPayload } from '../types';
 
 enum ClaimNames {
@@ -83,6 +84,7 @@ export const userDispatcher = () => {
             }
           }
         }
+        storage.set('userSettings', newSettings);
         return newSettings;
       });
     }


### PR DESCRIPTION
## Description

This change lets the user's settings stay around in localStorage, which is then used to initialize the Recoil store. Without it, the preferences would last through a session but then disappear on reload.

## Task Item

fixes #3824 

## Screenshots

![image](https://user-images.githubusercontent.com/61990921/89839233-225b4800-db22-11ea-8520-51f057a4fef7.png)
