### PR TITLE
fix: azure publish failed

### DIFF
--- a/Composer/packages/server/package.json
+++ b/Composer/packages/server/package.json
@@ -62,7 +62,7 @@
     "@bfc/lg-languageserver": "*",
     "@bfc/lu-languageserver": "*",
     "@bfc/shared": "*",
-    "@microsoft/bf-dispatcher": "^4.11.0-beta.20201015.008a3a4",
+    "@microsoft/bf-dispatcher": "^4.11.0-beta.20201016.393c6b2",
     "@microsoft/bf-generate-library": "^4.10.0-daily.20201015.174962",
     "@microsoft/bf-lu": "^4.11.0-dev.20201013.7ccb128",
     "archiver": "^5.0.2",

--- a/Composer/yarn.lock
+++ b/Composer/yarn.lock
@@ -2980,10 +2980,10 @@
     fs-extra "^7.0.1"
     tslib "~1.10.0"
 
-"@microsoft/bf-dispatcher@^4.11.0-beta.20201015.008a3a4":
-  version "4.11.0-beta.20201015.008a3a4"
-  resolved "https://registry.yarnpkg.com/@microsoft/bf-dispatcher/-/bf-dispatcher-4.11.0-beta.20201015.008a3a4.tgz#a80b68b8a123653ae52e35cde25cb2d1d1b98390"
-  integrity sha512-EN1hdAKSh8siN4UDuhMsM5QJtVlAj5X6peiXB8z18rPNL7oyGUFzgEfUoQ9ZqfWpRUasz1Zj8sAyoFS76NpkGQ==
+"@microsoft/bf-dispatcher@^4.11.0-beta.20201016.393c6b2":
+  version "4.11.0-beta.20201016.393c6b2"
+  resolved "https://registry.yarnpkg.com/@microsoft/bf-dispatcher/-/bf-dispatcher-4.11.0-beta.20201016.393c6b2.tgz#7dab414752f8711fed37ae5625c38fdd0192eddb"
+  integrity sha512-pR1vVy17riuTos33IvQfDCmGG8xFmNoPUEb376kXITTtugNWVXgsD62P+thk0EAeegr7lCohNk+Zy3rfJ9lgvQ==
   dependencies:
     "@microsoft/bf-lu" next
     "@oclif/command" "~1.5.19"

--- a/extensions/azurePublish/package.json
+++ b/extensions/azurePublish/package.json
@@ -22,7 +22,7 @@
     "@bfc/indexers": "../../Composer/packages/lib/indexers",
     "@bfc/shared": "../../Composer/packages/lib/shared",
     "@botframework-composer/types": "0.0.1",
-    "@microsoft/bf-lu": "^4.11.0-dev.20201013.7ccb128",
+    "@microsoft/bf-lu": "4.11.0-dev.20201005.7e5e1b8",
     "@microsoft/bf-luis-cli": "^4.10.0-dev.20200721.8bb21ac",
     "@types/archiver": "3.1.0",
     "@types/fs-extra": "8.1.0",

--- a/extensions/azurePublish/src/luisAndQnA.ts
+++ b/extensions/azurePublish/src/luisAndQnA.ts
@@ -227,7 +227,7 @@ export class LuisAndQnaPublish {
     // Assign the appropriate account to each of the applicable LUIS apps for this bot.
     // DOCS HERE: https://westus.dev.cognitive.microsoft.com/docs/services/5890b47c39e2bb17b84a55ff/operations/5be32228e8473de116325515
     for (const dialogKey in luisAppIds) {
-      const luisAppId = luisAppIds[dialogKey];
+      const luisAppId = luisAppIds[dialogKey].appId;
       this.logger({
         status: BotProjectDeployLoggerType.DEPLOY_INFO,
         message: `Assigning to luis app id: ${luisAppId}`,

--- a/extensions/azurePublish/yarn.lock
+++ b/extensions/azurePublish/yarn.lock
@@ -231,6 +231,28 @@
     semver "^5.5.1"
     tslib "^1.10.0"
 
+"@microsoft/bf-lu@4.11.0-dev.20201005.7e5e1b8":
+  version "4.11.0-dev.20201005.7e5e1b8"
+  resolved "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@microsoft/bf-lu/-/@microsoft/bf-lu-4.11.0-dev.20201005.7e5e1b8.tgz#62f9a37bb8340456e41853e179f2941dab9dfc87"
+  integrity sha1-Yvmje7g0BFbkGFPhefKUHaud/Ic=
+  dependencies:
+    "@azure/cognitiveservices-luis-authoring" "4.0.0-preview.1"
+    "@azure/ms-rest-azure-js" "2.0.1"
+    "@types/node-fetch" "~2.5.5"
+    antlr4 "^4.7.2"
+    chalk "2.4.1"
+    console-stream "^0.1.1"
+    deep-equal "^1.0.1"
+    delay "^4.3.0"
+    fs-extra "^8.1.0"
+    get-stdin "^6.0.0"
+    globby "^10.0.1"
+    intercept-stdout "^0.1.2"
+    lodash "^4.17.19"
+    node-fetch "~2.6.0"
+    semver "^5.5.1"
+    tslib "^1.10.0"
+
 "@microsoft/bf-lu@^4.11.0-dev.20201013.7ccb128":
   version "4.11.0-dev.20201014.d8a6b54"
   resolved "https://registry.yarnpkg.com/@microsoft/bf-lu/-/bf-lu-4.11.0-dev.20201014.d8a6b54.tgz#59bdb6e94e54307f76ccadd606ca9e61b6ee4aed"
@@ -877,6 +899,9 @@ buffer@^5.1.0, buffer@^5.5.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.6.0.tgz#a31749dc7d81d84db08abf937b6b8c4033f62786"
   integrity sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
 
 cardinal@^2.1.1:
   version "2.1.1"

--- a/extensions/runtimes/src/index.ts
+++ b/extensions/runtimes/src/index.ts
@@ -19,7 +19,7 @@ export default async (composer: any): Promise<void> => {
     key: 'csharp-azurewebapp',
     name: 'C#',
     startCommand: 'dotnet run --project azurewebapp',
-    path: path.resolve(__dirname, '../../../../runtime/dotnet'),
+    path: path.resolve(__dirname, '../../../runtime/dotnet'),
     build: async (runtimePath: string, _project: any) => {
       composer.log(`BUILD THIS C# PROJECT! at ${runtimePath}...`);
       composer.log('Run dotnet user-secrets init...');


### PR DESCRIPTION
## Description
In #4351 we have updated the bf-cli version. But the azure publish copied the build logic from the server and client. It will fail if we update the bf-lu version. 

1. use previous bf-lu version in azure publish as a short term fix.
2. The luis settings' structure changed  (lubuild result)  in previous PR. update the get function.
3. update the azure plugin relative path. (the plugins folder path changed in #4399).
4. update the down-sampling library version
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
#minor
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
