### PR TITLE
fix: Update getSelectedOption to return correct option for enums

### DIFF
--- a/Composer/packages/extensions/adaptive-form/src/components/fields/ExpressionField/__tests__/utils.test.ts
+++ b/Composer/packages/extensions/adaptive-form/src/components/fields/ExpressionField/__tests__/utils.test.ts
@@ -177,6 +177,16 @@ describe('getSelectedOption', () => {
         schema: { type: 'string' as const },
       },
     },
+    {
+      key: 'enum',
+      text: 'enum',
+      data: {
+        schema: {
+          type: 'string' as const,
+          enum: ['value1', 'value2', 'value3'],
+        },
+      },
+    },
   ];
 
   it('returns undefined if there are no options', () => {
@@ -220,6 +230,12 @@ describe('getSelectedOption', () => {
 
     it('returns the first option if no type match found', () => {
       expect(getSelectedOption(['foo'], options)).toEqual(options[3]);
+    });
+  });
+
+  describe('when the value is included in an enum', () => {
+    it('returns the enum option', () => {
+      expect(getSelectedOption('value2', options)).toEqual(options[6]);
     });
   });
 });

--- a/Composer/packages/extensions/adaptive-form/src/components/fields/ExpressionField/utils.ts
+++ b/Composer/packages/extensions/adaptive-form/src/components/fields/ExpressionField/utils.ts
@@ -113,7 +113,13 @@ export function getOptions(schema: JSONSchema7, definitions): SchemaOption[] {
 
 export function getSelectedOption(value: any | undefined, options: SchemaOption[]): SchemaOption | undefined {
   const expressionOption = options.find(({ key }) => key === 'expression');
+  const enumOption = options.find(({ data: { schema } }) => schema.enum?.includes(value));
   let valueType = getValueType(value);
+
+  // return the enumOption if the value is included in the option's enum schema
+  if (enumOption) {
+    return enumOption;
+  }
 
   // if its an array, we know it's not an expression
 


### PR DESCRIPTION
## Description
Update the `getSelectedOption` function to check if the field's `value` is included an options enum schema and return the correct option accordingly.

## Task Item
Closes #3580 
