### PR TITLE
fix: resolve conflict between Electron native shortcut and FlowEditor shortcuts 

### DIFF
--- a/Composer/packages/client/src/hooks/useElectronFeatures.ts
+++ b/Composer/packages/client/src/hooks/useElectronFeatures.ts
@@ -5,14 +5,19 @@ import { useEffect } from 'react';
 import get from 'lodash/get';
 import { getEditorAPI } from '@bfc/shared';
 
-export const useElectronFeatures = (actionSelected: boolean, canUndo: boolean, canRedo: boolean) => {
+export const useElectronFeatures = (
+  actionSelected: boolean,
+  flowFocused: boolean,
+  canUndo: boolean,
+  canRedo: boolean
+) => {
   // Sync selection state to Electron main process
   useEffect(() => {
     if (!window.__IS_ELECTRON__) return;
     if (!window.ipcRenderer || typeof window.ipcRenderer.send !== 'function') return;
 
-    window.ipcRenderer.send('composer-state-change', { actionSelected, canUndo, canRedo });
-  }, [actionSelected, canUndo, canRedo]);
+    window.ipcRenderer.send('composer-state-change', { actionSelected, flowFocused, canUndo, canRedo });
+  }, [actionSelected, flowFocused, canUndo, canRedo]);
 
   // Subscribe Electron app menu events (copy/cut/del/undo/redo)
   useEffect(() => {

--- a/Composer/packages/client/src/pages/design/DesignPage.tsx
+++ b/Composer/packages/client/src/pages/design/DesignPage.tsx
@@ -575,9 +575,9 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
                 ) : (
                   <Extension plugins={pluginConfig} shell={shellForFlowEditor}>
                     <VisualEditor
-                      onFocus={() => setFlowEditorFocused(true)}
-                      onBlur={() => setFlowEditorFocused(false)}
                       openNewTriggerModal={openNewTriggerModal}
+                      onBlur={() => setFlowEditorFocused(false)}
+                      onFocus={() => setFlowEditorFocused(true)}
                     />
                   </Extension>
                 )}

--- a/Composer/packages/client/src/pages/design/DesignPage.tsx
+++ b/Composer/packages/client/src/pages/design/DesignPage.tsx
@@ -242,6 +242,7 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
     }
   };
 
+  const [flowEditorFocused, setFlowEditorFocused] = useState(false);
   const { actionSelected, showDisableBtn, showEnableBtn } = useMemo(() => {
     const actionSelected = Array.isArray(visualEditorSelection) && visualEditorSelection.length > 0;
     if (!actionSelected) {
@@ -253,7 +254,7 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
     return { actionSelected, showDisableBtn, showEnableBtn };
   }, [visualEditorSelection]);
 
-  useElectronFeatures(actionSelected, canUndo(), canRedo());
+  useElectronFeatures(actionSelected, flowEditorFocused, canUndo(), canRedo());
 
   const EditorAPI = getEditorAPI();
   const toolbarItems: IToolbarItem[] = [
@@ -573,7 +574,11 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
                   />
                 ) : (
                   <Extension plugins={pluginConfig} shell={shellForFlowEditor}>
-                    <VisualEditor openNewTriggerModal={openNewTriggerModal} />
+                    <VisualEditor
+                      onFocus={() => setFlowEditorFocused(true)}
+                      onBlur={() => setFlowEditorFocused(false)}
+                      openNewTriggerModal={openNewTriggerModal}
+                    />
                   </Extension>
                 )}
               </div>

