### PR TITLE
fix: Handle luis.endpoint empty

### DIFF
--- a/runtime/dotnet/core/ComposerSettingsExtensions.cs
+++ b/runtime/dotnet/core/ComposerSettingsExtensions.cs
@@ -28,7 +28,12 @@ namespace Microsoft.BotFramework.Composer.Core
             var qnaRegion = configuration.GetValue<string>("qna:qnaRegion") ?? "westus";
             var environment = configuration.GetValue<string>("luis:environment") ?? Environment.UserName;
             var settings = new Dictionary<string, string>();
-            settings["luis:endpoint"] = configuration.GetValue<string>("luis:endpoint") ?? $"https://{luisRegion}.api.cognitive.microsoft.com";
+            var luisEndpoint = configuration.GetValue<string>("luis:endpoint");
+            if (String.IsNullOrWhiteSpace(luisEndpoint))
+            {
+                luisEndpoint = $"https://{luisRegion}.api.cognitive.microsoft.com";
+            }
+            settings["luis:endpoint"] = luisEndpoint;
             settings["BotRoot"] = botRoot;
             builder.AddInMemoryCollection(settings);
             if (environment == "Development")


### PR DESCRIPTION
## Description

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

Currently the runtime logic is if the luis.endpoint is missing from the setting, just use https://{luisRegion}.api.cognitive.microsoft.com

The runtime should also handle the condition when luis.endpoint does exist but it is an empty string. 

## Task Item

closes #4026 

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
