### PR TITLE
feat: Design tweaks to Skill Manifest Generation Wizard

### DIFF
--- a/Composer/packages/client/src/pages/design/exportSkillModal/__tests__/generateSkillManifest.test.ts
+++ b/Composer/packages/client/src/pages/design/exportSkillModal/__tests__/generateSkillManifest.test.ts
@@ -79,7 +79,7 @@ describe('generateOtherActivities', () => {
 describe('generateActivity', () => {
   it('should return simple activity when there is no dialog schema', () => {
     const dialogSchemas = [];
-    const dialog: any = { id: 'test' };
+    const dialog: any = { id: 'test', content: { $designer: {} } };
     const result = generateActivity(dialogSchemas, dialog);
     expect(result).toEqual(
       expect.objectContaining({
@@ -93,13 +93,14 @@ describe('generateActivity', () => {
 
   it('should return activity that includes value and result when dialog schema is available', () => {
     const dialogSchemas = [dialogSchema];
-    const dialog: any = { id: 'test' };
+    const dialog: any = { id: 'test', content: { $designer: { description: 'Test Dialog' } } };
     const result = generateActivity(dialogSchemas, dialog);
     expect(result).toEqual(
       expect.objectContaining({
         test: {
           type: 'event',
           name: 'test',
+          description: 'Test Dialog',
           value: {
             type: 'object',
             properties: {
@@ -134,7 +135,7 @@ describe('generateActivities', () => {
   it('should return an object containing activities', () => {
     const dialogSchemas = [dialogSchema];
     const triggers: any = [{ $kind: SDKKinds.OnTypingActivity }, { $kind: SDKKinds.OnHandoffActivity }];
-    const dialogs: any = [{ id: 'test' }];
+    const dialogs: any = [{ id: 'test', content: { $designer: {} } }];
     const result = generateActivities(dialogSchemas, triggers, dialogs);
     expect(result).toEqual(
       expect.objectContaining({

--- a/Composer/packages/client/src/pages/design/exportSkillModal/constants.tsx
+++ b/Composer/packages/client/src/pages/design/exportSkillModal/constants.tsx
@@ -78,7 +78,9 @@ export interface Language {
 }
 
 export interface DispatchModels {
-  languages?: Language[];
+  languages?: {
+    [local: string]: Language[];
+  };
   intents?: string[];
 }
 

--- a/Composer/packages/client/src/pages/design/exportSkillModal/content/Endpoints.tsx
+++ b/Composer/packages/client/src/pages/design/exportSkillModal/content/Endpoints.tsx
@@ -24,7 +24,8 @@ export const Endpoints: React.FC<ContentProps> = ({ errors, value, schema, onCha
     label: false,
     properties: {
       endpoints: {
-        order: [['name', 'endpointUrl'], ['description', 'protocol'], '*'],
+        hidden: ['protocol'],
+        order: [['name', 'endpointUrl'], ['description', 'msAppId'], '*'],
       },
     },
   };

--- a/Composer/packages/client/src/pages/design/exportSkillModal/content/SelectItems.tsx
+++ b/Composer/packages/client/src/pages/design/exportSkillModal/content/SelectItems.tsx
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/** @jsx jsx */
+import { css, jsx } from '@emotion/core';
+import React from 'react';
+import {
+  CheckboxVisibility,
+  DetailsList,
+  DetailsListLayoutMode,
+  IDetailsRowProps,
+  SelectionMode,
+  IColumn,
+  SelectAllVisibility,
+} from 'office-ui-fabric-react/lib/DetailsList';
+import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
+import { IRenderFunction, ISelection, IObjectWithKey } from 'office-ui-fabric-react/lib/Utilities';
+import { Sticky, StickyPositionType } from 'office-ui-fabric-react/lib/Sticky';
+import { ScrollablePane, ScrollbarVisibility } from 'office-ui-fabric-react/lib/ScrollablePane';
+import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
+import formatMessage from 'format-message';
+
+const styles = {
+  detailListContainer: css`
+    height: 350px;
+    margin-bottom: 10px
+    position: relative;
+    padding-top: 10px;
+    overflow: hidden;
+  `,
+};
+
+interface SelectItemsProps {
+  items: any[];
+  selection: ISelection<IObjectWithKey>;
+  tableColumns: IColumn[];
+}
+
+export const SelectItems: React.FC<SelectItemsProps> = ({ items, selection, tableColumns }) => {
+  const onRenderDetailsHeader = (props, defaultRender) => {
+    return (
+      <Sticky isScrollSynced stickyPosition={StickyPositionType.Header}>
+        {defaultRender({
+          ...props,
+          selectAllVisibility: SelectAllVisibility.hidden,
+          onRenderColumnHeaderTooltip: (tooltipHostProps) => <TooltipHost {...tooltipHostProps} />,
+        })}
+      </Sticky>
+    );
+  };
+
+  const onRenderRow = (props?: IDetailsRowProps, defaultRender?: IRenderFunction<IDetailsRowProps>): JSX.Element => {
+    return <div data-selection-toggle>{defaultRender && defaultRender(props)}</div>;
+  };
+
+  const handleToggleSelectAll = () => {
+    selection.setAllSelected(!selection.isAllSelected());
+  };
+
+  return (
+    <React.Fragment>
+      <div css={styles.detailListContainer}>
+        <ScrollablePane scrollbarVisibility={ScrollbarVisibility.auto}>
+          <DetailsList
+            checkboxVisibility={CheckboxVisibility.always}
+            columns={tableColumns}
+            compact={false}
+            getKey={(item) => item.id}
+            items={items}
+            layoutMode={DetailsListLayoutMode.justified}
+            selection={selection}
+            selectionMode={SelectionMode.multiple}
+            onRenderDetailsHeader={onRenderDetailsHeader}
+            onRenderRow={onRenderRow}
+          />
+        </ScrollablePane>
+      </div>
+      <Checkbox
+        checked={selection.isAllSelected()}
+        label={formatMessage('Select all')}
+        styles={{ root: { marginTop: '10px' } }}
+        onChange={handleToggleSelectAll}
+      />
+    </React.Fragment>
+  );
+};

--- a/Composer/packages/client/src/pages/design/exportSkillModal/content/SelectItems.tsx
+++ b/Composer/packages/client/src/pages/design/exportSkillModal/content/SelectItems.tsx
@@ -22,10 +22,9 @@ import formatMessage from 'format-message';
 
 const styles = {
   detailListContainer: css`
+    flex-grow: 1;
     height: 350px;
-    margin-bottom: 10px
     position: relative;
-    padding-top: 10px;
     overflow: hidden;
   `,
 };

--- a/Composer/packages/client/src/pages/design/exportSkillModal/content/SelectTriggers.tsx
+++ b/Composer/packages/client/src/pages/design/exportSkillModal/content/SelectTriggers.tsx
@@ -2,21 +2,10 @@
 // Licensed under the MIT License.
 
 /** @jsx jsx */
-import { css, jsx } from '@emotion/core';
+import { jsx } from '@emotion/core';
 import React, { useMemo } from 'react';
-import {
-  CheckboxVisibility,
-  DetailsList,
-  DetailsListLayoutMode,
-  IDetailsRowProps,
-  SelectionMode,
-} from 'office-ui-fabric-react/lib/DetailsList';
 import { DialogInfo, ITrigger, SDKKinds } from '@bfc/shared';
-import { IRenderFunction } from 'office-ui-fabric-react/lib/Utilities';
 import { Selection } from 'office-ui-fabric-react/lib/DetailsList';
-import { Sticky, StickyPositionType } from 'office-ui-fabric-react/lib/Sticky';
-import { ScrollablePane, ScrollbarVisibility } from 'office-ui-fabric-react/lib/ScrollablePane';
-import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
 import { useRecoilValue } from 'recoil';
 import formatMessage from 'format-message';
 
@@ -25,15 +14,7 @@ import { dialogsState, schemasState } from '../../../../recoilModel';
 import { getFriendlyName } from '../../../../utils/dialogUtil';
 import { isSupportedTrigger } from '../generateSkillManifest';
 
-const styles = {
-  detailListContainer: css`
-    flex-grow: 1;
-    height: 350px;
-    position: relative;
-    padding-top: 10px;
-    overflow: hidden;
-  `,
-};
+import { SelectItems } from './SelectItems';
 
 const getLabel = (kind: SDKKinds, uiSchema) => {
   const { label } = uiSchema?.[kind]?.form || {};
@@ -111,38 +92,5 @@ export const SelectTriggers: React.FC<ContentProps> = ({ setSelectedTriggers }) 
     []
   );
 
-  function onRenderDetailsHeader(props, defaultRender) {
-    return (
-      <Sticky isScrollSynced stickyPosition={StickyPositionType.Header}>
-        {defaultRender({
-          ...props,
-          onRenderColumnHeaderTooltip: (tooltipHostProps) => <TooltipHost {...tooltipHostProps} />,
-        })}
-      </Sticky>
-    );
-  }
-
-  const onRenderRow = (props?: IDetailsRowProps, defaultRender?: IRenderFunction<IDetailsRowProps>): JSX.Element => {
-    return <div data-selection-toggle="true">{defaultRender && defaultRender(props)}</div>;
-  };
-
-  return (
-    <div css={styles.detailListContainer}>
-      <ScrollablePane scrollbarVisibility={ScrollbarVisibility.auto}>
-        <DetailsList
-          isHeaderVisible
-          checkboxVisibility={CheckboxVisibility.always}
-          columns={tableColumns}
-          compact={false}
-          getKey={(item) => item.id}
-          items={items}
-          layoutMode={DetailsListLayoutMode.justified}
-          selection={selection}
-          selectionMode={SelectionMode.multiple}
-          onRenderDetailsHeader={onRenderDetailsHeader}
-          onRenderRow={onRenderRow}
-        />
-      </ScrollablePane>
-    </div>
-  );
+  return <SelectItems items={items} selection={selection} tableColumns={tableColumns} />;
 };

--- a/Composer/packages/extensions/adaptive-form/src/components/FormRow.tsx
+++ b/Composer/packages/extensions/adaptive-form/src/components/FormRow.tsx
@@ -6,7 +6,7 @@ import { FieldProps, UIOptions } from '@bfc/extension';
 import { css, jsx } from '@emotion/core';
 import React from 'react';
 
-import { resolvePropSchema } from '../utils';
+import { isPropertyHidden, resolvePropSchema } from '../utils';
 
 import { SchemaField } from './SchemaField';
 
@@ -46,6 +46,7 @@ export const getRowProps = (rowProps: FormRowProps, field: string) => {
   return {
     id: `${id}.${field}`,
     schema: fieldSchema ?? {},
+    hidden: isPropertyHidden(uiOptions, value, field),
     label: (label === false ? false : undefined) as false | undefined,
     name: field,
     rawErrors: rawErrors?.[field],

--- a/Composer/packages/extensions/adaptive-form/src/components/SchemaField.tsx
+++ b/Composer/packages/extensions/adaptive-form/src/components/SchemaField.tsx
@@ -29,6 +29,7 @@ const SchemaField: React.FC<FieldProps> = (props) => {
     value,
     rawErrors,
     hideError,
+    hidden,
     onChange,
     ...rest
   } = props;
@@ -40,30 +41,30 @@ const SchemaField: React.FC<FieldProps> = (props) => {
     ...baseUIOptions,
   };
 
-  useEffect(() => {
-    if (typeof value === 'undefined') {
-      if (schema?.const) {
-        onChange(schema.const);
-      } else if (schema?.default) {
-        onChange(schema.default);
-      }
-    }
-  }, []);
-
-  if (name.startsWith('$')) {
-    return null;
-  }
-
-  const error = typeof rawErrors === 'string' && (
-    <ErrorMessage error={rawErrors} helpLink={uiOptions.helpLink} label={getUiLabel(props)} />
-  );
-
   const handleChange = (newValue: any) => {
     const serializedValue =
       typeof uiOptions?.serializer?.set === 'function' ? uiOptions.serializer.set(newValue) : newValue;
 
     onChange(serializedValue);
   };
+
+  useEffect(() => {
+    if (typeof value === 'undefined') {
+      if (schema.const) {
+        handleChange(schema.const);
+      } else if (schema.default) {
+        handleChange(schema.default);
+      }
+    }
+  }, []);
+
+  if (name.startsWith('$') || hidden) {
+    return null;
+  }
+
+  const error = typeof rawErrors === 'string' && (
+    <ErrorMessage error={rawErrors} helpLink={uiOptions.helpLink} label={getUiLabel(props)} />
+  );
 
   const deserializedValue = typeof uiOptions?.serializer?.get === 'function' ? uiOptions.serializer.get(value) : value;
 

--- a/Composer/packages/extensions/adaptive-form/src/components/fields/ObjectArrayField.tsx
+++ b/Composer/packages/extensions/adaptive-form/src/components/fields/ObjectArrayField.tsx
@@ -14,7 +14,7 @@ import { FontSizes, NeutralColors, SharedColors } from '@uifabric/fluent-theme';
 import formatMessage from 'format-message';
 import map from 'lodash/map';
 
-import { getArrayItemProps, getOrderedProperties, useArrayItems, resolveRef } from '../../utils';
+import { getArrayItemProps, getOrderedProperties, useArrayItems, resolveRef, isPropertyHidden } from '../../utils';
 import { FieldLabel } from '../FieldLabel';
 
 import { objectArrayField } from './styles';
@@ -80,21 +80,16 @@ const ObjectArrayField: React.FC<FieldProps<any[]>> = (props) => {
     itemSchema && typeof itemSchema !== 'boolean' ? itemSchema : {},
     uiOptions,
     value
-  );
+  ).filter((property) => Array.isArray(property) || !isPropertyHidden(uiOptions, value, property));
 
   const stackArrayItems = useMemo(() => {
-    const allOrderProps = orderedProperties.reduce((all, prop) => {
-      if (Array.isArray(prop)) {
-        all.push(...prop);
-      } else {
-        all.push(prop);
-      }
-
-      return all;
-    }, [] as string[]);
+    const allOrderProps = orderedProperties.reduce((all: string[], prop: string | string[]) => {
+      return [...all, ...(Array.isArray(prop) ? prop : [prop])];
+    }, []);
 
     return (
       allOrderProps.length > 2 ||
+      orderedProperties.some((property) => Array.isArray(property)) ||
       Object.entries(properties).some(([key, propSchema]) => {
         const resolved = resolveRef(propSchema as JSONSchema7, props.definitions);
         return allOrderProps.includes(key) && resolved.$role === 'expression';

--- a/Composer/packages/extensions/adaptive-form/src/utils/__tests__/getOrderedProperties.test.ts
+++ b/Composer/packages/extensions/adaptive-form/src/utils/__tests__/getOrderedProperties.test.ts
@@ -20,9 +20,26 @@ const schema = {
 const data = 'form data';
 
 describe('getOrderedProperties', () => {
-  it('excludes fields according to hidden option', () => {
-    expect(getOrderedProperties(schema, { hidden: ['two'] }, data)).not.toContain('two');
-    expect(getOrderedProperties(schema, { hidden: () => ['two'] }, data)).not.toContain('two');
+  it('includes hidden fields', () => {
+    expect(getOrderedProperties(schema, { hidden: ['two'] }, data)).toContain('two');
+    expect(getOrderedProperties(schema, { hidden: () => ['two'] }, data)).toContain('two');
+  });
+
+  it('includes hidden fields when all non-hidden fields are in the order', () => {
+    const order = ['one', 'three', 'four', 'five', 'six', 'seven'];
+
+    expect(getOrderedProperties(schema, { order, hidden: ['two'] }, data)).toContain('two');
+    expect(getOrderedProperties(schema, { order, hidden: () => ['two'] }, data)).toContain('two');
+  });
+
+  it('includes hidden fields when all non-hidden fields are in the order', () => {
+    const order = ['one', 'three', ['four', 'five'], 'six', 'seven'];
+    const expectedResult = ['one', 'three', ['four', 'five'], 'six', 'seven', 'two'];
+
+    // @ts-expect-error
+    expect(getOrderedProperties(schema, { order, hidden: ['two'] }, data)).toEqual(expectedResult);
+    // @ts-expect-error
+    expect(getOrderedProperties(schema, { order, hidden: () => ['two'] }, data)).toEqual(expectedResult);
   });
 
   it('sorts according to order option', () => {

--- a/Composer/packages/extensions/adaptive-form/src/utils/getHiddenProperties.ts
+++ b/Composer/packages/extensions/adaptive-form/src/utils/getHiddenProperties.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { UIOptions } from '@bfc/extension';
+
+export const globalHiddenProperties = ['$kind', '$id', '$copy', '$designer', 'id', 'disabled'];
+
+export const getHiddenProperties = (uiOptions: UIOptions, value: any) => {
+  const hiddenProperties = typeof uiOptions.hidden === 'function' ? uiOptions.hidden(value) : uiOptions.hidden || [];
+  return new Set([...globalHiddenProperties, ...hiddenProperties]);
+};
+
+export const isPropertyHidden = (uiOptions: UIOptions, value: any, property: string) =>
+  getHiddenProperties(uiOptions, value).has(property);

--- a/Composer/packages/extensions/adaptive-form/src/utils/getOrderedProperties.ts
+++ b/Composer/packages/extensions/adaptive-form/src/utils/getOrderedProperties.ts
@@ -4,20 +4,19 @@ import { UIOptions, JSONSchema7 } from '@bfc/extension';
 import cloneDeep from 'lodash/cloneDeep';
 import formatMessage from 'format-message';
 
-const globalHiddenProperties = ['$kind', '$id', '$copy', '$designer', 'id', 'disabled'];
+import { getHiddenProperties } from './getHiddenProperties';
 
 type OrderConfig = (string | [string, string])[];
 
 export function getOrderedProperties(
   schema: JSONSchema7,
-  uiOptions: UIOptions,
+  baseUiOptions: UIOptions,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   data: any
 ): OrderConfig {
-  const { hidden, order = ['*'] } = cloneDeep(uiOptions);
-
-  const hiddenFieldSet = new Set(typeof hidden === 'function' ? hidden(data) : hidden || []);
-  globalHiddenProperties.forEach((f) => hiddenFieldSet.add(f));
+  const uiOptions = cloneDeep(baseUiOptions);
+  const { order = ['*'] } = uiOptions;
+  const hiddenFieldSet = getHiddenProperties(uiOptions, data);
 
   const uiOrder = typeof order === 'function' ? order(data) : order || [];
   const orderedFieldSet = new Set<string>();
@@ -59,7 +58,7 @@ export function getOrderedProperties(
   const restIdx = orderedFields.indexOf('*');
   // only validate wildcard if not all properties are ordered already
   if (allProperties.some((p) => !orderedFieldSet.has(p))) {
-    let errorMsg = '';
+    let errorMsg;
     if (restIdx === -1) {
       errorMsg = formatMessage('no wildcard');
     } else if (restIdx !== orderedFields.lastIndexOf('*')) {
@@ -75,15 +74,16 @@ export function getOrderedProperties(
         })
       );
     }
+  }
 
-    const restFields = Object.keys(schema.properties || {}).filter((p) => {
-      return !orderedFieldSet.has(p) && !hiddenFieldSet.has(p) && !p.startsWith('$');
-    });
+  const restFields = Object.keys(schema.properties || {}).filter((p) => {
+    return !orderedFieldSet.has(p) && !p.startsWith('$');
+  });
 
+  if (restIdx === -1) {
+    orderedFields.push(...restFields);
+  } else {
     orderedFields.splice(restIdx, 1, ...restFields);
-  } else if (restIdx > -1) {
-    // remove the wildcard
-    orderedFields.splice(restIdx, 1);
   }
 
   return orderedFields;

--- a/Composer/packages/extensions/adaptive-form/src/utils/index.ts
+++ b/Composer/packages/extensions/adaptive-form/src/utils/index.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 export * from './arrayUtils';
+export * from './getHiddenProperties';
 export * from './getOrderedProperties';
 export * from './getUIOptions';
 export * from './getValueType';

--- a/Composer/packages/extensions/adaptive-form/src/utils/resolveRef.ts
+++ b/Composer/packages/extensions/adaptive-form/src/utils/resolveRef.ts
@@ -8,6 +8,10 @@ export function resolveRef(
   definitions: { [key: string]: JSONSchema7Definition } = {}
 ): JSONSchema7 {
   if (typeof schema?.$ref === 'string') {
+    if (!schema?.$ref?.startsWith('#/definitions/')) {
+      return schema;
+    }
+
     const defName = schema.$ref.replace('#/definitions/', '');
     const defSchema = definitions?.[defName] as JSONSchema7;
 

--- a/Composer/packages/extensions/extension/src/types/form.ts
+++ b/Composer/packages/extensions/extension/src/types/form.ts
@@ -40,6 +40,7 @@ export interface FieldProps<T = any> {
   disabled?: boolean;
   enumOptions?: string[];
   error?: string | JSX.Element;
+  hidden?: boolean;
   hideError?: boolean;
   id: string;
   label?: string | false;


### PR DESCRIPTION
## Description
- Endpoints Step
  - Hide the `protocol` property since it can only be set to 'BotFrameworkv3' at the moment
    - There was a bug in the Adaptive Form package that didn't set the default/const for hidden properties. To resolve this, we shifted the responsibility for hiding fields from the `ObjectField` to the `SchemaField` where the default/const values are set.
- Dialog Selection Step
  - Added a description column with an editable field to change the dialog description
  - Added a 'Select all' checkbox and hid the select all checkbox in the table
- Select Trigger Step
  - Added a 'Select all' checkbox and hid the select all checkbox in the table

## Task Item
closes #3333

## Screenshots
### Endpoints Step
![image](https://user-images.githubusercontent.com/17039790/90665978-00408480-e20a-11ea-8da1-cc1cdc3a65bd.png)
### Select Dialogs
![image](https://user-images.githubusercontent.com/17039790/90667460-0c2d4600-e20c-11ea-8ef3-b74b5744819b.png)

### Select Triggers Step
![image](https://user-images.githubusercontent.com/17039790/90667504-194a3500-e20c-11ea-9f2f-20fde7c11bae.png)
