### PR TITLE
Fix authentication configuration

### DIFF
--- a/runtime/dotnet/azurewebapp/Startup.cs
+++ b/runtime/dotnet/azurewebapp/Startup.cs
@@ -142,6 +142,10 @@ namespace Microsoft.BotFramework.Composer.WebAppTemplates
             {
                 services.AddSingleton(sp => new AuthenticationConfiguration { ClaimsValidator = new AllowedCallersClaimsValidator(settings.Skill) });
             }
+            else
+            {
+                services.AddSingleton(sp => new AuthenticationConfiguration());
+            }
 
             // register components.
             ComponentRegistration.Add(new DialogsComponentRegistration());
@@ -196,7 +200,8 @@ namespace Microsoft.BotFramework.Composer.WebAppTemplates
 
             resourceExplorer.RegisterType<OnQnAMatch>("Microsoft.OnQnAMatch");
 
-            services.AddSingleton<IBotFrameworkHttpAdapter, BotFrameworkHttpAdapter>((s) => GetBotAdapter(storage, settings, userState, conversationState, s, s.GetService<TelemetryInitializerMiddleware>()));
+            services.AddSingleton<IBotFrameworkHttpAdapter, BotFrameworkHttpAdapter>((s) =>
+                GetBotAdapter(storage, settings, userState, conversationState, s, s.GetService<TelemetryInitializerMiddleware>()));
 
             var removeRecipientMention = settings?.Feature?.RemoveRecipientMention ?? false;
 

--- a/runtime/dotnet/azurewebapp/Startup.cs
+++ b/runtime/dotnet/azurewebapp/Startup.cs
@@ -92,7 +92,15 @@ namespace Microsoft.BotFramework.Composer.WebAppTemplates
 
         public BotFrameworkHttpAdapter GetBotAdapter(IStorage storage, BotSettings settings, UserState userState, ConversationState conversationState, IServiceProvider s, TelemetryInitializerMiddleware telemetryInitializerMiddleware)
         {
-            var adapter = IsSkill(settings) ? new BotFrameworkHttpAdapter(new ConfigurationCredentialProvider(this.Configuration), s.GetService<AuthenticationConfiguration>()) : new BotFrameworkHttpAdapter(new ConfigurationCredentialProvider(this.Configuration));
+            BotFrameworkHttpAdapter adapter;
+            if (IsSkill(settings))
+            {
+                adapter = new BotFrameworkHttpAdapter(new ConfigurationCredentialProvider(this.Configuration), s.GetService<AuthenticationConfiguration>());
+            }
+            else
+            {
+                adapter = new BotFrameworkHttpAdapter(new ConfigurationCredentialProvider(this.Configuration));
+            }
 
             adapter
               .UseStorage(storage)


### PR DESCRIPTION
## Description
Bot wasn't starting complaning that the service Microsoft.Bot.Connector.Authentication.AuthenticationConfiguration wasn't found.

It's a common exception when something is not added to the ServiceProviders, therefore, the DI engine cannot find it.

When the screen for Skills were created, a validation to check whether it is a skill or not was also added, because the AllowedCallersClaimsValidator method.
![image](https://user-images.githubusercontent.com/4707327/94921924-a16c5d00-048f-11eb-95db-001033f395da.png)

If not, the AuthenticationConfiguration wasn't added:
![image](https://user-images.githubusercontent.com/4707327/94922015-cd87de00-048f-11eb-8590-c0e1df2cc1a7.png)


Later on the Startup.cs, on the GetBotAdapter method, when creating the BotFrameworkHttpAdapter, the ServiceProvider was called to get the AuthenticationConfiguration method, which did not exist, causing the exception.

![image](https://user-images.githubusercontent.com/4707327/94922206-2a839400-0490-11eb-9b0f-d10521ef8dfb.png)

Since, on the Service Locator Pattern, optional Dependencies are considered an anti-pattern, the AuthenticationConfiguration should always exists, and not be branched.
![image](https://user-images.githubusercontent.com/4707327/94923005-8dc1f600-0491-11eb-98ed-c693ac40a9e0.png)

For that to work, the Singleton for AuthenticationConfiguration should be changed to:
![image](https://user-images.githubusercontent.com/4707327/94923077-a8946a80-0491-11eb-886d-590b8c393d44.png)



## Task Item
Closes #4313 