### PR TITLE
fix: Windows platform 'spawn npm ENOENT' error

### DIFF
--- a/Composer/packages/extension/src/utils/npm.ts
+++ b/Composer/packages/extension/src/utils/npm.ts
@@ -38,7 +38,7 @@ export async function npm(command: NpmCommand, args: string, opts: NpmOptions = 
     let stdout = '';
     let stderr = '';
 
-    const proc = spawn('npm', spawnArgs);
+    const proc = spawn(/^win/.test(process.platform) ? 'npm.cmd' : 'npm', spawnArgs);
 
     proc.stdout.on('data', (data) => {
       stdout += data;


### PR DESCRIPTION
## Description
closes #4244 
![fa86d1bc-b28c-47d3-b605-ef8dbc1c4807](https://user-images.githubusercontent.com/8528761/94025553-349bf780-fdeb-11ea-9083-531db6f534c1.jpg)
For Windows platform, the first time Composer invokes `spawn("npm")` requires the path be `npm.cmd` instead of `npm`.
Once the `npm` PATH is resolved and cached by Windows OS, spawn command with either `npm` or `npm.cmd` will be executed correctly.

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
