### PR TITLE
fix: Adding missing tslib reference to server packages

### DIFF
--- a/Composer/packages/server/package.json
+++ b/Composer/packages/server/package.json
@@ -93,6 +93,7 @@
     "portfinder": "1.0.25",
     "rimraf": "^3.0.2",
     "ts-md5": "^1.2.7",
+    "tslib": "^2.0.0",
     "uuid": "^8.3.0",
     "vscode-languageserver": "^5.3.0-next",
     "vscode-ws-jsonrpc": "^0.1.1",


### PR DESCRIPTION
## Description
Adds the missing reference to \Composer\packages\server\package.json
"tslib": "^2.0.0",

## Task Item
Closes #4024