### PR TITLE
fix: fix loading of extensions by removing sample-ui-plugin

### DIFF
--- a/Composer/packages/extension/src/manager/manager.ts
+++ b/Composer/packages/extension/src/manager/manager.ts
@@ -245,12 +245,15 @@ class ExtensionManager {
       const extensionInstallPath = path.dirname(fullPath);
       const packageJson = (await readJson(fullPath)) as PackageJSON;
       const isEnabled = packageJson?.composer && packageJson.composer.enabled !== false;
+      const metadata = getExtensionMetadata(extensionInstallPath, packageJson);
       if (packageJson && (isEnabled || packageJson.extendsComposer === true)) {
-        const metadata = getExtensionMetadata(extensionInstallPath, packageJson);
         this.manifest.updateExtensionConfig(packageJson.name, {
           ...metadata,
           builtIn: true,
         });
+      } else if (this.manifest.getExtensionConfig(packageJson.name)) {
+        // remove the extension if it exists in the manifest
+        this.manifest.removeExtension(packageJson.name);
       }
     }
   }

--- a/Composer/packages/extension/src/storage/extensionManifestStore.ts
+++ b/Composer/packages/extension/src/storage/extensionManifestStore.ts
@@ -33,6 +33,13 @@ export class ExtensionManifestStore {
       this.manifest = (this.manifest.extensions as unknown) as ExtensionMap;
       this.writeManifestToDisk();
     }
+
+    // fix for sample-ui-plugin
+    // TODO: remove in the future
+    /* istanbul ignore next */
+    if (this.getExtensionConfig('sample-ui-plugin')) {
+      this.removeExtension('sample-ui-plugin');
+    }
   }
 
   public getExtensionConfig(id: string) {

--- a/Composer/packages/extension/src/storage/extensionManifestStore.ts
+++ b/Composer/packages/extension/src/storage/extensionManifestStore.ts
@@ -33,13 +33,6 @@ export class ExtensionManifestStore {
       this.manifest = (this.manifest.extensions as unknown) as ExtensionMap;
       this.writeManifestToDisk();
     }
-
-    // fix for sample-ui-plugin
-    // TODO: remove in the future
-    /* istanbul ignore next */
-    if (this.getExtensionConfig('sample-ui-plugin')) {
-      this.removeExtension('sample-ui-plugin');
-    }
   }
 
   public getExtensionConfig(id: string) {


### PR DESCRIPTION
## Description

In #4224, the way builtin plugins are loaded changed which breaks when the `extensions.json` file already existed, due to a failure to load the `sample-ui-plugin`. This just removes that from the manifest.

## Task Item

#minor