### PR TITLE
fix: perf problem of Action flyout menu

### DIFF
--- a/Composer/packages/client/src/pages/design/DesignPage.tsx
+++ b/Composer/packages/client/src/pages/design/DesignPage.tsx
@@ -280,7 +280,6 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
     }
   };
 
-  const [flowEditorFocused, setFlowEditorFocused] = useState(false);
   const { actionSelected, showDisableBtn, showEnableBtn } = useMemo(() => {
     const actionSelected = Array.isArray(visualEditorSelection) && visualEditorSelection.length > 0;
     if (!actionSelected) {
@@ -292,7 +291,7 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
     return { actionSelected, showDisableBtn, showEnableBtn };
   }, [visualEditorSelection]);
 
-  useElectronFeatures(actionSelected, flowEditorFocused, canUndo(), canRedo());
+  const { onFocusFlowEditor, onBlurFlowEditor } = useElectronFeatures(actionSelected, canUndo(), canRedo());
 
   const EditorAPI = getEditorAPI();
   const toolbarItems: IToolbarItem[] = [
@@ -640,8 +639,8 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
                       <EditorExtension plugins={pluginConfig} projectId={projectId} shell={shellForFlowEditor}>
                         <VisualEditor
                           openNewTriggerModal={openNewTriggerModal}
-                          onBlur={() => setFlowEditorFocused(false)}
-                          onFocus={() => setFlowEditorFocused(true)}
+                          onBlur={() => onBlurFlowEditor()}
+                          onFocus={() => onFocusFlowEditor()}
                         />
                       </EditorExtension>
                     )}


### PR DESCRIPTION
## Description

#minor

**Problem** When moving cursor around Action flyout menu, whole UI stuck.

**Root cause**
According to this issue https://github.com/microsoft/fluentui/issues/5642 , when loading FluentUI's ContextualMenu, browser's focus state will be affected unexpectedly. In our case, when using the Action flyout menu, the browser focus state (triggered by onFocus and onBlur event) would be changed repeatedly for multiple (around 20) times.

Unfortunately, the browser's focus state was saved as a React state in DesignPage and post to Electron via IPC to enable/disbale the Electron app menu. As a result, everytime user moves cursor around the flyout menu, the design page will be redraw for tons of times which led to the UI stuck.

**Solution**
This PR fixes this issue by saving the focus state as a ref by using `useRef()` hook rather than `useState()`.
Instead of subscribing the focus state change with `useEffect()`, whenever the ref is updated, now Composer will proactively report status to Electron app menu.

With this fix, DesignPage won't be redraw when the browser focus state changes.

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
