### PR TITLE
fix: Monaco editor links opened in blank window in electron

### DIFF
--- a/Composer/packages/lib/code-editor/src/BaseEditor.tsx
+++ b/Composer/packages/lib/code-editor/src/BaseEditor.tsx
@@ -13,6 +13,8 @@ import { Diagnostic } from '@bfc/shared';
 import { findErrors, combineSimpleMessage, findWarnings } from '@bfc/indexers';
 import { CodeEditorSettings, assignDefined } from '@bfc/shared';
 
+import { isElectron } from './utils';
+
 const defaultOptions = {
   scrollBeyondLastLine: false,
   wordWrap: 'off',
@@ -32,6 +34,7 @@ const defaultOptions = {
   renderLineHighlight: 'none',
   formatOnType: true,
   fixedOverflowWidgets: true,
+  links: isElectron() ? false : true, // disable in electron@8.2.4 before monaco editor can set target '_blank'
 };
 
 const styles = {

--- a/Composer/packages/lib/code-editor/src/utils/common.ts
+++ b/Composer/packages/lib/code-editor/src/utils/common.ts
@@ -4,3 +4,8 @@
 export function processSize(size) {
   return !/^\d+$/.test(size) ? size : `${size}px`;
 }
+
+export function isElectron(): boolean {
+  // eslint-disable-next-line no-prototype-builtins
+  return window.hasOwnProperty('__IS_ELECTRON__');
+}

--- a/Composer/packages/lib/code-editor/src/utils/common.ts
+++ b/Composer/packages/lib/code-editor/src/utils/common.ts
@@ -6,6 +6,5 @@ export function processSize(size) {
 }
 
 export function isElectron(): boolean {
-  // eslint-disable-next-line no-prototype-builtins
-  return window.hasOwnProperty('__IS_ELECTRON__');
+  return !window.__IS_ELECTRON__;
 }

--- a/Composer/packages/lib/code-editor/src/utils/common.ts
+++ b/Composer/packages/lib/code-editor/src/utils/common.ts
@@ -6,5 +6,5 @@ export function processSize(size) {
 }
 
 export function isElectron(): boolean {
-  return !window.__IS_ELECTRON__;
+  return !(window as any).__IS_ELECTRON__;
 }


### PR DESCRIPTION
## Description


Monaco editor has option config to auto detect urls in text. ctrl + click on it will call vscode.open() -> window.open() open url.
Our current electron setting can handle `<a target="_blank">open in browser</a>`, but electron@8.2.4 seems has issue accept correct arguments. then we will see a empty page, case the accepted arguments `url` is `about:blank`.

### Alternative solution
If we upgrade electron@10.1.1, the electron opened window would be correctly, but still failed to open in default browser.

### Current solution
So before find a better way, current fix is disable link detecting in BaseEditor.text for electron environment.

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
close #4070

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

Before (electron): 

<img width="752" alt="image" src="https://user-images.githubusercontent.com/49866537/94251559-45687c80-ff55-11ea-8dbe-3d8bd1a6097a.png">

After (electron):

<img width="1165" alt="image" src="https://user-images.githubusercontent.com/49866537/94253927-96c63b00-ff58-11ea-80a5-09175b2c07c6.png">


<!---
Please include screenshots or gifs if your PR include UX changes.
--->
