### PR TITLE
fix: SwitchCondition's path cannot be parsed correctly

### DIFF
--- a/Composer/packages/client/__tests__/utils/convertUtils/designerPathEncoder.test.ts
+++ b/Composer/packages/client/__tests__/utils/convertUtils/designerPathEncoder.test.ts
@@ -50,7 +50,17 @@ describe('decodeDesignerPathToArrayPath()', () => {
     expect(decodeDesignerPathToArrayPath(dialog, `triggers["1234"].actions["5678"]`)).toEqual('triggers[0].actions[0]');
   });
 
-  it('can handle valid designer path.', () => {
+  it('should transform array index path.', () => {
+    expect(decodeDesignerPathToArrayPath(dialog, `triggers[0].actions[0]`)).toEqual('triggers[0].actions[0]');
+    expect(decodeDesignerPathToArrayPath(dialog, `triggers[1].actions[1]`)).toEqual('triggers[1].actions[1]');
+  });
+
+  it('should transform path in mixed format.', () => {
+    expect(decodeDesignerPathToArrayPath(dialog, `triggers[0].actions["5678"]`)).toEqual(`triggers[0].actions[0]`);
+    expect(decodeDesignerPathToArrayPath(dialog, `triggers["1234"].actions[1]`)).toEqual(`triggers[0].actions[1]`);
+  });
+
+  it('can handle invalid designer path.', () => {
     expect(decodeDesignerPathToArrayPath(dialog, `triggers["1234"].actions["9999"]`)).toEqual(
       `triggers["1234"].actions["9999"]`
     );

--- a/Composer/packages/client/src/utils/convertUtils/designerPathEncoder.ts
+++ b/Composer/packages/client/src/utils/convertUtils/designerPathEncoder.ts
@@ -83,13 +83,14 @@ export const decodeDesignerPathToArrayPath = (dialog, path: string): string => {
 
   let rootData = dialog;
   for (const p of subpaths) {
-    const pathInfo = parseDesignerPath(p);
-    if (!pathInfo) {
-      // For invalid input path, fallback to origin designer path
+    const designerPathInfo = parseDesignerPath(p);
+    const arrayPathInfo = parseArrayPath(p);
+
+    const arrayName = designerPathInfo?.prefix ?? arrayPathInfo?.prefix;
+    if (!arrayName) {
+      // For invalid input path, fallback to origin input path
       return path;
     }
-
-    const { prefix: arrayName, designerId } = pathInfo;
 
     const arrayData = get(rootData, arrayName);
     if (!Array.isArray(arrayData)) {
@@ -97,9 +98,16 @@ export const decodeDesignerPathToArrayPath = (dialog, path: string): string => {
       return path;
     }
 
-    const arrayIndex = arrayData.findIndex((x) => get(x, '$designer.id') === designerId);
+    let arrayIndex = -1;
+    if (designerPathInfo) {
+      const { designerId } = designerPathInfo;
+      arrayIndex = arrayData.findIndex((x) => get(x, '$designer.id') === designerId);
+    } else if (arrayPathInfo) {
+      arrayIndex = arrayPathInfo.index;
+    }
+
     if (arrayIndex === -1) {
-      // Can't find given designer id, fallback to input path.
+      // Can't find given designer id or index, fallback to input path.
       return path;
     }
 


### PR DESCRIPTION
## Description

#minor 

When clicking on a child action under a case of SwitchCondition, Composer will redirect to root dialog.

This is caused by the data path `triggers["nPWg4L"].actions["CSz3HO"].cases[0].actions["r3Mhiy"]` cannot be recognized by url decoder.

Previously, the url decoder only supports pure index-based format or pure designer-based format. This PR lets the decoder support a mixed format data path.

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
