### PR TITLE
fix: fix custom runtime setting error message not shown

### DIFF
--- a/Composer/plugins/localPublish/src/index.ts
+++ b/Composer/plugins/localPublish/src/index.ts
@@ -82,12 +82,7 @@ class LocalPublisher {
           project.fileStorage
         );
       } else {
-        throw {
-          status: 500,
-          result: {
-            message: 'Custom runtime settings are incomplete. Please specify path and command.',
-          },
-        };
+        throw new Error('Custom runtime settings are incomplete. Please specify path and command.');
       }
       await this.setBot(botId, version, fullSettings, project);
     } catch (error) {


### PR DESCRIPTION
## Description
Fix custom runtime setting error message not shown.

## Task Item

#minor 

## Screenshots
previous: 
![image](https://user-images.githubusercontent.com/21174180/91725007-aad48200-ebd0-11ea-89bb-01468ed7b6f9.png)

after fix:
![image](https://user-images.githubusercontent.com/21174180/91707531-849fe980-ebb2-11ea-92a1-7cff2f75d943.png)

