### PR TITLE
feat: support app schema

### DIFF
--- a/Composer/packages/server/src/models/bot/botProject.ts
+++ b/Composer/packages/server/src/models/bot/botProject.ts
@@ -155,16 +155,16 @@ export class BotProject implements IBotProject {
     return this.files.get('app.schema') ?? this.files.get('sdk.schema');
   }
 
-  public get schemaOverrides() {
-    return this.files.get('app.override.schema') ?? this.files.get('sdk.override.schema');
-  }
-
   public get uiSchema() {
     return this.files.get('app.uischema') ?? this.files.get('sdk.uischema');
   }
 
   public get uiSchemaOverrides() {
     return this.files.get('app.override.uischema') ?? this.files.get('sdk.override.uischema');
+  }
+
+  public get schemaOverrides() {
+    return this.files.get('app.override.schema') ?? this.files.get('sdk.override.schema');
   }
 
   public getFile(id: string) {

--- a/Composer/packages/server/src/models/bot/botProject.ts
+++ b/Composer/packages/server/src/models/bot/botProject.ts
@@ -152,19 +152,19 @@ export class BotProject implements IBotProject {
   }
 
   public get schema() {
-    return this.files.get('sdk.schema');
-  }
-
-  public get uiSchema() {
-    return this.files.get('sdk.uischema');
-  }
-
-  public get uiSchemaOverrides() {
-    return this.files.get('sdk.override.uischema');
+    return this.files.get('app.schema') ?? this.files.get('sdk.schema');
   }
 
   public get schemaOverrides() {
-    return this.files.get('sdk.override.schema');
+    return this.files.get('app.override.schema') ?? this.files.get('sdk.override.schema');
+  }
+
+  public get uiSchema() {
+    return this.files.get('app.uischema') ?? this.files.get('sdk.uischema');
+  }
+
+  public get uiSchemaOverrides() {
+    return this.files.get('app.override.uischema') ?? this.files.get('sdk.override.uischema');
   }
 
   public getFile(id: string) {
@@ -736,6 +736,10 @@ export class BotProject implements IBotProject {
       'sdk.override.uischema',
       'sdk.schema',
       'sdk.uischema',
+      'app.override.schema',
+      'app.override.uischema',
+      'app.schema',
+      'app.uischema',
       '*.botproj',
     ];
     for (const pattern of patterns) {


### PR DESCRIPTION
## Description

#minor
closes #4419 

PVA prefers the naming convention `app.*schema` over the `sdk.*schema`.

This PR lets the project loader load 4 aliases of schema files:
- `app.schema` -> `sdk.schema`
- `app.override.schema` -> `sdk.override.schema`
- `app.uischema` -> `sdk.uischema`
- `app.override.uischema` -> `sdk.override.uischema`

The `app.*` schema files will take priority over `sdk.*` files.
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
