### PR TITLE
fix: refresh page client state lost error.

### DIFF
--- a/Composer/cypress/support/index.ts
+++ b/Composer/cypress/support/index.ts
@@ -6,6 +6,7 @@ import './commands';
 beforeEach(() => {
   cy.exec('yarn test:integration:clean');
   window.localStorage.setItem('composer:OnboardingState', JSON.stringify({ complete: true }));
+  window.sessionStorage.setItem('composer:ProjectIdCache', '');
 });
 
 after(() => {

--- a/Composer/packages/client/src/components/CreationFlow/CreationFlow.tsx
+++ b/Composer/packages/client/src/components/CreationFlow/CreationFlow.tsx
@@ -17,7 +17,6 @@ import {
   storagesState,
   focusedStorageFolderState,
 } from '../../recoilModel';
-import { useProjectIdCache } from '../../utils/hooks';
 import Home from '../../pages/home/Home';
 
 import { CreateOptions } from './CreateOptions';
@@ -39,7 +38,6 @@ const CreationFlow: React.FC<CreationFlowProps> = () => {
     updateCurrentPathForStorage,
     updateFolder,
     saveTemplateId,
-    fetchProjectById,
   } = useRecoilValue(dispatcherState);
   const creationFlowStatus = useRecoilValue(creationFlowStatusState);
   const projectId = useRecoilValue(projectIdState);
@@ -49,10 +47,6 @@ const CreationFlow: React.FC<CreationFlowProps> = () => {
   const currentStorageIndex = useRef(0);
   const storage = storages[currentStorageIndex.current];
   const currentStorageId = storage ? storage.id : 'default';
-
-  // when fresh page, projectId in store are empty, no project are opened at client
-  // use cached projectId do fetch.
-  const cachedProjectId = useProjectIdCache();
 
   useEffect(() => {
     if (storages && storages.length) {
@@ -64,12 +58,9 @@ const CreationFlow: React.FC<CreationFlowProps> = () => {
   }, [storages]);
 
   useEffect(() => {
-    if (!projectId && cachedProjectId) {
-      fetchProjectById(cachedProjectId);
-    }
     fetchStorages();
     fetchTemplates();
-  }, [projectId]);
+  }, []);
 
   const updateCurrentPath = async (newPath, storageId) => {
     if (!storageId) {

--- a/Composer/packages/client/src/components/CreationFlow/CreationFlow.tsx
+++ b/Composer/packages/client/src/components/CreationFlow/CreationFlow.tsx
@@ -53,11 +53,6 @@ const CreationFlow: React.FC<CreationFlowProps> = () => {
   // when fresh page, projectId in store are empty, no project are opened at client
   // use cached projectId do fetch.
   const cachedProjectId = useProjectIdCache();
-  useEffect(() => {
-    if (!projectId && cachedProjectId) {
-      fetchProjectById(cachedProjectId);
-    }
-  }, [projectId]);
 
   useEffect(() => {
     if (storages && storages.length) {
@@ -69,9 +64,12 @@ const CreationFlow: React.FC<CreationFlowProps> = () => {
   }, [storages]);
 
   useEffect(() => {
+    if (!projectId && cachedProjectId) {
+      fetchProjectById(cachedProjectId);
+    }
     fetchStorages();
     fetchTemplates();
-  }, []);
+  }, [projectId]);
 
   const updateCurrentPath = async (newPath, storageId) => {
     if (!storageId) {

--- a/Composer/packages/client/src/components/CreationFlow/CreationFlow.tsx
+++ b/Composer/packages/client/src/components/CreationFlow/CreationFlow.tsx
@@ -17,6 +17,7 @@ import {
   storagesState,
   focusedStorageFolderState,
 } from '../../recoilModel';
+import { useProjectIdCache } from '../../utils/hooks';
 import Home from '../../pages/home/Home';
 
 import { CreateOptions } from './CreateOptions';
@@ -38,6 +39,7 @@ const CreationFlow: React.FC<CreationFlowProps> = () => {
     updateCurrentPathForStorage,
     updateFolder,
     saveTemplateId,
+    fetchProjectById,
   } = useRecoilValue(dispatcherState);
   const creationFlowStatus = useRecoilValue(creationFlowStatusState);
   const projectId = useRecoilValue(projectIdState);
@@ -47,6 +49,15 @@ const CreationFlow: React.FC<CreationFlowProps> = () => {
   const currentStorageIndex = useRef(0);
   const storage = storages[currentStorageIndex.current];
   const currentStorageId = storage ? storage.id : 'default';
+
+  // when fresh page, projectId in store are empty, no project are opened at client
+  // use cached projectId do fetch.
+  const cachedProjectId = useProjectIdCache();
+  useEffect(() => {
+    if (!projectId && cachedProjectId) {
+      fetchProjectById(cachedProjectId);
+    }
+  }, [projectId]);
 
   useEffect(() => {
     if (storages && storages.length) {

--- a/Composer/packages/client/src/pages/home/Home.tsx
+++ b/Composer/packages/client/src/pages/home/Home.tsx
@@ -3,7 +3,7 @@
 
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback } from 'react';
 import formatMessage from 'format-message';
 import { Link } from 'office-ui-fabric-react/lib/Link';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
@@ -62,13 +62,9 @@ const Home: React.FC<RouteComponentProps> = () => {
   const recentProjects = useRecoilValue(recentProjectsState);
   const projectId = useRecoilValue(projectIdState);
   const templateId = useRecoilValue(templateIdState);
-  const {
-    openBotProject,
-    fetchRecentProjects,
-    setCreationFlowStatus,
-    onboardingAddCoachMarkRef,
-    saveTemplateId,
-  } = useRecoilValue(dispatcherState);
+  const { openBotProject, setCreationFlowStatus, onboardingAddCoachMarkRef, saveTemplateId } = useRecoilValue(
+    dispatcherState
+  );
 
   const onItemChosen = async (item) => {
     if (item && item.path) {
@@ -135,10 +131,6 @@ const Home: React.FC<RouteComponentProps> = () => {
       disabled: botName ? false : true,
     },
   ];
-
-  useEffect(() => {
-    fetchRecentProjects();
-  }, []);
 
   return (
     <div css={home.outline}>

--- a/Composer/packages/client/src/pages/setting/SettingsPage.tsx
+++ b/Composer/packages/client/src/pages/setting/SettingsPage.tsx
@@ -26,7 +26,6 @@ import { INavTreeItem } from '../../components/NavTree';
 import { useLocation } from '../../utils/hooks';
 import { IToolbarItem } from '../../components/Toolbar';
 import { AddLanguageModal, DeleteLanguageModal } from '../../components/MultiLanguage/index';
-import { useProjectIdCache } from '../../utils/hooks';
 
 import { SettingsRoutes } from './router';
 
@@ -43,7 +42,6 @@ const SettingPage: React.FC<RouteComponentProps<{ '*': string }>> = () => {
     delLanguageDialogCancel,
     addLanguages,
     deleteLanguages,
-    fetchProjectById,
   } = useRecoilValue(dispatcherState);
   const projectId = useRecoilValue(projectIdState);
   const locale = useRecoilValue(localeState);
@@ -52,14 +50,6 @@ const SettingPage: React.FC<RouteComponentProps<{ '*': string }>> = () => {
   const { defaultLanguage, languages } = useRecoilValue(settingsState);
   const { navigate } = useLocation();
 
-  // when fresh page, projectId in store are empty, no project are opened at client
-  // use cached projectId do fetch.
-  const cachedProjectId = useProjectIdCache();
-  useEffect(() => {
-    if (!projectId && cachedProjectId) {
-      fetchProjectById(cachedProjectId);
-    }
-  }, [projectId]);
   // If no project is open and user tries to access a bot-scoped settings (e.g., browser history, deep link)
   // Redirect them to the default settings route that is not bot-scoped
   useEffect(() => {

--- a/Composer/packages/client/src/pages/setting/SettingsPage.tsx
+++ b/Composer/packages/client/src/pages/setting/SettingsPage.tsx
@@ -26,6 +26,7 @@ import { INavTreeItem } from '../../components/NavTree';
 import { useLocation } from '../../utils/hooks';
 import { IToolbarItem } from '../../components/Toolbar';
 import { AddLanguageModal, DeleteLanguageModal } from '../../components/MultiLanguage/index';
+import { useProjectIdCache } from '../../utils/hooks';
 
 import { SettingsRoutes } from './router';
 
@@ -42,6 +43,7 @@ const SettingPage: React.FC<RouteComponentProps<{ '*': string }>> = () => {
     delLanguageDialogCancel,
     addLanguages,
     deleteLanguages,
+    fetchProjectById,
   } = useRecoilValue(dispatcherState);
   const projectId = useRecoilValue(projectIdState);
   const locale = useRecoilValue(localeState);
@@ -50,6 +52,14 @@ const SettingPage: React.FC<RouteComponentProps<{ '*': string }>> = () => {
   const { defaultLanguage, languages } = useRecoilValue(settingsState);
   const { navigate } = useLocation();
 
+  // when fresh page, projectId in store are empty, no project are opened at client
+  // use cached projectId do fetch.
+  const cachedProjectId = useProjectIdCache();
+  useEffect(() => {
+    if (!projectId && cachedProjectId) {
+      fetchProjectById(cachedProjectId);
+    }
+  }, [projectId]);
   // If no project is open and user tries to access a bot-scoped settings (e.g., browser history, deep link)
   // Redirect them to the default settings route that is not bot-scoped
   useEffect(() => {

--- a/Composer/packages/client/src/pages/setting/SettingsPage.tsx
+++ b/Composer/packages/client/src/pages/setting/SettingsPage.tsx
@@ -26,6 +26,7 @@ import { INavTreeItem } from '../../components/NavTree';
 import { useLocation } from '../../utils/hooks';
 import { IToolbarItem } from '../../components/Toolbar';
 import { AddLanguageModal, DeleteLanguageModal } from '../../components/MultiLanguage/index';
+import { useProjectIdCache } from '../../utils/hooks';
 
 import { SettingsRoutes } from './router';
 
@@ -42,6 +43,7 @@ const SettingPage: React.FC<RouteComponentProps<{ '*': string }>> = () => {
     delLanguageDialogCancel,
     addLanguages,
     deleteLanguages,
+    fetchProjectById,
   } = useRecoilValue(dispatcherState);
   const projectId = useRecoilValue(projectIdState);
   const locale = useRecoilValue(localeState);
@@ -49,6 +51,15 @@ const SettingPage: React.FC<RouteComponentProps<{ '*': string }>> = () => {
   const showDelLanguageModal = useRecoilValue(showDelLanguageModalState);
   const { defaultLanguage, languages } = useRecoilValue(settingsState);
   const { navigate } = useLocation();
+
+  // when fresh page, projectId in store are empty, no project are opened at client
+  // use cached projectId do fetch.
+  const cachedProjectId = useProjectIdCache();
+  useEffect(() => {
+    if (!projectId && cachedProjectId) {
+      fetchProjectById(cachedProjectId);
+    }
+  }, []);
 
   // If no project is open and user tries to access a bot-scoped settings (e.g., browser history, deep link)
   // Redirect them to the default settings route that is not bot-scoped

--- a/Composer/packages/client/src/pages/setting/dialog-settings/DialogSettings.tsx
+++ b/Composer/packages/client/src/pages/setting/dialog-settings/DialogSettings.tsx
@@ -8,7 +8,7 @@ import formatMessage from 'format-message';
 import { Link } from 'office-ui-fabric-react/lib/Link';
 import { RouteComponentProps } from '@reach/router';
 import { useRecoilValue } from 'recoil';
-import React, { useMemo, useEffect } from 'react';
+import React, { useMemo } from 'react';
 import { Stack, StackItem } from 'office-ui-fabric-react/lib/Stack';
 import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
 import cloneDeep from 'lodash/cloneDeep';
@@ -23,7 +23,6 @@ import {
   localeState,
 } from '../../../recoilModel';
 import { languageListTemplates } from '../../../components/MultiLanguage';
-import { navigateTo } from '../../../utils/navigation';
 
 import { settingsEditor, toolbar } from './style';
 import { BotSettings } from './constants';
@@ -37,9 +36,6 @@ export const DialogSettings: React.FC<RouteComponentProps> = () => {
   const { setSettings, setLocale, addLanguageDialogBegin } = useRecoilValue(dispatcherState);
 
   const { languages, defaultLanguage } = settings;
-  useEffect(() => {
-    if (!botName) navigateTo('/home');
-  }, [botName]);
 
   const saveChangeResult = (result) => {
     try {

--- a/Composer/packages/client/src/pages/setting/runtime-settings/RuntimeSettings.tsx
+++ b/Composer/packages/client/src/pages/setting/runtime-settings/RuntimeSettings.tsx
@@ -47,7 +47,7 @@ export const RuntimeSettings: React.FC<RouteComponentProps> = () => {
 
   useEffect(() => {
     // check the status of the boilerplate material and see if it requires an update
-    getBoilerplateVersion(projectId);
+    if (projectId) getBoilerplateVersion(projectId);
   }, []);
 
   useEffect(() => {

--- a/Composer/packages/client/src/recoilModel/dispatchers/project.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/project.ts
@@ -141,6 +141,7 @@ export const projectDispatcher = () => {
         return dialog;
       });
 
+      // Important: gotoSnapshot will wipe all states.
       const newSnapshot = snapshot.map(({ set }) => {
         set(skillManifestsState, skillManifestFiles);
         set(luFilesState, initLuFilesStatus(botName, luFiles, dialogs));

--- a/Composer/packages/client/src/recoilModel/dispatchers/project.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/project.ts
@@ -19,6 +19,7 @@ import settingStorage from '../../utils/dialogSettingStorage';
 import filePersistence from '../persistence/FilePersistence';
 import { navigateTo } from '../../utils/navigation';
 import languageStorage from '../../utils/languageStorage';
+import { projectIdCache } from '../../utils/projectCache';
 import { designPageLocationState } from '../atoms/botState';
 
 import {
@@ -117,6 +118,9 @@ export const projectDispatcher = () => {
     const { files, botName, botEnvironment, location, schemas, settings, id: projectId, diagnostics, skills } = data;
     const storedLocale = languageStorage.get(botName)?.locale;
     const locale = settings.languages.includes(storedLocale) ? storedLocale : settings.defaultLanguage;
+
+    // cache current projectId in session, resolve page refresh caused state lost.
+    projectIdCache.set(projectId);
 
     try {
       schemas.sdk.content = processSchema(projectId, schemas.sdk.content);

--- a/Composer/packages/client/src/router.tsx
+++ b/Composer/packages/client/src/router.tsx
@@ -16,7 +16,6 @@ import { botOpeningState, projectIdState, dispatcherState, schemasState } from '
 import { openAlertModal } from './components/Modal/AlertDialog';
 import { dialogStyle } from './components/Modal/dialogStyle';
 import { LoadingSpinner } from './components/LoadingSpinner';
-import { useProjectIdCache } from './utils/hooks';
 
 const DesignPage = React.lazy(() => import('./pages/design/DesignPage'));
 const LUPage = React.lazy(() => import('./pages/language-understanding/LUPage'));
@@ -29,16 +28,6 @@ const BotCreationFlowRouter = React.lazy(() => import('./components/CreationFlow
 
 const Routes = (props) => {
   const botOpening = useRecoilValue(botOpeningState);
-  const cachedProjectId = useProjectIdCache();
-  const projectId = useRecoilValue(projectIdState);
-  const { fetchProjectById } = useRecoilValue(dispatcherState);
-  // when fresh page, projectId in store are empty, no project are opened at client
-  // use cached projectId do fetch.
-  useEffect(() => {
-    if (!projectId && cachedProjectId) {
-      fetchProjectById(cachedProjectId);
-    }
-  }, []);
 
   return (
     <div css={data}>

--- a/Composer/packages/client/src/router.tsx
+++ b/Composer/packages/client/src/router.tsx
@@ -16,6 +16,7 @@ import { botOpeningState, projectIdState, dispatcherState, schemasState } from '
 import { openAlertModal } from './components/Modal/AlertDialog';
 import { dialogStyle } from './components/Modal/dialogStyle';
 import { LoadingSpinner } from './components/LoadingSpinner';
+import { useProjectIdCache } from './utils/hooks';
 
 const DesignPage = React.lazy(() => import('./pages/design/DesignPage'));
 const LUPage = React.lazy(() => import('./pages/language-understanding/LUPage'));
@@ -28,6 +29,17 @@ const BotCreationFlowRouter = React.lazy(() => import('./components/CreationFlow
 
 const Routes = (props) => {
   const botOpening = useRecoilValue(botOpeningState);
+  const cachedProjectId = useProjectIdCache();
+  const projectId = useRecoilValue(projectIdState);
+  const { fetchProjectById } = useRecoilValue(dispatcherState);
+  // when fresh page, projectId in store are empty, no project are opened at client
+  // use cached projectId do fetch.
+  useEffect(() => {
+    if (!projectId && cachedProjectId) {
+      fetchProjectById(cachedProjectId);
+    }
+  }, []);
+
   return (
     <div css={data}>
       <Suspense fallback={<LoadingSpinner />}>

--- a/Composer/packages/client/src/router.tsx
+++ b/Composer/packages/client/src/router.tsx
@@ -28,7 +28,6 @@ const BotCreationFlowRouter = React.lazy(() => import('./components/CreationFlow
 
 const Routes = (props) => {
   const botOpening = useRecoilValue(botOpeningState);
-
   return (
     <div css={data}>
       <Suspense fallback={<LoadingSpinner />}>

--- a/Composer/packages/client/src/utils/hooks.ts
+++ b/Composer/packages/client/src/utils/hooks.ts
@@ -10,6 +10,7 @@ import { useRecoilValue } from 'recoil';
 import { projectIdState, designPageLocationState } from './../recoilModel';
 import { bottomLinks, topLinks } from './pageLinks';
 import routerCache from './routerCache';
+import { projectIdCache } from './projectCache';
 
 export const useLocation = () => {
   const { location, navigate } = globalHistory;
@@ -47,4 +48,13 @@ export const useRouterCache = (to: string) => {
   }, []);
 
   return state[to] || to;
+};
+
+export const useProjectIdCache = () => {
+  const [projectId, setProjectId] = useState(projectIdCache.get());
+  useEffect(() => {
+    setProjectId(projectIdCache.get());
+  }, []);
+
+  return projectId;
 };

--- a/Composer/packages/client/src/utils/projectCache.ts
+++ b/Composer/packages/client/src/utils/projectCache.ts
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+import { ClientStorage } from './storage';
+
+const KEY = 'ProjectIdCache';
+
+class ProjectIdCache {
+  private storage: ClientStorage;
+  private currentProjectId;
+
+  constructor() {
+    this.storage = new ClientStorage(window.sessionStorage);
+    this.currentProjectId = this.storage.get(KEY, '');
+  }
+
+  get() {
+    return this.currentProjectId;
+  }
+
+  set(projectId: string) {
+    this.currentProjectId = projectId;
+    this.storage.set(KEY, this.currentProjectId);
+  }
+}
+
+export const projectIdCache = new ProjectIdCache();


### PR DESCRIPTION
## Description

Current if re-fresh page in home/setting page, all client state are lost. Notice `navigation` are disabled:
![Untitled5](https://user-images.githubusercontent.com/49866537/90368644-f8170680-e09c-11ea-92f3-363326508b11.gif)

other page (design/lg/lu) which url include `:projectId` don't have this issue, cause when refresh page, `projectId` is still in url.

### Changes made to fix this
1. Cache projectId at client session storage.
2. Auto-fetch project if current no project is opened.

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
close #3845 
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

Refresh in home/setting page wouldn't lost states

![Untitled4](https://user-images.githubusercontent.com/49866537/90368486-aec6b700-e09c-11ea-83e1-9d51757436d1.gif)

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
