### PR TITLE
fix: do not allow editing of publish profile name

### DIFF
--- a/Composer/packages/client/src/pages/publish/createPublishTarget.tsx
+++ b/Composer/packages/client/src/pages/publish/createPublishTarget.tsx
@@ -98,6 +98,7 @@ const CreatePublishTarget: React.FC<CreatePublishTargetProps> = (props) => {
           errorMessage={errorMessage}
           label={formatMessage('Name')}
           placeholder={formatMessage('My Publish Profile')}
+          readOnly={props.current ? true : false}
           onChange={updateName}
         />
         <Dropdown

--- a/Composer/packages/client/src/recoilModel/dispatchers/publisher.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/publisher.ts
@@ -65,7 +65,6 @@ export const publisherDispatcher = () => {
         ],
       };
     });
-    set(publishTypesState, data);
   };
 
   const updatePublishStatus = ({ set }: CallbackInterface, projectId: string, target: any, data: any) => {


### PR DESCRIPTION
## Description

Make profile name not editable, because we use name as key in targetList.
Fix profile edit issue because of publishTypes update issue.

## Task Item

#minor 

## Screenshots

Profile edit issue during publishing : 
![image](https://user-images.githubusercontent.com/21174180/91028895-adfbcb00-e630-11ea-8151-617ed15a0d5e.png)
