### PR TITLE
feat: Updating uiSchema in Composer

### DIFF
--- a/Composer/packages/server/schemas/sdk.uischema
+++ b/Composer/packages/server/schemas/sdk.uischema
@@ -23,68 +23,6 @@
       }
     }
   },
-  "Microsoft.IEntityRecognizer": {},
-  "Microsoft.ILanguageGenerator": {},
-  "Microsoft.ITrigger": {},
-  "Microsoft.ITriggerSelector": {},
-  "Microsoft.LanguagePolicy": {},
-  "Microsoft.Ask": {},
-  "Microsoft.AttachmentInput": {
-    "form": {
-      "helpLink": "https://aka.ms/bfc-ask-for-user-input",
-      "label": "Prompt for a file or an attachment",
-      "subtitle": "Attachment Input"
-    }
-  },
-  "Microsoft.ChoiceInput": {
-    "form": {
-      "helpLink": "https://aka.ms/bfc-ask-for-user-input",
-      "label": "Prompt with multi-choice",
-      "subtitle": "Choice Input"
-    }
-  },
-  "Microsoft.ConfirmInput": {
-    "form": {
-      "helpLink": "https://aka.ms/bfc-ask-for-user-input",
-      "label": "Prompt for confirmation",
-      "subtitle": "Confirm Input"
-    }
-  },
-  "Microsoft.DateTimeInput": {
-    "form": {
-      "helpLink": "https://aka.ms/bfc-ask-for-user-input",
-      "label": "Prompt for a date or a time",
-      "subtitle": "Date Time Input"
-    }
-  },
-  "Microsoft.InputDialog": {},
-  "Microsoft.NumberInput": {
-    "form": {
-      "helpLink": "https://aka.ms/bfc-ask-for-user-input",
-      "label": "Prompt for a number",
-      "subtitle": "Number Input"
-    }
-  },
-  "Microsoft.OAuthInput": {
-    "form": {
-      "helpLink": "https://aka.ms/bfc-using-oauth",
-      "label": "OAuth login",
-      "order": [
-        "connectionName",
-        "*"
-      ],
-      "subtitle": "OAuth Input"
-    }
-  },
-  "Microsoft.TextInput": {
-    "form": {
-      "helpLink": "https://aka.ms/bfc-ask-for-user-input",
-      "label": "Prompt for text",
-      "subtitle": "Text Input"
-    }
-  },
-  "Microsoft.ResourceMultiLanguageGenerator": {},
-  "Microsoft.TemplateEngineLanguageGenerator": {},
   "Microsoft.BeginDialog": {
     "form": {
       "helpLink": "https://aka.ms/bfc-understanding-dialogs",
@@ -95,6 +33,13 @@
         "resultProperty",
         "*"
       ],
+      "properties": {
+        "resultProperty": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
       "subtitle": "Begin Dialog"
     }
   },
@@ -102,6 +47,13 @@
     "form": {
       "helpLink": "https://aka.ms/bf-composer-docs-connect-skill",
       "label": "Connect to a skill",
+      "properties": {
+        "resultProperty": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
       "subtitle": "Skill Dialog"
     }
   },
@@ -118,7 +70,6 @@
       "subtitle": "Cancel All Dialogs"
     }
   },
-  "Microsoft.CancelDialog": {},
   "Microsoft.ContinueLoop": {
     "form": {
       "label": "Continue loop",
@@ -134,6 +85,13 @@
     "form": {
       "helpLink": "https://aka.ms/bfc-using-memory",
       "label": "Delete properties",
+      "properties": {
+        "properties": {
+          "intellisenseScopes": [
+            "user-variables"
+          ]
+        }
+      },
       "subtitle": "Delete Properties"
     }
   },
@@ -141,12 +99,14 @@
     "form": {
       "helpLink": "https://aka.ms/bfc-using-memory",
       "label": "Delete a property",
+      "properties": {
+        "property": {
+          "intellisenseScopes": [
+            "user-variables"
+          ]
+        }
+      },
       "subtitle": "Delete Property"
-    }
-  },
-  "Microsoft.DeleteActivity": {
-    "form": {
-      "label": "Delete activity"
     }
   },
   "Microsoft.EditActions": {
@@ -159,6 +119,18 @@
     "form": {
       "helpLink": "https://aka.ms/bfc-using-memory",
       "label": "Edit an array property",
+      "properties": {
+        "itemsProperty": {
+          "intellisenseScopes": [
+            "user-variables"
+          ]
+        },
+        "resultProperty": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
       "subtitle": "Edit Array"
     }
   },
@@ -194,6 +166,23 @@
         "itemsProperty",
         "*"
       ],
+      "properties": {
+        "index": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        },
+        "itemsProperty": {
+          "intellisenseScopes": [
+            "user-variables"
+          ]
+        },
+        "value": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
       "subtitle": "For Each"
     }
   },
