### PR TITLE
fix qna bug

### DIFF
--- a/Composer/packages/client/src/components/CreationFlow/CreationFlow.tsx
+++ b/Composer/packages/client/src/components/CreationFlow/CreationFlow.tsx
@@ -178,6 +178,7 @@ const CreationFlow: React.FC<CreationFlowProps> = () => {
           onOpen={openBot}
         />
         <ImportQnAFromUrlModal
+          isCreateFromoScratchButtonVisiable
           dialogId={formData.name.toLowerCase()}
           path="create/QnASample/importQnA"
           onDismiss={handleDismiss}

--- a/Composer/packages/client/src/pages/design/DesignPage.tsx
+++ b/Composer/packages/client/src/pages/design/DesignPage.tsx
@@ -689,7 +689,12 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
           />
         )}
         {importQnAModalVisibility && (
-          <ImportQnAFromUrlModal dialogId={dialogId} onDismiss={cancelImportQnAModal} onSubmit={handleCreateQnA} />
+          <ImportQnAFromUrlModal
+            dialogId={dialogId}
+            isCreateFromoScratchButtonVisiable={false}
+            onDismiss={cancelImportQnAModal}
+            onSubmit={handleCreateQnA}
+          />
         )}
         {displaySkillManifest && (
           <DisplayManifestModal manifestId={displaySkillManifest} onDismiss={dismissManifestModal} />

--- a/Composer/packages/client/src/pages/knowledge-base/ImportQnAFromUrlModal.tsx
+++ b/Composer/packages/client/src/pages/knowledge-base/ImportQnAFromUrlModal.tsx
@@ -83,6 +83,7 @@ interface ImportQnAFromUrlModalProps
   }> {
   dialogId: string;
   subscriptionKey?: string;
+  isCreateFromoScratchButtonVisiable?: boolean;
   onDismiss: () => void;
   onSubmit: (urls: string[]) => void;
 }
@@ -119,8 +120,8 @@ const validateUrls = (urls: string[]) => {
   const errors = Array(urls.length).fill('');
 
   for (let i = 0; i < urls.length; i++) {
-    for (let j = 0; j < urls.length; j++) {
-      if (urls[i] && urls[j] && urls[i] === urls[j] && i !== j) {
+    for (let j = i + 1; j < urls.length; j++) {
+      if (urls[i] && urls[j] && (urls[i] === urls[j] || urls[i] === urls[j] + '/' || urls[i] + '/' === urls[j])) {
         errors[i] = errors[j] = formatMessage('This url is duplicated');
       }
     }
@@ -143,7 +144,7 @@ const formConfig: FieldConfig<FormField> = {
 };
 
 export const ImportQnAFromUrlModal: React.FC<ImportQnAFromUrlModalProps> = (props) => {
-  const { onDismiss, onSubmit, dialogId } = props;
+  const { onDismiss, onSubmit, dialogId, isCreateFromoScratchButtonVisiable = true } = props;
   const [urlErrors, setUrlErrors] = useState(['']);
 
   const { formData, updateField, hasErrors } = useForm(formConfig);
@@ -224,17 +225,19 @@ export const ImportQnAFromUrlModal: React.FC<ImportQnAFromUrlModalProps> = (prop
         </Stack>
       </div>
       <DialogFooter>
-        <DefaultButton
-          data-testid={'createKnowledgeBaseFromScratch'}
-          styles={{ root: { marginRight: 155 } }}
-          text={formatMessage('Create knowledge base from scratch')}
-          onClick={() => {
-            if (hasErrors) {
-              return;
-            }
-            onSubmit([]);
-          }}
-        />
+        {isCreateFromoScratchButtonVisiable && (
+          <DefaultButton
+            data-testid={'createKnowledgeBaseFromScratch'}
+            styles={{ root: { marginRight: 155 } }}
+            text={formatMessage('Create knowledge base from scratch')}
+            onClick={() => {
+              if (hasErrors) {
+                return;
+              }
+              onSubmit([]);
+            }}
+          />
+        )}
         <DefaultButton text={formatMessage('Cancel')} onClick={onDismiss} />
         <PrimaryButton
           data-testid={'createKnowledgeBase'}

--- a/Composer/packages/client/src/pages/knowledge-base/QnAPage.tsx
+++ b/Composer/packages/client/src/pages/knowledge-base/QnAPage.tsx
@@ -156,7 +156,12 @@ const QnAPage: React.FC<QnAPageProps> = (props) => {
           <LoadingSpinner message={'Extracting QnA pairs. This could take a moment.'} />
         )}
         {importQnAFromUrlModalVisiability && (
-          <ImportQnAFromUrlModal dialogId={dialogId} onDismiss={onDismiss} onSubmit={onSubmit} />
+          <ImportQnAFromUrlModal
+            dialogId={dialogId}
+            isCreateFromoScratchButtonVisiable={false}
+            onDismiss={onDismiss}
+            onSubmit={onSubmit}
+          />
         )}
       </Suspense>
     </Page>


### PR DESCRIPTION
## Description
urls with one more trailing / should be duplicated.
http://abc/  is duplicated with http://abc

When creating a qna bot, we can see the create from scratch button. But when we only want to import qna file, we should hide the button.

## Task Item


## Screenshots
![duplicatedUrl](https://user-images.githubusercontent.com/24380525/91536796-db55bb00-e947-11ea-861a-87d34e02cf15.png)
![hidden button](https://user-images.githubusercontent.com/24380525/91536797-dc86e800-e947-11ea-85ab-fa8e700841de.png)

