### PR TITLE
fix: Adjust cross-train to use id as key-value instead of path in config

### DIFF
--- a/Composer/packages/client/src/utils/buildUtil.ts
+++ b/Composer/packages/client/src/utils/buildUtil.ts
@@ -10,7 +10,7 @@ import { getReferredQnaFiles } from './qnaUtil';
 import { getBaseName } from './fileUtil';
 
 function createConfigId(fileId: string, language: string) {
-  return `${fileId}.${language}.lu`;
+  return `${fileId}.${language}`;
 }
 
 export function createCrossTrainConfig(dialogs: DialogInfo[], luFiles: LuFile[], languages: string[]) {
@@ -29,7 +29,7 @@ export function createCrossTrainConfig(dialogs: DialogInfo[], luFiles: LuFile[],
       const triggers = filtered.reduce((result, { intent, dialogs }) => {
         const ids = dialogs
           .map((dialog) => createConfigId(dialog, language))
-          .filter((id) => luFiles.some((file) => `${file.id}.lu` === id));
+          .filter((id) => luFiles.some((file) => `${file.id}` === id));
         if (!ids.length && dialogs.length) return result;
         result[intent] = ids;
         return result;

--- a/Composer/packages/server/package.json
+++ b/Composer/packages/server/package.json
@@ -65,6 +65,7 @@
     "@microsoft/bf-dispatcher": "^4.11.0-beta.20201016.393c6b2",
     "@microsoft/bf-generate-library": "^4.10.0-daily.20201015.174962",
     "@microsoft/bf-lu": "^4.11.0-dev.20201013.7ccb128",
+    "@bfcomposer/bf-lu": "1.5.5",
     "archiver": "^5.0.2",
     "axios": "^0.19.2",
     "azure-storage": "^2.10.3",

--- a/Composer/packages/server/src/models/bot/builder.ts
+++ b/Composer/packages/server/src/models/bot/builder.ts
@@ -12,7 +12,7 @@ import log from '../../logger';
 
 import { luImportResolverGenerator, getLUFiles, getQnAFiles } from './luResolver';
 
-const crossTrainer = require('@microsoft/bf-lu/lib/parser/cross-train/crossTrainer.js');
+const crossTrainer = require('@bfcomposer/bf-lu/lib/parser/cross-train/crossTrainer.js');
 const luBuild = require('@microsoft/bf-lu/lib/parser/lubuild/builder.js');
 const qnaBuild = require('@microsoft/bf-lu/lib/parser/qnabuild/builder.js');
 const LuisBuilder = require('@microsoft/bf-lu/lib/parser/luis/luisBuilder');
@@ -110,11 +110,11 @@ export class Builder {
 
   private async crossTrain(luFiles: FileInfo[], qnaFiles: FileInfo[], allFiles: FileInfo[]) {
     const luContents = luFiles.map((file) => {
-      return { content: file.content, id: file.name };
+      return { content: file.content, id: Path.basename(file.name, '.lu') };
     });
 
     const qnaContents = qnaFiles.map((file) => {
-      return { content: file.content, id: file.name };
+      return { content: file.content, id: Path.basename(file.name, '.qna') };
     });
 
     const importResolver = luImportResolverGenerator([...getLUFiles(allFiles), ...getQnAFiles(allFiles)]);

--- a/Composer/packages/server/src/models/bot/preBuilder.ts
+++ b/Composer/packages/server/src/models/bot/preBuilder.ts
@@ -44,56 +44,11 @@ export class PreBuilder {
 
   async updateCrossTrainConfig(luFiles: FileInfo[], crossTrainConfig?: CrossTrainConfig) {
     if (crossTrainConfig && luFiles.length) {
-      const configWithPath = this.generateCrossTrainConfig(crossTrainConfig, luFiles);
       await this.storage.writeFile(
         `${this.folderPath}/cross-train.config.json`,
-        JSON.stringify(configWithPath, null, 2)
+        JSON.stringify(crossTrainConfig, null, 2)
       );
     }
-  }
-
-  replaceCrossTrainId(id: string, files: FileInfo[]) {
-    if (!id) return id;
-    const luFile = files.find((item) => item.name === id);
-    return Path.relative(this.folderPath, luFile?.path ?? '');
-  }
-
-  /**
-   * convert the cross train config from id to relativePath. The cli use the config to find the files.
-   * config = {
-   * 'main.lu': {
-   *  rootDialog: true,
-   *    triggers: {
-   *      'intentA':'diaA.lu',
-   *       'intentB': 'diaB.lu'
-   *    }
-   *  }
-   * }
-   */
-  generateCrossTrainConfig(crossTrainConfig: CrossTrainConfig, files: FileInfo[]) {
-    const pathCache = {};
-
-    const configWithPath = keys(crossTrainConfig).reduce((result: CrossTrainConfig, key: string) => {
-      const { triggers: preTriggers, rootDialog } = crossTrainConfig[key];
-      // replace the key with path
-      if (!pathCache[key]) pathCache[key] = this.replaceCrossTrainId(key, files);
-
-      const triggers = keys(preTriggers).reduce((result: { [key: string]: string[] }, key) => {
-        const ids = preTriggers[key];
-        result[key] = ids.map((item) => {
-          // replace the trigger value with path
-          if (!pathCache[item]) pathCache[item] = this.replaceCrossTrainId(item, files);
-
-          return pathCache[item];
-        });
-        return result;
-      }, {});
-
-      result[pathCache[key]] = { triggers, rootDialog };
-      return result;
-    }, {});
-
-    return configWithPath;
   }
 
   /**


### PR DESCRIPTION
## Description
use file names without any path or extension in config.

need to wait for the @microsoft/bf-lu nightly build
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
refs https://github.com/microsoft/botframework-cli/pull/1030
#minor 
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
