### PR TITLE
chore: add selfsigned to resolutions

### DIFF
--- a/Composer/package.json
+++ b/Composer/package.json
@@ -3,16 +3,16 @@
   "license": "MIT",
   "private": true,
   "resolutions": {
-    "@types/react": "16.9.23",
-    "mkdirp": "^0.5.2",
-    "serialize-javascript": "^3.1.0",
-    "lodash": "^4.17.12",
-    "set-value": "^3.0.2",
-    "kind-of": "^6.0.3",
-    "elliptic": "^6.5.3",
     "@babel/parser": "^7.11.3",
+    "@types/react": "16.9.23",
     "bl": "^2.2.1",
-    "node-forge": "0.9.0"
+    "elliptic": "^6.5.3",
+    "kind-of": "^6.0.3",
+    "lodash": "^4.17.12",
+    "mkdirp": "^0.5.2",
+    "selfsigned": "1.10.8",
+    "serialize-javascript": "^3.1.0",
+    "set-value": "^3.0.2"
   },
   "engines": {
     "node": ">=12"

--- a/Composer/yarn.lock
+++ b/Composer/yarn.lock
@@ -13665,10 +13665,10 @@ node-fetch@^2.1.2, node-fetch@^2.6.0, node-fetch@~2.6.0:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
-node-forge@0.9.0:
-  version "0.9.0"
-  resolved "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/node-forge/-/node-forge-0.9.0.tgz#d624050edbb44874adca12bb9a52ec63cb782579"
-  integrity sha1-1iQFDtu0SHStyhK7mlLsY8t4JXk=
+node-forge@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
+  integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -16849,12 +16849,12 @@ select-hose@^2.0.0:
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
   integrity sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=
 
-selfsigned@^1.10.7:
-  version "1.10.7"
-  resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.10.7.tgz#da5819fd049d5574f28e88a9bcc6dbc6e6f3906b"
-  integrity sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==
+selfsigned@1.10.8, selfsigned@^1.10.7:
+  version "1.10.8"
+  resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.10.8.tgz#0d17208b7d12c33f8eac85c41835f27fc3d81a30"
+  integrity sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==
   dependencies:
-    node-forge "0.9.0"
+    node-forge "^0.10.0"
 
 semver-compare@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Description

Adds `selfsigned` to resoltuions instead of `node-forge` which bumps the `node-forge` dependency.

## Task Item

#minor
