### PR TITLE
fix: update name don't need to re-render the inline editor when creating a new trigger

### DIFF
--- a/Composer/packages/client/src/components/ProjectTree/TriggerCreationModal.tsx
+++ b/Composer/packages/client/src/components/ProjectTree/TriggerCreationModal.tsx
@@ -432,7 +432,7 @@ export const TriggerCreationModal: React.FC<TriggerCreationModalProps> = (props)
                 luOption={{
                   projectId,
                   fileId: dialogId,
-                  sectionId: formData.intent || PlaceHolderSectionName,
+                  sectionId: PlaceHolderSectionName,
                 }}
                 placeholder={inlineModePlaceholder}
                 value={formData.triggerPhrases}


### PR DESCRIPTION
## Description
update the name will update the formdata.intent. Then the formdata.intent will update the luOption and luOption will trigger the inline editor re-render. The monaco-editor will have two requests when re-rendering.

In this PR use placeholder to fix the luoption and avoid the editor to re-render.
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
closes #3967
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
