### PR TITLE
fix: change Flow Editor Trigger icon to 'LightningBolt'

### DIFF
--- a/Composer/packages/adaptive-flow/src/adaptive-flow-renderer/widgets/TriggerSummary/TriggerSummary.tsx
+++ b/Composer/packages/adaptive-flow/src/adaptive-flow-renderer/widgets/TriggerSummary/TriggerSummary.tsx
@@ -40,7 +40,7 @@ export const TriggerSummary = ({ data, onClick = () => {} }): JSX.Element => {
     <div css={triggerContainerStyle}>
       <div css={triggerContentStyle}>
         <div css={titleStyle}>
-          <Icon iconName="Flow" style={triggerIconStyle} />
+          <Icon iconName="LightningBolt" style={triggerIconStyle} />
           <h1 css={titleContentStyle}>{name}</h1>
         </div>
         <div className="trigger__content-label" css={subtitleStyle}>


### PR DESCRIPTION
## Description
closes #4481 
![image](https://user-images.githubusercontent.com/8528761/96965289-7a5cf480-153e-11eb-9c63-231b507bc5f0.png)

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
