### PR TITLE
fix: Fixed useArrayItems and useObjectItems

### DIFF
--- a/Composer/packages/adaptive-form/src/utils/arrayUtils.ts
+++ b/Composer/packages/adaptive-form/src/utils/arrayUtils.ts
@@ -4,7 +4,7 @@
 import { generateUniqueId } from '@bfc/shared';
 import { ChangeHandler } from '@bfc/extension-client';
 import { useEffect, useState } from 'react';
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 type ArrayChangeHandler<ItemType> = (items: ArrayItem<ItemType>[]) => void;
 

--- a/Composer/packages/adaptive-form/src/utils/arrayUtils.ts
+++ b/Composer/packages/adaptive-form/src/utils/arrayUtils.ts
@@ -3,7 +3,8 @@
 
 import { generateUniqueId } from '@bfc/shared';
 import { ChangeHandler } from '@bfc/extension-client';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { isEqual } from 'lodash';
 
 type ArrayChangeHandler<ItemType> = (items: ArrayItem<ItemType>[]) => void;
 
@@ -77,6 +78,19 @@ export function useArrayItems<ItemType = unknown>(
   onChange: ChangeHandler<ItemType[]>
 ): ArrayItemState<ItemType> {
   const [cache, setCache] = useState(generateArrayItems(items));
+
+  useEffect(() => {
+    const newCache = generateArrayItems(items);
+
+    if (
+      !isEqual(
+        cache.map(({ value }) => value),
+        newCache.map(({ value }) => value)
+      )
+    ) {
+      setCache(newCache);
+    }
+  }, [items]);
 
   const handleChange = (newItems: ArrayItem<ItemType>[]) => {
     setCache(newItems);

--- a/Composer/packages/adaptive-form/src/utils/objectUtils.ts
+++ b/Composer/packages/adaptive-form/src/utils/objectUtils.ts
@@ -3,7 +3,8 @@
 
 import { generateUniqueId } from '@bfc/shared';
 import { ChangeHandler } from '@bfc/extension-client';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import isEqual from 'lodash/isEqual';
 
 type ItemType<ValueType = unknown> = { [key: string]: ValueType };
 type ObjectChangeHandler<ValueType = unknown> = (items: ObjectItem<ValueType>[]) => void;
@@ -63,6 +64,19 @@ export function useObjectItems<ValueType = unknown>(
   onChange: ChangeHandler<ItemType<ValueType>>
 ): ObjectItemState<ValueType> {
   const [cache, setCache] = useState(generateObjectEntries(items));
+
+  useEffect(() => {
+    const newCache = generateObjectEntries(items);
+
+    if (
+      !isEqual(
+        newCache.map(({ id, ...rest }) => rest),
+        cache.map(({ id, ...rest }) => rest)
+      )
+    ) {
+      setCache(generateObjectEntries(items));
+    }
+  }, [items]);
 
   const handleChange = (items) => {
     setCache(items);


### PR DESCRIPTION
## Description
When the Property Editor switches between two actions of the same type, the `useArrayItems` and `useObjectItems` caches were not resetting. 

## Task Item
Closes #4276