### PR TITLE
fix: "Reloading" spin forever when restart bot

### DIFF
--- a/Composer/packages/client/src/components/TestController/TestController.tsx
+++ b/Composer/packages/client/src/components/TestController/TestController.tsx
@@ -101,7 +101,6 @@ export const TestController: React.FC = () => {
         setBotStatus(BotStatus.pending);
         break;
       case BotStatus.published:
-        stopPollingRuntime();
         handleLoadBot();
         break;
       case BotStatus.reloading:

--- a/Composer/packages/client/src/components/TestController/TestController.tsx
+++ b/Composer/packages/client/src/components/TestController/TestController.tsx
@@ -50,12 +50,13 @@ export const botButton = css`
   margin-left: 5px;
 `;
 
+let botStatusInterval: NodeJS.Timeout | undefined = undefined;
+
 // -------------------- TestController -------------------- //
 const POLLING_INTERVAL = 2500;
 export const TestController: React.FC = () => {
   const [modalOpen, setModalOpen] = useState(false);
   const [calloutVisible, setCalloutVisible] = useState(false);
-  const [botStatusInterval, setBotStatusInterval] = useState<NodeJS.Timeout | undefined>(undefined);
 
   const botActionRef = useRef(null);
   const notifications = useNotifications();
@@ -101,6 +102,7 @@ export const TestController: React.FC = () => {
         setBotStatus(BotStatus.pending);
         break;
       case BotStatus.published:
+        stopPollingRuntime();
         handleLoadBot();
         break;
       case BotStatus.reloading:
@@ -111,7 +113,6 @@ export const TestController: React.FC = () => {
         stopPollingRuntime();
         break;
     }
-    // return the stoppolling function so the component will clean up
     return () => {
       stopPollingRuntime();
       return;
@@ -140,14 +141,14 @@ export const TestController: React.FC = () => {
         // get publish status
         getPublishStatus(projectId, defaultPublishConfig);
       }, POLLING_INTERVAL);
-      setBotStatusInterval(cancelInterval);
+      botStatusInterval = cancelInterval;
     }
   }
 
   function stopPollingRuntime() {
     if (botStatusInterval) {
       clearInterval(botStatusInterval);
-      setBotStatusInterval(undefined);
+      botStatusInterval = undefined;
     }
   }
 


### PR DESCRIPTION
## Description
Move botStatusInterval out of TestController component, to make sure it won't create duplicated every time component reloaded.

## Task Item

close #3930 

## Screenshots

