### PR TITLE
[Do not merge] fix: Typing too fast in composer results in dropped characters. (by solving over rendering)

### DIFF
--- a/Composer/packages/adaptive-form/src/components/fields/ArrayField.tsx
+++ b/Composer/packages/adaptive-form/src/components/fields/ArrayField.tsx
@@ -3,7 +3,6 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import React, { useState } from 'react';
-import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import { IconButton } from 'office-ui-fabric-react/lib/Button';
 import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
 import { SharedColors, NeutralColors, FontSizes } from '@uifabric/fluent-theme';
@@ -16,6 +15,7 @@ import { FieldLabel } from '../FieldLabel';
 import { arrayField } from './styles';
 import { ArrayFieldItem } from './ArrayFieldItem';
 import { UnsupportedField } from './UnsupportedField';
+import { WrappedTextField } from './WrappedTextField';
 
 const ArrayField: React.FC<FieldProps<unknown[]>> = (props) => {
   const {
@@ -79,7 +79,7 @@ const ArrayField: React.FC<FieldProps<unknown[]>> = (props) => {
       </div>
       <div css={arrayField.inputFieldContainer}>
         <div css={arrayField.field}>
-          <TextField
+          <WrappedTextField
             ariaLabel={formatMessage('New value')}
             data-testid="string-array-text-input"
             iconProps={{

--- a/Composer/packages/adaptive-form/src/components/fields/EditableField.tsx
+++ b/Composer/packages/adaptive-form/src/components/fields/EditableField.tsx
@@ -2,10 +2,12 @@
 // Licensed under the MIT License.
 
 import React, { useState, useEffect } from 'react';
-import { TextField, ITextFieldStyles } from 'office-ui-fabric-react/lib/TextField';
+import { ITextFieldStyles } from 'office-ui-fabric-react/lib/TextField';
 import { NeutralColors } from '@uifabric/fluent-theme';
 import { mergeStyleSets } from '@uifabric/styling';
 import { FieldProps } from '@bfc/extension-client';
+
+import { WrappedTextField } from './WrappedTextField';
 
 interface EditableFieldProps extends Omit<FieldProps, 'definitions'> {
   fontSize?: string;
@@ -64,7 +66,7 @@ const EditableField: React.FC<EditableFieldProps> = (props) => {
       onMouseEnter={() => setEditing(true)}
       onMouseLeave={() => !hasFocus && setEditing(false)}
     >
-      <TextField
+      <WrappedTextField
         ariaLabel={ariaLabel}
         autoComplete="off"
         errorMessage={error as string}

--- a/Composer/packages/adaptive-form/src/components/fields/ExpressionField/ExpressionEditor.tsx
+++ b/Composer/packages/adaptive-form/src/components/fields/ExpressionField/ExpressionEditor.tsx
@@ -4,10 +4,11 @@
 import { FieldProps, useShellApi } from '@bfc/extension-client';
 import { IntellisenseTextField } from '@bfc/intellisense';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
-import { TextField } from 'office-ui-fabric-react/lib/TextField';
+// import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import React from 'react';
 
 import { getIntellisenseUrl } from '../../../utils/getIntellisenseUrl';
+import { TestTextField } from '../TestTextField';
 
 const ExpressionEditor: React.FC<FieldProps> = (props) => {
   const { id, value = '', onChange, disabled, placeholder, readonly, error } = props;
@@ -24,7 +25,7 @@ const ExpressionEditor: React.FC<FieldProps> = (props) => {
       onChange={onChange}
     >
       {(textFieldValue, onValueChanged, onKeyDownTextField, onKeyUpTextField, onClickTextField) => (
-        <TextField
+        <TestTextField
           autoComplete="off"
           disabled={disabled}
           errorMessage={error}

--- a/Composer/packages/adaptive-form/src/components/fields/ExpressionField/ExpressionEditor.tsx
+++ b/Composer/packages/adaptive-form/src/components/fields/ExpressionField/ExpressionEditor.tsx
@@ -4,11 +4,10 @@
 import { FieldProps, useShellApi } from '@bfc/extension-client';
 import { IntellisenseTextField } from '@bfc/intellisense';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
-// import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import React from 'react';
 
 import { getIntellisenseUrl } from '../../../utils/getIntellisenseUrl';
-import { TestTextField } from '../TestTextField';
+import { WrappedTextField } from '../WrappedTextField';
 
 const ExpressionEditor: React.FC<FieldProps> = (props) => {
   const { id, value = '', onChange, disabled, placeholder, readonly, error } = props;
@@ -25,7 +24,7 @@ const ExpressionEditor: React.FC<FieldProps> = (props) => {
       onChange={onChange}
     >
       {(textFieldValue, onValueChanged, onKeyDownTextField, onKeyUpTextField, onClickTextField) => (
-        <TestTextField
+        <WrappedTextField
           autoComplete="off"
           disabled={disabled}
           errorMessage={error}

--- a/Composer/packages/adaptive-form/src/components/fields/IntellisenseField.tsx
+++ b/Composer/packages/adaptive-form/src/components/fields/IntellisenseField.tsx
@@ -3,11 +3,12 @@
 
 import { FieldProps } from '@bfc/extension-client';
 import { IntellisenseTextField } from '@bfc/intellisense';
-import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import React from 'react';
 
 import { getIntellisenseUrl } from '../../utils/getIntellisenseUrl';
 import { FieldLabel } from '../FieldLabel';
+
+import { WrappedTextField } from './WrappedTextField';
 
 export const IntellisenseField: React.FC<FieldProps<string>> = function IntellisenseField(props) {
   const { id, value = '', onChange, label, description, uiOptions, required } = props;
@@ -24,7 +25,7 @@ export const IntellisenseField: React.FC<FieldProps<string>> = function Intellis
         onChange={onChange}
       >
         {(textFieldValue, onValueChanged, onKeyDownTextField, onKeyUpTextField, onClickTextField) => (
-          <TextField
+          <WrappedTextField
             autoComplete="off"
             id={id}
             value={textFieldValue}

--- a/Composer/packages/adaptive-form/src/components/fields/ObjectArrayField.tsx
+++ b/Composer/packages/adaptive-form/src/components/fields/ObjectArrayField.tsx
@@ -8,7 +8,7 @@ import { FieldProps, useShellApi } from '@bfc/extension-client';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { JSONSchema7 } from 'json-schema';
 import { IconButton } from 'office-ui-fabric-react/lib/Button';
-import { TextField, ITextField } from 'office-ui-fabric-react/lib/TextField';
+import { ITextField } from 'office-ui-fabric-react/lib/TextField';
 import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
 import { FontSizes, NeutralColors, SharedColors } from '@uifabric/fluent-theme';
 import formatMessage from 'format-message';
@@ -20,6 +20,7 @@ import { FieldLabel } from '../FieldLabel';
 import { objectArrayField } from './styles';
 import { ArrayFieldItem } from './ArrayFieldItem';
 import { UnsupportedField } from './UnsupportedField';
+import { WrappedTextField } from './WrappedTextField';
 
 const getNewPlaceholder = (props: FieldProps<any[]>, propertyName: string): string | undefined => {
   const { uiOptions } = props;
@@ -152,7 +153,7 @@ const ObjectArrayField: React.FC<FieldProps<any[]>> = (props) => {
                   if (typeof property === 'string') {
                     return (
                       <div key={index} css={objectArrayField.objectItemInputField}>
-                        <TextField
+                        <WrappedTextField
                           ariaLabel={lastField ? END_OF_ROW_LABEL : INSIDE_ROW_LABEL}
                           autoComplete="off"
                           componentRef={index === 0 ? firstNewFieldRef : undefined}

--- a/Composer/packages/adaptive-form/src/components/fields/ObjectField.tsx
+++ b/Composer/packages/adaptive-form/src/components/fields/ObjectField.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-import React, { useRef } from 'react';
+import React from 'react';
 import { FieldProps } from '@bfc/extension-client';
 
 import { getOrderedProperties } from '../../utils';
@@ -8,8 +8,6 @@ import { FormRow } from '../FormRow';
 
 const ObjectField: React.FC<FieldProps<object>> = function ObjectField(props) {
   const { schema, uiOptions, depth, value, label, ...rest } = props;
-  const valueRef = useRef(value);
-  valueRef.current = value;
 
   if (!schema) {
     return null;
@@ -18,7 +16,7 @@ const ObjectField: React.FC<FieldProps<object>> = function ObjectField(props) {
   const newDepth = depth + 1;
 
   const handleChange = (field: string) => (data: any) => {
-    const newData = { ...valueRef.current };
+    const newData = { ...value };
 
     if (typeof data === 'undefined' || (typeof data === 'string' && data.length === 0)) {
       delete newData[field];

--- a/Composer/packages/adaptive-form/src/components/fields/ObjectField.tsx
+++ b/Composer/packages/adaptive-form/src/components/fields/ObjectField.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-import React from 'react';
+import React, { useRef } from 'react';
 import { FieldProps } from '@bfc/extension-client';
 
 import { getOrderedProperties } from '../../utils';
@@ -8,6 +8,8 @@ import { FormRow } from '../FormRow';
 
 const ObjectField: React.FC<FieldProps<object>> = function ObjectField(props) {
   const { schema, uiOptions, depth, value, label, ...rest } = props;
+  const valueRef = useRef(value);
+  valueRef.current = value;
 
   if (!schema) {
     return null;
@@ -16,7 +18,7 @@ const ObjectField: React.FC<FieldProps<object>> = function ObjectField(props) {
   const newDepth = depth + 1;
 
   const handleChange = (field: string) => (data: any) => {
-    const newData = { ...value };
+    const newData = { ...valueRef.current };
 
     if (typeof data === 'undefined' || (typeof data === 'string' && data.length === 0)) {
       delete newData[field];

--- a/Composer/packages/adaptive-form/src/components/fields/StringField.tsx
+++ b/Composer/packages/adaptive-form/src/components/fields/StringField.tsx
@@ -4,10 +4,11 @@
 import React from 'react';
 import { FieldProps } from '@bfc/extension-client';
 import { NeutralColors } from '@uifabric/fluent-theme';
-import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import formatMessage from 'format-message';
 
 import { FieldLabel } from '../FieldLabel';
+
+import { WrappedTextField } from './WrappedTextField';
 
 export const borderStyles = (transparentBorder: boolean, error: boolean) =>
   transparentBorder
@@ -63,7 +64,7 @@ export const StringField: React.FC<FieldProps<string>> = function StringField(pr
   return (
     <>
       <FieldLabel description={description} helpLink={uiOptions?.helpLink} id={id} label={label} required={required} />
-      <TextField
+      <WrappedTextField
         ariaLabel={label || formatMessage('string field')}
         disabled={disabled}
         errorMessage={error}

--- a/Composer/packages/adaptive-form/src/components/fields/TestTextField.tsx
+++ b/Composer/packages/adaptive-form/src/components/fields/TestTextField.tsx
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { TextField, ITextFieldProps } from 'office-ui-fabric-react/lib/TextField';
+import React from 'react';
+
+export class TestTextField extends React.Component<ITextFieldProps> {
+  shouldComponentUpdate(nextProps: ITextFieldProps, nextState) {
+    if (this.props.value !== nextProps.value) {
+      return true;
+    }
+
+    if (typeof nextProps.errorMessage === 'string' && this.props.errorMessage !== nextProps.errorMessage) {
+      return true;
+    }
+
+    return false;
+  }
+
+  render() {
+    return <TextField {...this.props} />;
+  }
+}

--- a/Composer/packages/adaptive-form/src/components/fields/WrappedTextField.tsx
+++ b/Composer/packages/adaptive-form/src/components/fields/WrappedTextField.tsx
@@ -4,8 +4,8 @@
 import { TextField, ITextFieldProps } from 'office-ui-fabric-react/lib/TextField';
 import React from 'react';
 
-export class TestTextField extends React.Component<ITextFieldProps> {
-  shouldComponentUpdate(nextProps: ITextFieldProps, nextState) {
+export class WrappedTextField extends React.Component<ITextFieldProps> {
+  shouldComponentUpdate(nextProps: ITextFieldProps) {
     if (this.props.value !== nextProps.value) {
       return true;
     }

--- a/Composer/packages/adaptive-form/src/components/fields/WrappedTextField.tsx
+++ b/Composer/packages/adaptive-form/src/components/fields/WrappedTextField.tsx
@@ -6,15 +6,11 @@ import React from 'react';
 
 export class WrappedTextField extends React.Component<ITextFieldProps> {
   shouldComponentUpdate(nextProps: ITextFieldProps) {
-    if (this.props.value !== nextProps.value) {
-      return true;
+    if (this.props.value === nextProps.value) {
+      return false;
     }
 
-    if (typeof nextProps.errorMessage === 'string' && this.props.errorMessage !== nextProps.errorMessage) {
-      return true;
-    }
-
-    return false;
+    return true;
   }
 
   render() {


### PR DESCRIPTION
## Description
This is a quick fix for TextField over rendering.

The first step is use class shouldComponentUpdate to trigger a render only  when the value and error changed.

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
refs #4171
closes #4102
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
