### PR TITLE
fix: qna settings duplicate endpointKey

### DIFF
--- a/Composer/packages/client/src/components/TestController/TestController.tsx
+++ b/Composer/packages/client/src/components/TestController/TestController.tsx
@@ -84,7 +84,7 @@ export const TestController: React.FC = () => {
   const addRef = useCallback((startBot) => onboardingAddCoachMarkRef({ startBot }), []);
   const errorLength = notifications.filter((n) => n.severity === 'Error').length;
   const showError = errorLength > 0;
-  const publishDialogConfig = { subscriptionKey: settings.qna.subscriptionKey, ...settings.luis } as IConfig;
+  const publishDialogConfig = { subscriptionKey: settings.qna?.subscriptionKey, ...settings.luis } as IConfig;
   const warningLength = notifications.filter((n) => n.severity === 'Warning').length;
   const showWarning = !showError && warningLength > 0;
 
@@ -156,7 +156,7 @@ export const TestController: React.FC = () => {
     setBotStatus(BotStatus.publishing);
     dismissDialog();
     const { luis, qna } = config;
-    const endpointKey = settings.qna.endpointKey;
+    const endpointKey = settings.qna?.endpointKey;
     await setSettings(projectId, {
       ...settings,
       luis: luis,
@@ -205,9 +205,9 @@ export const TestController: React.FC = () => {
       {
         luis: settings.luis,
         qna: {
-          subscriptionKey: settings.qna.subscriptionKey,
-          qnaRegion: settings.qna.qnaRegion,
-          endpointKey: settings.qna.endpointKey,
+          subscriptionKey: settings.qna?.subscriptionKey,
+          qnaRegion: settings.qna?.qnaRegion,
+          endpointKey: settings.qna?.endpointKey,
         },
       }
     );

--- a/Composer/packages/server/src/models/bot/botProject.ts
+++ b/Composer/packages/server/src/models/bot/botProject.ts
@@ -156,20 +156,35 @@ export class BotProject implements IBotProject {
 
   public getEnvSettings = async (obfuscate: boolean) => {
     const settings = await this.settingManager.get(obfuscate);
-    if (settings && oauthInput().MicrosoftAppId && oauthInput().MicrosoftAppId !== OBFUSCATED_VALUE) {
-      settings.MicrosoftAppId = oauthInput().MicrosoftAppId;
-    }
-    if (settings && oauthInput().MicrosoftAppPassword && oauthInput().MicrosoftAppPassword !== OBFUSCATED_VALUE) {
-      settings.MicrosoftAppPassword = oauthInput().MicrosoftAppPassword;
-    }
 
     // fix old bot have no language settings
     if (!settings?.defaultLanguage) {
       settings.defaultLanguage = defaultLanguage;
     }
+
     if (!settings?.languages) {
       settings.languages = [defaultLanguage];
     }
+
+    // migrate to qna.endpointKey
+    if (settings?.qna && typeof settings.qna.endpointkey === 'string') {
+      // if endpointKey has not been set, migrate old key to new key
+      if (!settings.qna.endpointKey) {
+        settings.qna.endpointKey = settings.qna.endpointkey;
+      }
+      delete settings.qna.endpointkey;
+      await this.updateEnvSettings(settings);
+    }
+
+    // set these after migrating qna settings to not write them to storage
+    if (settings && oauthInput().MicrosoftAppId && oauthInput().MicrosoftAppId !== OBFUSCATED_VALUE) {
+      settings.MicrosoftAppId = oauthInput().MicrosoftAppId;
+    }
+
+    if (settings && oauthInput().MicrosoftAppPassword && oauthInput().MicrosoftAppPassword !== OBFUSCATED_VALUE) {
+      settings.MicrosoftAppPassword = oauthInput().MicrosoftAppPassword;
+    }
+
     return settings;
   };
 


### PR DESCRIPTION
## Description

Migrates existing bots to use `qna.endpointKey` instead of `qna.endpointkey` and adds some more defensive accessors when reading from settings.

## Task Item

fixes #3948
fixes #3949