### PR TITLE
fix: Missing $ in format string

### DIFF
--- a/Composer/packages/client/src/components/ProjectTree/ProjectTree.tsx
+++ b/Composer/packages/client/src/components/ProjectTree/ProjectTree.tsx
@@ -365,7 +365,7 @@ export const ProjectTree: React.FC<Props> = ({
     triggers: ITrigger[],
     startDepth: number
   ) => {
-    const key = `${projectId}.${dialog.id}.group-{groupName}`;
+    const key = `${projectId}.${dialog.id}.group-${groupName}`;
 
     return (
       <ExpandableNode key={key} depth={startDepth} summary={renderTriggerGroupHeader(groupName, dialog, projectId)}>


### PR DESCRIPTION
## Description

Missing a $ in a format string for a project tree item key

## Task Item

#minor

## Screenshots
N/A
