### PR TITLE
fix: Improve performance of the editor behavior in LU

### DIFF
--- a/Composer/packages/client/src/recoilModel/dispatchers/lu.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/lu.ts
@@ -5,7 +5,6 @@ import { LuFile, LuIntentSection } from '@bfc/shared';
 import { useRecoilCallback, CallbackInterface } from 'recoil';
 import differenceBy from 'lodash/differenceBy';
 import formatMessage from 'format-message';
-import { luUtil } from '@bfc/indexers';
 
 import luWorker from '../parsers/luWorker';
 import { getBaseName, getExtension } from '../../utils/fileUtil';
@@ -18,7 +17,7 @@ const intentIsNotEmpty = ({ Name, Body }) => {
 // fill other locale luFile new added intent with '- '
 const initialBody = '- ';
 
-export const updateLuFileState = (luFiles: LuFile[], updatedLuFile: LuFile, projectId: string) => {
+export const updateLuFileState = async (luFiles: LuFile[], updatedLuFile: LuFile, projectId: string) => {
   const { id } = updatedLuFile;
   const dialogId = getBaseName(id);
   const locale = getExtension(id);
@@ -49,11 +48,11 @@ export const updateLuFileState = (luFiles: LuFile[], updatedLuFile: LuFile, proj
   // sync add/remove intents
   if (onlyAdds || onlyDeletes) {
     for (const item of sameIdOtherLocaleFiles) {
-      let newLuFile = luUtil.addIntents(item, addedIntents);
-      newLuFile = luUtil.removeIntents(
+      let newLuFile = (await luWorker.addIntents(item, addedIntents)) as LuFile;
+      newLuFile = (await luWorker.removeIntents(
         newLuFile,
         deletedIntents.map(({ Name }) => Name)
-      );
+      )) as LuFile;
       changes.push(newLuFile);
     }
   }
@@ -78,7 +77,7 @@ export const createLuFileState = async (
   const locale = await snapshot.getPromise(localeState);
   const { languages } = await snapshot.getPromise(settingsState);
   const createdLuId = `${id}.${locale}`;
-  const createdLuFile = (await luUtil.parse(id, content)) as LuFile;
+  const createdLuFile = (await luWorker.parse(id, content)) as LuFile;
   if (luFiles.find((lu) => lu.id === createdLuId)) {
     throw new Error('lu file already exist');
   }
@@ -114,7 +113,7 @@ export const removeLuFileState = async (callbackHelpers: CallbackInterface, { id
 
 export const luDispatcher = () => {
   const updateLuFile = useRecoilCallback(
-    ({ set }: CallbackInterface) => async ({
+    ({ set, snapshot }: CallbackInterface) => async ({
       id,
       content,
       projectId,
@@ -123,15 +122,15 @@ export const luDispatcher = () => {
       content: string;
       projectId: string;
     }) => {
+      const luFiles = await snapshot.getPromise(luFilesState);
       const updatedFile = (await luWorker.parse(id, content)) as LuFile;
-      set(luFilesState, (luFiles) => {
-        return updateLuFileState(luFiles, updatedFile, projectId);
-      });
+      const result = await updateLuFileState(luFiles, updatedFile, projectId);
+      set(luFilesState, result);
     }
   );
 
   const updateLuIntent = useRecoilCallback(
-    ({ set }: CallbackInterface) => ({
+    ({ set, snapshot }: CallbackInterface) => async ({
       id,
       intentName,
       intent,
@@ -140,39 +139,40 @@ export const luDispatcher = () => {
       intentName: string;
       intent: LuIntentSection;
     }) => {
-      set(luFilesState, (luFiles) => {
-        const luFile = luFiles.find((temp) => temp.id === id);
-        if (!luFile) return luFiles;
-        // const updatedFile = luUtil.updateIntent(file, intentName, intent);
-        // return updateLuFileState(luFiles, updatedFile, projectId);
+      const luFiles = await snapshot.getPromise(luFilesState);
+      const luFile = luFiles.find((temp) => temp.id === id);
+      if (!luFile) return luFiles;
 
-        const sameIdOtherLocaleFiles = luFiles.filter((file) => getBaseName(file.id) === getBaseName(id));
+      const sameIdOtherLocaleFiles = luFiles.filter((file) => getBaseName(file.id) === getBaseName(id));
 
-        // name change, need update cross multi locale file.
-        if (intent.Name !== intentName) {
-          const changes: LuFile[] = [];
-          for (const item of sameIdOtherLocaleFiles) {
-            const updatedFile = luUtil.updateIntent(item, intentName, { Name: intent.Name });
-            changes.push(updatedFile);
-          }
+      // name change, need update cross multi locale file.
+      if (intent.Name !== intentName) {
+        const changes: LuFile[] = [];
+        for (const item of sameIdOtherLocaleFiles) {
+          const updatedFile = (await luWorker.updateIntent(item, intentName, { Name: intent.Name })) as LuFile;
+          changes.push(updatedFile);
+        }
+
+        set(luFilesState, (luFiles) => {
           return luFiles.map((file) => {
             const changedFile = changes.find(({ id }) => id === file.id);
             return changedFile ? changedFile : file;
           });
-
-          // body change, only update current locale file
-        } else {
-          const updatedFile = luUtil.updateIntent(luFile, intentName, { Body: intent.Body });
+        });
+        // body change, only update current locale file
+      } else {
+        const updatedFile = (await luWorker.updateIntent(luFile, intentName, { Body: intent.Body })) as LuFile;
+        set(luFilesState, (luFiles) => {
           return luFiles.map((file) => {
             return file.id === id ? updatedFile : file;
           });
-        }
-      });
+        });
+      }
     }
   );
 
   const createLuIntent = useRecoilCallback(
-    ({ set }: CallbackInterface) => ({
+    ({ set, snapshot }: CallbackInterface) => async ({
       id,
       intent,
       projectId,
@@ -181,17 +181,17 @@ export const luDispatcher = () => {
       intent: LuIntentSection;
       projectId: string;
     }) => {
-      set(luFilesState, (luFiles) => {
-        const file = luFiles.find((temp) => temp.id === id);
-        if (!file) return luFiles;
-        const updatedFile = luUtil.addIntent(file, intent);
-        return updateLuFileState(luFiles, updatedFile, projectId);
-      });
+      const luFiles = await snapshot.getPromise(luFilesState);
+      const file = luFiles.find((temp) => temp.id === id);
+      if (!file) return luFiles;
+      const updatedFile = (await luWorker.addIntent(file, intent)) as LuFile;
+      const result = await updateLuFileState(luFiles, updatedFile, projectId);
+      set(luFilesState, result);
     }
   );
 
   const removeLuIntent = useRecoilCallback(
-    ({ set }: CallbackInterface) => ({
+    ({ set, snapshot }: CallbackInterface) => async ({
       id,
       intentName,
       projectId,
@@ -200,12 +200,12 @@ export const luDispatcher = () => {
       intentName: string;
       projectId: string;
     }) => {
-      set(luFilesState, (luFiles) => {
-        const file = luFiles.find((temp) => temp.id === id);
-        if (!file) return luFiles;
-        const updatedFile = luUtil.removeIntent(file, intentName);
-        return updateLuFileState(luFiles, updatedFile, projectId);
-      });
+      const luFiles = await snapshot.getPromise(luFilesState);
+      const file = luFiles.find((temp) => temp.id === id);
+      if (!file) return luFiles;
+      const updatedFile = (await luWorker.removeIntent(file, intentName)) as LuFile;
+      const result = await updateLuFileState(luFiles, updatedFile, projectId);
+      set(luFilesState, result);
     }
   );
 

--- a/Composer/packages/client/src/recoilModel/parsers/__test__/luWorker.test.ts
+++ b/Composer/packages/client/src/recoilModel/parsers/__test__/luWorker.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { Range, Position } from '@bfc/shared';
+import { Range, Position, LuIntentSection } from '@bfc/shared';
 
 import luWorker from '../luWorker';
 
@@ -10,7 +10,7 @@ jest.mock('./../workers/luParser.worker.ts', () => {
     onmessage = (data) => data;
 
     postMessage = (data) => {
-      const payload = require('../workers/luParser.worker').handleMessage({ data });
+      const payload = require('../workers/luParser.worker').handleMessage(data);
       this.onmessage({ data: { id: data.id, payload } });
     };
   }
@@ -18,6 +18,13 @@ jest.mock('./../workers/luParser.worker.ts', () => {
   return Test;
 });
 
+const getLuIntent = (Name, Body): LuIntentSection =>
+  ({
+    Name,
+    Body,
+  } as LuIntentSection);
+
+let luFile;
 describe('test lu worker', () => {
   it('get expected parse result', async () => {
     const content = `# Hello
@@ -27,6 +34,7 @@ describe('test lu worker', () => {
       { Body: '- hi', Entities: [], Name: 'Hello', range: new Range(new Position(1, 0), new Position(2, 4)) },
     ];
     expect(result.intents).toMatchObject(expected);
+    luFile = result;
   });
 
   it('should parse lu file with diagnostic', async () => {
@@ -44,5 +52,59 @@ hi
     expect(diagnostics[0].range.start.character).toEqual(0);
     expect(diagnostics[0].range.end.line).toEqual(2);
     expect(diagnostics[0].range.end.character).toEqual(2);
+  });
+
+  it('get expected add intent result', async () => {
+    const result: any = await luWorker.addIntent(luFile, getLuIntent('New', '-IntentValue'));
+    const expected = {
+      Body: '-IntentValue',
+      Entities: [],
+      Name: 'New',
+      range: new Range(new Position(4, 0), new Position(5, 12)),
+    };
+    expect(result.intents.length).toBe(2);
+    expect(result.intents[1]).toMatchObject(expected);
+    luFile = result;
+  });
+
+  it('get expected add intents result', async () => {
+    const result: any = await luWorker.addIntents(luFile, [
+      getLuIntent('New1', '-IntentValue1'),
+      getLuIntent('New2', '-IntentValue2'),
+    ]);
+    const expected = {
+      Body: '-IntentValue2',
+      Entities: [],
+      Name: 'New2',
+      range: new Range(new Position(10, 0), new Position(11, 13)),
+    };
+    expect(result.intents.length).toBe(4);
+    expect(result.intents[3]).toMatchObject(expected);
+    luFile = result;
+  });
+
+  it('get expected update intent result', async () => {
+    const result: any = await luWorker.updateIntent(luFile, 'New', getLuIntent('New', '-update'));
+    const expected = {
+      Body: '-update',
+      Entities: [],
+      Name: 'New',
+      range: new Range(new Position(4, 0), new Position(5, 7)),
+    };
+    expect(result.intents.length).toBe(4);
+    expect(result.intents[1]).toMatchObject(expected);
+    luFile = result;
+  });
+
+  it('get expected remove intent result', async () => {
+    const result: any = await luWorker.removeIntent(luFile, 'New2');
+    expect(result.intents.length).toBe(3);
+    expect(result.intents[3]).toBeUndefined();
+    luFile = result;
+  });
+
+  it('get expected remove intent result', async () => {
+    const result: any = await luWorker.removeIntents(luFile, ['New1', 'New']);
+    expect(result.intents.length).toBe(1);
   });
 });

--- a/Composer/packages/client/src/recoilModel/parsers/luWorker.ts
+++ b/Composer/packages/client/src/recoilModel/parsers/luWorker.ts
@@ -1,41 +1,48 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-import { LuIntentSection } from '@bfc/shared';
+import { LuIntentSection, LuFile } from '@bfc/shared';
 
 import Worker from './workers/luParser.worker.ts';
 import { BaseWorker } from './baseWorker';
-import { LuPayload, LuActionType } from './types';
-
+import {
+  LuActionType,
+  LuParsePayload,
+  LuAddIntentPayload,
+  LuAddIntentsPayload,
+  LuRemoveIntentsPayload,
+  LuRemoveIntentPayload,
+  LuUpdateIntentPayload,
+} from './types';
 // Wrapper class
 class LuWorker extends BaseWorker<LuActionType> {
   parse(id: string, content: string) {
     const payload = { id, content };
-    return this.sendMsg<LuPayload>(LuActionType.Parse, payload);
+    return this.sendMsg<LuParsePayload>(LuActionType.Parse, payload);
   }
 
-  addIntent(content: string, intent: LuIntentSection) {
-    const payload = { content, intent };
-    return this.sendMsg<LuPayload>(LuActionType.AddIntent, payload);
+  addIntent(luFile: LuFile, intent: LuIntentSection) {
+    const payload = { luFile, intent };
+    return this.sendMsg<LuAddIntentPayload>(LuActionType.AddIntent, payload);
   }
 
-  updateIntent(content: string, intentName: string, intent?: LuIntentSection) {
-    const payload = { content, intentName, intent };
-    return this.sendMsg<LuPayload>(LuActionType.UpdateIntent, payload);
+  updateIntent(luFile: LuFile, intentName: string, intent?: { Name?: string; Body?: string }) {
+    const payload = { luFile, intentName, intent };
+    return this.sendMsg<LuUpdateIntentPayload>(LuActionType.UpdateIntent, payload);
   }
 
-  removeIntent(content: string, intentName: string) {
-    const payload = { content, intentName };
-    return this.sendMsg<LuPayload>(LuActionType.RemoveIntent, payload);
+  removeIntent(luFile: LuFile, intentName: string) {
+    const payload = { luFile, intentName };
+    return this.sendMsg<LuRemoveIntentPayload>(LuActionType.RemoveIntent, payload);
   }
 
-  addIntents(content: string, intents: LuIntentSection[]) {
-    const payload = { content, intents };
-    return this.sendMsg<LuPayload>(LuActionType.AddIntents, payload);
+  addIntents(luFile: LuFile, intents: LuIntentSection[]) {
+    const payload = { luFile, intents };
+    return this.sendMsg<LuAddIntentsPayload>(LuActionType.AddIntents, payload);
   }
 
-  removeIntents(content: string, intentNames: string[]) {
-    const payload = { content, intentNames };
-    return this.sendMsg<LuPayload>(LuActionType.RemoveIntents, payload);
+  removeIntents(luFile: LuFile, intentNames: string[]) {
+    const payload = { luFile, intentNames };
+    return this.sendMsg<LuRemoveIntentsPayload>(LuActionType.RemoveIntents, payload);
   }
 }
 

--- a/Composer/packages/client/src/recoilModel/parsers/types.ts
+++ b/Composer/packages/client/src/recoilModel/parsers/types.ts
@@ -1,12 +1,36 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-import { LuIntentSection, LgFile, QnASection, FileInfo, LgTemplate } from '@bfc/shared';
+import { LuIntentSection, LgFile, LuFile, QnASection, FileInfo, LgTemplate } from '@bfc/shared';
 
-export type LuPayload = {
+export type LuParsePayload = {
+  id: string;
   content: string;
-  id?: string;
-  intentName?: string;
-  intent?: LuIntentSection;
+};
+
+export type LuAddIntentPayload = {
+  luFile: LuFile;
+  intent: LuIntentSection;
+};
+
+export type LuAddIntentsPayload = {
+  luFile: LuFile;
+  intents: LuIntentSection[];
+};
+
+export type LuUpdateIntentPayload = {
+  luFile: LuFile;
+  intentName: string;
+  intent?: { Name?: string; Body?: string };
+};
+
+export type LuRemoveIntentPayload = {
+  luFile: LuFile;
+  intentName: string;
+};
+
+export type LuRemoveIntentsPayload = {
+  luFile: LuFile;
+  intentNames: string[];
 };
 
 export type LgParsePayload = {

--- a/Composer/packages/client/src/recoilModel/parsers/workers/luParser.worker.ts
+++ b/Composer/packages/client/src/recoilModel/parsers/workers/luParser.worker.ts
@@ -1,18 +1,93 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import * as luUtil from '@bfc/indexers/lib/utils/luUtil';
+import { luUtil } from '@bfc/indexers';
 
-import { LuActionType } from '../types';
+import {
+  LuActionType,
+  LuParsePayload,
+  LuRemoveIntentsPayload,
+  LuRemoveIntentPayload,
+  LuUpdateIntentPayload,
+  LuAddIntentsPayload,
+  LuAddIntentPayload,
+} from '../types';
 const ctx: Worker = self as any;
 
-export const handleMessage = (msg) => {
-  const { type, payload } = msg.data;
-  const { content, id } = payload;
+interface ParseMessage {
+  id: string;
+  type: LuActionType.Parse;
+  payload: LuParsePayload;
+}
+
+interface AddMessage {
+  id: string;
+  type: LuActionType.AddIntent;
+  payload: LuAddIntentPayload;
+}
+
+interface AddsMessage {
+  id: string;
+  type: LuActionType.AddIntents;
+  payload: LuAddIntentsPayload;
+}
+
+interface UpdateMessage {
+  id: string;
+  type: LuActionType.UpdateIntent;
+  payload: LuUpdateIntentPayload;
+}
+
+interface RemoveMessage {
+  id: string;
+  type: LuActionType.RemoveIntent;
+  payload: LuRemoveIntentPayload;
+}
+
+interface RemoveIntentsMessage {
+  id: string;
+  type: LuActionType.RemoveIntents;
+  payload: LuRemoveIntentsPayload;
+}
+
+type LuMessageEvent = ParseMessage | AddMessage | AddsMessage | UpdateMessage | RemoveMessage | RemoveIntentsMessage;
+
+export const handleMessage = (msg: LuMessageEvent) => {
   let result: any = null;
-  switch (type) {
+  switch (msg.type) {
     case LuActionType.Parse: {
+      const { id, content } = msg.payload;
       result = luUtil.parse(id, content);
+      break;
+    }
+
+    case LuActionType.AddIntent: {
+      const { luFile, intent } = msg.payload;
+      result = luUtil.addIntent(luFile, intent);
+      break;
+    }
+
+    case LuActionType.AddIntents: {
+      const { luFile, intents } = msg.payload;
+      result = luUtil.addIntents(luFile, intents);
+      break;
+    }
+
+    case LuActionType.UpdateIntent: {
+      const { luFile, intentName, intent } = msg.payload;
+      result = luUtil.updateIntent(luFile, intentName, intent || null);
+      break;
+    }
+
+    case LuActionType.RemoveIntent: {
+      const { luFile, intentName } = msg.payload;
+      result = luUtil.removeIntent(luFile, intentName);
+      break;
+    }
+
+    case LuActionType.RemoveIntents: {
+      const { luFile, intentNames } = msg.payload;
+      result = luUtil.removeIntents(luFile, intentNames);
       break;
     }
   }
@@ -22,7 +97,7 @@ export const handleMessage = (msg) => {
 ctx.onmessage = function (msg) {
   const { id } = msg.data;
   try {
-    const payload = handleMessage(msg);
+    const payload = handleMessage(msg.data as LuMessageEvent);
 
     ctx.postMessage({ id, payload });
   } catch (error) {

--- a/Composer/packages/client/src/shell/luApi.ts
+++ b/Composer/packages/client/src/shell/luApi.ts
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react';
 import { LuFile, LuIntentSection } from '@bfc/shared';
 import { useRecoilValue } from 'recoil';
 import formatMessage from 'format-message';
+import debounce from 'lodash/debounce';
 
 import { projectIdState } from '../recoilModel/atoms/botState';
 import { useResolvers } from '../hooks/useResolver';
@@ -76,6 +77,7 @@ function createLuApi(
     getLuIntents,
     getLuIntent,
     updateLuIntent,
+    deboucedUpdateLuIntent: debounce(updateLuIntent, 250),
     renameLuIntent,
     removeLuIntent,
   };

--- a/Composer/packages/lib/shared/src/types/shell.ts
+++ b/Composer/packages/lib/shared/src/types/shell.ts
@@ -81,6 +81,7 @@ export interface ShellApi {
   getLuIntents: (id: string) => LuIntentSection[];
   addLuIntent: (id: string, intentName: string, intent: LuIntentSection) => Promise<void>;
   updateLuIntent: (id: string, intentName: string, intent: LuIntentSection) => Promise<void>;
+  deboucedUpdateLuIntent: (id: string, intentName: string, intent: LuIntentSection) => Promise<void>;
   renameLuIntent: (id: string, intentName: string, newIntentName: string) => Promise<void>;
   removeLuIntent: (id: string, intentName: string) => void;
   updateQnaContent: (id: string, content: string) => void;

--- a/Composer/packages/ui-plugins/luis/src/LuisIntentEditor.tsx
+++ b/Composer/packages/ui-plugins/luis/src/LuisIntentEditor.tsx
@@ -40,7 +40,7 @@ const LuisIntentEditor: React.FC<FieldProps<string>> = (props) => {
     }
 
     const newIntent = { Name: intentName, Body: newValue };
-    shellApi.updateLuIntent(luFile.id, intentName, newIntent);
+    shellApi.deboucedUpdateLuIntent(luFile.id, intentName, newIntent);
     onChange(intentName);
   };
 


### PR DESCRIPTION
## Description
The same as #3900 
1. bring all parse worker back to worker. The lu parse result has no parse tree, so there is no need to cache the result.
2. add debounced shell api for lu inline editor

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
refs #3900
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
