### PR TITLE
doc: add helplinks for validation rules

### DIFF
--- a/Composer/packages/ui-plugins/prompts/src/index.tsx
+++ b/Composer/packages/ui-plugins/prompts/src/index.tsx
@@ -108,6 +108,7 @@ const config: PluginConfig = {
           },
           validations: {
             label: () => formatMessage('Validation Rules'),
+            helpLink: 'https://aka.ms/bf-composer-docs-ask-input#prompt-settings-and-validation',
             placeholder: () => formatMessage('Add new validation rule here'),
           },
         },
@@ -124,6 +125,7 @@ const config: PluginConfig = {
           },
           validations: {
             label: () => formatMessage('Validation Rules'),
+            helpLink: 'https://aka.ms/bf-composer-docs-ask-input#prompt-settings-and-validation',
             placeholder: () => formatMessage('Add new validation rule here'),
           },
           choices: {
@@ -144,6 +146,7 @@ const config: PluginConfig = {
           },
           validations: {
             label: () => formatMessage('Validation Rules'),
+            helpLink: 'https://aka.ms/bf-composer-docs-ask-input#prompt-settings-and-validation',
             placeholder: () => formatMessage('Add new validation rule here'),
           },
           confirmChoices: {
@@ -164,6 +167,7 @@ const config: PluginConfig = {
           },
           validations: {
             label: () => formatMessage('Validation Rules'),
+            helpLink: 'https://aka.ms/bf-composer-docs-ask-input#prompt-settings-and-validation',
             placeholder: () => formatMessage('Add new validation rule here'),
           },
         },
@@ -180,6 +184,7 @@ const config: PluginConfig = {
           },
           validations: {
             label: () => formatMessage('Validation Rules'),
+            helpLink: 'https://aka.ms/bf-composer-docs-ask-input#prompt-settings-and-validation',
             placeholder: () => formatMessage('Add new validation rule here'),
           },
         },
@@ -196,6 +201,7 @@ const config: PluginConfig = {
           },
           validations: {
             label: () => formatMessage('Validation Rules'),
+            helpLink: 'https://aka.ms/bf-composer-docs-ask-input#prompt-settings-and-validation',
             placeholder: () => formatMessage('Add new validation rule here'),
           },
         },


### PR DESCRIPTION
## Description

Per @benbrown's request. 
Added helplinks in Validation Rules.
help link: https://aka.ms/bf-composer-docs-ask-input#prompt-settings-and-validation
The doc will be merged to live soon and the link will point to the newly added "prompt setting and validation" section specifically. 

#minor

## Realted issues:
https://github.com/microsoft/BotFramework-Composer/issues/3906
https://github.com/microsoft/BotFramework-Composer/issues/3907

## Screenshots
![validation-helplink-test](https://user-images.githubusercontent.com/32497439/91777271-43a0d880-eba4-11ea-8281-a353625776ed.png)

## Additional text
Did e2e test and verified the help links exist in all the different types of prompts as required.