@@ -209,12 +198,26 @@
         "pageSize",
         "*"
       ],
+      "properties": {
+        "itemsProperty": {
+          "intellisenseScopes": [
+            "user-variables"
+          ]
+        },
+        "page": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        },
+        "pageIndex": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
       "subtitle": "For Each Page"
     }
   },
-  "Microsoft.GetActivityMembers": {},
-  "Microsoft.GetConversationMembers": {},
-  "Microsoft.GotoAction": {},
   "Microsoft.HttpRequest": {
     "form": {
       "helpLink": "https://aka.ms/bfc-using-http",
@@ -226,6 +229,13 @@
         "headers",
         "*"
       ],
+      "properties": {
+        "resultProperty": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
       "subtitle": "HTTP Request"
     }
   },
@@ -285,6 +295,17 @@
     "form": {
       "helpLink": "https://aka.ms/bfc-using-memory",
       "label": "Set properties",
+      "properties": {
+        "assignments": {
+          "properties": {
+            "property": {
+              "intellisenseScopes": [
+                "variable-scopes"
+              ]
+            }
+          }
+        }
+      },
       "subtitle": "Set Properties"
     }
   },
@@ -292,6 +313,13 @@
     "form": {
       "helpLink": "https://aka.ms/bfc-using-memory",
       "label": "Set a property",
+      "properties": {
+        "property": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
       "subtitle": "Set Property"
     }
   },
@@ -313,12 +341,16 @@
           "hidden": [
             "actions"
           ]
+        },
+        "condition": {
+          "intellisenseScopes": [
+            "user-variables"
+          ]
         }
       },
       "subtitle": "Switch Condition"
     }
   },
-  "Microsoft.TelemetryTrackEvent": {},
   "Microsoft.TraceActivity": {
     "form": {
       "helpLink": "https://aka.ms/bfc-debugging-bots",
@@ -326,14 +358,101 @@
       "subtitle": "Trace Activity"
     }
   },
