### PR TITLE
refactor: change method of installing extensions

### DIFF
--- a/Composer/.eslintrc.js
+++ b/Composer/.eslintrc.js
@@ -105,6 +105,7 @@ module.exports = {
         '@typescript-eslint/no-non-null-assertion': 'off',
         '@typescript-eslint/no-object-literal-type-assertion': 'off',
         '@typescript-eslint/unbound-method': 'off',
+        '@typescript-eslint/no-explicit-any': 'off',
 
         'security/detect-buffer-noassert': 'off',
         'security/detect-child-process': 'off',

--- a/Composer/package.json
+++ b/Composer/package.json
@@ -12,7 +12,8 @@
     "mkdirp": "^0.5.2",
     "selfsigned": "1.10.8",
     "serialize-javascript": "^3.1.0",
-    "set-value": "^3.0.2"
+    "set-value": "^3.0.2",
+    "terser-webpack-plugin": "^2.3.7"
   },
   "engines": {
     "node": ">=12"

--- a/Composer/packages/electron-server/src/main.ts
+++ b/Composer/packages/electron-server/src/main.ts
@@ -63,7 +63,7 @@ async function createAppDataDir() {
   const azurePublishPath: string = join(composerAppDataPath, 'publishBots');
   process.env.COMPOSER_APP_DATA = join(composerAppDataPath, 'data.json'); // path to the actual data file
   process.env.COMPOSER_EXTENSION_DATA = join(composerAppDataPath, 'extensions.json');
-  process.env.COMPOSER_REMOTE_EXTENSIONS_DIR = join(composerAppDataPath, '.composer');
+  process.env.COMPOSER_REMOTE_EXTENSIONS_DIR = join(composerAppDataPath, 'extensions');
 
   log('creating composer app data path at: ', composerAppDataPath);
 

--- a/Composer/packages/extension/package.json
+++ b/Composer/packages/extension/package.json
@@ -20,6 +20,7 @@
     "@types/path-to-regexp": "^1.7.0",
     "@types/tar": "^4.0.3",
     "json-schema": "^0.2.5",
+    "rimraf": "^3.0.2",
     "typescript": "^3.8.3"
   },
   "dependencies": {

--- a/Composer/packages/extension/package.json
+++ b/Composer/packages/extension/package.json
@@ -18,6 +18,7 @@
     "@types/fs-extra": "^9.0.1",
     "@types/passport": "^1.0.3",
     "@types/path-to-regexp": "^1.7.0",
+    "@types/tar": "^4.0.3",
     "json-schema": "^0.2.5",
     "rimraf": "^3.0.2",
     "typescript": "^3.8.3"
@@ -26,7 +27,10 @@
     "debug": "^4.1.1",
     "fs-extra": "^9.0.1",
     "globby": "^11.0.0",
+    "node-fetch": "^2.6.1",
     "passport": "^0.4.1",
-    "path-to-regexp": "^6.1.0"
+    "path-to-regexp": "^6.1.0",
+    "rimraf": "^3.0.2",
+    "tar": "^6.0.5"
   }
 }

--- a/Composer/packages/extension/package.json
+++ b/Composer/packages/extension/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "yarn build:clean && yarn build:ts",
     "build:ts": "tsc -p tsconfig.build.json",
-    "build:clean": "rimraf lib && rimraf build",
+    "build:clean": "rimraf lib",
     "lint": "eslint --quiet ./src",
     "test": "jest"
   },
@@ -20,7 +20,6 @@
     "@types/path-to-regexp": "^1.7.0",
     "@types/tar": "^4.0.3",
     "json-schema": "^0.2.5",
-    "rimraf": "^3.0.2",
     "typescript": "^3.8.3"
   },
   "dependencies": {
@@ -30,7 +29,6 @@
     "node-fetch": "^2.6.1",
     "passport": "^0.4.1",
     "path-to-regexp": "^6.1.0",
-    "rimraf": "^3.0.2",
     "tar": "^6.0.5"
   }
 }