--- a/Composer/packages/client/src/pages/design/VisualEditor.tsx
+++ b/Composer/packages/client/src/pages/design/VisualEditor.tsx
@@ -50,10 +50,12 @@ function onRenderBlankVisual(isTriggerEmpty, onClickAddTrigger) {
 
 interface VisualEditorProps {
   openNewTriggerModal: () => void;
+  onFocus?: (event: React.FocusEvent<HTMLDivElement>) => void;
+  onBlur?: (event: React.FocusEvent<HTMLDivElement>) => void;
 }
 
 const VisualEditor: React.FC<VisualEditorProps> = (props) => {
-  const { openNewTriggerModal } = props;
+  const { openNewTriggerModal, onFocus, onBlur } = props;
   const [triggerButtonVisible, setTriggerButtonVisibility] = useState(false);
   const designPageLocation = useRecoilValue(designPageLocationState);
   const { onboardingAddCoachMarkRef } = useRecoilValue(dispatcherState);
@@ -77,7 +79,7 @@ const VisualEditor: React.FC<VisualEditorProps> = (props) => {
         css={visualEditor(triggerButtonVisible || !selected)}
         data-testid="VisualEditor"
       >
-        <VisualDesigner schema={schemas.sdk?.content} />
+        <VisualDesigner onFocus={onFocus} onBlur={onBlur} schema={schemas.sdk?.content} />
       </div>
       {!selected && onRenderBlankVisual(triggerButtonVisible, openNewTriggerModal)}
     </React.Fragment>

--- a/Composer/packages/client/src/pages/design/VisualEditor.tsx
+++ b/Composer/packages/client/src/pages/design/VisualEditor.tsx
@@ -79,7 +79,7 @@ const VisualEditor: React.FC<VisualEditorProps> = (props) => {
         css={visualEditor(triggerButtonVisible || !selected)}
         data-testid="VisualEditor"
       >
-        <VisualDesigner onFocus={onFocus} onBlur={onBlur} schema={schemas.sdk?.content} />
+        <VisualDesigner schema={schemas.sdk?.content} onBlur={onBlur} onFocus={onFocus} />
       </div>
       {!selected && onRenderBlankVisual(triggerButtonVisible, openNewTriggerModal)}
     </React.Fragment>

--- a/Composer/packages/electron-server/__tests__/appMenu.test.ts
+++ b/Composer/packages/electron-server/__tests__/appMenu.test.ts
@@ -40,7 +40,7 @@ describe('App menu', () => {
 
     // Edit
     expect(menuTemplate[1].label).toBe('Edit');
-    expect(menuTemplate[1].submenu.length).toBe(8);
+    expect(menuTemplate[1].submenu.length).toBe(12);
 
     // View
     expect(menuTemplate[2].label).toBe('View');
@@ -75,7 +75,7 @@ describe('App menu', () => {
 
     // Edit
     expect(menuTemplate[2].label).toBe('Edit');
-    expect(menuTemplate[2].submenu.length).toBe(8);
+    expect(menuTemplate[2].submenu.length).toBe(12);
 
     // View
     expect(menuTemplate[3].label).toBe('View');

--- a/Composer/packages/electron-server/src/appMenu.ts
+++ b/Composer/packages/electron-server/src/appMenu.ts
@@ -195,11 +195,22 @@ export function initAppMenu(win?: Electron.BrowserWindow) {
 
   if (ipcMain && ipcMain.on) {
     ipcMain.on('composer-state-change', (e, state) => {
-      // Let menu enable/disable status reflects action selection states.
-      const actionSelected = !!state.actionSelected;
-      ['Cut', 'Copy', 'Delete'].forEach((id) => {
-        menu.getMenuItemById(id).enabled = actionSelected;
-      });
+      // Turn shortcuts to Action editing mode when Flow Editor is focused.
+      const flowFocused = !!state.flowFocused;
+      if (flowFocused) {
+        // Let menu enable/disable status reflects action selection states.
+        const actionSelected = !!state.actionSelected;
+        ['Cut', 'Copy', 'Delete'].forEach((id) => {
+          menu.getMenuItemById(id).enabled = actionSelected;
+          menu.getMenuItemById(id).role = undefined;
+        });
+      } else {
+        ['Cut', 'Copy', 'Delete'].forEach((id) => {
+          menu.getMenuItemById(id).enabled = true;
+          // Use Electron default behavior based on role
+          menu.getMenuItemById(id).role = id.toLowerCase() as any;
+        });
+      }
 
       // Let menu undo/redo status reflects history status
       const canUndo = !!state.canUndo;

--- a/Composer/packages/electron-server/src/appMenu.ts
+++ b/Composer/packages/electron-server/src/appMenu.ts
@@ -95,6 +95,7 @@ export function initAppMenu(win?: Electron.BrowserWindow) {
         {
           id: 'Delete-native',
           label: 'delete',
+          role: 'delete',
         },
         // Action editing mode shortcuts
         {

--- a/Composer/packages/electron-server/src/appMenu.ts
+++ b/Composer/packages/electron-server/src/appMenu.ts
@@ -93,6 +93,11 @@ export function initAppMenu(win?: Electron.BrowserWindow) {
           role: 'copy',
         },
         {
+          id: 'Paste-native',
+          label: 'Paste',
+          role: 'paste',
+        },
+        {
           id: 'Delete-native',
           label: 'Delete',
           role: 'delete',
@@ -227,6 +232,7 @@ export function initAppMenu(win?: Electron.BrowserWindow) {
           menu.getMenuItemById(nativeModeId).visible = mode === 'native';
           menu.getMenuItemById(actionModeId).visible = mode === 'action';
         });
+        menu.getMenuItemById('Paste-native').visible = mode === 'native';
       };
 
       // Turn shortcuts to Action editing mode when Flow Editor is focused.

--- a/Composer/packages/electron-server/src/appMenu.ts
+++ b/Composer/packages/electron-server/src/appMenu.ts
@@ -66,7 +66,6 @@ export function initAppMenu(win?: Electron.BrowserWindow) {
     {
       label: 'Edit',
       submenu: [
-        // NOTE: Avoid using builtin `role`, it won't override the click handler.
         {
           id: 'Undo',
           label: 'Undo',
@@ -82,11 +81,35 @@ export function initAppMenu(win?: Electron.BrowserWindow) {
           click: () => handleMenuEvents('redo'),
         },
         { type: 'separator' },
-        { id: 'Cut', label: 'Cut', enabled: false, accelerator: 'CmdOrCtrl+X', click: () => handleMenuEvents('cut') },
+        // Native mode shorcuts
+        {
+          id: 'Cut-native',
+          label: 'Cut',
+          role: 'cut',
+        },
+        {
+          id: 'Copy-native',
+          label: 'Copy',
+          role: 'copy',
+        },
+        {
+          id: 'Delete-native',
+          label: 'delete',
+        },
+        // Action editing mode shortcuts
+        {
+          id: 'Cut',
+          label: 'Cut',
+          enabled: false,
+          visible: false,
+          accelerator: 'CmdOrCtrl+X',
+          click: () => handleMenuEvents('cut'),
+        },
         {
           id: 'Copy',
           label: 'Copy',
           enabled: false,
+          visible: false,
           accelerator: 'CmdOrCtrl+C',
           click: () => handleMenuEvents('copy'),
         },
@@ -94,6 +117,7 @@ export function initAppMenu(win?: Electron.BrowserWindow) {
           id: 'Delete',
           label: 'Delete',
           enabled: false,
+          visible: false,
           accelerator: 'Delete',
           click: () => handleMenuEvents('delete'),
         },
@@ -195,21 +219,27 @@ export function initAppMenu(win?: Electron.BrowserWindow) {
 
   if (ipcMain && ipcMain.on) {
     ipcMain.on('composer-state-change', (e, state) => {
+      const toggleEditingMode = (menu: Menu, mode: 'native' | 'action') => {
+        ['Cut', 'Copy', 'Delete'].forEach((label) => {
+          const nativeModeId = label + '-native';
+          const actionModeId = label;
+          menu.getMenuItemById(nativeModeId).visible = mode === 'native';
+          menu.getMenuItemById(actionModeId).visible = mode === 'action';
+        });
+      };
+
       // Turn shortcuts to Action editing mode when Flow Editor is focused.
       const flowFocused = !!state.flowFocused;
       if (flowFocused) {
+        toggleEditingMode(menu, 'action');
+
         // Let menu enable/disable status reflects action selection states.
         const actionSelected = !!state.actionSelected;
         ['Cut', 'Copy', 'Delete'].forEach((id) => {
           menu.getMenuItemById(id).enabled = actionSelected;
-          menu.getMenuItemById(id).role = undefined;
         });
       } else {
-        ['Cut', 'Copy', 'Delete'].forEach((id) => {
-          menu.getMenuItemById(id).enabled = true;
-          // Use Electron default behavior based on role
-          menu.getMenuItemById(id).role = id.toLowerCase() as any;
-        });
+        toggleEditingMode(menu, 'native');
       }
 
       // Let menu undo/redo status reflects history status

--- a/Composer/packages/electron-server/src/appMenu.ts
+++ b/Composer/packages/electron-server/src/appMenu.ts
@@ -94,7 +94,7 @@ export function initAppMenu(win?: Electron.BrowserWindow) {
         },
         {
           id: 'Delete-native',
-          label: 'delete',
+          label: 'Delete',
           role: 'delete',
         },
         // Action editing mode shortcuts

--- a/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-editor/AdaptiveFlowEditor.tsx
+++ b/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-editor/AdaptiveFlowEditor.tsx
@@ -58,9 +58,11 @@ const styles = css`
 `;
 
 export interface VisualDesignerProps {
+  onFocus?: (event: React.FocusEvent<HTMLDivElement>) => void;
+  onBlur?: (event: React.FocusEvent<HTMLDivElement>) => void;
   schema?: JSONSchema7;
 }
-const VisualDesigner: React.FC<VisualDesignerProps> = ({ schema }): JSX.Element => {
+const VisualDesigner: React.FC<VisualDesignerProps> = ({ onFocus, onBlur, schema }): JSX.Element => {
   const { shellApi, ...shellData } = useShellApi();
   const { schema: schemaFromPlugins, widgets: widgetsFromPlugins } = useFlowUIOptions();
   const {
@@ -137,6 +139,8 @@ const VisualDesigner: React.FC<VisualDesignerProps> = ({ schema }): JSX.Element 
             ref={divRef}
             css={styles}
             tabIndex={0}
+            onFocus={onFocus}
+            onBlur={onBlur}
             {...enableKeyboardCommandAttributes(handleCommand)}
             data-testid="visualdesigner-container"
           >

--- a/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-editor/AdaptiveFlowEditor.tsx
+++ b/Composer/packages/extensions/adaptive-flow/src/adaptive-flow-editor/AdaptiveFlowEditor.tsx
@@ -139,8 +139,8 @@ const VisualDesigner: React.FC<VisualDesignerProps> = ({ onFocus, onBlur, schema
             ref={divRef}
             css={styles}
             tabIndex={0}
-            onFocus={onFocus}
             onBlur={onBlur}
+            onFocus={onFocus}
             {...enableKeyboardCommandAttributes(handleCommand)}
             data-testid="visualdesigner-container"
           >


### PR DESCRIPTION
## Description
closes #3844

When Flow Editor is active, use Flow Editor shortcuts.
When Flow Editor is inactive, use Electron native shortcuts.

**Problem**:
Flow Editor registered several shortcuts `cut / copy / delete` in Electron app menu. Those shortcuts overrided and affected native cut copy delete behavior and caused user cannot do plain text editing in Form Editor.

**Solution**
Leveraging Electron menu's `visibile` property, conditionally switching between Flow's shortcuts and native shortcuts.
- When Flow Editor is focused, set mode to 'action', use Flow Editor's shortcut group
- When Flow Editor is blured, set mode to 'native', use system default shortcut group

The focus/blur state of FlowEditor is still posted by Electron rpc api. A new state `flowFocused` was added.

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

[Copy-Paste]
![electron-coptpaste](https://user-images.githubusercontent.com/8528761/90225094-52b52600-de43-11ea-85ff-e20748497a8a.gif)

[Cut]
![electron-cut](https://user-images.githubusercontent.com/8528761/90225117-5b0d6100-de43-11ea-9f00-1c4b3bb40bd3.gif)

[Delete]
![electron-del](https://user-images.githubusercontent.com/8528761/90225798-89d80700-de44-11ea-8d82-86c8d24d1c35.gif)

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
