### PR TITLE
fix: clean the cache when deleting a bot

### DIFF
--- a/Composer/packages/client/src/recoilModel/dispatchers/project.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/project.ts
@@ -256,6 +256,7 @@ export const projectDispatcher = () => {
       await httpClient.delete(`/projects/${projectId}`);
       luFileStatusStorage.removeAllStatuses(projectId);
       settingStorage.remove(projectId);
+      projectIdCache.clear();
       reset(projectIdState);
       reset(dialogsState);
       reset(botEnvironmentState);

--- a/Composer/packages/client/src/utils/projectCache.ts
+++ b/Composer/packages/client/src/utils/projectCache.ts
@@ -21,6 +21,10 @@ class ProjectIdCache {
     this.currentProjectId = projectId;
     this.storage.set(KEY, this.currentProjectId);
   }
+
+  clear() {
+    this.set('');
+  }
 }
 
 export const projectIdCache = new ProjectIdCache();


### PR DESCRIPTION
## Description

The project id is saved to the session storage. When the bot is deleted, composer will use cache to fetch the project.

In this PR, clean the id cache when deleting a bot.

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
closes #3882 
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
