### PR TITLE
fix: open a new bot will navigate to the old bot

### DIFF
--- a/Composer/packages/client/src/pages/design/DesignPage.tsx
+++ b/Composer/packages/client/src/pages/design/DesignPage.tsx
@@ -172,7 +172,7 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
 
   useEffect(() => {
     const index = currentDialog.triggers.findIndex(({ type }) => type === SDKKinds.OnBeginDialog);
-    if (index >= 0 && !designPageLocation.selected) {
+    if (index >= 0 && !designPageLocation.selected && designPageLocation.projectId === projectId) {
       selectTo(createSelectedPath(index));
     }
   }, [currentDialog?.id]);


### PR DESCRIPTION
## Description

The reason is the design page will use the location state to navigate to the begin dialog action. The location will be updated by the @reach\router, then we use the location to update the location in our state management. So the first open will use the old location to navigate and get the old project id.

In this PR, check the project to avoid the page navigate to the old bot. 

**I think in R11 we need to make the router and state one way data flow.** #3022
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
closes #3865
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
