### PR TITLE
fix: Hoisted LU editor in form view is not correctly initialized when creating new trigger

### DIFF
--- a/Composer/packages/client/src/shell/triggerApi.ts
+++ b/Composer/packages/client/src/shell/triggerApi.ts
@@ -41,7 +41,7 @@ function createTriggerApi(
     const index = get(newDialog, 'content.triggers', []).length - 1;
     if (formData.$kind === intentTypeKey && formData.triggerPhrases) {
       const intent = { Name: formData.intent, Body: formData.triggerPhrases };
-      luFile && createLuIntent({ id: luFile.id, intent, projectId });
+      luFile && (await createLuIntent({ id: luFile.id, intent, projectId }));
     } else if (formData.$kind === qnaMatcherKey) {
       const designerId1 = getDesignerIdFromDialogPath(
         newDialog,


### PR DESCRIPTION
## Description
We need to wait for the lu intent creation to finish before navigating to the new url.

I think we need a  mechanism to sync the data between the inline editor and shell in the future.
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
closes #3971 
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
