### PR TITLE
feat: Generate skill manifest

### DIFF
--- a/Composer/packages/client/package.json
+++ b/Composer/packages/client/package.json
@@ -26,10 +26,10 @@
     "@bfc/indexers": "*",
     "@bfc/shared": "*",
     "@bfc/ui-plugin-composer": "*",
+    "@bfc/ui-plugin-dialog-schema-editor": "*",
     "@bfc/ui-plugin-lg": "*",
     "@bfc/ui-plugin-luis": "*",
     "@bfc/ui-plugin-prompts": "*",
-    "@bfc/ui-plugin-dialog-schema-editor": "*",
     "@bfc/ui-plugin-select-dialog": "*",
     "@bfc/ui-plugin-select-skill-dialog": "*",
     "@emotion/core": "^10.0.27",
@@ -56,6 +56,7 @@
     "react-timeago": "^4.4.0",
     "recoil": "^0.0.10",
     "styled-components": "^4.1.3",
+    "uuid": "^8.3.0",
     "webpack-bundle-analyzer": "^3.8.0"
   },
   "browserslist": [

--- a/Composer/packages/client/src/pages/design/exportSkillModal/__tests__/generateSkillManifest.test.ts
+++ b/Composer/packages/client/src/pages/design/exportSkillModal/__tests__/generateSkillManifest.test.ts
@@ -208,9 +208,9 @@ describe('generateDispatchModels', () => {
     expect(result).toEqual({});
   });
 
-  it("should return empty object if the schema doesn't include dispatchModels", () => {
+  it('should return dispatch models', () => {
     const schema = { properties: { dispatchModels: {} } };
-    const dialogs: any = [{ id: 'test', content: { recognizer: 'test.lu' } }];
+    const dialogs: any = [{ id: 'test', content: { recognizer: 'test.lu' }, isRoot: true }];
     const selectedTriggers = [{ $kind: SDKKinds.OnIntent, intent: 'testIntent' }];
     const luFiles: any = [{ id: 'test.en-us' }, { id: 'test.fr-FR' }];
     const result = generateDispatchModels(schema, dialogs, selectedTriggers, luFiles);

--- a/Composer/packages/client/src/pages/design/exportSkillModal/__tests__/generateSkillManifest.test.ts
+++ b/Composer/packages/client/src/pages/design/exportSkillModal/__tests__/generateSkillManifest.test.ts
@@ -1,0 +1,243 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { SDKKinds } from '@bfc/shared';
+
+import {
+  generateOtherActivities,
+  generateActivity,
+  generateActivities,
+  getDefinitions,
+  generateDispatchModels,
+} from '../generateSkillManifest';
+
+const dialogSchema = {
+  id: 'test',
+  content: {
+    type: 'object',
+    properties: {
+      age: {
+        title: 'User Age',
+        $ref: '#/definitions/integerExpression',
+      },
+    },
+    $result: {
+      type: 'object',
+      properties: {
+        title: 'Dog Years',
+        type: 'integer',
+      },
+    },
+    definitions: {
+      equalsExpression: {
+        $role: 'expression',
+        type: 'string',
+      },
+      integerExpression: {
+        oneOf: [
+          {
+            type: 'string',
+            title: 'String',
+          },
+          {
+            $ref: '#/definitions/equalsExpression',
+          },
+        ],
+      },
+    },
+  },
+};
+
+describe('generateOtherActivities', () => {
+  it('generateOtherActivities should return other activity', () => {
+    expect(generateOtherActivities(SDKKinds.OnConversationUpdateActivity)).toEqual(
+      expect.objectContaining({
+        conversationUpdate: {
+          type: 'conversationUpdate',
+        },
+      })
+    );
+
+    expect(generateOtherActivities(SDKKinds.OnEndOfConversationActivity)).toEqual(
+      expect.objectContaining({
+        endOfConversation: {
+          type: 'endOfConversation',
+        },
+      })
+    );
+
+    expect(generateOtherActivities(SDKKinds.OnIntent)).toEqual(
+      expect.objectContaining({
+        message: {
+          type: 'message',
+        },
+      })
+    );
+  });
+});
+
+describe('generateActivity', () => {
+  it('should return simple activity when there is no dialog schema', () => {
+    const dialogSchemas = [];
+    const dialog: any = { id: 'test' };
+    const result = generateActivity(dialogSchemas, dialog);
+    expect(result).toEqual(
+      expect.objectContaining({
+        test: {
+          type: 'event',
+          name: 'test',
+        },
+      })
+    );
+  });
+
+  it('should return activity that includes value and result when dialog schema is available', () => {
+    const dialogSchemas = [dialogSchema];
+    const dialog: any = { id: 'test' };
+    const result = generateActivity(dialogSchemas, dialog);
+    expect(result).toEqual(
+      expect.objectContaining({
+        test: {
+          type: 'event',
+          name: 'test',
+          value: {
+            type: 'object',
+            properties: {
+              age: {
+                title: 'User Age',
+                $ref: '#/definitions/integerExpression',
+              },
+            },
+          },
+          resultValue: {
+            type: 'object',
+            properties: {
+              title: 'Dog Years',
+              type: 'integer',
+            },
+          },
+        },
+      })
+    );
+  });
+});
+
+describe('generateActivities', () => {
+  it('should return an empty object when there are no selected dialogs or triggers', () => {
+    const dialogSchemas = [dialogSchema];
+    const triggers = [];
+    const dialogs = [];
+    const result = generateActivities(dialogSchemas, triggers, dialogs);
+    expect(result).toEqual({});
+  });
+
+  it('should return an object containing activities', () => {
+    const dialogSchemas = [dialogSchema];
+    const triggers: any = [{ $kind: SDKKinds.OnTypingActivity }, { $kind: SDKKinds.OnHandoffActivity }];
+    const dialogs: any = [{ id: 'test' }];
+    const result = generateActivities(dialogSchemas, triggers, dialogs);
+    expect(result).toEqual(
+      expect.objectContaining({
+        activities: {
+          typing: {
+            type: 'typing',
+          },
+          handoff: {
+            type: 'handoff',
+          },
+          test: expect.objectContaining({
+            name: 'test',
+            type: 'event',
+            value: expect.any(Object),
+            resultValue: expect.any(Object),
+          }),
+        },
+      })
+    );
+  });
+});
+
+describe('getDefinitions', () => {
+  it('should return an empty object if there are no definitions', () => {
+    const dialogSchemas = [];
+    const selectedDialogs: any = [{ id: 'test' }];
+    const result = getDefinitions(dialogSchemas, selectedDialogs);
+    expect(result).toEqual({});
+  });
+
+  it('should return an object containing definitions', () => {
+    const dialogSchemas = [dialogSchema];
+    const selectedDialogs: any = [{ id: 'test' }];
+    const result = getDefinitions(dialogSchemas, selectedDialogs);
+    expect(result).toEqual(
+      expect.objectContaining({
+        definitions: {
+          equalsExpression: expect.any(Object),
+          integerExpression: expect.any(Object),
+        },
+      })
+    );
+  });
+});
+
+describe('generateDispatchModels', () => {
+  it("should return empty object if there aren't any intents selected", () => {
+    const schema = { properties: { dispatchModels: {} } };
+    const dialogs: any = [{ id: 'test', content: { recognizer: 'test.lu' } }];
+    const selectedTriggers = [];
+    const luFiles = [];
+    const result = generateDispatchModels(schema, dialogs, selectedTriggers, luFiles);
+    expect(result).toEqual({});
+  });
+
+  it("should return empty object if the schema doesn't include dispatchModels", () => {
+    const schema = { properties: {} };
+    const dialogs: any = [{ id: 'test', content: { recognizer: 'test.lu' } }];
+    const selectedTriggers = [{ $kind: SDKKinds.OnIntent, intent: 'testIntent' }];
+    const luFiles: any = [{ id: 'test.en-us' }, { id: 'test.fr-FR' }];
+    const result = generateDispatchModels(schema, dialogs, selectedTriggers, luFiles);
+    expect(result).toEqual({});
+  });
+
+  it('should return empty object if the recognizer type is not luis', () => {
+    const schema = { properties: {} };
+    const dialogs: any = [{ id: 'test', content: {} }];
+    const selectedTriggers = [{ $kind: SDKKinds.OnIntent, intent: 'testIntent' }];
+    const luFiles: any = [{ id: 'test.en-us' }, { id: 'test.fr-FR' }];
+    const result = generateDispatchModels(schema, dialogs, selectedTriggers, luFiles);
+    expect(result).toEqual({});
+  });
+
+  it("should return empty object if the schema doesn't include dispatchModels", () => {
+    const schema = { properties: { dispatchModels: {} } };
+    const dialogs: any = [{ id: 'test', content: { recognizer: 'test.lu' } }];
+    const selectedTriggers = [{ $kind: SDKKinds.OnIntent, intent: 'testIntent' }];
+    const luFiles: any = [{ id: 'test.en-us' }, { id: 'test.fr-FR' }];
+    const result = generateDispatchModels(schema, dialogs, selectedTriggers, luFiles);
+    expect(result).toEqual(
+      expect.objectContaining({
+        dispatchModels: {
+          languages: {
+            'en-us': [
+              {
+                name: 'test',
+                contentType: 'application/lu',
+                url: `<test.en-us url>`,
+                description: '<description>',
+              },
+            ],
+            'fr-FR': [
+              {
+                name: 'test',
+                contentType: 'application/lu',
+                url: `<test.fr-FR url>`,
+                description: '<description>',
+              },
+            ],
+          },
+          intents: ['testIntent'],
+        },
+      })
+    );
+  });
+});

--- a/Composer/packages/client/src/pages/design/exportSkillModal/__tests__/getManifestId.test.ts
+++ b/Composer/packages/client/src/pages/design/exportSkillModal/__tests__/getManifestId.test.ts
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { getManifestId } from '../content';
+
+const skillManifest = {
+  id: 'test',
+  content: {
+    $schema: 'https://schemas.botframework.com/schemas/skills/skill-manifest-2.1.1.json',
+  },
+};
+
+describe('geManifestId', () => {
+  it('should generate valid id without manifest schema version', () => {
+    const result = getManifestId('test', [], {});
+    expect(result).toEqual('test-manifest');
+  });
+
+  it('should generate valid, non-conflicting id without manifest schema version', () => {
+    const skillManifests: any = [{ id: 'test-manifest' }, { id: 'test-manifest-0' }];
+    const result = getManifestId('test', skillManifests, {});
+    expect(result).toEqual('test-manifest-1');
+  });
+
+  it('should generate valid id with manifest schema version', () => {
+    const result = getManifestId('test', [], skillManifest);
+    expect(result).toEqual('test-2-1-1-manifest');
+  });
+
+  it('should generate valid, non-conflicting id with manifest schema version', () => {
+    const skillManifests: any = [{ id: 'test-2-1-1-manifest' }, { id: 'test-2-1-1-manifest-0' }];
+    const result = getManifestId('test', skillManifests, skillManifest);
+    expect(result).toEqual('test-2-1-1-manifest-1');
+  });
+});

--- a/Composer/packages/client/src/pages/design/exportSkillModal/constants.tsx
+++ b/Composer/packages/client/src/pages/design/exportSkillModal/constants.tsx
@@ -3,10 +3,23 @@
 
 import formatMessage from 'format-message';
 import { JSONSchema7 } from '@bfc/extension';
-import startCase from 'lodash/startCase';
+import { resolveRef } from '@bfc/adaptive-form';
 import { SkillManifest } from '@bfc/shared';
+import startCase from 'lodash/startCase';
+import { SDKKinds } from '@bfc/shared';
 
-import { Description, FetchManifestSchema, ReviewManifest, SelectManifest } from './content';
+import { nameRegex } from '../../../constants';
+
+import {
+  Description,
+  Endpoints,
+  FetchManifestSchema,
+  ReviewManifest,
+  SaveManifest,
+  SelectDialogs,
+  SelectManifest,
+  SelectTriggers,
+} from './content';
 
 export const VERSION_REGEX = /\d\.\d\.(\d+|preview-\d+)/i;
 
@@ -15,13 +28,70 @@ export const SCHEMA_URIS = [
   'https://schemas.botframework.com/schemas/skills/skill-manifest-2.0.0.json',
 ];
 
+export enum ActivityTypes {
+  ContactRelationUpdate = 'contactRelationUpdate',
+  ConversationUpdate = 'conversationUpdate',
+  DeleteUserData = 'deleteUserData',
+  EndOfConversation = 'endOfConversation',
+  Event = 'event',
+  Handoff = 'handoff',
+  InstallationUpdate = 'installationUpdate',
+  Invoke = 'invoke',
+  Message = 'message',
+  MessageDelete = 'messageDelete',
+  MessageReaction = 'messageReaction',
+  MessageUpdate = 'messageUpdate',
+  Suggestion = 'suggestion',
+  Trace = 'trace',
+  Typing = 'typing',
+}
+
+export const activityHandlerMap = {
+  [SDKKinds.AdaptiveDialog]: ActivityTypes.Event,
+  [SDKKinds.OnConversationUpdateActivity]: ActivityTypes.ConversationUpdate,
+  [SDKKinds.OnEndOfConversationActivity]: ActivityTypes.EndOfConversation,
+  [SDKKinds.OnIntent]: ActivityTypes.Message,
+  [SDKKinds.OnHandoffActivity]: ActivityTypes.Handoff,
+  [SDKKinds.OnMessageActivity]: ActivityTypes.Message,
+  [SDKKinds.OnMessageDeleteActivity]: ActivityTypes.MessageDelete,
+  [SDKKinds.OnMessageReactionActivity]: ActivityTypes.MessageReaction,
+  [SDKKinds.OnMessageUpdateActivity]: ActivityTypes.MessageUpdate,
+  [SDKKinds.OnTypingActivity]: ActivityTypes.Typing,
+};
+
+export interface Activity {
+  type: string;
+  name?: string;
+  value?: any;
+  resultValue?: any;
+}
+
+export interface Activities {
+  [name: string]: Activity;
+}
+
+export interface Language {
+  contentType: string;
+  descriptions?: string;
+  name: string;
+  url: string;
+}
+
+export interface DispatchModels {
+  languages?: Language[];
+  intents?: string[];
+}
+
 export interface ContentProps {
   completeStep: () => void;
   errors: { [key: string]: any };
   editJson: () => void;
+  manifest: Partial<SkillManifest>;
   setErrors: (errors: { [key: string]: any }) => void;
   setSchema: (_: JSONSchema7) => void;
-  setSkillManifest: (name: string) => void;
+  setSelectedDialogs: (dialogs: any[]) => void;
+  setSelectedTriggers: (selectedTriggers: any[]) => void;
+  setSkillManifest: (_: Partial<SkillManifest>) => void;
   schema: JSONSchema7;
   skillManifests: SkillManifest[];
   value: { [key: string]: any };
@@ -35,6 +105,14 @@ interface Button {
   onClick: (_: any) => () => void;
 }
 
+interface ValidationDetails {
+  content: any;
+  editingId?: string;
+  id?: string;
+  schema: any;
+  skillManifests: SkillManifest[];
+}
+
 interface EditorStep {
   buttons?: Button[];
   editJson?: boolean;
@@ -42,21 +120,29 @@ interface EditorStep {
   title: () => string;
   subText?: () => any;
   content: React.FC<ContentProps>;
-  validate?: (value: any, schema: any) => { [key: string]: any };
+  validate?: (_: ValidationDetails) => { [key: string]: any };
 }
 
 export enum ManifestEditorSteps {
+  ENDPOINTS = 'ENDPOINTS',
   FETCH_MANIFEST_SCHEMA = 'FETCH_MANIFEST_SCHEMA',
   MANIFEST_DESCRIPTION = 'MANIFEST_DESCRIPTION',
   MANIFEST_REVIEW = 'MANIFEST_REVIEW',
+  SAVE_MANIFEST = 'SAVE_MANIFEST',
   SELECT_MANIFEST = 'SELECT_MANIFEST',
+  SELECT_DIALOGS = 'SELECT_DIALOGS',
+  SELECT_TRIGGERS = 'SELECT_TRIGGERS',
 }
 
 export const order: ManifestEditorSteps[] = [
   ManifestEditorSteps.SELECT_MANIFEST,
   ManifestEditorSteps.FETCH_MANIFEST_SCHEMA,
   ManifestEditorSteps.MANIFEST_DESCRIPTION,
+  ManifestEditorSteps.ENDPOINTS,
+  ManifestEditorSteps.SELECT_DIALOGS,
+  ManifestEditorSteps.SELECT_TRIGGERS,
   ManifestEditorSteps.MANIFEST_REVIEW,
+  ManifestEditorSteps.SAVE_MANIFEST,
 ];
 
 const cancelButton: Button = {
@@ -70,15 +156,34 @@ const nextButton: Button = {
   onClick: ({ onNext }) => onNext,
 };
 
+const validate = ({ content, schema }) => {
+  const required = schema?.required || [];
+
+  return required
+    .filter((key) => {
+      const property = schema?.properties?.[key];
+      return property && !['array', 'object'].includes(property.type);
+    })
+    .reduce((acc, key) => {
+      if (!content?.[key]) {
+        const { title } = schema.properties[key];
+        return { ...acc, [key]: formatMessage('Please enter a value for {key}', { key: title || startCase(key) }) };
+      }
+      return acc;
+    }, {});
+};
+
 export const editorSteps: { [key in ManifestEditorSteps]: EditorStep } = {
   [ManifestEditorSteps.SELECT_MANIFEST]: {
     buttons: [
       cancelButton,
       {
-        disabled: ({ manifest }) => !manifest,
+        disabled: ({ manifest }) => !manifest?.id,
         primary: true,
         text: () => formatMessage('Edit'),
-        onClick: ({ onNext }) => onNext,
+        onClick: ({ onNext, manifest }) => () => {
+          onNext({ id: manifest?.id });
+        },
       },
     ],
     content: SelectManifest,
@@ -97,20 +202,28 @@ export const editorSteps: { [key in ManifestEditorSteps]: EditorStep } = {
     editJson: true,
     title: () => formatMessage('Describe your skill'),
     subText: () => formatMessage('To make your bot available for others as a skill, we need to generate a manifest.'),
-    validate: (value, schema) => {
-      const required = schema?.required || [];
+    validate,
+  },
+  [ManifestEditorSteps.ENDPOINTS]: {
+    buttons: [cancelButton, nextButton],
+    content: Endpoints,
+    editJson: true,
+    subText: () =>
+      formatMessage('We need to define the endpoints for the skill to allow other bots to interact with it.'),
+    title: () => formatMessage('Skill endpoints'),
+    validate: ({ content, schema }) => {
+      const { items, minItems } = schema.properties?.endpoints;
 
-      return required
-        .filter((key) => {
-          const property = schema?.properties?.[key];
-          return property && !['array', 'object'].includes(property.type);
-        })
-        .reduce((acc, key) => {
-          if (!value?.[key]) {
-            return { ...acc, [key]: formatMessage('Please enter a value for {key}', { key: startCase(key) }) };
-          }
-          return acc;
-        }, {});
+      if (!content.endpoints || content.endpoints.length < minItems) {
+        return { endpoints: formatMessage('Please add at least {minItems} endpoint', { minItems }) };
+      }
+
+      const endpointSchema = resolveRef(items, schema.definitions);
+      const endpoints = (content.endpoints || []).map((endpoint) =>
+        validate({ content: endpoint, schema: endpointSchema })
+      );
+
+      return endpoints.some((endpoint) => Object.keys(endpoint).length) ? { endpoints } : {};
     },
   },
   [ManifestEditorSteps.MANIFEST_REVIEW]: {
@@ -118,12 +231,79 @@ export const editorSteps: { [key in ManifestEditorSteps]: EditorStep } = {
       cancelButton,
       {
         primary: true,
-        text: () => formatMessage('Done'),
-        onClick: ({ onDismiss }) => onDismiss,
+        text: () => formatMessage('Next'),
+        onClick: ({ onNext }) => onNext,
       },
     ],
     content: ReviewManifest,
     subText: () => formatMessage('The manifest can be edited and refined manually if and where needed.'),
     title: () => formatMessage('Review and generate'),
+  },
+  [ManifestEditorSteps.SELECT_DIALOGS]: {
+    buttons: [
+      cancelButton,
+      {
+        primary: true,
+        text: () => formatMessage('Next'),
+        onClick: ({ onNext }) => onNext,
+      },
+    ],
+    content: SelectDialogs,
+    editJson: true,
+    subText: () =>
+      formatMessage(
+        'These tasks will be used to generate the manifest and describe the capabilities of this skill to those who may want to use it.'
+      ),
+    title: () => formatMessage('Select which dialogs are included in the skill manifest'),
+  },
+  [ManifestEditorSteps.SELECT_TRIGGERS]: {
+    buttons: [
+      cancelButton,
+      {
+        primary: true,
+        text: () => formatMessage('Generate'),
+        onClick: ({ generateManifest, onNext }) => () => {
+          generateManifest();
+          onNext();
+        },
+      },
+    ],
+    content: SelectTriggers,
+    editJson: true,
+    subText: () =>
+      formatMessage(
+        'These tasks will be used to generate the manifest and describe the capabilities of this skill to those who may want to use it.'
+      ),
+    title: () => formatMessage('Select which tasks this skill can perform'),
+  },
+  [ManifestEditorSteps.SAVE_MANIFEST]: {
+    buttons: [
+      cancelButton,
+      {
+        primary: true,
+        text: () => formatMessage('Save'),
+        onClick: ({ onNext }) => () => {
+          onNext({ dismiss: true, save: true });
+        },
+      },
+    ],
+    content: SaveManifest,
+    editJson: true,
+    subText: () => formatMessage('Name and save your skill manifest.'),
+    title: () => formatMessage('Save your skill manifest'),
+    validate: ({ editingId, id, skillManifests }) => {
+      if (!id || !nameRegex.test(id)) {
+        return { id: formatMessage('Spaces and special characters are not allowed. Use letters, numbers, -, or _.') };
+      }
+
+      if (
+        (typeof editingId === 'undefined' || editingId !== id) &&
+        skillManifests.some(({ id: manifestId }) => manifestId === id)
+      ) {
+        return { id: formatMessage('{id} already exists. Please enter a unique file name.', { id }) };
+      }
+
+      return {};
+    },
   },
 };

--- a/Composer/packages/client/src/pages/design/exportSkillModal/content/Description.tsx
+++ b/Composer/packages/client/src/pages/design/exportSkillModal/content/Description.tsx
@@ -8,6 +8,7 @@ import AdaptiveForm, { FieldLabel } from '@bfc/adaptive-form';
 import { FieldProps, JSONSchema7, UIOptions } from '@bfc/extension';
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import { useRecoilValue } from 'recoil';
+import { v4 as uuid } from 'uuid';
 
 import { ContentProps } from '../constants';
 import { botNameState } from '../../../../recoilModel/atoms/botState';
@@ -82,7 +83,7 @@ export const Description: React.FC<ContentProps> = ({ errors, value, schema, onC
 
   useEffect(() => {
     if (!value.$id) {
-      onChange({ $schema, $id: botName, name: botName, ...rest });
+      onChange({ $schema, $id: `${botName}-${uuid()}`, endpoints: [{}], name: botName, ...rest });
     }
   }, []);
 

--- a/Composer/packages/client/src/pages/design/exportSkillModal/content/Endpoints.tsx
+++ b/Composer/packages/client/src/pages/design/exportSkillModal/content/Endpoints.tsx
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/** @jsx jsx */
+import { css, jsx } from '@emotion/core';
+import React, { useMemo } from 'react';
+import AdaptiveForm from '@bfc/adaptive-form';
+import { JSONSchema7, UIOptions } from '@bfc/extension';
+
+import { ContentProps } from '../constants';
+
+const styles = {
+  container: css`
+    height: 350px;
+    overflow: auto;
+  `,
+};
+
+export const Endpoints: React.FC<ContentProps> = ({ errors, value, schema, onChange }) => {
+  const hidden = useMemo(() => Object.keys(schema?.properties as JSONSchema7).filter((key) => key !== 'endpoints'), []);
+
+  const uiOptions: UIOptions = {
+    hidden,
+    label: false,
+    properties: {
+      endpoints: {
+        order: [['name', 'endpointUrl'], ['description', 'protocol'], '*'],
+      },
+    },
+  };
+
+  return (
+    <div css={styles.container}>
+      <AdaptiveForm errors={errors} formData={value} schema={schema} uiOptions={uiOptions} onChange={onChange} />
+    </div>
+  );
+};

--- a/Composer/packages/client/src/pages/design/exportSkillModal/content/SaveManifest.tsx
+++ b/Composer/packages/client/src/pages/design/exportSkillModal/content/SaveManifest.tsx
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/** @jsx jsx */
+import { css, jsx } from '@emotion/core';
+import React, { useEffect } from 'react';
+import { Label } from 'office-ui-fabric-react/lib/Label';
+import { SkillManifest } from '@bfc/shared';
+import { TextField } from 'office-ui-fabric-react/lib/TextField';
+import { useRecoilValue } from 'recoil';
+import formatMessage from 'format-message';
+
+import { ContentProps, VERSION_REGEX } from '../constants';
+import { botNameState, skillManifestsState } from '../../../../recoilModel';
+
+const styles = {
+  container: css`
+    height: 350px;
+    overflow: auto;
+  `,
+};
+
+export const getManifestId = (
+  botName: string,
+  skillManifests: SkillManifest[],
+  { content: { $schema } = {} }: Partial<SkillManifest>
+): string => {
+  const [version] = VERSION_REGEX.exec($schema) || [''];
+
+  let fileId = version ? `${botName}-${version.replace(/\./g, '-')}-manifest` : `${botName}-manifest`;
+  let i = -1;
+
+  while (skillManifests.some(({ id }) => id === fileId)) {
+    if (i < 0) {
+      fileId = fileId.concat(`-${++i}`);
+    } else {
+      fileId = fileId.substr(0, fileId.lastIndexOf('-')).concat(`-${++i}`);
+    }
+  }
+
+  return fileId;
+};
+
+export const SaveManifest: React.FC<ContentProps> = ({ errors, manifest, setSkillManifest }) => {
+  const botName = useRecoilValue(botNameState);
+  const skillManifests = useRecoilValue(skillManifestsState);
+
+  const { id } = manifest;
+
+  const handleChange = (_, id) => {
+    setSkillManifest({ ...manifest, id });
+  };
+
+  useEffect(() => {
+    if (!id) {
+      const fileId = getManifestId(botName, skillManifests, manifest);
+      setSkillManifest({ ...manifest, id: fileId });
+    }
+  }, []);
+
+  return (
+    <div css={styles.container}>
+      <Label required>{formatMessage('File name')}</Label>
+      <TextField errorMessage={errors.id} styles={{ root: { width: '400px' } }} value={id} onChange={handleChange} />
+    </div>
+  );
+};

--- a/Composer/packages/client/src/pages/design/exportSkillModal/content/SelectDialogs.tsx
+++ b/Composer/packages/client/src/pages/design/exportSkillModal/content/SelectDialogs.tsx
@@ -1,0 +1,105 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/** @jsx jsx */
+import { css, jsx } from '@emotion/core';
+import React, { useMemo } from 'react';
+import {
+  CheckboxVisibility,
+  DetailsList,
+  DetailsListLayoutMode,
+  IDetailsRowProps,
+  SelectionMode,
+} from 'office-ui-fabric-react/lib/DetailsList';
+import { DialogInfo } from '@bfc/shared';
+import { IRenderFunction } from 'office-ui-fabric-react/lib/Utilities';
+import { Selection } from 'office-ui-fabric-react/lib/DetailsList';
+import { Sticky, StickyPositionType } from 'office-ui-fabric-react/lib/Sticky';
+import { ScrollablePane, ScrollbarVisibility } from 'office-ui-fabric-react/lib/ScrollablePane';
+import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
+import { useRecoilValue } from 'recoil';
+import formatMessage from 'format-message';
+
+import { ContentProps } from '../constants';
+import { dialogsState } from '../../../../recoilModel';
+
+const styles = {
+  detailListContainer: css`
+    flex-grow: 1;
+    height: 350px;
+    position: relative;
+    padding-top: 10px;
+    overflow: hidden;
+  `,
+};
+
+export const SelectDialogs: React.FC<ContentProps> = ({ editJson, schema, setSelectedDialogs }) => {
+  const items = useRecoilValue(dialogsState);
+
+  // for detail file list in open panel
+  const tableColumns = [
+    {
+      key: 'column1',
+      name: formatMessage('Name'),
+      fieldName: 'id',
+      minWidth: 300,
+      maxWidth: 350,
+      isRowHeader: true,
+      isResizable: true,
+      isSortedDescending: false,
+      sortAscendingAriaLabel: formatMessage('Sorted A to Z'),
+      sortDescendingAriaLabel: formatMessage('Sorted Z to A'),
+      data: 'string',
+      onRender: (item: DialogInfo) => {
+        return <span aria-label={item.displayName}>{item.displayName}</span>;
+      },
+      isPadded: true,
+    },
+  ];
+
+  const selection = useMemo(
+    () =>
+      new Selection({
+        onSelectionChanged: () => {
+          const selectedItems = selection.getSelection();
+          setSelectedDialogs(selectedItems);
+        },
+      }),
+    []
+  );
+
+  function onRenderDetailsHeader(props, defaultRender) {
+    return (
+      <Sticky isScrollSynced stickyPosition={StickyPositionType.Header}>
+        {defaultRender({
+          ...props,
+          onRenderColumnHeaderTooltip: (tooltipHostProps) => <TooltipHost {...tooltipHostProps} />,
+        })}
+      </Sticky>
+    );
+  }
+
+  const onRenderRow = (props?: IDetailsRowProps, defaultRender?: IRenderFunction<IDetailsRowProps>): JSX.Element => {
+    return <div data-selection-toggle="true">{defaultRender && defaultRender(props)}</div>;
+  };
+
+  return (
+    <div css={styles.detailListContainer}>
+      <ScrollablePane scrollbarVisibility={ScrollbarVisibility.auto}>
+        <DetailsList
+          isHeaderVisible
+          checkboxVisibility={CheckboxVisibility.always}
+          columns={tableColumns}
+          compact={false}
+          getKey={(item) => item.id}
+          items={items}
+          layoutMode={DetailsListLayoutMode.justified}
+          selection={selection}
+          selectionMode={SelectionMode.multiple}
+          onRenderDetailsHeader={onRenderDetailsHeader}
+          onRenderRow={onRenderRow}
+        />
+      </ScrollablePane>
+    </div>
+  );
+};

--- a/Composer/packages/client/src/pages/design/exportSkillModal/content/SelectTriggers.tsx
+++ b/Composer/packages/client/src/pages/design/exportSkillModal/content/SelectTriggers.tsx
@@ -11,7 +11,7 @@ import {
   IDetailsRowProps,
   SelectionMode,
 } from 'office-ui-fabric-react/lib/DetailsList';
-import { DialogInfo, ITrigger } from '@bfc/shared';
+import { DialogInfo, ITrigger, SDKKinds } from '@bfc/shared';
 import { IRenderFunction } from 'office-ui-fabric-react/lib/Utilities';
 import { Selection } from 'office-ui-fabric-react/lib/DetailsList';
 import { Sticky, StickyPositionType } from 'office-ui-fabric-react/lib/Sticky';
@@ -21,7 +21,7 @@ import { useRecoilValue } from 'recoil';
 import formatMessage from 'format-message';
 
 import { ContentProps } from '../constants';
-import { dialogsState } from '../../../../recoilModel';
+import { dialogsState, schemasState } from '../../../../recoilModel';
 import { getFriendlyName } from '../../../../utils/dialogUtil';
 import { isSupportedTrigger } from '../generateSkillManifest';
 
@@ -35,8 +35,14 @@ const styles = {
   `,
 };
 
+const getLabel = (kind: SDKKinds, uiSchema) => {
+  const { label } = uiSchema?.[kind]?.form || {};
+  return label || kind.replace('Microsoft.', '');
+};
+
 export const SelectTriggers: React.FC<ContentProps> = ({ setSelectedTriggers }) => {
   const dialogs = useRecoilValue(dialogsState);
+  const schemas = useRecoilValue(schemasState);
 
   const items = useMemo(() => {
     const { triggers = [] } = dialogs.find(({ isRoot }) => isRoot) || ({} as DialogInfo);
@@ -87,7 +93,8 @@ export const SelectTriggers: React.FC<ContentProps> = ({ setSelectedTriggers }) 
       sortDescendingAriaLabel: formatMessage('Sorted Z to A'),
       data: 'string',
       onRender: (item: ITrigger) => {
-        return <span aria-label={item.type}>{item.type}</span>;
+        const label = getLabel(item.type as SDKKinds, schemas.ui?.content || {});
+        return <span aria-label={label}>{label}</span>;
       },
       isPadded: true,
     },

--- a/Composer/packages/client/src/pages/design/exportSkillModal/content/SelectTriggers.tsx
+++ b/Composer/packages/client/src/pages/design/exportSkillModal/content/SelectTriggers.tsx
@@ -1,0 +1,141 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/** @jsx jsx */
+import { css, jsx } from '@emotion/core';
+import React, { useMemo } from 'react';
+import {
+  CheckboxVisibility,
+  DetailsList,
+  DetailsListLayoutMode,
+  IDetailsRowProps,
+  SelectionMode,
+} from 'office-ui-fabric-react/lib/DetailsList';
+import { DialogInfo, ITrigger } from '@bfc/shared';
+import { IRenderFunction } from 'office-ui-fabric-react/lib/Utilities';
+import { Selection } from 'office-ui-fabric-react/lib/DetailsList';
+import { Sticky, StickyPositionType } from 'office-ui-fabric-react/lib/Sticky';
+import { ScrollablePane, ScrollbarVisibility } from 'office-ui-fabric-react/lib/ScrollablePane';
+import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
+import { useRecoilValue } from 'recoil';
+import formatMessage from 'format-message';
+
+import { ContentProps } from '../constants';
+import { dialogsState } from '../../../../recoilModel';
+import { getFriendlyName } from '../../../../utils/dialogUtil';
+import { isSupportedTrigger } from '../generateSkillManifest';
+
+const styles = {
+  detailListContainer: css`
+    flex-grow: 1;
+    height: 350px;
+    position: relative;
+    padding-top: 10px;
+    overflow: hidden;
+  `,
+};
+
+export const SelectTriggers: React.FC<ContentProps> = ({ setSelectedTriggers }) => {
+  const dialogs = useRecoilValue(dialogsState);
+
+  const items = useMemo(() => {
+    const { triggers = [] } = dialogs.find(({ isRoot }) => isRoot) || ({} as DialogInfo);
+
+    return triggers
+      .filter(isSupportedTrigger)
+      .sort((a, b) =>
+        a.type === b.type
+          ? a.displayName.toLowerCase() > b.displayName.toLowerCase()
+            ? 1
+            : -1
+          : a.type > b.type
+          ? 1
+          : -1
+      );
+  }, [dialogs]);
+
+  // for detail file list in open panel
+  const tableColumns = [
+    {
+      key: 'column1',
+      name: formatMessage('Name'),
+      fieldName: 'id',
+      minWidth: 300,
+      maxWidth: 350,
+      isRowHeader: true,
+      isResizable: true,
+      isSortedDescending: false,
+      sortAscendingAriaLabel: formatMessage('Sorted A to Z'),
+      sortDescendingAriaLabel: formatMessage('Sorted Z to A'),
+      data: 'string',
+      onRender: (item: ITrigger) => {
+        return <span aria-label={item.displayName}>{item.displayName || getFriendlyName({ $kind: item.type })}</span>;
+      },
+      isPadded: true,
+    },
+    {
+      key: 'column2',
+      name: formatMessage('Type'),
+      fieldName: 'type',
+      minWidth: 300,
+      maxWidth: 350,
+      isRowHeader: true,
+      isResizable: true,
+      isSorted: true,
+      isSortedDescending: false,
+      sortAscendingAriaLabel: formatMessage('Sorted A to Z'),
+      sortDescendingAriaLabel: formatMessage('Sorted Z to A'),
+      data: 'string',
+      onRender: (item: ITrigger) => {
+        return <span aria-label={item.type}>{item.type}</span>;
+      },
+      isPadded: true,
+    },
+  ];
+
+  const selection = useMemo(
+    () =>
+      new Selection({
+        onSelectionChanged: () => {
+          const selectedItems = selection.getSelection();
+          setSelectedTriggers(selectedItems);
+        },
+      }),
+    []
+  );
+
+  function onRenderDetailsHeader(props, defaultRender) {
+    return (
+      <Sticky isScrollSynced stickyPosition={StickyPositionType.Header}>
+        {defaultRender({
+          ...props,
+          onRenderColumnHeaderTooltip: (tooltipHostProps) => <TooltipHost {...tooltipHostProps} />,
+        })}
+      </Sticky>
+    );
+  }
+
+  const onRenderRow = (props?: IDetailsRowProps, defaultRender?: IRenderFunction<IDetailsRowProps>): JSX.Element => {
+    return <div data-selection-toggle="true">{defaultRender && defaultRender(props)}</div>;
+  };
+
+  return (
+    <div css={styles.detailListContainer}>
+      <ScrollablePane scrollbarVisibility={ScrollbarVisibility.auto}>
+        <DetailsList
+          isHeaderVisible
+          checkboxVisibility={CheckboxVisibility.always}
+          columns={tableColumns}
+          compact={false}
+          getKey={(item) => item.id}
+          items={items}
+          layoutMode={DetailsListLayoutMode.justified}
+          selection={selection}
+          selectionMode={SelectionMode.multiple}
+          onRenderDetailsHeader={onRenderDetailsHeader}
+          onRenderRow={onRenderRow}
+        />
+      </ScrollablePane>
+    </div>
+  );
+};

--- a/Composer/packages/client/src/pages/design/exportSkillModal/content/index.ts
+++ b/Composer/packages/client/src/pages/design/exportSkillModal/content/index.ts
@@ -2,6 +2,10 @@
 // Licensed under the MIT License.
 
 export * from './Description';
+export * from './Endpoints';
 export * from './FetchManifestSchema';
 export * from './ReviewManifest';
+export * from './SaveManifest';
 export * from './SelectManifest';
+export * from './SelectDialogs';
+export * from './SelectTriggers';

--- a/Composer/packages/client/src/pages/design/exportSkillModal/generateSkillManifest.ts
+++ b/Composer/packages/client/src/pages/design/exportSkillModal/generateSkillManifest.ts
@@ -1,0 +1,161 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import get from 'lodash/get';
+import { DialogInfo, DialogSchemaFile, ITrigger, SDKKinds, SkillManifest, LuFile } from '@bfc/shared';
+import { JSONSchema7 } from '@bfc/extension';
+
+import { Activities, Activity, activityHandlerMap, ActivityTypes, DispatchModels } from './constants';
+
+const getActivityType = (kind: SDKKinds): ActivityTypes | undefined => activityHandlerMap[kind];
+
+export const isSupportedTrigger = ({ type }: ITrigger) => Object.keys(activityHandlerMap).includes(type as SDKKinds);
+
+export const generateSkillManifest = (
+  schema: JSONSchema7,
+  skillManifest: Partial<SkillManifest>,
+  dialogs: DialogInfo[],
+  dialogSchemas: DialogSchemaFile[],
+  luFiles: LuFile[],
+  selectedTriggers: ITrigger[],
+  selectedDialogs: DialogInfo[]
+) => {
+  const {
+    activities: previousActivities,
+    dispatchModels: previousDispatchModels,
+    definitions: previousDefinitions,
+    ...rest
+  } = skillManifest.content;
+  const rootDialog = dialogs.find((dialog) => dialog?.isRoot);
+
+  if (!rootDialog) {
+    return skillManifest;
+  }
+
+  const { content } = rootDialog;
+  const triggers = selectedTriggers.reduce((acc: ITrigger[], { id: path }) => {
+    const trigger = get(content, path);
+    return trigger ? [...acc, trigger] : acc;
+  }, []);
+
+  const activities = generateActivities(dialogSchemas, triggers, selectedDialogs);
+  const dispatchModels = generateDispatchModels(schema, dialogs, triggers, luFiles);
+  const definitions = getDefinitions(dialogSchemas, selectedDialogs);
+
+  return {
+    ...skillManifest,
+    content: {
+      ...rest,
+      ...activities,
+      ...dispatchModels,
+      ...definitions,
+    },
+  };
+};
+
+export const generateActivities = (
+  dialogSchemas: DialogSchemaFile[],
+  triggers: ITrigger[],
+  dialogs: DialogInfo[]
+): { activities?: { [name: string]: Activity } } => {
+  const dialogActivities = dialogs.reduce((acc: any, dialog) => {
+    const activity = generateActivity(dialogSchemas, dialog);
+    return { ...acc, ...activity };
+  }, {});
+
+  const activities = triggers.reduce((acc: any, { $kind }: any) => {
+    const activity = generateOtherActivities($kind);
+
+    return { ...acc, ...activity };
+  }, dialogActivities);
+
+  return { ...(Object.keys(activities).length ? { activities } : {}) };
+};
+
+export const generateActivity = (dialogSchemas: DialogSchemaFile[], dialog: DialogInfo): Activities => {
+  const { id: name } = dialog;
+
+  const { content = {} } = dialogSchemas.find(({ id }) => id === name) || {};
+  const { properties, $result: resultValue, type } = content;
+
+  return {
+    [name]: {
+      type: ActivityTypes.Event,
+      name,
+      ...(Object.keys(properties || {}).length ? { value: { properties, type } } : {}),
+      ...(Object.keys(resultValue?.properties || {}).length ? { resultValue } : {}),
+    },
+  };
+};
+
+export const generateOtherActivities = (kind: SDKKinds): Activities => {
+  const type = getActivityType(kind);
+  return type ? { [type]: { type } } : {};
+};
+
+export const generateDispatchModels = (
+  schema: JSONSchema7,
+  dialogs: DialogInfo[],
+  selectedTriggers: any[],
+  luFiles: LuFile[]
+): { dispatchModels?: DispatchModels } => {
+  const intents = selectedTriggers.filter(({ $kind }) => $kind === SDKKinds.OnIntent).map(({ intent }) => intent);
+  const { id: rootId } = dialogs.find((dialog) => dialog?.isRoot) || {};
+
+  const rootLuFiles = luFiles.filter(({ id: luFileId }) => {
+    const [luId] = luFileId.split('.');
+    return luId === rootId;
+  });
+
+  if (!intents.length || !schema.properties?.dispatchModels) {
+    return {};
+  }
+
+  const languages = rootLuFiles.reduce((acc, { id }) => {
+    const [name, locale] = id.split('.');
+    const { content = {} } = dialogs.find(({ id }) => id === name) || {};
+    const { recognizer = '' } = content;
+
+    if (!''.endsWith.call(recognizer, '.lu')) {
+      return acc;
+    }
+
+    return {
+      ...acc,
+      [locale]: [
+        ...(acc[locale] ?? []),
+        {
+          name,
+          contentType: 'application/lu',
+          url: `<${id} url>`,
+          description: '<description>',
+        },
+      ],
+    };
+  }, {} as any);
+
+  return {
+    dispatchModels: {
+      ...(Object.keys(languages || {}).length ? { languages } : {}),
+      ...(intents.length ? { intents } : {}),
+    },
+  };
+};
+
+export const getDefinitions = (
+  dialogSchema: DialogSchemaFile[],
+  selectedDialogs: DialogInfo[]
+): { definitions?: { [key: string]: any } } => {
+  const definitions = dialogSchema.reduce((acc, { content = {}, id }) => {
+    if (selectedDialogs.some(({ id: dialogId }) => dialogId === id)) {
+      const { definitions = {} } = content;
+      return { ...acc, ...definitions };
+    }
+
+    return acc;
+  }, {});
+
+  return {
+    ...(Object.keys(definitions).length ? { definitions } : {}),
+  };
+};

--- a/Composer/packages/client/src/pages/design/exportSkillModal/index.tsx
+++ b/Composer/packages/client/src/pages/design/exportSkillModal/index.tsx
@@ -3,7 +3,7 @@
 
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
-import React, { useMemo, useState } from 'react';
+import React, { useState } from 'react';
 import formatMessage from 'format-message';
 import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react/lib/Dialog';
 import { DefaultButton, PrimaryButton } from 'office-ui-fabric-react/lib/Button';
@@ -12,9 +12,16 @@ import { Link } from 'office-ui-fabric-react/lib/components/Link';
 import { useRecoilValue } from 'recoil';
 import { SkillManifest } from '@bfc/shared';
 
-import { skillManifestsState, dispatcherState } from '../../../recoilModel';
+import {
+  dialogSchemasState,
+  dialogsState,
+  dispatcherState,
+  luFilesState,
+  skillManifestsState,
+} from '../../../recoilModel';
 
 import { editorSteps, ManifestEditorSteps, order } from './constants';
+import { generateSkillManifest } from './generateSkillManifest';
 import { styles } from './styles';
 
 interface ExportSkillModalProps {
@@ -23,23 +30,40 @@ interface ExportSkillModalProps {
   onSubmit: () => void;
 }
 
-const ExportSkillModal: React.FC<ExportSkillModalProps> = ({ onSubmit, onDismiss }) => {
+const ExportSkillModal: React.FC<ExportSkillModalProps> = ({ onSubmit, onDismiss: handleDismiss }) => {
+  const dialogs = useRecoilValue(dialogsState);
+  const dialogSchemas = useRecoilValue(dialogSchemasState);
+  const luFiles = useRecoilValue(luFilesState);
   const skillManifests = useRecoilValue(skillManifestsState);
   const { updateSkillManifest } = useRecoilValue(dispatcherState);
 
+  const [editingId, setEditingId] = useState<string>();
   const [currentStep, setCurrentStep] = useState(0);
   const [errors, setErrors] = useState({});
   const [schema, setSchema] = useState<JSONSchema7>({});
 
-  const [selectedManifest, setSelectedManifest] = useState<string>('');
-  const skillManifest = useMemo(() => skillManifests.find(({ id }) => id === selectedManifest), [
-    selectedManifest,
-    skillManifests,
-  ]);
-  const { content = {} } = skillManifest || {};
+  const [skillManifest, setSkillManifest] = useState<Partial<SkillManifest>>({});
+
+  const { content = {}, id } = skillManifest;
+
+  const [selectedDialogs, setSelectedDialogs] = useState<any[]>([]);
+  const [selectedTriggers, setSelectedTriggers] = useState<any[]>([]);
 
   const editorStep = order[currentStep];
   const { buttons = [], content: Content, editJson, helpLink, subText, title, validate } = editorSteps[editorStep];
+
+  const handleGenerateManifest = () => {
+    const manifest = generateSkillManifest(
+      schema,
+      skillManifest,
+      dialogs,
+      dialogSchemas,
+      luFiles,
+      selectedTriggers,
+      selectedDialogs
+    );
+    setSkillManifest(manifest);
+  };
 
   const handleEditJson = () => {
     const step = order.findIndex((step) => step === ManifestEditorSteps.MANIFEST_REVIEW);
@@ -49,23 +73,25 @@ const ExportSkillModal: React.FC<ExportSkillModalProps> = ({ onSubmit, onDismiss
     }
   };
 
-  const handleNext = () => {
-    const validated = typeof validate === 'function' ? validate(content, schema) : errors;
+  const handleSave = () => {
+    if (skillManifest.content && skillManifest.id) {
+      updateSkillManifest(skillManifest as SkillManifest);
+    }
+  };
+
+  const handleNext = (options?: { dismiss?: boolean; id?: string; save?: boolean }) => {
+    const validated =
+      typeof validate === 'function' ? validate({ content, editingId, id, schema, skillManifests }) : errors;
 
     if (!Object.keys(validated).length) {
       setCurrentStep((current) => (current + 1 < order.length ? current + 1 : current));
+      options?.save && handleSave();
+      options?.id && setEditingId(options.id);
+      options?.dismiss && handleDismiss();
       setErrors({});
     } else {
       setErrors(validated);
     }
-  };
-
-  const handleSave = (manifest?: SkillManifest) => {
-    updateSkillManifest(manifest || content);
-  };
-
-  const handleSelectManifest = (manifest) => {
-    setSelectedManifest(manifest);
   };
 
   return (
@@ -80,7 +106,7 @@ const ExportSkillModal: React.FC<ExportSkillModalProps> = ({ onSubmit, onDismiss
         isBlocking: false,
         styles: styles.modal,
       }}
-      onDismiss={onDismiss}
+      onDismiss={handleDismiss}
     >
       <div css={styles.container}>
         <p>
@@ -99,13 +125,16 @@ const ExportSkillModal: React.FC<ExportSkillModalProps> = ({ onSubmit, onDismiss
             completeStep={handleNext}
             editJson={handleEditJson}
             errors={errors}
+            manifest={skillManifest}
             schema={schema}
             setErrors={setErrors}
             setSchema={setSchema}
-            setSkillManifest={handleSelectManifest}
-            skillManifests={skillManifests as SkillManifest[]}
+            setSelectedDialogs={setSelectedDialogs}
+            setSelectedTriggers={setSelectedTriggers}
+            setSkillManifest={setSkillManifest}
+            skillManifests={skillManifests}
             value={content}
-            onChange={(manifestContent) => updateSkillManifest({ ...skillManifest, content: manifestContent })}
+            onChange={(manifestContent) => setSkillManifest({ ...skillManifest, content: manifestContent })}
           />
         </div>
         <DialogFooter>
@@ -113,7 +142,6 @@ const ExportSkillModal: React.FC<ExportSkillModalProps> = ({ onSubmit, onDismiss
             <div>
               {buttons.map(({ disabled, primary, text, onClick }, index) => {
                 const Button = primary ? PrimaryButton : DefaultButton;
-                const buttonText = text();
                 const isDisabled = typeof disabled === 'function' ? disabled({ manifest: skillManifest }) : !!disabled;
 
                 return (
@@ -121,10 +149,12 @@ const ExportSkillModal: React.FC<ExportSkillModalProps> = ({ onSubmit, onDismiss
                     key={index}
                     disabled={isDisabled}
                     styles={{ root: { marginLeft: '8px' } }}
-                    text={buttonText}
+                    text={text()}
                     onClick={onClick({
+                      generateManifest: handleGenerateManifest,
                       setCurrentStep,
-                      onDismiss,
+                      manifest: skillManifest,
+                      onDismiss: handleDismiss,
                       onNext: handleNext,
                       onSave: handleSave,
                       onSubmit,

--- a/Composer/packages/client/src/pages/design/exportSkillModal/styles.ts
+++ b/Composer/packages/client/src/pages/design/exportSkillModal/styles.ts
@@ -27,7 +27,7 @@ export const styles: { dialog: Partial<IDialogContentStyles>; modal: Partial<IMo
     },
   },
   container: css`
-    height: 550px;
+    height: 520px;
     display: flex;
     flex-direction: column;
     justify-content: space-between;
@@ -36,7 +36,8 @@ export const styles: { dialog: Partial<IDialogContentStyles>; modal: Partial<IMo
   `,
   content: css`
     flex: 1;
-    overflow: auto;
+
+    label: Content;
   `,
   buttonContainer: css`
     display: flex;

--- a/Composer/packages/client/src/recoilModel/dispatchers/skill.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/skill.ts
@@ -3,6 +3,7 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 
 import { CallbackInterface, useRecoilCallback } from 'recoil';
+import { SkillManifest } from '@bfc/shared';
 
 import httpClient from '../../utils/httpUtil';
 
@@ -25,11 +26,18 @@ export const skillDispatcher = () => {
     set(skillManifestsState, (skillManifests) => skillManifests.filter((manifest) => manifest.id !== id));
   });
 
-  const updateSkillManifest = useRecoilCallback(({ set }: CallbackInterface) => async ({ id, content }) => {
-    set(skillManifestsState, (skillManifests) =>
-      skillManifests.map((manifest) => (manifest.id === id ? { id, content } : manifest))
-    );
-  });
+  const updateSkillManifest = useRecoilCallback(
+    ({ set, snapshot }: CallbackInterface) => async ({ id, content }: SkillManifest) => {
+      const manifests = await snapshot.getPromise(skillManifestsState);
+      if (!manifests.some((manifest) => manifest.id === id)) {
+        createSkillManifest({ id, content });
+      }
+
+      set(skillManifestsState, (skillManifests) =>
+        skillManifests.map((manifest) => (manifest.id === id ? { id, content } : manifest))
+      );
+    }
+  );
 
   const updateSkill = useRecoilCallback(
     (callbackHelpers: CallbackInterface) => async ({ projectId, targetId, skillData }) => {

--- a/Composer/packages/extensions/adaptive-form/src/components/FormRow.tsx
+++ b/Composer/packages/extensions/adaptive-form/src/components/FormRow.tsx
@@ -65,7 +65,6 @@ export const getRowProps = (rowProps: FormRowProps, field: string) => {
 const formRow = {
   row: css`
     display: flex;
-    margin: 10px 18px;
 
     label: FormRowContainer;
   `,

--- a/Composer/packages/extensions/adaptive-form/src/utils/resolveFieldWidget.ts
+++ b/Composer/packages/extensions/adaptive-form/src/utils/resolveFieldWidget.ts
@@ -63,7 +63,7 @@ export function resolveFieldWidget(
 
         if (Array.isArray(items) && typeof items[0] === 'object' && items[0].type === 'object') {
           return DefaultFields.ObjectArrayField;
-        } else if (!Array.isArray(items) && typeof items === 'object' && items?.type === 'object') {
+        } else if (!Array.isArray(items) && typeof items === 'object' && items.type === 'object') {
           return DefaultFields.ObjectArrayField;
         }
 

--- a/Composer/packages/extensions/adaptive-form/src/utils/resolveRef.ts
+++ b/Composer/packages/extensions/adaptive-form/src/utils/resolveRef.ts
@@ -30,6 +30,22 @@ export function resolveRef(
     } as JSONSchema7;
 
     return resolvedSchema;
+  } else if (
+    typeof schema.items === 'object' &&
+    !Array.isArray(schema.items) &&
+    typeof schema.items.$ref === 'string'
+  ) {
+    const { $ref, ...rest } = schema.items;
+    const items = resolveRef(schema.items, definitions);
+    const resolvedSchema = {
+      ...schema,
+      items: {
+        ...items,
+        ...rest,
+      },
+    } as JSONSchema7;
+
+    return resolvedSchema;
   }
 
   return schema;

--- a/Composer/yarn.lock
+++ b/Composer/yarn.lock
@@ -8486,8 +8486,8 @@ elegant-spinner@^1.0.1:
 
 elliptic@^6.0.0, elliptic@^6.5.3:
   version "6.5.3"
-  resolved "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
-  integrity sha1-y1nrLv2vc6C9eMzXAVpirW4Pk9Y=
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
+  integrity sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==
   dependencies:
     bn.js "^4.4.0"
     brorand "^1.0.1"
@@ -12427,8 +12427,8 @@ killable@^1.0.1:
 
 kind-of@^2.0.1, kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0, kind-of@^4.0.0, kind-of@^5.0.0, kind-of@^6.0.0, kind-of@^6.0.2, kind-of@^6.0.3:
   version "6.0.3"
-  resolved "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
-  integrity sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0=
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
+  integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
 kleur@^3.0.2:
   version "3.0.2"
@@ -12852,8 +12852,8 @@ lodash.uniq@^4.5.0:
 
 lodash@4.17.15, "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
   version "4.17.19"
-  resolved "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
-  integrity sha1-5I3e2+MLMyF4PFtDAfvTU7weSks=
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
+  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
 log-driver@^1.2.7:
   version "1.2.7"
@@ -13373,8 +13373,8 @@ mixin-object@^2.0.1:
 
 mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.2, mkdirp@^0.5.3, mkdirp@^0.5.4, mkdirp@~0.5.1:
   version "0.5.5"
-  resolved "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
-  integrity sha1-2Rzv1i0UNsoPQWIOJRKI1CAJne8=
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
+  integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
 
@@ -16878,8 +16878,8 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
 
 set-value@^0.4.3, set-value@^2.0.0, set-value@^3.0.2:
   version "3.0.2"
-  resolved "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/set-value/-/set-value-3.0.2.tgz#74e8ecd023c33d0f77199d415409a40f21e61b90"
-  integrity sha1-dOjs0CPDPQ93GZ1BVAmkDyHmG5A=
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-3.0.2.tgz#74e8ecd023c33d0f77199d415409a40f21e61b90"
+  integrity sha512-npjkVoz+ank0zjlV9F47Fdbjfj/PfXyVhZvGALWsyIYU/qrMzpi6avjKW3/7KeSU2Df3I46BrN1xOI1+6vW0hA==
   dependencies:
     is-plain-object "^2.0.4"
 
@@ -18706,6 +18706,11 @@ uuid@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
   integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
+
+uuid@^8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.0.tgz#ab738085ca22dc9a8c92725e459b1d507df5d6ea"
+  integrity sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==
 
 v8-compile-cache@2.0.3:
   version "2.0.3"


### PR DESCRIPTION
## Description
- New Steps:
  - Configure endpoints
    - [#3756] Previously, users had add and configure the manifest's endpoint property in the JSON Editor. This new steps uses the Adaptive Form package to create a schema driven form that allows users to easily modify endpoints and add new ones.
  - Select dialogs
    - In the select dialogs step, users select which dialogs they want to include in the skill manifest. The dialogs get add to the manifest as event activities in the `activities` property. If the dialog added has a dialog schema, the `value` and `resultValue` schema definitions are included in the manifest.
  - Select triggers
     - This step is very simple to the previous step - select triggers; however, instead of selecting which dialogs to include, the user selects which triggers from the root dialog they want to include. These triggers are also added to the skill manifest's `activities` property. 
  - Save manifest
    - The previous version of the Skill Manifest wizard generated a name for the manifest that user couldn't edit. This new steps now suggests a name for the manifest that user's can edit. It also allows users to save the manifest to a new file if they are editing an existing manifest.



## Task Item
Closes #3380
Closes #3756

## Screenshots
### Configure endpoints step
![image](https://user-images.githubusercontent.com/17039790/90069303-5c0d8980-dcaf-11ea-996d-09cd57a88e39.png)

### Select dialogs step
![image](https://user-images.githubusercontent.com/17039790/90069389-78112b00-dcaf-11ea-8e5f-f464195a1748.png)

### Select triggers step
![image](https://user-images.githubusercontent.com/17039790/90163767-c37d1500-dd53-11ea-8650-c81ef0060db1.png)


### Save manifest step
![image](https://user-images.githubusercontent.com/17039790/90069486-96772680-dcaf-11ea-961d-b393a7f8c6bd.png)