--- a/Composer/packages/extension/src/extensionContext.ts
+++ b/Composer/packages/extension/src/extensionContext.ts
@@ -88,7 +88,7 @@ class ExtensionContext {
     const packageJSON = fs.readFileSync(packageJsonPath, 'utf8');
     const json = JSON.parse(packageJSON);
 
-    if (json.extendsComposer) {
+    if (json.composer?.enabled !== false) {
       const modulePath = path.dirname(packageJsonPath);
       try {
         // eslint-disable-next-line security/detect-non-literal-require, @typescript-eslint/no-var-requires

--- a/Composer/packages/extension/src/manager/__tests__/manager.test.ts
+++ b/Composer/packages/extension/src/manager/__tests__/manager.test.ts
@@ -302,6 +302,19 @@ describe('#search', () => {
     expect(search).toHaveBeenCalledWith('foo');
     expect(results).toHaveLength(2);
   });
+
+  it('omits currently installed extensions', async () => {
+    (manifest.getExtensionConfig as jest.Mock).mockImplementation((id) => {
+      return mockManifest[id];
+    });
+
+    manager = new ExtensionManagerImp(manifest);
+
+    const results = await manager.search('foo');
+
+    expect(search).toHaveBeenCalledWith('foo');
+    expect(results).toHaveLength(1);
+  });
 });
 
 // describe('#getBundle', () => {});

--- a/Composer/packages/extension/src/manager/__tests__/manager.test.ts
+++ b/Composer/packages/extension/src/manager/__tests__/manager.test.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { writeJsonSync, esnureDir } from 'fs-extra';
+import { readJson, ensureDir } from 'fs-extra';
+import glob from 'globby';
 
 import { ExtensionManifestStore, ExtensionManifest } from '../../storage/extensionManifestStore';
 import { ExtensionManagerImp } from '../manager';
@@ -24,9 +25,12 @@ const mockManifest = ({
 
 jest.mock('../../storage/extensionManifestStore');
 
-// jest.mock('fs-extra', () => {
+jest.mock('globby', () => jest.fn());
 
-// });
+jest.mock('fs-extra', () => ({
+  ensureDir: jest.fn(),
+  readJson: jest.fn(),
+}));
 
 let manager: ExtensionManagerImp;
 let manifest: ExtensionManifestStore;
@@ -69,22 +73,101 @@ describe('#find', () => {
 });
 
 describe('#loadAll', () => {
-  it('loads built-in extensions and remote extensions that are enabled', async () => {
-    const loadSpy = jest.spyOn(manager, 'loadFromDir');
+  let loadSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    manager = new ExtensionManagerImp(manifest);
+    loadSpy = jest.spyOn(manager, 'loadFromDir');
 
     loadSpy.mockReturnValue(Promise.resolve());
+  });
 
+  it('ensures remote dir is created', async () => {
+    await manager.loadAll();
+
+    expect(ensureDir).toHaveBeenCalledWith(process.env.COMPOSER_REMOTE_EXTENSIONS_DIR);
+  });
+
+  it('loads built-in extensions and remote extensions that are enabled', async () => {
     await manager.loadAll();
 
     expect(loadSpy).toHaveBeenCalledTimes(2);
-    expect(loadSpy).toHaveBeenNthCalledWith(1, process.env.COMPOSER_BUILTIN_EXTENSIONS_DIR);
+    expect(loadSpy).toHaveBeenNthCalledWith(1, process.env.COMPOSER_BUILTIN_EXTENSIONS_DIR, true);
     expect(loadSpy).toHaveBeenNthCalledWith(2, process.env.COMPOSER_REMOTE_EXTENSIONS_DIR);
   });
 });
 
+describe('#loadFromDir', () => {
+  it('finds all package.json files in dir', async () => {
+    ((glob as unknown) as jest.Mock).mockReturnValue([]);
+    manager = new ExtensionManagerImp(manifest);
+
+    await manager.loadFromDir('/some/dir');
+    expect(glob).toHaveBeenCalledWith('*/package.json', { cwd: '/some/dir' });
+  });
+
+  it('updates the extension manifest and loads each extension found', async () => {
+    ((glob as unknown) as jest.Mock).mockReturnValue(['extension1/package.json', 'extension2/package.json']);
+    (readJson as jest.Mock).mockImplementation((path) => {
+      if (path.includes('extension1')) {
+        return {
+          name: 'extension1',
+        };
+      } else if (path.includes('extension2')) {
+        return {
+          name: 'extension2',
+        };
+      }
+
+      return {};
+    });
+
+    manager = new ExtensionManagerImp(manifest);
+    const loadSpy = jest.spyOn(manager, 'load');
+    loadSpy.mockResolvedValue(undefined);
+
+    await manager.loadFromDir('/some/dir');
+
+    expect(readJson).toHaveBeenCalledWith('/some/dir/extension1/package.json');
+    expect(readJson).toHaveBeenCalledWith('/some/dir/extension2/package.json');
+
+    expect(manifest.updateExtensionConfig).toHaveBeenCalledWith(
+      'extension1',
+      expect.objectContaining({ id: 'extension1' })
+    );
+    expect(manifest.updateExtensionConfig).toHaveBeenCalledWith(
+      'extension2',
+      expect.objectContaining({ id: 'extension2' })
+    );
+
+    expect(loadSpy).toHaveBeenCalledWith('extension1');
+    expect(loadSpy).toHaveBeenCalledWith('extension2');
+  });
+
+  it('removes the extension from the manifest if not enabled', async () => {
+    ((glob as unknown) as jest.Mock).mockReturnValue(['extension1/package.json']);
+    (readJson as jest.Mock).mockResolvedValue({
+      name: 'extension1',
+      composer: {
+        enabled: false,
+      },
+    });
+    (manifest.getExtensionConfig as jest.Mock).mockReturnValueOnce('extension1');
+
+    manager = new ExtensionManagerImp(manifest);
+    const loadSpy = jest.spyOn(manager, 'load');
+    loadSpy.mockResolvedValue(undefined);
+
+    await manager.loadFromDir('/some/dir');
+
+    expect(manifest.updateExtensionConfig).not.toHaveBeenCalled();
+    expect(loadSpy).not.toHaveBeenCalled();
+    expect(manifest.removeExtension).toHaveBeenCalledTimes(1);
+    expect(manifest.removeExtension).toHaveBeenCalledWith('extension1');
+  });
+});
+
 // describe('#installRemote', () => {});
-// describe('#loadBuiltinExtensions', () => {});
-// describe('#loadRemotePlugins', () => {});
 // describe('#load', () => {});
 // describe('#enable', () => {});
 // describe('#disable', () => {});

--- a/Composer/packages/extension/src/manager/__tests__/manager.test.ts
+++ b/Composer/packages/extension/src/manager/__tests__/manager.test.ts
@@ -264,58 +264,42 @@ describe('#search', () => {
   beforeEach(() => {
     (search as jest.Mock).mockResolvedValue([
       {
-        name: 'extension1',
+        id: 'extension1',
         keywords: ['botframework-composer', 'extension', 'foo', 'bar'],
         description: 'LOREM ipsum',
         version: '1.0.0',
-        links: { npm: 'extension1 npm link' },
+        url: 'extension1 npm link',
       },
       {
-        name: 'extension-2',
+        id: 'extension-2',
         keywords: ['botframework-composer', 'extension', 'bar'],
         description: 'foo',
         version: '1.0.0',
-        links: { npm: 'extension-2 npm link' },
+        url: 'extension-2 npm link',
       },
       {
-        name: 'foo',
-        keywords: ['botframework-composer', 'extension'],
+        id: 'foo',
+        keywords: ['botframework-composer'],
         description: 'lorem ipsum',
         version: '1.0.0',
-        links: { npm: 'foo npm link' },
+        url: 'foo npm link',
       },
       {
-        name: 'bar',
-        keywords: ['botframework-composer', 'extension'],
+        id: 'bar',
+        keywords: ['botframework-composer'],
         description: '',
         version: '1.0.0',
-        links: { npm: 'bar npm link' },
+        url: 'bar npm link',
       },
     ]);
   });
 
-  it('filters the search cache by the query', async () => {
+  it('filters the search results by the extension keyword', async () => {
     manager = new ExtensionManagerImp(manifest);
 
     const results = await manager.search('foo');
-    expect(results).toHaveLength(3);
-  });
 
-  it('does not use case sensitive', async () => {
-    manager = new ExtensionManagerImp(manifest);
-
-    const results = await manager.search('LoReM');
-    expect(results).toHaveLength(2);
-  });
-
-  it('omits installed extensions', async () => {
-    (manifest.getExtensionConfig as jest.Mock).mockImplementation((id) => {
-      return mockManifest[id];
-    });
-
-    manager = new ExtensionManagerImp(manifest);
-
-    const results = await manager.search('foo');
+    expect(search).toHaveBeenCalledWith('foo');
     expect(results).toHaveLength(2);
   });
 });

--- a/Composer/packages/extension/src/manager/__tests__/manager.test.ts
+++ b/Composer/packages/extension/src/manager/__tests__/manager.test.ts
@@ -1,9 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+import path from 'path';
 
 import { readJson, ensureDir } from 'fs-extra';
 import glob from 'globby';
+import rimraf from 'rimraf';
 
+import { search, downloadPackage } from '../../utils/npm';
 import { ExtensionManifestStore, ExtensionManifest } from '../../storage/extensionManifestStore';
 import { ExtensionManagerImp } from '../manager';
 
@@ -26,11 +29,14 @@ const mockManifest = ({
 jest.mock('../../storage/extensionManifestStore');
 
 jest.mock('globby', () => jest.fn());
+jest.mock('rimraf', () => jest.fn().mockImplementation((path, cb) => cb()));
 
 jest.mock('fs-extra', () => ({
   ensureDir: jest.fn(),
   readJson: jest.fn(),
 }));
+
+jest.mock('../../utils/npm');
 
 let manager: ExtensionManagerImp;
 let manifest: ExtensionManifestStore;
@@ -167,11 +173,151 @@ describe('#loadFromDir', () => {
   });
 });
 
-// describe('#installRemote', () => {});
+describe('#installRemote', () => {
+  it('ensures remote dir exists', async () => {
+    manager = new ExtensionManagerImp(manifest);
+    await manager.installRemote('extension1');
+
+    expect(ensureDir).toHaveBeenLastCalledWith(process.env.COMPOSER_REMOTE_EXTENSIONS_DIR);
+  });
+
+  it('downloads package and updates the manifest', async () => {
+    (readJson as jest.Mock).mockResolvedValue({
+      name: 'extension1',
+    });
+
+    manager = new ExtensionManagerImp(manifest);
+    await manager.installRemote('extension1');
+
+    expect(downloadPackage).toHaveBeenCalledWith(
+      'extension1',
+      'latest',
+      path.join(process.env.COMPOSER_REMOTE_EXTENSIONS_DIR as string, 'extension1')
+    );
+
+    expect(manifest.updateExtensionConfig).toHaveBeenCalledWith(
+      'extension1',
+      expect.objectContaining({ id: 'extension1' })
+    );
+  });
+
+  it('throws an error if problem downloading', () => {
+    (downloadPackage as jest.Mock).mockRejectedValue(undefined);
+    manager = new ExtensionManagerImp(manifest);
+
+    expect(manager.installRemote('extension1', '2.0.0')).rejects.toThrow(/Unable to install/);
+  });
+});
+
 // describe('#load', () => {});
-// describe('#enable', () => {});
-// describe('#disable', () => {});
-// describe('#remove', () => {});
-// describe('#search', () => {});
-// describe('#getAllBundles', () => {});
+
+describe('#enable', () => {
+  it('updates the manifest and reloads the extension', async () => {
+    manager = new ExtensionManagerImp(manifest);
+    const loadSpy = jest.spyOn(manager, 'load');
+    (loadSpy as jest.Mock).mockResolvedValue(undefined);
+
+    await manager.enable('extension1');
+
+    expect(manifest.updateExtensionConfig).toHaveBeenCalledWith('extension1', { enabled: true });
+    expect(loadSpy).toHaveBeenCalledWith('extension1');
+  });
+});
+
+describe('#disable', () => {
+  it('updates the manifest', async () => {
+    manager = new ExtensionManagerImp(manifest);
+
+    await manager.disable('extension1');
+
+    expect(manifest.updateExtensionConfig).toHaveBeenCalledWith('extension1', { enabled: false });
+  });
+});
+
+describe('#remove', () => {
+  it('throws an error if extension not found', () => {
+    (manifest.getExtensionConfig as jest.Mock).mockReturnValue(undefined);
+    manager = new ExtensionManagerImp(manifest);
+
+    expect(manager.remove('extension1')).rejects.toThrow(/Unable to remove extension/);
+  });
+
+  it('throws an error if extension is builtin', () => {
+    (manifest.getExtensionConfig as jest.Mock).mockReturnValue({ builtIn: true });
+    manager = new ExtensionManagerImp(manifest);
+
+    expect(manager.remove('extension1')).rejects.toThrow(/Cannot remove builtin extension./);
+  });
+
+  it('removes the extension from the manifest and cleans up', async () => {
+    (manifest.getExtensionConfig as jest.Mock).mockReturnValue({ builtIn: false, path: '/some/path' });
+    manager = new ExtensionManagerImp(manifest);
+
+    await manager.remove('extension1');
+
+    expect(rimraf).toHaveBeenCalledWith('/some/path', expect.any(Function));
+    expect(manifest.removeExtension).toHaveBeenCalledWith('extension1');
+  });
+});
+
+describe('#search', () => {
+  beforeEach(() => {
+    (search as jest.Mock).mockResolvedValue([
+      {
+        name: 'extension1',
+        keywords: ['botframework-composer', 'extension', 'foo', 'bar'],
+        description: 'LOREM ipsum',
+        version: '1.0.0',
+        links: { npm: 'extension1 npm link' },
+      },
+      {
+        name: 'extension-2',
+        keywords: ['botframework-composer', 'extension', 'bar'],
+        description: 'foo',
+        version: '1.0.0',
+        links: { npm: 'extension-2 npm link' },
+      },
+      {
+        name: 'foo',
+        keywords: ['botframework-composer', 'extension'],
+        description: 'lorem ipsum',
+        version: '1.0.0',
+        links: { npm: 'foo npm link' },
+      },
+      {
+        name: 'bar',
+        keywords: ['botframework-composer', 'extension'],
+        description: '',
+        version: '1.0.0',
+        links: { npm: 'bar npm link' },
+      },
+    ]);
+  });
+
+  it('filters the search cache by the query', async () => {
+    manager = new ExtensionManagerImp(manifest);
+
+    const results = await manager.search('foo');
+    expect(results).toHaveLength(3);
+  });
+
+  it('does not use case sensitive', async () => {
+    manager = new ExtensionManagerImp(manifest);
+
+    const results = await manager.search('LoReM');
+    expect(results).toHaveLength(2);
+  });
+
+  it('omits installed extensions', async () => {
+    (manifest.getExtensionConfig as jest.Mock).mockImplementation((id) => {
+      return mockManifest[id];
+    });
+
+    manager = new ExtensionManagerImp(manifest);
+
+    const results = await manager.search('foo');
+    expect(results).toHaveLength(2);
+  });
+});
+
 // describe('#getBundle', () => {});

--- a/Composer/packages/extension/src/manager/__tests__/manager.test.ts
+++ b/Composer/packages/extension/src/manager/__tests__/manager.test.ts
@@ -202,6 +202,12 @@ describe('#installRemote', () => {
     expect(ensureDir).toHaveBeenLastCalledWith(process.env.COMPOSER_REMOTE_EXTENSIONS_DIR);
   });
 
+  it('validates destination directory', () => {
+    manager = new ExtensionManagerImp(manifest);
+    expect(manager.installRemote('../extension')).rejects.toThrow();
+    expect(manager.installRemote('../../extension')).rejects.toThrow();
+  });
+
   it('downloads package and updates the manifest', async () => {
     (readJson as jest.Mock).mockResolvedValue({
       name: 'extension1',

--- a/Composer/packages/extension/src/manager/__tests__/manager.test.ts
+++ b/Composer/packages/extension/src/manager/__tests__/manager.test.ts
@@ -15,6 +15,12 @@ const mockManifest = ({
     id: 'extension1',
     builtIn: true,
     enabled: true,
+    bundles: [
+      {
+        id: 'bundleId',
+        path: '/some/path',
+      },
+    ],
   },
   extension2: {
     id: 'extension2',
@@ -317,4 +323,25 @@ describe('#search', () => {
   });
 });
 
-// describe('#getBundle', () => {});
+describe('#getBundle', () => {
+  beforeEach(() => {
+    (manifest.getExtensionConfig as jest.Mock).mockImplementation((id) => {
+      return mockManifest[id];
+    });
+  });
+
+  it('throws an error if extension not found', () => {
+    manager = new ExtensionManagerImp(manifest);
+    expect(() => manager.getBundle('does-not-exist', 'bundleId')).toThrow('extension not found');
+  });
+
+  it('throws an error if bundle not found', () => {
+    manager = new ExtensionManagerImp(manifest);
+    expect(() => manager.getBundle('extension1', 'does-not-exist')).toThrow('bundle not found');
+  });
+
+  it('returns the bundle path', () => {
+    manager = new ExtensionManagerImp(manifest);
+    expect(manager.getBundle('extension1', 'bundleId')).toEqual('/some/path');
+  });
+});

--- a/Composer/packages/extension/src/manager/__tests__/manager.test.ts
+++ b/Composer/packages/extension/src/manager/__tests__/manager.test.ts
@@ -263,11 +263,14 @@ describe('#remove', () => {
     expect(manager.remove('extension1')).rejects.toThrow(/Unable to remove extension/);
   });
 
-  it('throws an error if extension is builtin', () => {
+  it('is a no-op if the extension is builtin', async () => {
     (manifest.getExtensionConfig as jest.Mock).mockReturnValue({ builtIn: true });
     manager = new ExtensionManagerImp(manifest);
 
-    expect(manager.remove('extension1')).rejects.toThrow(/Cannot remove builtin extension./);
+    await manager.remove('extension1');
+
+    expect(remove).not.toHaveBeenCalled();
+    expect(manifest.removeExtension).not.toHaveBeenCalled();
   });
 
   it('removes the extension from the manifest and cleans up', async () => {

--- a/Composer/packages/extension/src/manager/manager.ts
+++ b/Composer/packages/extension/src/manager/manager.ts
@@ -191,8 +191,8 @@ export class ExtensionManagerImp {
     const results = await search(query);
 
     return results.filter((searchResult) => {
-      const { keywords } = searchResult;
-      return keywords.includes('botframework-composer') && keywords.includes('extension');
+      const { id, keywords } = searchResult;
+      return !this.find(id) && keywords.includes('extension');
     });
   }
 

--- a/Composer/packages/extension/src/manager/manager.ts
+++ b/Composer/packages/extension/src/manager/manager.ts
@@ -2,19 +2,15 @@
 // Licensed under the MIT License.
 
 import path from 'path';
-import { promisify } from 'util';
 
 import glob from 'globby';
-import { readJson, ensureDir } from 'fs-extra';
+import { readJson, ensureDir, remove } from 'fs-extra';
 
 import { ExtensionContext } from '../extensionContext';
 import logger from '../logger';
 import { ExtensionManifestStore } from '../storage/extensionManifestStore';
 import { ExtensionBundle, PackageJSON, ExtensionMetadata } from '../types/extension';
 import { search, downloadPackage } from '../utils/npm';
-
-// eslint-disable-next-line @typescript-eslint/no-var-requires, import/order
-const rimraf = promisify(require('rimraf'));
 
 const log = logger.extend('manager');
 
@@ -176,7 +172,7 @@ export class ExtensionManagerImp {
         throw new Error('Cannot remove builtin extension.');
       }
 
-      await rimraf(metadata.path);
+      await remove(metadata.path);
       this.manifest.removeExtension(id);
     } else {
       throw new Error(`Unable to remove extension: ${id}`);

--- a/Composer/packages/extension/src/manager/manager.ts
+++ b/Composer/packages/extension/src/manager/manager.ts
@@ -11,6 +11,7 @@ import logger from '../logger';
 import { ExtensionManifestStore } from '../storage/extensionManifestStore';
 import { ExtensionBundle, PackageJSON, ExtensionMetadata } from '../types/extension';
 import { search, downloadPackage } from '../utils/npm';
+import { isSubdirectory } from '../utils/isSubdirectory';
 
 const log = logger.extend('manager');
 
@@ -103,6 +104,11 @@ export class ExtensionManagerImp {
 
     try {
       const destination = path.join(this.remoteDir, name);
+
+      if (!isSubdirectory(this.remoteDir, destination)) {
+        throw new Error('Cannot install outside of the configured directory.');
+      }
+
       await downloadPackage(name, version ?? 'latest', destination);
 
       const packageJson = await this.getPackageJson(name, this.remoteDir);

--- a/Composer/packages/extension/src/manager/manager.ts
+++ b/Composer/packages/extension/src/manager/manager.ts
@@ -68,7 +68,7 @@ export class ExtensionManagerImp {
   public async loadAll() {
     await ensureDir(this.remoteDir);
 
-    await this.loadFromDir(this.builtinDir);
+    await this.loadFromDir(this.builtinDir, true);
     await this.loadFromDir(this.remoteDir);
   }
 
@@ -255,20 +255,17 @@ export class ExtensionManagerImp {
     }
   }
 
-  public reloadManifest() {
-    this._manifest = undefined;
-  }
-
   private get manifest() {
-    if (this._manifest) {
-      return this._manifest;
+    /* istanbul ignore next */
+    if (!this._manifest) {
+      this._manifest = new ExtensionManifestStore(process.env.COMPOSER_EXTENSION_DATA as string);
     }
 
-    this._manifest = new ExtensionManifestStore(process.env.COMPOSER_EXTENSION_DATA as string);
     return this._manifest;
   }
 
   private get builtinDir() {
+    /* istanbul ignore next */
     if (!process.env.COMPOSER_BUILTIN_EXTENSIONS_DIR) {
       throw new Error('COMPOSER_BUILTIN_EXTENSIONS_DIR must be set.');
     }
@@ -277,6 +274,7 @@ export class ExtensionManagerImp {
   }
 
   private get remoteDir() {
+    /* istanbul ignore next */
     if (!process.env.COMPOSER_REMOTE_EXTENSIONS_DIR) {
       throw new Error('COMPOSER_REMOTE_EXTENSIONS_DIR must be set.');
     }

--- a/Composer/packages/extension/src/manager/manager.ts
+++ b/Composer/packages/extension/src/manager/manager.ts
@@ -209,20 +209,6 @@ export class ExtensionManagerImp {
   }
 
   /**
-   * Returns a list of all of an extension's bundles
-   * @param id The ID of the extension for which we will fetch the list of bundles
-   */
-  public async getAllBundles(id: string) {
-    const info = this.find(id);
-
-    if (!info) {
-      throw new Error('extension not found');
-    }
-
-    return info.bundles ?? [];
-  }
-
-  /**
    * Returns a specific bundle for an extension
    * @param id The id of the desired extension
    * @param bundleId The id of the desired extension's bundle
@@ -249,7 +235,7 @@ export class ExtensionManagerImp {
       log('fetching package.json for %s at %s', id, extensionPackagePath);
       const packageJson = await readJson(extensionPackagePath);
       return packageJson as PackageJSON;
-    } catch (err) {
+    } catch (err) /* istanbul ignore next */ {
       log('Error getting package json for %s', id);
       log('%O', err);
     }
@@ -303,7 +289,7 @@ export class ExtensionManagerImp {
             }
           });
         }
-      } catch (err) {
+      } catch (err) /* istanbul ignore next */ {
         log('%O', err);
       }
     }

--- a/Composer/packages/extension/src/manager/manager.ts
+++ b/Composer/packages/extension/src/manager/manager.ts
@@ -120,7 +120,7 @@ class ExtensionManager {
 
       return name;
     } catch (err) {
-      log('%s', err.message ?? err);
+      log('%O', err);
       throw new Error(`Unable to install ${packageNameAndVersion}`);
     }
   }
@@ -250,8 +250,7 @@ class ExtensionManager {
       return packageJson as PackageJSON;
     } catch (err) {
       log('Error getting package json for %s', id);
-      // eslint-disable-next-line no-console
-      console.error(err);
+      log('%O', err);
     }
   }
 

--- a/Composer/packages/extension/src/manager/manager.ts
+++ b/Composer/packages/extension/src/manager/manager.ts
@@ -40,10 +40,11 @@ function getExtensionMetadata(extensionPath: string, packageJson: PackageJSON): 
   };
 }
 
-class ExtensionManager {
+export class ExtensionManagerImp {
   private searchCache = new Map<string, ExtensionSearchResult>();
-  private _manifest: ExtensionManifestStore | undefined;
   private _lastSearchTimestamp: Date | undefined;
+
+  public constructor(private _manifest?: ExtensionManifestStore) {}
 
   /**
    * Returns all extensions currently in the extension manifest
@@ -311,6 +312,6 @@ class ExtensionManager {
   }
 }
 
-const manager = new ExtensionManager();
+const ExtensionManager = new ExtensionManagerImp();
 
-export { manager as ExtensionManager };
+export { ExtensionManager };

--- a/Composer/packages/extension/src/manager/manager.ts
+++ b/Composer/packages/extension/src/manager/manager.ts
@@ -11,7 +11,7 @@ import { ExtensionContext } from '../extensionContext';
 import logger from '../logger';
 import { ExtensionManifestStore } from '../storage/extensionManifestStore';
 import { ExtensionBundle, PackageJSON, ExtensionMetadata, ExtensionSearchResult } from '../types/extension';
-import { npm, downloadPackage } from '../utils/npm';
+import { search, downloadPackage } from '../utils/npm';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires, import/order
 const rimraf = promisify(require('rimraf'));
@@ -287,15 +287,11 @@ class ExtensionManager {
   private async updateSearchCache() {
     const timeout = new Date(new Date().getTime() - SEARCH_CACHE_TIMEOUT);
     if (!this._lastSearchTimestamp || this._lastSearchTimestamp < timeout) {
-      const { stdout } = await npm('search', '', {
-        '--json': '',
-        '--searchopts': '"keywords:botframework-composer extension"',
-      });
-
       try {
-        const result = JSON.parse(stdout);
-        if (Array.isArray(result)) {
-          result.forEach((searchResult) => {
+        const results = await search();
+
+        if (Array.isArray(results)) {
+          results.forEach((searchResult) => {
             const { name, keywords = [], version, description, links } = searchResult;
             if (keywords.includes('botframework-composer') && keywords.includes('extension')) {
               const url = links?.npm ?? '';

--- a/Composer/packages/extension/src/manager/manager.ts
+++ b/Composer/packages/extension/src/manager/manager.ts
@@ -84,9 +84,9 @@ export class ExtensionManagerImp {
       const fullPath = path.join(dir, extensionPackageJsonPath);
       const extensionInstallPath = path.dirname(fullPath);
       const packageJson = (await readJson(fullPath)) as PackageJSON;
-      const isEnabled = packageJson?.composer && packageJson.composer.enabled !== false;
+      const isEnabled = packageJson.composer?.enabled !== false;
       const metadata = getExtensionMetadata(extensionInstallPath, packageJson);
-      if (packageJson && (isEnabled || packageJson.extendsComposer === true)) {
+      if (isEnabled) {
         this.manifest.updateExtensionConfig(metadata.id, {
           ...metadata,
           builtIn: isBuiltin,

--- a/Composer/packages/extension/src/manager/manager.ts
+++ b/Composer/packages/extension/src/manager/manager.ts
@@ -169,7 +169,7 @@ export class ExtensionManagerImp {
 
     if (metadata) {
       if (metadata.builtIn) {
-        throw new Error('Cannot remove builtin extension.');
+        return;
       }
 
       await remove(metadata.path);

--- a/Composer/packages/extension/src/types/extension.ts
+++ b/Composer/packages/extension/src/types/extension.ts
@@ -62,7 +62,6 @@ export interface PackageJSON {
   name: string;
   version: string;
   description: string;
-  extendsComposer: boolean;
   composer?: {
     name?: string;
     enabled?: boolean;

--- a/Composer/packages/extension/src/utils/__tests__/isSubdirectory.test.ts
+++ b/Composer/packages/extension/src/utils/__tests__/isSubdirectory.test.ts
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { isSubdirectory } from '../isSubdirectory';
+
+const testCases = [
+  ['/foo/bar', '/foo/bar', false],
+  ['/foo/bar', '/bar/foo', false],
+  ['/foo/bar', '/foo/bar/../baz', false],
+  ['/foo/bar', '/foo/bar/../', false],
+  ['/foo/bar', '/foo/bar/baz/../', false],
+  ['/foo/bar', '/foo/baz/bar/', false],
+  ['/foo/bar', '/foo', false],
+  ['/foo/bar', '/', false],
+
+  ['/foo/bar', '/foo/bar/baz', true],
+  ['/foo/bar', '/foo/bar/baz/../qux', true],
+  ['/foo/bar', '/foo/bar/baz/qux/foo/../../bar', true],
+];
+
+if (process.platform === 'win32') {
+  testCases.push(['C:\\Foo', 'C:\\Foo\\Bar', true], ['C:\\Foo', 'C:\\Bar', false], ['C:\\Foo', 'D:\\Foo\\Bar', false]);
+}
+
+it.each(testCases)('isSubDir(%s, %s) -> %s', (parent, dir, expected) => {
+  expect(isSubdirectory(parent as string, dir as string)).toBe(expected);
+});

--- a/Composer/packages/extension/src/utils/__tests__/npm.test.ts
+++ b/Composer/packages/extension/src/utils/__tests__/npm.test.ts
@@ -1,9 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-
+/* eslint-disable no-underscore-dangle */
 import { spawn } from 'child_process';
+import { Readable, Writable } from 'stream';
 
-import { npm, search } from '../npm';
+import fetch from 'node-fetch';
+import rimraf from 'rimraf';
+import { mkdir } from 'fs-extra';
+import tar from 'tar';
+
+import { npm, search, downloadPackage } from '../npm';
 
 const mockProc = {
   stdout: {
@@ -15,8 +21,35 @@ const mockProc = {
   on: jest.fn(),
 };
 
+class MockBody extends Readable {
+  _read() {
+    setTimeout(() => {
+      this.emit('end');
+    }, 1);
+  }
+}
+
+class MockExtractor extends Writable {
+  _write(chunk: any, enc: string, next) {
+    next();
+  }
+}
+
 jest.mock('child_process', () => ({
   spawn: jest.fn().mockImplementation(() => mockProc),
+}));
+
+jest.mock('node-fetch', () => jest.fn());
+jest.mock('rimraf', () => {
+  return jest.fn().mockImplementation((path, cb) => {
+    cb();
+  });
+});
+jest.mock('fs-extra', () => ({
+  mkdir: jest.fn(),
+}));
+jest.mock('tar', () => ({
+  extract: jest.fn(),
 }));
 
 beforeEach(() => {
@@ -89,5 +122,71 @@ describe('search', () => {
     );
 
     expect(results).toEqual(stdout);
+  });
+});
+
+describe('downloadPackage', () => {
+  const packageName = 'some-package';
+
+  const packageMetadata = {
+    'dist-tags': {
+      latest: '1.0.1',
+    },
+    versions: {
+      '1.0.0': {
+        dist: {
+          tarball: 'tarball url 1.0.0',
+        },
+      },
+      '1.0.1': {
+        dist: {
+          tarball: 'tarball url 1.0.1',
+        },
+      },
+    },
+  };
+
+  beforeEach(() => {
+    const mockRes = {
+      json: jest.fn(),
+      body: new MockBody(),
+    };
+    ((fetch as unknown) as jest.Mock).mockImplementation(() => mockRes);
+    mockRes.json.mockResolvedValue(packageMetadata);
+
+    const extractor = new MockExtractor();
+    (tar.extract as jest.Mock).mockReturnValue(extractor);
+
+    mockRes.body.push('some data');
+  });
+
+  it('gets package metadata from npm', async () => {
+    await downloadPackage(packageName, 'latest', '/some/path');
+
+    expect(fetch).toHaveBeenCalledWith('https://registry.npmjs.org/some-package');
+  });
+
+  it.each([
+    ['latest', '1.0.1'],
+    ['1.0.0', '1.0.0'],
+  ])('can resolve %s to %s', async (tagOrVersion, expectedVersion) => {
+    await downloadPackage(packageName, tagOrVersion, '/some/path');
+    expect(fetch).toHaveBeenCalledWith(`tarball url ${expectedVersion}`);
+  });
+
+  it('throws when version not found', () => {
+    expect(downloadPackage(packageName, '2.0.0', '/some/path')).rejects.toThrow(/Could not find/);
+  });
+
+  it('prepares the destination directory', async () => {
+    await downloadPackage(packageName, 'latest', '/some/path');
+    expect(rimraf).toHaveBeenCalledWith('/some/path', expect.any(Function));
+    expect(mkdir).toHaveBeenCalledWith('/some/path');
+  });
+
+  it('extracts the tarball into destination', async () => {
+    await downloadPackage(packageName, 'latest', '/some/path');
+
+    expect(tar.extract).toHaveBeenCalledWith({ strip: 1, C: '/some/path', strict: true });
   });
 });

--- a/Composer/packages/extension/src/utils/__tests__/npm.test.ts
+++ b/Composer/packages/extension/src/utils/__tests__/npm.test.ts
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { spawn } from 'child_process';
+
+import { npm } from '../npm';
+
+const mockProc = {
+  stdout: {
+    on: jest.fn(),
+  },
+  stderr: {
+    on: jest.fn(),
+  },
+  on: jest.fn(),
+};
+
+jest.mock('child_process', () => ({
+  spawn: jest.fn().mockImplementation(() => mockProc),
+}));
+
+describe('npm', () => {
+  beforeEach(() => {
+    mockProc.stdout.on.mockImplementation((event, cb) => {
+      if (event === 'data') {
+        cb('stdout data');
+      }
+    });
+    mockProc.stderr.on.mockImplementation((event, cb) => {
+      if (event === 'data') {
+        cb('stderr data');
+      }
+    });
+    mockProc.on.mockImplementation((event, cb) => {
+      if (event === 'close') {
+        cb(0);
+      }
+    });
+  });
+
+  it('spawns an npm process', async () => {
+    const { stdout, stderr, code } = await npm('search', 'arg1 arg2', { '--prefix': '/foo' }, { cwd: '/foo' });
+    expect(spawn).toHaveBeenCalledWith(
+      'npm',
+      ['search', '--no-fund', '--no-audit', '--quiet', '--prefix=/foo', 'arg1 arg2'],
+      {
+        cwd: '/foo',
+        shell: false,
+      }
+    );
+    expect(stdout).toEqual('stdout data');
+    expect(stderr).toEqual('stderr data');
+    expect(code).toEqual(0);
+  });
+
+  it('uses a shell if on windows', async () => {
+    await npm('search', '', {}, {}, 'win32');
+    expect(spawn).toHaveBeenCalledWith('npm', expect.any(Array), { shell: true });
+  });
+
+  it('rejects when error', () => {
+    mockProc.on.mockImplementation((event, cb) => {
+      if (event === 'close') {
+        cb(1);
+      }
+    });
+    expect(npm('search', '')).rejects.toEqual(expect.objectContaining({ code: 1 }));
+  });
+});

--- a/Composer/packages/extension/src/utils/__tests__/npm.test.ts
+++ b/Composer/packages/extension/src/utils/__tests__/npm.test.ts
@@ -4,8 +4,7 @@
 import { Readable, Writable } from 'stream';
 
 import fetch from 'node-fetch';
-import rimraf from 'rimraf';
-import { mkdir } from 'fs-extra';
+import { mkdir, remove } from 'fs-extra';
 import tar from 'tar';
 
 import { search, downloadPackage } from '../npm';
@@ -25,13 +24,9 @@ class MockExtractor extends Writable {
 }
 
 jest.mock('node-fetch', () => jest.fn());
-jest.mock('rimraf', () => {
-  return jest.fn().mockImplementation((path, cb) => {
-    cb();
-  });
-});
 jest.mock('fs-extra', () => ({
   mkdir: jest.fn(),
+  remove: jest.fn(),
 }));
 jest.mock('tar', () => ({
   extract: jest.fn(),
@@ -138,7 +133,7 @@ describe('downloadPackage', () => {
 
   it('prepares the destination directory', async () => {
     await downloadPackage(packageName, 'latest', '/some/path');
-    expect(rimraf).toHaveBeenCalledWith('/some/path', expect.any(Function));
+    expect(remove).toHaveBeenCalledWith('/some/path');
     expect(mkdir).toHaveBeenCalledWith('/some/path');
   });
 

--- a/Composer/packages/extension/src/utils/__tests__/npm.test.ts
+++ b/Composer/packages/extension/src/utils/__tests__/npm.test.ts
@@ -3,7 +3,7 @@
 
 import { spawn } from 'child_process';
 
-import { npm } from '../npm';
+import { npm, search } from '../npm';
 
 const mockProc = {
   stdout: {
@@ -19,25 +19,25 @@ jest.mock('child_process', () => ({
   spawn: jest.fn().mockImplementation(() => mockProc),
 }));
 
-describe('npm', () => {
-  beforeEach(() => {
-    mockProc.stdout.on.mockImplementation((event, cb) => {
-      if (event === 'data') {
-        cb('stdout data');
-      }
-    });
-    mockProc.stderr.on.mockImplementation((event, cb) => {
-      if (event === 'data') {
-        cb('stderr data');
-      }
-    });
-    mockProc.on.mockImplementation((event, cb) => {
-      if (event === 'close') {
-        cb(0);
-      }
-    });
+beforeEach(() => {
+  mockProc.stdout.on.mockImplementation((event, cb) => {
+    if (event === 'data') {
+      cb('stdout data');
+    }
   });
+  mockProc.stderr.on.mockImplementation((event, cb) => {
+    if (event === 'data') {
+      cb('stderr data');
+    }
+  });
+  mockProc.on.mockImplementation((event, cb) => {
+    if (event === 'close') {
+      cb(0);
+    }
+  });
+});
 
+describe('npm', () => {
   it('spawns an npm process', async () => {
     const { stdout, stderr, code } = await npm('search', 'arg1 arg2', { '--prefix': '/foo' }, { cwd: '/foo' });
     expect(spawn).toHaveBeenCalledWith(
@@ -65,5 +65,29 @@ describe('npm', () => {
       }
     });
     expect(npm('search', '')).rejects.toEqual(expect.objectContaining({ code: 1 }));
+  });
+});
+
+describe('search', () => {
+  const stdout = [{ name: 'package1' }, { name: 'package2' }];
+
+  beforeEach(() => {
+    mockProc.stdout.on.mockImplementation((event, cb) => {
+      if (event === 'data') {
+        cb(JSON.stringify(stdout));
+      }
+    });
+  });
+
+  it('returns results of npm search', async () => {
+    const results = await search();
+
+    expect(spawn).toHaveBeenCalledWith(
+      'npm',
+      expect.arrayContaining(['search', '--searchopts="keywords:botframework-composer extension"', '--json']),
+      expect.any(Object)
+    );
+
+    expect(results).toEqual(stdout);
   });
 });

--- a/Composer/packages/extension/src/utils/isSubdirectory.ts
+++ b/Composer/packages/extension/src/utils/isSubdirectory.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import path from 'path';
+
+/**
+ * Returns true if dir is a descendant of parent, false otherwise.
+ * @param parent parent directory
+ * @param dir directory to test
+ */
+export function isSubdirectory(parent, dir) {
+  const relative = path.relative(parent, dir);
+  return Boolean(relative && !relative.startsWith('..') && !path.isAbsolute(relative));
+}

--- a/Composer/packages/extension/src/utils/npm.ts
+++ b/Composer/packages/extension/src/utils/npm.ts
@@ -22,7 +22,7 @@ type NpmOutput = {
   stderr: string;
   code: number;
 };
-type NpmCommand = 'uninstall' | 'search';
+type NpmCommand = 'search';
 type NpmOptions = {
   [key: string]: string;
 };
@@ -45,7 +45,8 @@ export async function npm(
   command: NpmCommand,
   args: string,
   opts: NpmOptions = {},
-  spawnOpts: SpawnOptionsWithoutStdio = {}
+  spawnOpts: SpawnOptionsWithoutStdio = {},
+  platform = process.platform
 ): Promise<NpmOutput> {
   return new Promise((resolve, reject) => {
     const cmdOptions = processOptions(opts);
@@ -54,7 +55,7 @@ export async function npm(
     let stdout = '';
     let stderr = '';
 
-    const proc = spawn('npm', spawnArgs, { ...spawnOpts, shell: process.platform === 'win32' });
+    const proc = spawn('npm', spawnArgs, { ...spawnOpts, shell: platform === 'win32' });
 
     proc.stdout.on('data', (data) => {
       stdout += data;

--- a/Composer/packages/extension/src/utils/npm.ts
+++ b/Composer/packages/extension/src/utils/npm.ts
@@ -113,14 +113,13 @@ export async function downloadPackage(name: string, versionOrTag: string, destin
   await rimraf(destination);
   await mkdir(destination);
 
+  const extractor = tar.extract({
+    strip: 1,
+    C: destination,
+    strict: true,
+  });
+
   dLog('Extracting tarball.');
-  await streamPipeline(
-    tarball,
-    tar.extract({
-      strip: 1,
-      C: destination,
-      strict: true,
-    })
-  );
+  await streamPipeline(tarball, extractor);
   dLog('Done downloading.');
 }

--- a/Composer/packages/extension/src/utils/npm.ts
+++ b/Composer/packages/extension/src/utils/npm.ts
@@ -63,7 +63,9 @@ export async function downloadPackage(name: string, versionOrTag: string, destin
   dLog('Fetching tarball.');
   const tarball = (await fetch(tarballUrl)).body;
   // clean up previous version
+  // lgtm[js/path-injection]
   await remove(destination);
+  // lgtm[js/path-injection]
   await mkdir(destination);
 
   const extractor = tar.extract({

--- a/Composer/packages/extension/src/utils/npm.ts
+++ b/Composer/packages/extension/src/utils/npm.ts
@@ -3,7 +3,7 @@
 
 import { promisify } from 'util';
 
-import { mkdir } from 'fs-extra';
+import { mkdir, remove } from 'fs-extra';
 import fetch from 'node-fetch';
 import tar from 'tar';
 
@@ -11,9 +11,6 @@ import logger from '../logger';
 import { ExtensionSearchResult } from '../types/extension';
 
 const streamPipeline = promisify(require('stream').pipeline);
-
-// eslint-disable-next-line @typescript-eslint/no-var-requires, import/order
-const rimraf = promisify(require('rimraf'));
 
 const log = logger.extend('npm');
 
@@ -66,7 +63,7 @@ export async function downloadPackage(name: string, versionOrTag: string, destin
   dLog('Fetching tarball.');
   const tarball = (await fetch(tarballUrl)).body;
   // clean up previous version
-  await rimraf(destination);
+  await remove(destination);
   await mkdir(destination);
 
   const extractor = tar.extract({

--- a/Composer/packages/extension/src/utils/npm.ts
+++ b/Composer/packages/extension/src/utils/npm.ts
@@ -2,8 +2,18 @@
 // Licensed under the MIT License.
 
 import { spawn, SpawnOptionsWithoutStdio } from 'child_process';
+import { promisify } from 'util';
+
+import { mkdir } from 'fs-extra';
+import fetch from 'node-fetch';
+import tar from 'tar';
 
 import logger from '../logger';
+
+const streamPipeline = promisify(require('stream').pipeline);
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires, import/order
+const rimraf = promisify(require('rimraf'));
 
 const log = logger.extend('npm');
 
@@ -12,7 +22,7 @@ type NpmOutput = {
   stderr: string;
   code: number;
 };
-type NpmCommand = 'install' | 'uninstall' | 'search' | 'link';
+type NpmCommand = 'uninstall' | 'search';
 type NpmOptions = {
   [key: string]: string;
 };
@@ -62,4 +72,38 @@ export async function npm(
       }
     });
   });
+}
+
+export async function downloadPackage(name: string, versionOrTag: string, destination: string) {
+  const dLog = log.extend(name);
+  dLog('Starting download.');
+  const res = await fetch(`https://registry.npmjs.org/${name}`);
+  const metadata = await res.json();
+  const targetVersion = metadata['dist-tags'][versionOrTag] ?? versionOrTag;
+
+  dLog('Resolved version %s to %s', versionOrTag, targetVersion);
+
+  const tarballUrl = metadata.versions[targetVersion]?.dist.tarball;
+
+  if (!tarballUrl) {
+    dLog('Unable to get tarball url.');
+    throw new Error(`Could not find ${name}@${targetVersion} on npm.`);
+  }
+
+  dLog('Fetching tarball.');
+  const tarball = (await fetch(tarballUrl)).body;
+  // clean up previous version
+  await rimraf(destination);
+  await mkdir(destination);
+
+  dLog('Extracting tarball.');
+  await streamPipeline(
+    tarball,
+    tar.extract({
+      strip: 1,
+      C: destination,
+      strict: true,
+    })
+  );
+  dLog('Done downloading.');
 }

--- a/Composer/packages/extension/src/utils/npm.ts
+++ b/Composer/packages/extension/src/utils/npm.ts
@@ -75,6 +75,22 @@ export async function npm(
   });
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function search(): Promise<any[]> {
+  try {
+    const { stdout } = await npm('search', '', {
+      '--json': '',
+      '--searchopts': '"keywords:botframework-composer extension"',
+    });
+
+    return JSON.parse(stdout);
+  } catch (err) {
+    log('%O', err);
+
+    return [];
+  }
+}
+
 export async function downloadPackage(name: string, versionOrTag: string, destination: string) {
   const dLog = log.extend(name);
   dLog('Starting download.');

--- a/Composer/packages/server/src/server.ts
+++ b/Composer/packages/server/src/server.ts
@@ -47,7 +47,7 @@ export async function start(): Promise<number | string> {
   ExtensionContext.useExpress(app);
 
   // load all installed plugins
-  setEnvDefault('COMPOSER_EXTENSION_DATA', path.resolve(__dirname, '../extensions.json'));
+  setEnvDefault('COMPOSER_EXTENSION_DATA', path.resolve(__dirname, '../../../.composer/extensions.json'));
   setEnvDefault('COMPOSER_BUILTIN_EXTENSIONS_DIR', path.resolve(__dirname, '../../../plugins'));
   // Composer/.composer/extensions
   setEnvDefault('COMPOSER_REMOTE_EXTENSIONS_DIR', path.resolve(__dirname, '../../../.composer/extensions'));

--- a/Composer/packages/server/src/server.ts
+++ b/Composer/packages/server/src/server.ts
@@ -49,7 +49,8 @@ export async function start(): Promise<number | string> {
   // load all installed plugins
   setEnvDefault('COMPOSER_EXTENSION_DATA', path.resolve(__dirname, '../extensions.json'));
   setEnvDefault('COMPOSER_BUILTIN_EXTENSIONS_DIR', path.resolve(__dirname, '../../../plugins'));
-  setEnvDefault('COMPOSER_REMOTE_EXTENSIONS_DIR', path.resolve(__dirname, '../../../.composer'));
+  // Composer/.composer/extensions
+  setEnvDefault('COMPOSER_REMOTE_EXTENSIONS_DIR', path.resolve(__dirname, '../../../.composer/extensions'));
   await ExtensionManager.loadAll();
 
   const { login, authorize } = getAuthProvider();

--- a/Composer/packages/tools/language-servers/language-understanding/package.json
+++ b/Composer/packages/tools/language-servers/language-understanding/package.json
@@ -41,7 +41,6 @@
     "ts-loader": "7.0.4",
     "ts-node": "^8.3.0",
     "typescript": "3.9.2",
-    "uglifyjs-webpack-plugin": "^2.2.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",
     "webpack-dev-server": "^3.11.0",

--- a/Composer/plugins/README.md
+++ b/Composer/plugins/README.md
@@ -41,7 +41,7 @@ Plugin modules must come in one of the following forms:
 * A function called `initialize` is exported from the module
 
 Currently, plugins can be loaded into Composer using 1 of 2 methods:
-* The plugin is placed in the /plugins/ folder, and contains a package.json file with `extendsComposer` set to `true`
+* The plugin is placed in the /plugins/ folder
 * The plugin is loaded directly via changes to Composer code, using `ExtensionContext.loadPlugin(name, plugin)`
 
 The simplest form of a plugin module is below:

--- a/Composer/plugins/authTest/package.json
+++ b/Composer/plugins/authTest/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "extendsComposer": false,
+  "composer": {
+    "enabled": false
+  },
   "author": "",
   "license": "ISC",
   "dependencies": {

--- a/Composer/plugins/azurePublish/package.json
+++ b/Composer/plugins/azurePublish/package.json
@@ -7,7 +7,6 @@
   "scripts": {
     "build": "tsc"
   },
-  "extendsComposer": true,
   "dependencies": {
     "@azure/arm-appinsights": "2.1.0",
     "@azure/arm-appservice-profile-2019-03-01-hybrid": "1.0.0",

--- a/Composer/plugins/githubAuth/package.json
+++ b/Composer/plugins/githubAuth/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "extendsComposer": false,
+  "composer": {
+    "enabled": false
+  },
   "author": "",
   "license": "ISC",
   "dependencies": {

--- a/Composer/plugins/localPublish/package.json
+++ b/Composer/plugins/localPublish/package.json
@@ -7,7 +7,6 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "tsc"
   },
-  "extendsComposer": true,
   "author": "",
   "license": "ISC",
   "dependencies": {

--- a/Composer/plugins/mockRemotePublish/package.json
+++ b/Composer/plugins/mockRemotePublish/package.json
@@ -7,7 +7,9 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "tsc"
   },
-  "extendsComposer": false,
+  "composer": {
+    "enabled": false
+  },
   "author": "",
   "license": "ISC",
   "dependencies": {

--- a/Composer/plugins/mongoStorage/package.json
+++ b/Composer/plugins/mongoStorage/package.json
@@ -7,7 +7,9 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "tsc"
   },
-  "extendsComposer": false,
+  "composer": {
+    "enabled": false
+  },
   "author": "benbro@microsoft.com",
   "license": "MIT",
   "dependencies": {

--- a/Composer/plugins/publishTest/package.json
+++ b/Composer/plugins/publishTest/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "extendsComposer": false,
+  "composer": {
+    "enabled": false
+  },
   "author": "",
   "license": "ISC"
 }

--- a/Composer/plugins/runtimes/package.json
+++ b/Composer/plugins/runtimes/package.json
@@ -7,7 +7,6 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "tsc"
   },
-  "extendsComposer": true,
   "author": "",
   "license": "ISC",
   "dependencies": {

--- a/Composer/plugins/samples/package.json
+++ b/Composer/plugins/samples/package.json
@@ -8,7 +8,6 @@
     "build": "tsc",
     "start": "node lib/index.js"
   },
-  "extendsComposer": true,
   "author": "",
   "license": "ISC",
   "dependencies": {

--- a/Composer/plugins/webRoute/package.json
+++ b/Composer/plugins/webRoute/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "extendsComposer": false,
+  "composer": {
+    "enabled": false
+  },
   "author": "",
   "license": "ISC"
 }

--- a/Composer/yarn.lock
+++ b/Composer/yarn.lock
@@ -880,7 +880,7 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.10.4", "@babel/parser@^7.10.5", "@babel/parser@^7.11.5", "@babel/parser@^7.2.2", "@babel/parser@^7.3.4", "@babel/parser@^7.4.0", "@babel/parser@^7.7.0", "@babel/parser@^7.7.4", "@babel/parser@^7.7.5", "@babel/parser@^7.8.6", "@babel/parser@^7.9.0", "@babel/parser@^7.9.6":
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.10.4", "@babel/parser@^7.10.5", "@babel/parser@^7.11.3", "@babel/parser@^7.11.5", "@babel/parser@^7.2.2", "@babel/parser@^7.3.4", "@babel/parser@^7.4.0", "@babel/parser@^7.7.0", "@babel/parser@^7.7.4", "@babel/parser@^7.7.5", "@babel/parser@^7.8.6", "@babel/parser@^7.9.0", "@babel/parser@^7.9.6":
   version "7.11.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.5.tgz#c7ff6303df71080ec7a4f5b8c003c58f1cf51037"
   integrity sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==
@@ -5527,14 +5527,13 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
   integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
 
-bl@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/bl/-/bl-4.0.3.tgz#12d6287adc29080e22a705e5764b2a9522cdc489"
-  integrity sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==
+bl@^2.2.1, bl@^4.0.3:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-2.2.1.tgz#8c11a7b730655c5d56898cdc871224f40fd901d5"
+  integrity sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==
   dependencies:
-    buffer "^5.5.0"
-    inherits "^2.0.4"
-    readable-stream "^3.4.0"
+    readable-stream "^2.3.5"
+    safe-buffer "^5.1.1"
 
 blob-util@2.0.2:
   version "2.0.2"
@@ -5865,14 +5864,6 @@ buffer@^5.1.0:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
 
-buffer@^5.5.0:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.6.0.tgz#a31749dc7d81d84db08abf937b6b8c4033f62786"
-  integrity sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==
-  dependencies:
-    base64-js "^1.0.2"
-    ieee754 "^1.1.4"
-
 builder-util-runtime@8.6.2:
   version "8.6.2"
   resolved "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-8.6.2.tgz#8270e15b012d8d3b110f3e327b0fd8b0e07b1686"
@@ -5923,27 +5914,6 @@ bytes@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
   integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
-
-cacache@^12.0.2:
-  version "12.0.3"
-  resolved "https://registry.yarnpkg.com/cacache/-/cacache-12.0.3.tgz#be99abba4e1bf5df461cd5a2c1071fc432573390"
-  integrity sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==
-  dependencies:
-    bluebird "^3.5.5"
-    chownr "^1.1.1"
-    figgy-pudding "^3.5.1"
-    glob "^7.1.4"
-    graceful-fs "^4.1.15"
-    infer-owner "^1.0.3"
-    lru-cache "^5.1.1"
-    mississippi "^3.0.0"
-    mkdirp "^0.5.1"
-    move-concurrently "^1.0.1"
-    promise-inflight "^1.0.1"
-    rimraf "^2.6.3"
-    ssri "^6.0.1"
-    unique-filename "^1.1.1"
-    y18n "^4.0.0"
 
 cacache@^13.0.1:
   version "13.0.1"
@@ -6712,7 +6682,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-concat-stream@^1.5.0, concat-stream@^1.5.2, concat-stream@^1.6.2:
+concat-stream@^1.5.2, concat-stream@^1.6.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
@@ -7420,11 +7390,6 @@ csstype@^2.5.7:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.3.tgz#b701e5968245bf9b08d54ac83d00b624e622a9fa"
   integrity sha512-rINUZXOkcBmoHWEyu7JdHu5JMzkGRoMX4ov9830WNgxf5UYxcBUO0QTKAqeJ5EZfSdlrcJYkC8WwfVW7JYi4yg==
-
-cyclist@~0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
-  integrity sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=
 
 cypress-plugin-tab@^1.0.5:
   version "1.0.5"
@@ -8460,16 +8425,6 @@ duplexer@^0.1.1:
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
   integrity sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=
 
-duplexify@^3.4.2, duplexify@^3.6.0:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.7.1.tgz#2a4df5317f6ccfd91f86d6fd25d8d8a103b88309"
-  integrity sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==
-  dependencies:
-    end-of-stream "^1.0.0"
-    inherits "^2.0.1"
-    readable-stream "^2.0.0"
-    stream-shift "^1.0.0"
-
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
@@ -8589,7 +8544,7 @@ elegant-spinner@^1.0.1:
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
   integrity sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=
 
-elliptic@^6.0.0:
+elliptic@^6.0.0, elliptic@^6.5.3:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
   integrity sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==
@@ -8641,7 +8596,7 @@ encoding@^0.1.11:
   dependencies:
     iconv-lite "~0.4.13"
 
-end-of-stream@^1.0.0, end-of-stream@^1.1.0:
+end-of-stream@^1.1.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
   integrity sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==
@@ -8674,7 +8629,7 @@ env-paths@^2.2.0:
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.0.tgz#cdca557dc009152917d6166e2febe1f039685e43"
   integrity sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==
 
-errno@^0.1.3, errno@~0.1.7:
+errno@^0.1.3:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.7.tgz#4684d71779ad39af177e3f007996f7c67c852618"
   integrity sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==
@@ -9710,7 +9665,7 @@ find-cache-dir@^0.1.1:
     mkdirp "^0.5.1"
     pkg-dir "^1.0.0"
 
-find-cache-dir@^2.0.0, find-cache-dir@^2.1.0:
+find-cache-dir@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
   integrity sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==
@@ -9813,14 +9768,6 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
   integrity sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=
-
-flush-write-stream@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.1.1.tgz#8dd7d873a1babc207d94ead0c2e0e44276ebf2e8"
-  integrity sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==
-  dependencies:
-    inherits "^2.0.3"
-    readable-stream "^2.3.6"
 
 fn-name@~2.0.1:
   version "2.0.1"
@@ -9969,7 +9916,7 @@ fresh@0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
 
-from2@^2.1.0, from2@^2.1.1:
+from2@^2.1.1:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/from2/-/from2-2.3.0.tgz#8bfb5502bde4a4d36cfdeea007fcca21d7e382af"
   integrity sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=
@@ -10520,7 +10467,7 @@ got@^9.6.0:
     to-readable-stream "^1.0.0"
     url-parse-lax "^3.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
+graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
@@ -11152,7 +11099,7 @@ indexes-of@^1.0.1:
   resolved "https://registry.yarnpkg.com/indexes-of/-/indexes-of-1.0.1.tgz#f30f716c8e2bd346c7b67d3df3915566a7c05607"
   integrity sha1-8w9xbI4r00bHtn0985FVZqfAVgc=
 
-infer-owner@^1.0.3, infer-owner@^1.0.4:
+infer-owner@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/infer-owner/-/infer-owner-1.0.4.tgz#c4cefcaa8e51051c2a40ba2ce8a3d27295af9467"
   integrity sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==
@@ -11174,11 +11121,6 @@ inherits@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
   integrity sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=
-
-inherits@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
-  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
 ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
   version "1.3.5"
@@ -11363,11 +11305,6 @@ is-binary-path@~2.1.0:
   integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
   dependencies:
     binary-extensions "^2.0.0"
-
-is-buffer@^1.0.2, is-buffer@^1.1.5:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
-  integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
 is-buffer@^2.0.0, is-buffer@^2.0.2:
   version "2.0.3"
@@ -11622,7 +11559,7 @@ is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
 
-is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
+is-plain-object@^2.0.1, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
   integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
@@ -12585,33 +12522,7 @@ killable@^1.0.1:
   resolved "https://registry.yarnpkg.com/killable/-/killable-1.0.1.tgz#4c8ce441187a061c7474fb87ca08e2a638194892"
   integrity sha512-LzqtLKlUwirEUyl/nicirVmNiPvYs7l5n8wOPP7fyJVpUPkvCnW/vuiXGpylGUlnPDnB7311rARzAt3Mhswpjg==
 
-kind-of@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-2.0.1.tgz#018ec7a4ce7e3a86cb9141be519d24c8faa981b5"
-  integrity sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=
-  dependencies:
-    is-buffer "^1.0.2"
-
-kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
-  integrity sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=
-  dependencies:
-    is-buffer "^1.1.5"
-
-kind-of@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
-  integrity sha1-IIE989cSkosgc3hpGkUGb65y3Vc=
-  dependencies:
-    is-buffer "^1.1.5"
-
-kind-of@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
-  integrity sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==
-
-kind-of@^6.0.0, kind-of@^6.0.2:
+kind-of@^2.0.1, kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0, kind-of@^4.0.0, kind-of@^5.0.0, kind-of@^6.0.0, kind-of@^6.0.2, kind-of@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
@@ -13026,7 +12937,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
+"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -13474,11 +13385,6 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
-
 minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
@@ -13535,22 +13441,6 @@ minizlib@^2.1.1:
     minipass "^3.0.0"
     yallist "^4.0.0"
 
-mississippi@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/mississippi/-/mississippi-3.0.0.tgz#ea0a3291f97e0b5e8776b363d5f0a12d94c67022"
-  integrity sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==
-  dependencies:
-    concat-stream "^1.5.0"
-    duplexify "^3.4.2"
-    end-of-stream "^1.1.0"
-    flush-write-stream "^1.0.0"
-    from2 "^2.1.0"
-    parallel-transform "^1.1.0"
-    pump "^3.0.0"
-    pumpify "^1.3.3"
-    stream-each "^1.1.0"
-    through2 "^2.0.0"
-
 mixin-deep@^1.2.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"
@@ -13567,24 +13457,12 @@ mixin-object@^2.0.1:
     for-in "^0.1.3"
     is-extendable "^0.1.1"
 
-mkdirp@0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
-  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
-  dependencies:
-    minimist "0.0.8"
-
-mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.4, mkdirp@~0.5.1:
+mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.2, mkdirp@^0.5.3, mkdirp@^0.5.4, mkdirp@^1.0.3, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
-
-mkdirp@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
-  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 mocha@^5.2.0:
   version "5.2.0"
@@ -14557,15 +14435,6 @@ pako@~1.0.5:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.10.tgz#4328badb5086a426aa90f541977d4955da5c9732"
   integrity sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==
-
-parallel-transform@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/parallel-transform/-/parallel-transform-1.1.0.tgz#d410f065b05da23081fcd10f28854c29bda33b06"
-  integrity sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=
-  dependencies:
-    cyclist "~0.2.2"
-    inherits "^2.0.3"
-    readable-stream "^2.1.5"
 
 param-case@2.1.x, param-case@^2.1.1:
   version "2.1.1"
@@ -15825,14 +15694,6 @@ public-encrypt@^4.0.0:
     randombytes "^2.0.1"
     safe-buffer "^5.1.2"
 
-pump@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/pump/-/pump-2.0.1.tgz#12399add6e4cf7526d973cbc8b5ce2e2908b3909"
-  integrity sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==
-  dependencies:
-    end-of-stream "^1.1.0"
-    once "^1.3.1"
-
 pump@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
@@ -15840,15 +15701,6 @@ pump@^3.0.0:
   dependencies:
     end-of-stream "^1.1.0"
     once "^1.3.1"
-
-pumpify@^1.3.3:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/pumpify/-/pumpify-1.5.1.tgz#36513be246ab27570b1a374a5ce278bfd74370ce"
-  integrity sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==
-  dependencies:
-    duplexify "^3.6.0"
-    inherits "^2.0.3"
-    pump "^2.0.0"
 
 punycode@1.3.2:
   version "1.3.2"
@@ -16186,10 +16038,23 @@ read-text-file@^1.1.0:
     iconv-lite "^0.4.17"
     jschardet "^1.4.2"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
+
+readable-stream@^2.3.5:
+  version "2.3.7"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
+  integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"
@@ -16991,7 +16856,7 @@ select-hose@^2.0.0:
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
   integrity sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=
 
-selfsigned@^1.10.7:
+selfsigned@1.10.8, selfsigned@^1.10.7:
   version "1.10.8"
   resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.10.8.tgz#0d17208b7d12c33f8eac85c41835f27fc3d81a30"
   integrity sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==
@@ -17090,17 +16955,7 @@ serialize-error@^5.0.0:
   dependencies:
     type-fest "^0.8.0"
 
-serialize-javascript@^1.7.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.9.1.tgz#cfc200aef77b600c47da9bb8149c943e798c2fdb"
-  integrity sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==
-
-serialize-javascript@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
-  integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
-
-serialize-javascript@^3.1.0:
+serialize-javascript@^3.1.0, serialize-javascript@^4.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-3.1.0.tgz#8bf3a9170712664ef2561b44b691eafe399214ea"
   integrity sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==
@@ -17145,25 +17000,12 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
 
-set-value@^0.4.3:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/set-value/-/set-value-0.4.3.tgz#7db08f9d3d22dc7f78e53af3c3bf4666ecdfccf1"
-  integrity sha1-fbCPnT0i3H945Trzw79GZuzfzPE=
+set-value@^0.4.3, set-value@^2.0.0, set-value@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-3.0.2.tgz#74e8ecd023c33d0f77199d415409a40f21e61b90"
+  integrity sha512-npjkVoz+ank0zjlV9F47Fdbjfj/PfXyVhZvGALWsyIYU/qrMzpi6avjKW3/7KeSU2Df3I46BrN1xOI1+6vW0hA==
   dependencies:
-    extend-shallow "^2.0.1"
-    is-extendable "^0.1.1"
-    is-plain-object "^2.0.1"
-    to-object-path "^0.3.0"
-
-set-value@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.1.tgz#a18d40530e6f07de4228c7defe4227af8cad005b"
-  integrity sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==
-  dependencies:
-    extend-shallow "^2.0.1"
-    is-extendable "^0.1.1"
-    is-plain-object "^2.0.3"
-    split-string "^3.0.1"
+    is-plain-object "^2.0.4"
 
 setimmediate@^1.0.4, setimmediate@^1.0.5:
   version "1.0.5"
@@ -17568,7 +17410,7 @@ split-on-first@^1.0.0:
   resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
   integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
 
-split-string@^3.0.1, split-string@^3.0.2:
+split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
   integrity sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==
@@ -17606,13 +17448,6 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
-
-ssri@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.1.tgz#2a3c41b28dd45b62b63676ecb74001265ae9edd8"
-  integrity sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==
-  dependencies:
-    figgy-pudding "^3.5.1"
 
 ssri@^7.0.0:
   version "7.1.0"
@@ -17680,14 +17515,6 @@ stream-browserify@^2.0.1:
     inherits "~2.0.1"
     readable-stream "^2.0.2"
 
-stream-each@^1.1.0:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/stream-each/-/stream-each-1.2.3.tgz#ebe27a0c389b04fbcc233642952e10731afa9bae"
-  integrity sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==
-  dependencies:
-    end-of-stream "^1.1.0"
-    stream-shift "^1.0.0"
-
 stream-http@^2.7.2:
   version "2.8.3"
   resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-2.8.3.tgz#b2d242469288a5a27ec4fe8933acf623de6514fc"
@@ -17698,11 +17525,6 @@ stream-http@^2.7.2:
     readable-stream "^2.3.6"
     to-arraybuffer "^1.0.0"
     xtend "^4.0.0"
-
-stream-shift@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
-  integrity sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=
 
 strict-uri-encode@^1.0.0:
   version "1.1.0"
@@ -18196,44 +18018,20 @@ terminal-link@^2.0.0:
     ansi-escapes "^4.2.1"
     supports-hyperlinks "^2.0.0"
 
-terser-webpack-plugin@2.3.7:
-  version "2.3.7"
-  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-2.3.7.tgz#4910ff5d1a872168cc7fa6cd3749e2b0d60a8a0b"
-  integrity sha512-xzYyaHUNhzgaAdBsXxk2Yvo/x1NJdslUaussK3fdpBbvttm1iIwU+c26dj9UxJcwk2c5UWt5F55MUTIA8BE7Dg==
+terser-webpack-plugin@2.3.7, terser-webpack-plugin@^1.4.3, terser-webpack-plugin@^2.3.7:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-2.3.8.tgz#894764a19b0743f2f704e7c2a848c5283a696724"
+  integrity sha512-/fKw3R+hWyHfYx7Bv6oPqmk4HGQcrWLtV3X6ggvPuwPNHSnzvVV51z6OaaCOus4YLjutYGOz3pEpbhe6Up2s1w==
   dependencies:
     cacache "^13.0.1"
     find-cache-dir "^3.3.1"
     jest-worker "^25.4.0"
     p-limit "^2.3.0"
     schema-utils "^2.6.6"
-    serialize-javascript "^3.1.0"
+    serialize-javascript "^4.0.0"
     source-map "^0.6.1"
     terser "^4.6.12"
     webpack-sources "^1.4.3"
-
-terser-webpack-plugin@^1.4.3:
-  version "1.4.3"
-  resolved "https://botbuilder.myget.org/F/botframework-cli/npm/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz#5ecaf2dbdc5fb99745fd06791f46fc9ddb1c9a7c"
-  integrity sha1-Xsry29xfuZdF/QZ5H0b8ndscmnw=
-  dependencies:
-    cacache "^12.0.2"
-    find-cache-dir "^2.1.0"
-    is-wsl "^1.1.0"
-    schema-utils "^1.0.0"
-    serialize-javascript "^2.1.2"
-    source-map "^0.6.1"
-    terser "^4.1.2"
-    webpack-sources "^1.4.0"
-    worker-farm "^1.7.0"
-
-terser@^4.1.2:
-  version "4.3.9"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-4.3.9.tgz#e4be37f80553d02645668727777687dad26bbca8"
-  integrity sha512-NFGMpHjlzmyOtPL+fDw3G7+6Ueh/sz4mkaUYa4lJCxOPTNzd0Uj0aZJOmsDYoSQyfuVoWDMSWTPU3huyOm2zdA==
-  dependencies:
-    commander "^2.20.0"
-    source-map "~0.6.1"
-    source-map-support "~0.5.12"
 
 terser@^4.6.12:
   version "4.7.0"
@@ -18273,7 +18071,7 @@ throttleit@^1.0.0:
   resolved "https://registry.yarnpkg.com/throttleit/-/throttleit-1.0.0.tgz#9e785836daf46743145a5984b6268d828528ac6c"
   integrity sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=
 
-through2@^2.0.0, through2@^2.0.1:
+through2@^2.0.1:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
   integrity sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==
@@ -18679,29 +18477,6 @@ uglify-js@^3.5.1:
   dependencies:
     commander "~2.20.3"
     source-map "~0.6.1"
-
-uglify-js@^3.6.0:
-  version "3.7.3"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.7.3.tgz#f918fce9182f466d5140f24bb0ff35c2d32dcc6a"
-  integrity sha512-7tINm46/3puUA4hCkKYo4Xdts+JDaVC9ZPRcG8Xw9R4nhO/gZgUM3TENq8IF4Vatk8qCig4MzP/c8G4u2BkVQg==
-  dependencies:
-    commander "~2.20.3"
-    source-map "~0.6.1"
-
-uglifyjs-webpack-plugin@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-2.2.0.tgz#e75bc80e7f1937f725954c9b4c5a1e967ea9d0d7"
-  integrity sha512-mHSkufBmBuJ+KHQhv5H0MXijtsoA1lynJt1lXOaotja8/I0pR4L9oGaPIZw+bQBOFittXZg9OC1sXSGO9D9ZYg==
-  dependencies:
-    cacache "^12.0.2"
-    find-cache-dir "^2.1.0"
-    is-wsl "^1.1.0"
-    schema-utils "^1.0.0"
-    serialize-javascript "^1.7.0"
-    source-map "^0.6.1"
-    uglify-js "^3.6.0"
-    webpack-sources "^1.4.0"
-    worker-farm "^1.7.0"
 
 uid-safe@~2.1.5:
   version "2.1.5"
@@ -19412,7 +19187,7 @@ webpack-sources@^1.1.0:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-sources@^1.4.3:
+webpack-sources@^1.4.1, webpack-sources@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.4.3.tgz#eedd8ec0b928fbf1cbfe994e22d2d890f330a933"
   integrity sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==
@@ -19705,13 +19480,6 @@ workbox-window@^4.3.1:
   integrity sha1-7mBRvxDwavpUg8m436BTGZTt4PM=
   dependencies:
     workbox-core "^4.3.1"
-
-worker-farm@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.7.0.tgz#26a94c5391bbca926152002f69b84a4bf772e5a8"
-  integrity sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==
-  dependencies:
-    errno "~0.1.7"
 
 worker-loader@^2.0.0:
   version "2.0.0"

--- a/Composer/yarn.lock
+++ b/Composer/yarn.lock
@@ -880,7 +880,7 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.10.4", "@babel/parser@^7.10.5", "@babel/parser@^7.11.3", "@babel/parser@^7.11.5", "@babel/parser@^7.2.2", "@babel/parser@^7.3.4", "@babel/parser@^7.4.0", "@babel/parser@^7.7.0", "@babel/parser@^7.7.4", "@babel/parser@^7.7.5", "@babel/parser@^7.8.6", "@babel/parser@^7.9.0", "@babel/parser@^7.9.6":
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.10.4", "@babel/parser@^7.10.5", "@babel/parser@^7.11.5", "@babel/parser@^7.2.2", "@babel/parser@^7.3.4", "@babel/parser@^7.4.0", "@babel/parser@^7.7.0", "@babel/parser@^7.7.4", "@babel/parser@^7.7.5", "@babel/parser@^7.8.6", "@babel/parser@^7.9.0", "@babel/parser@^7.9.6":
   version "7.11.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.5.tgz#c7ff6303df71080ec7a4f5b8c003c58f1cf51037"
   integrity sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==
@@ -3700,6 +3700,13 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
+"@types/minipass@*":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@types/minipass/-/minipass-2.2.0.tgz#51ad404e8eb1fa961f75ec61205796807b6f9651"
+  integrity sha512-wuzZksN4w4kyfoOv/dlpov4NOunwutLA/q7uc00xU02ZyUY+aoM5PWIXEKBMnm0NHd4a+N71BMjq+x7+2Af1fg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/mock-fs@^3.6.30":
   version "3.6.30"
   resolved "https://registry.yarnpkg.com/@types/mock-fs/-/mock-fs-3.6.30.tgz#4d812541e87b23577261a5aa95f704dd3d01e410"
@@ -3898,6 +3905,14 @@
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.4.tgz#b4ffc7dc97b498c969b360a41eee247f82616370"
   integrity sha512-78AdXtlhpCHT0K3EytMpn4JNxaf5tbqbLcbIRoQIHzpTIyjpxLQKRoxU55ujBXAtg3Nl2h/XWvfDa9dsMOd0pQ==
+
+"@types/tar@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@types/tar/-/tar-4.0.3.tgz#e2cce0b8ff4f285293243f5971bd7199176ac489"
+  integrity sha512-Z7AVMMlkI8NTWF0qGhC4QIX0zkV/+y0J8x7b/RsHrN0310+YNjoJd8UrApCiGBCWtKjxS9QhNqLi2UJNToh5hA==
+  dependencies:
+    "@types/minipass" "*"
+    "@types/node" "*"
 
 "@types/testing-library__dom@*":
   version "7.0.2"
@@ -5512,13 +5527,14 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
   integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
 
-bl@^2.2.1, bl@^4.0.3:
-  version "2.2.1"
-  resolved "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/bl/-/bl-2.2.1.tgz#8c11a7b730655c5d56898cdc871224f40fd901d5"
-  integrity sha1-jBGntzBlXF1WiYzchxIk9A/ZAdU=
+bl@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.0.3.tgz#12d6287adc29080e22a705e5764b2a9522cdc489"
+  integrity sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==
   dependencies:
-    readable-stream "^2.3.5"
-    safe-buffer "^5.1.1"
+    buffer "^5.5.0"
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
 
 blob-util@2.0.2:
   version "2.0.2"
@@ -5845,6 +5861,14 @@ buffer@^5.1.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.2.1.tgz#dd57fa0f109ac59c602479044dca7b8b3d0b71d6"
   integrity sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+
+buffer@^5.5.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.6.0.tgz#a31749dc7d81d84db08abf937b6b8c4033f62786"
+  integrity sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
@@ -6275,6 +6299,11 @@ chownr@^1.1.2:
   version "1.1.3"
   resolved "https://botbuilder.myget.org/F/botbuilder-declarative/npm/chownr/-/chownr-1.1.3.tgz#42d837d5239688d55f303003a508230fa6727142"
   integrity sha1-Qtg31SOWiNVfMDADpQgjD6ZycUI=
+
+chownr@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
+  integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
 chrome-trace-event@^1.0.2:
   version "1.0.2"
@@ -8560,7 +8589,7 @@ elegant-spinner@^1.0.1:
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
   integrity sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=
 
-elliptic@^6.0.0, elliptic@^6.5.3:
+elliptic@^6.0.0:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
   integrity sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==
@@ -11146,6 +11175,11 @@ inherits@2.0.1:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
   integrity sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=
 
+inherits@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
 ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
@@ -11329,6 +11363,11 @@ is-binary-path@~2.1.0:
   integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
   dependencies:
     binary-extensions "^2.0.0"
+
+is-buffer@^1.0.2, is-buffer@^1.1.5:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+  integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
 is-buffer@^2.0.0, is-buffer@^2.0.2:
   version "2.0.3"
@@ -11583,7 +11622,7 @@ is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
 
-is-plain-object@^2.0.1, is-plain-object@^2.0.4:
+is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
   integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
@@ -12546,7 +12585,33 @@ killable@^1.0.1:
   resolved "https://registry.yarnpkg.com/killable/-/killable-1.0.1.tgz#4c8ce441187a061c7474fb87ca08e2a638194892"
   integrity sha512-LzqtLKlUwirEUyl/nicirVmNiPvYs7l5n8wOPP7fyJVpUPkvCnW/vuiXGpylGUlnPDnB7311rARzAt3Mhswpjg==
 
-kind-of@^2.0.1, kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0, kind-of@^4.0.0, kind-of@^5.0.0, kind-of@^6.0.0, kind-of@^6.0.2, kind-of@^6.0.3:
+kind-of@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-2.0.1.tgz#018ec7a4ce7e3a86cb9141be519d24c8faa981b5"
+  integrity sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=
+  dependencies:
+    is-buffer "^1.0.2"
+
+kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
+  integrity sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=
+  dependencies:
+    is-buffer "^1.1.5"
+
+kind-of@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
+  integrity sha1-IIE989cSkosgc3hpGkUGb65y3Vc=
+  dependencies:
+    is-buffer "^1.1.5"
+
+kind-of@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
+  integrity sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==
+
+kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
@@ -12961,7 +13026,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
+"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -13409,6 +13474,11 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimist@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
+
 minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
@@ -13457,6 +13527,14 @@ minizlib@^1.1.1:
   dependencies:
     minipass "^2.2.1"
 
+minizlib@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
+  integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
+  dependencies:
+    minipass "^3.0.0"
+    yallist "^4.0.0"
+
 mississippi@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/mississippi/-/mississippi-3.0.0.tgz#ea0a3291f97e0b5e8776b363d5f0a12d94c67022"
@@ -13489,12 +13567,24 @@ mixin-object@^2.0.1:
     for-in "^0.1.3"
     is-extendable "^0.1.1"
 
-mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.2, mkdirp@^0.5.3, mkdirp@^0.5.4, mkdirp@~0.5.1:
+mkdirp@0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
+  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
+  dependencies:
+    minimist "0.0.8"
+
+mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.4, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
+
+mkdirp@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 mocha@^5.2.0:
   version "5.2.0"
@@ -13716,6 +13806,11 @@ node-fetch@^2.1.2, node-fetch@^2.6.0, node-fetch@~2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
+
+node-fetch@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-forge@^0.10.0:
   version "0.10.0"
@@ -16104,19 +16199,6 @@ read-text-file@^1.1.0:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^2.3.5:
-  version "2.3.7"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
-  integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.3"
-    isarray "~1.0.0"
-    process-nextick-args "~2.0.0"
-    safe-buffer "~5.1.1"
-    string_decoder "~1.1.1"
-    util-deprecate "~1.0.1"
-
 readable-stream@^3.0.6, readable-stream@^3.1.1:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.2.0.tgz#de17f229864c120a9f56945756e4f32c4045245d"
@@ -16909,7 +16991,7 @@ select-hose@^2.0.0:
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
   integrity sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=
 
-selfsigned@1.10.8, selfsigned@^1.10.7:
+selfsigned@^1.10.7:
   version "1.10.8"
   resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.10.8.tgz#0d17208b7d12c33f8eac85c41835f27fc3d81a30"
   integrity sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==
@@ -17008,7 +17090,17 @@ serialize-error@^5.0.0:
   dependencies:
     type-fest "^0.8.0"
 
-serialize-javascript@^1.7.0, serialize-javascript@^2.1.2, serialize-javascript@^3.1.0:
+serialize-javascript@^1.7.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.9.1.tgz#cfc200aef77b600c47da9bb8149c943e798c2fdb"
+  integrity sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==
+
+serialize-javascript@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
+  integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
+
+serialize-javascript@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-3.1.0.tgz#8bf3a9170712664ef2561b44b691eafe399214ea"
   integrity sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==
@@ -17053,12 +17145,25 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
 
-set-value@^0.4.3, set-value@^2.0.0, set-value@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/set-value/-/set-value-3.0.2.tgz#74e8ecd023c33d0f77199d415409a40f21e61b90"
-  integrity sha512-npjkVoz+ank0zjlV9F47Fdbjfj/PfXyVhZvGALWsyIYU/qrMzpi6avjKW3/7KeSU2Df3I46BrN1xOI1+6vW0hA==
+set-value@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-0.4.3.tgz#7db08f9d3d22dc7f78e53af3c3bf4666ecdfccf1"
+  integrity sha1-fbCPnT0i3H945Trzw79GZuzfzPE=
   dependencies:
-    is-plain-object "^2.0.4"
+    extend-shallow "^2.0.1"
+    is-extendable "^0.1.1"
+    is-plain-object "^2.0.1"
+    to-object-path "^0.3.0"
+
+set-value@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.1.tgz#a18d40530e6f07de4228c7defe4227af8cad005b"
+  integrity sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-extendable "^0.1.1"
+    is-plain-object "^2.0.3"
+    split-string "^3.0.1"
 
 setimmediate@^1.0.4, setimmediate@^1.0.5:
   version "1.0.5"
@@ -17463,7 +17568,7 @@ split-on-first@^1.0.0:
   resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
   integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
 
-split-string@^3.0.2:
+split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
   integrity sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==
@@ -18050,6 +18155,18 @@ tar@^4:
     mkdirp "^0.5.0"
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
+
+tar@^6.0.5:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.0.5.tgz#bde815086e10b39f1dcd298e89d596e1535e200f"
+  integrity sha512-0b4HOimQHj9nXNEAA7zWwMM91Zhhba3pspja6sQbgTpynOJf+bkjBnfybNYzbpLbnwXnbyB4LOREvlyXLkCHSg==
+  dependencies:
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^3.0.0"
+    minizlib "^2.1.1"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
 
 temp-file@^3.3.7:
   version "3.3.7"

--- a/Composer/yarn.lock
+++ b/Composer/yarn.lock
@@ -880,7 +880,7 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.10.4", "@babel/parser@^7.10.5", "@babel/parser@^7.11.5", "@babel/parser@^7.2.2", "@babel/parser@^7.3.4", "@babel/parser@^7.4.0", "@babel/parser@^7.7.0", "@babel/parser@^7.7.4", "@babel/parser@^7.7.5", "@babel/parser@^7.8.6", "@babel/parser@^7.9.0", "@babel/parser@^7.9.6":
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.10.4", "@babel/parser@^7.10.5", "@babel/parser@^7.11.3", "@babel/parser@^7.11.5", "@babel/parser@^7.2.2", "@babel/parser@^7.3.4", "@babel/parser@^7.4.0", "@babel/parser@^7.7.0", "@babel/parser@^7.7.4", "@babel/parser@^7.7.5", "@babel/parser@^7.8.6", "@babel/parser@^7.9.0", "@babel/parser@^7.9.6":
   version "7.11.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.5.tgz#c7ff6303df71080ec7a4f5b8c003c58f1cf51037"
   integrity sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==
@@ -5527,14 +5527,13 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
   integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
 
-bl@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/bl/-/bl-4.0.3.tgz#12d6287adc29080e22a705e5764b2a9522cdc489"
-  integrity sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==
+bl@^2.2.1, bl@^4.0.3:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-2.2.1.tgz#8c11a7b730655c5d56898cdc871224f40fd901d5"
+  integrity sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==
   dependencies:
-    buffer "^5.5.0"
-    inherits "^2.0.4"
-    readable-stream "^3.4.0"
+    readable-stream "^2.3.5"
+    safe-buffer "^5.1.1"
 
 blob-util@2.0.2:
   version "2.0.2"
@@ -5861,14 +5860,6 @@ buffer@^5.1.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.2.1.tgz#dd57fa0f109ac59c602479044dca7b8b3d0b71d6"
   integrity sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==
-  dependencies:
-    base64-js "^1.0.2"
-    ieee754 "^1.1.4"
-
-buffer@^5.5.0:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.6.0.tgz#a31749dc7d81d84db08abf937b6b8c4033f62786"
-  integrity sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
@@ -8589,7 +8580,7 @@ elegant-spinner@^1.0.1:
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
   integrity sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=
 
-elliptic@^6.0.0:
+elliptic@^6.0.0, elliptic@^6.5.3:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
   integrity sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==
@@ -11175,11 +11166,6 @@ inherits@2.0.1:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
   integrity sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=
 
-inherits@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
-  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
-
 ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
@@ -11363,11 +11349,6 @@ is-binary-path@~2.1.0:
   integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
   dependencies:
     binary-extensions "^2.0.0"
-
-is-buffer@^1.0.2, is-buffer@^1.1.5:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
-  integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
 is-buffer@^2.0.0, is-buffer@^2.0.2:
   version "2.0.3"
@@ -11622,7 +11603,7 @@ is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
 
-is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
+is-plain-object@^2.0.1, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
   integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
@@ -12585,33 +12566,7 @@ killable@^1.0.1:
   resolved "https://registry.yarnpkg.com/killable/-/killable-1.0.1.tgz#4c8ce441187a061c7474fb87ca08e2a638194892"
   integrity sha512-LzqtLKlUwirEUyl/nicirVmNiPvYs7l5n8wOPP7fyJVpUPkvCnW/vuiXGpylGUlnPDnB7311rARzAt3Mhswpjg==
 
-kind-of@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-2.0.1.tgz#018ec7a4ce7e3a86cb9141be519d24c8faa981b5"
-  integrity sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=
-  dependencies:
-    is-buffer "^1.0.2"
-
-kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
-  integrity sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=
-  dependencies:
-    is-buffer "^1.1.5"
-
-kind-of@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
-  integrity sha1-IIE989cSkosgc3hpGkUGb65y3Vc=
-  dependencies:
-    is-buffer "^1.1.5"
-
-kind-of@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
-  integrity sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==
-
-kind-of@^6.0.0, kind-of@^6.0.2:
+kind-of@^2.0.1, kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0, kind-of@^4.0.0, kind-of@^5.0.0, kind-of@^6.0.0, kind-of@^6.0.2, kind-of@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
@@ -13026,7 +12981,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
+"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -13474,11 +13429,6 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
-
 minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
@@ -13567,24 +13517,12 @@ mixin-object@^2.0.1:
     for-in "^0.1.3"
     is-extendable "^0.1.1"
 
-mkdirp@0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
-  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
-  dependencies:
-    minimist "0.0.8"
-
-mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.4, mkdirp@~0.5.1:
+mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.2, mkdirp@^0.5.3, mkdirp@^0.5.4, mkdirp@^1.0.3, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
-
-mkdirp@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
-  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 mocha@^5.2.0:
   version "5.2.0"
@@ -16199,6 +16137,19 @@ read-text-file@^1.1.0:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
+readable-stream@^2.3.5:
+  version "2.3.7"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
+  integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
+
 readable-stream@^3.0.6, readable-stream@^3.1.1:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.2.0.tgz#de17f229864c120a9f56945756e4f32c4045245d"
@@ -16991,7 +16942,7 @@ select-hose@^2.0.0:
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
   integrity sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=
 
-selfsigned@^1.10.7:
+selfsigned@1.10.8, selfsigned@^1.10.7:
   version "1.10.8"
   resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.10.8.tgz#0d17208b7d12c33f8eac85c41835f27fc3d81a30"
   integrity sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==
@@ -17090,17 +17041,7 @@ serialize-error@^5.0.0:
   dependencies:
     type-fest "^0.8.0"
 
-serialize-javascript@^1.7.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.9.1.tgz#cfc200aef77b600c47da9bb8149c943e798c2fdb"
-  integrity sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==
-
-serialize-javascript@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
-  integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
-
-serialize-javascript@^3.1.0:
+serialize-javascript@^1.7.0, serialize-javascript@^2.1.2, serialize-javascript@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-3.1.0.tgz#8bf3a9170712664ef2561b44b691eafe399214ea"
   integrity sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==
@@ -17145,25 +17086,12 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
 
-set-value@^0.4.3:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/set-value/-/set-value-0.4.3.tgz#7db08f9d3d22dc7f78e53af3c3bf4666ecdfccf1"
-  integrity sha1-fbCPnT0i3H945Trzw79GZuzfzPE=
+set-value@^0.4.3, set-value@^2.0.0, set-value@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-3.0.2.tgz#74e8ecd023c33d0f77199d415409a40f21e61b90"
+  integrity sha512-npjkVoz+ank0zjlV9F47Fdbjfj/PfXyVhZvGALWsyIYU/qrMzpi6avjKW3/7KeSU2Df3I46BrN1xOI1+6vW0hA==
   dependencies:
-    extend-shallow "^2.0.1"
-    is-extendable "^0.1.1"
-    is-plain-object "^2.0.1"
-    to-object-path "^0.3.0"
-
-set-value@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.1.tgz#a18d40530e6f07de4228c7defe4227af8cad005b"
-  integrity sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==
-  dependencies:
-    extend-shallow "^2.0.1"
-    is-extendable "^0.1.1"
-    is-plain-object "^2.0.3"
-    split-string "^3.0.1"
+    is-plain-object "^2.0.4"
 
 setimmediate@^1.0.4, setimmediate@^1.0.5:
   version "1.0.5"
@@ -17568,7 +17496,7 @@ split-on-first@^1.0.0:
   resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
   integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
 
-split-string@^3.0.1, split-string@^3.0.2:
+split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
   integrity sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==

--- a/Composer/yarn.lock
+++ b/Composer/yarn.lock
@@ -880,7 +880,7 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.10.4", "@babel/parser@^7.10.5", "@babel/parser@^7.11.3", "@babel/parser@^7.11.5", "@babel/parser@^7.2.2", "@babel/parser@^7.3.4", "@babel/parser@^7.4.0", "@babel/parser@^7.7.0", "@babel/parser@^7.7.4", "@babel/parser@^7.7.5", "@babel/parser@^7.8.6", "@babel/parser@^7.9.0", "@babel/parser@^7.9.6":
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.10.4", "@babel/parser@^7.10.5", "@babel/parser@^7.11.5", "@babel/parser@^7.2.2", "@babel/parser@^7.3.4", "@babel/parser@^7.4.0", "@babel/parser@^7.7.0", "@babel/parser@^7.7.4", "@babel/parser@^7.7.5", "@babel/parser@^7.8.6", "@babel/parser@^7.9.0", "@babel/parser@^7.9.6":
   version "7.11.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.5.tgz#c7ff6303df71080ec7a4f5b8c003c58f1cf51037"
   integrity sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==
@@ -5527,13 +5527,14 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
   integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
 
-bl@^2.2.1, bl@^4.0.3:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/bl/-/bl-2.2.1.tgz#8c11a7b730655c5d56898cdc871224f40fd901d5"
-  integrity sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==
+bl@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.0.3.tgz#12d6287adc29080e22a705e5764b2a9522cdc489"
+  integrity sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==
   dependencies:
-    readable-stream "^2.3.5"
-    safe-buffer "^5.1.1"
+    buffer "^5.5.0"
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
 
 blob-util@2.0.2:
   version "2.0.2"
@@ -5860,6 +5861,14 @@ buffer@^5.1.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.2.1.tgz#dd57fa0f109ac59c602479044dca7b8b3d0b71d6"
   integrity sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+
+buffer@^5.5.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.6.0.tgz#a31749dc7d81d84db08abf937b6b8c4033f62786"
+  integrity sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
@@ -8580,7 +8589,7 @@ elegant-spinner@^1.0.1:
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
   integrity sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=
 
-elliptic@^6.0.0, elliptic@^6.5.3:
+elliptic@^6.0.0:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
   integrity sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==
@@ -11166,6 +11175,11 @@ inherits@2.0.1:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
   integrity sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=
 
+inherits@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
 ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
@@ -11349,6 +11363,11 @@ is-binary-path@~2.1.0:
   integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
   dependencies:
     binary-extensions "^2.0.0"
+
+is-buffer@^1.0.2, is-buffer@^1.1.5:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+  integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
 is-buffer@^2.0.0, is-buffer@^2.0.2:
   version "2.0.3"
@@ -11603,7 +11622,7 @@ is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
 
-is-plain-object@^2.0.1, is-plain-object@^2.0.4:
+is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
   integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
@@ -12566,7 +12585,33 @@ killable@^1.0.1:
   resolved "https://registry.yarnpkg.com/killable/-/killable-1.0.1.tgz#4c8ce441187a061c7474fb87ca08e2a638194892"
   integrity sha512-LzqtLKlUwirEUyl/nicirVmNiPvYs7l5n8wOPP7fyJVpUPkvCnW/vuiXGpylGUlnPDnB7311rARzAt3Mhswpjg==
 
-kind-of@^2.0.1, kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0, kind-of@^4.0.0, kind-of@^5.0.0, kind-of@^6.0.0, kind-of@^6.0.2, kind-of@^6.0.3:
+kind-of@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-2.0.1.tgz#018ec7a4ce7e3a86cb9141be519d24c8faa981b5"
+  integrity sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=
+  dependencies:
+    is-buffer "^1.0.2"
+
+kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
+  integrity sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=
+  dependencies:
+    is-buffer "^1.1.5"
+
+kind-of@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
+  integrity sha1-IIE989cSkosgc3hpGkUGb65y3Vc=
+  dependencies:
+    is-buffer "^1.1.5"
+
+kind-of@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
+  integrity sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==
+
+kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
@@ -12981,7 +13026,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
+"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -13429,6 +13474,11 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimist@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
+
 minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
@@ -13517,12 +13567,24 @@ mixin-object@^2.0.1:
     for-in "^0.1.3"
     is-extendable "^0.1.1"
 
-mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.2, mkdirp@^0.5.3, mkdirp@^0.5.4, mkdirp@^1.0.3, mkdirp@~0.5.1:
+mkdirp@0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
+  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
+  dependencies:
+    minimist "0.0.8"
+
+mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.4, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
+
+mkdirp@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 mocha@^5.2.0:
   version "5.2.0"
@@ -16137,19 +16199,6 @@ read-text-file@^1.1.0:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^2.3.5:
-  version "2.3.7"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
-  integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.3"
-    isarray "~1.0.0"
-    process-nextick-args "~2.0.0"
-    safe-buffer "~5.1.1"
-    string_decoder "~1.1.1"
-    util-deprecate "~1.0.1"
-
 readable-stream@^3.0.6, readable-stream@^3.1.1:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.2.0.tgz#de17f229864c120a9f56945756e4f32c4045245d"
@@ -16942,7 +16991,7 @@ select-hose@^2.0.0:
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
   integrity sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=
 
-selfsigned@1.10.8, selfsigned@^1.10.7:
+selfsigned@^1.10.7:
   version "1.10.8"
   resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.10.8.tgz#0d17208b7d12c33f8eac85c41835f27fc3d81a30"
   integrity sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==
@@ -17041,7 +17090,17 @@ serialize-error@^5.0.0:
   dependencies:
     type-fest "^0.8.0"
 
-serialize-javascript@^1.7.0, serialize-javascript@^2.1.2, serialize-javascript@^3.1.0:
+serialize-javascript@^1.7.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.9.1.tgz#cfc200aef77b600c47da9bb8149c943e798c2fdb"
+  integrity sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==
+
+serialize-javascript@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
+  integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
+
+serialize-javascript@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-3.1.0.tgz#8bf3a9170712664ef2561b44b691eafe399214ea"
   integrity sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==
@@ -17086,12 +17145,25 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
 
-set-value@^0.4.3, set-value@^2.0.0, set-value@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/set-value/-/set-value-3.0.2.tgz#74e8ecd023c33d0f77199d415409a40f21e61b90"
-  integrity sha512-npjkVoz+ank0zjlV9F47Fdbjfj/PfXyVhZvGALWsyIYU/qrMzpi6avjKW3/7KeSU2Df3I46BrN1xOI1+6vW0hA==
+set-value@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-0.4.3.tgz#7db08f9d3d22dc7f78e53af3c3bf4666ecdfccf1"
+  integrity sha1-fbCPnT0i3H945Trzw79GZuzfzPE=
   dependencies:
-    is-plain-object "^2.0.4"
+    extend-shallow "^2.0.1"
+    is-extendable "^0.1.1"
+    is-plain-object "^2.0.1"
+    to-object-path "^0.3.0"
+
+set-value@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.1.tgz#a18d40530e6f07de4228c7defe4227af8cad005b"
+  integrity sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-extendable "^0.1.1"
+    is-plain-object "^2.0.3"
+    split-string "^3.0.1"
 
 setimmediate@^1.0.4, setimmediate@^1.0.5:
   version "1.0.5"
@@ -17496,7 +17568,7 @@ split-on-first@^1.0.0:
   resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
   integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
 
-split-string@^3.0.2:
+split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
   integrity sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==


### PR DESCRIPTION
## Description

Directly download and unpack extensions using the npm registry api. This enables a unified approach to loading built-in vs remote extensions and results in more transparent installation output.

## Task Item

#minor