-  "Microsoft.UpdateActivity": {
+  "Microsoft.AttachmentInput": {
     "form": {
-      "label": "Update an activity"
+      "helpLink": "https://aka.ms/bfc-ask-for-user-input",
+      "label": "Prompt for a file or an attachment",
+      "properties": {
+        "property": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
+      "subtitle": "Attachment Input"
     }
   },
-  "Microsoft.CrossTrainedRecognizerSet": {},
-  "Microsoft.MultiLanguageRecognizer": {},
-  "Microsoft.RecognizerSet": {},
+  "Microsoft.ChoiceInput": {
+    "form": {
+      "helpLink": "https://aka.ms/bfc-ask-for-user-input",
+      "label": "Prompt with multi-choice",
+      "properties": {
+        "property": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
+      "subtitle": "Choice Input"
+    }
+  },
+  "Microsoft.ConfirmInput": {
+    "form": {
+      "helpLink": "https://aka.ms/bfc-ask-for-user-input",
+      "label": "Prompt for confirmation",
+      "properties": {
+        "property": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
+      "subtitle": "Confirm Input"
+    }
+  },
+  "Microsoft.DateTimeInput": {
+    "form": {
+      "helpLink": "https://aka.ms/bfc-ask-for-user-input",
+      "label": "Prompt for a date or a time",
+      "properties": {
+        "property": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
+      "subtitle": "Date Time Input"
+    }
+  },
+  "Microsoft.NumberInput": {
+    "form": {
+      "helpLink": "https://aka.ms/bfc-ask-for-user-input",
+      "label": "Prompt for a number",
+      "properties": {
+        "property": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
+      "subtitle": "Number Input"
+    }
+  },
+  "Microsoft.OAuthInput": {
+    "form": {
+      "helpLink": "https://aka.ms/bfc-using-oauth",
+      "label": "OAuth login",
+      "order": [
+        "connectionName",
+        "*"
+      ],
+      "subtitle": "OAuth Input"
+    }
+  },
+  "Microsoft.TextInput": {
+    "form": {
+      "helpLink": "https://aka.ms/bfc-ask-for-user-input",
+      "label": "Prompt for text",
+      "properties": {
+        "property": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
+      "subtitle": "Text Input"
+    }
+  },
   "Microsoft.RegexRecognizer": {
     "form": {
       "hidden": [
@@ -341,14 +460,6 @@
       ]
     }
   },
-  "Microsoft.ConditionalSelector": {},
-  "Microsoft.FirstSelector": {},
-  "Microsoft.MostSpecificSelector": {},
-  "Microsoft.RandomSelector": {},
-  "Microsoft.TrueSelector": {},
-  "Microsoft.ActivityTemplate": {},
-  "Microsoft.StaticActivityTemplate": {},
-  "Microsoft.TextTemplate": {},
   "Microsoft.OnActivity": {
     "form": {
       "hidden": [
@@ -362,7 +473,6 @@
       "subtitle": "Activity received"
     }
   },
-  "Microsoft.OnAssignEntity": {},
   "Microsoft.OnBeginDialog": {
     "form": {
       "hidden": [
@@ -389,9 +499,6 @@
       "subtitle": "Cancel dialog event"
     }
   },
-  "Microsoft.OnChooseEntity": {},
-  "Microsoft.OnChooseIntent": {},
-  "Microsoft.OnChooseProperty": {},
   "Microsoft.OnCondition": {
     "form": {
       "hidden": [
@@ -405,7 +512,6 @@
       "subtitle": "Condition"
     }
   },
-  "Microsoft.OnContinueConversation": {},
   "Microsoft.OnConversationUpdateActivity": {
     "form": {
       "description": "Handle the events fired when a user begins a new conversation with the bot.",
@@ -434,7 +540,6 @@
       "subtitle": "Dialog event"
     }
   },
-  "Microsoft.OnEndOfActions": {},
   "Microsoft.OnEndOfConversationActivity": {
     "form": {
       "hidden": [
@@ -485,6 +590,19 @@
         "*"
       ],
       "subtitle": "Handoff activity"
+    }
+  },
+  "Microsoft.OnInstallationUpdateActivity": {
+    "form": {
+      "hidden": [
+        "actions"
+      ],
+      "label": "Installation updated",
+      "order": [
+        "condition",
+        "*"
+      ],
+      "subtitle": "Installation updated activity"
     }
   },
   "Microsoft.OnIntent": {
@@ -567,7 +685,6 @@
       "subtitle": "Message updated activity"
     }
   },
-  "Microsoft.OnQnAMatch": {},
   "Microsoft.OnRepromptDialog": {
     "form": {
       "hidden": [
@@ -606,23 +723,5 @@
       ],
       "subtitle": "Unknown intent recognized"
     }
-  },
-  "Microsoft.AgeEntityRecognizer": {},
-  "Microsoft.ConfirmationEntityRecognizer": {},
-  "Microsoft.CurrencyEntityRecognizer": {},
-  "Microsoft.DateTimeEntityRecognizer": {},
-  "Microsoft.DimensionEntityRecognizer": {},
-  "Microsoft.EmailEntityRecognizer": {},
-  "Microsoft.GuidEntityRecognizer": {},
-  "Microsoft.HashtagEntityRecognizer": {},
-  "Microsoft.IpEntityRecognizer": {},
-  "Microsoft.MentionEntityRecognizer": {},
-  "Microsoft.NumberEntityRecognizer": {},
-  "Microsoft.NumberRangeEntityRecognizer": {},
-  "Microsoft.OrdinalEntityRecognizer": {},
-  "Microsoft.PercentageEntityRecognizer": {},
-  "Microsoft.PhoneNumberEntityRecognizer": {},
-  "Microsoft.RegexEntityRecognizer": {},
-  "Microsoft.TemperatureEntityRecognizer": {},
-  "Microsoft.UrlEntityRecognizer": {}
+  }
 }

--- a/runtime/dotnet/azurewebapp/Schemas/sdk.uischema
+++ b/runtime/dotnet/azurewebapp/Schemas/sdk.uischema
@@ -33,6 +33,13 @@
         "resultProperty",
         "*"
       ],
+      "properties": {
+        "resultProperty": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
       "subtitle": "Begin Dialog"
     }
   },
@@ -40,6 +47,13 @@
     "form": {
       "helpLink": "https://aka.ms/bf-composer-docs-connect-skill",
       "label": "Connect to a skill",
+      "properties": {
+        "resultProperty": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
       "subtitle": "Skill Dialog"
     }
   },
@@ -71,6 +85,13 @@
     "form": {
       "helpLink": "https://aka.ms/bfc-using-memory",
       "label": "Delete properties",
+      "properties": {
+        "properties": {
+          "intellisenseScopes": [
+            "user-variables"
+          ]
+        }
+      },
       "subtitle": "Delete Properties"
     }
   },
@@ -78,6 +99,13 @@
     "form": {
       "helpLink": "https://aka.ms/bfc-using-memory",
       "label": "Delete a property",
+      "properties": {
+        "property": {
+          "intellisenseScopes": [
+            "user-variables"
+          ]
+        }
+      },
       "subtitle": "Delete Property"
     }
   },
@@ -91,6 +119,18 @@
     "form": {
       "helpLink": "https://aka.ms/bfc-using-memory",
       "label": "Edit an array property",
+      "properties": {
+        "itemsProperty": {
+          "intellisenseScopes": [
+            "user-variables"
+          ]
+        },
+        "resultProperty": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
       "subtitle": "Edit Array"
     }
   },
@@ -126,6 +166,23 @@
         "itemsProperty",
         "*"
       ],
+      "properties": {
+        "index": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        },
+        "itemsProperty": {
+          "intellisenseScopes": [
+            "user-variables"
+          ]
+        },
+        "value": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
       "subtitle": "For Each"
     }
   },
