### PR TITLE
fix: Fixed uischema backup extension filename in update-schema.ps1

### DIFF
--- a/runtime/dotnet/azurewebapp/Schemas/update-schema.ps1
+++ b/runtime/dotnet/azurewebapp/Schemas/update-schema.ps1
@@ -4,7 +4,7 @@ param (
 $SCHEMA_FILE="sdk.schema"
 $UISCHEMA_FILE="sdk.uischema"
 $BACKUP_SCHEMA_FILE="sdk-backup.schema"
-$BACKUP_UISCHEMA_FILE="sdk-backup.schema"
+$BACKUP_UISCHEMA_FILE="sdk-backup.uischema"
 
 Write-Host "Running schema merge on $runtime runtime."
 


### PR DESCRIPTION
## Description

The backup filename for the sdk schema and UI schema are the same in the update-schema.ps1 script.  This is not a bug in the sh script.  Updated the extension to .uischema in the ps1.

## Task Item

#minor

## Screenshots

N/A