@@ -141,6 +198,23 @@
         "pageSize",
         "*"
       ],
+      "properties": {
+        "itemsProperty": {
+          "intellisenseScopes": [
+            "user-variables"
+          ]
+        },
+        "page": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        },
+        "pageIndex": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
       "subtitle": "For Each Page"
     }
   },
@@ -155,6 +229,13 @@
         "headers",
         "*"
       ],
+      "properties": {
+        "resultProperty": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
       "subtitle": "HTTP Request"
     }
   },
@@ -214,6 +295,17 @@
     "form": {
       "helpLink": "https://aka.ms/bfc-using-memory",
       "label": "Set properties",
+      "properties": {
+        "assignments": {
+          "properties": {
+            "property": {
+              "intellisenseScopes": [
+                "variable-scopes"
+              ]
+            }
+          }
+        }
+      },
       "subtitle": "Set Properties"
     }
   },
@@ -221,6 +313,13 @@
     "form": {
       "helpLink": "https://aka.ms/bfc-using-memory",
       "label": "Set a property",
+      "properties": {
+        "property": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
       "subtitle": "Set Property"
     }
   },
@@ -242,6 +341,11 @@
           "hidden": [
             "actions"
           ]
+        },
+        "condition": {
+          "intellisenseScopes": [
+            "user-variables"
+          ]
         }
       },
       "subtitle": "Switch Condition"
@@ -258,6 +362,13 @@
     "form": {
       "helpLink": "https://aka.ms/bfc-ask-for-user-input",
       "label": "Prompt for a file or an attachment",
+      "properties": {
+        "property": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
       "subtitle": "Attachment Input"
     }
   },
@@ -265,6 +376,13 @@
     "form": {
       "helpLink": "https://aka.ms/bfc-ask-for-user-input",
       "label": "Prompt with multi-choice",
+      "properties": {
+        "property": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
       "subtitle": "Choice Input"
     }
   },
@@ -272,6 +390,13 @@
     "form": {
       "helpLink": "https://aka.ms/bfc-ask-for-user-input",
       "label": "Prompt for confirmation",
+      "properties": {
+        "property": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
       "subtitle": "Confirm Input"
     }
   },
@@ -279,6 +404,13 @@
     "form": {
       "helpLink": "https://aka.ms/bfc-ask-for-user-input",
       "label": "Prompt for a date or a time",
+      "properties": {
+        "property": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
       "subtitle": "Date Time Input"
     }
   },
@@ -286,6 +418,13 @@
     "form": {
       "helpLink": "https://aka.ms/bfc-ask-for-user-input",
       "label": "Prompt for a number",
+      "properties": {
+        "property": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
       "subtitle": "Number Input"
     }
   },
@@ -304,6 +443,13 @@
     "form": {
       "helpLink": "https://aka.ms/bfc-ask-for-user-input",
       "label": "Prompt for text",
+      "properties": {
+        "property": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
       "subtitle": "Text Input"
     }
   },
@@ -444,6 +590,19 @@
         "*"
       ],
       "subtitle": "Handoff activity"
+    }
+  },
+  "Microsoft.OnInstallationUpdateActivity": {
+    "form": {
+      "hidden": [
+        "actions"
+      ],
+      "label": "Installation updated",
+      "order": [
+        "condition",
+        "*"
+      ],
+      "subtitle": "Installation updated activity"
     }
   },
   "Microsoft.OnIntent": {


### PR DESCRIPTION
## Description

Those changes enable Intellisense to leverage the uiSchema in order to know what type of completion items to show.

Step 1 was modifying the schema of the uiSchema: microsoft/botframework-sdk#6047
Step 2 was updating the uiSchema of individual components: microsoft/botbuilder-dotnet#4704
Step 3 was updating Composer to leverage the uiSchema for Intellisense: https://github.com/microsoft/BotFramework-Composer/pull/4263

This final step is to update Composer's uiSchema itself.
The schema was generated running bf _dialog:merge "libraries/**/*.schema" "libraries/**/*.uischema"_ from botbuilder-dotnet

## Task Item

fixes #4187
fixes #4189 

## Screenshots

Intellisense:
![image](https://user-images.githubusercontent.com/66701106/96201048-5bdc7500-0f10-11eb-97b0-c49a29ef8787.png)

Example of schema change:
![image](https://user-images.githubusercontent.com/66701106/96201128-91815e00-0f10-11eb-946c-afbab7710b2b.png)

