### PR TITLE
fix: Expressions not starting with "=" can resolve to a regular TextField

### DIFF
--- a/Composer/packages/adaptive-form/src/utils/resolveFieldWidget.ts
+++ b/Composer/packages/adaptive-form/src/utils/resolveFieldWidget.ts
@@ -58,8 +58,24 @@ export function resolveFieldWidget(params: {
       return { field: DefaultFields.OneOfField };
     }
 
-    if (expression && typeof value === 'string' && value.startsWith('=')) {
-      return { field: isOneOf ? DefaultFields.IntellisenseExpressionField : IntellisenseExpressionFieldWithIcon };
+    if (expression && typeof value === 'string') {
+      // The schema has two types of expressions: "equalsExpression" and "expression".
+      // "equalsExpression" inputs start with "=". For those we want to have access to the adaptive expressions built-in functions and have intellisense surface it, thus using IntellisenseExpressionField.
+      // "expression" inputs don't leverage the built-in functions. For those, we only want to show IntellisenseTextField.
+      if (value.startsWith('=')) {
+        return { field: isOneOf ? DefaultFields.IntellisenseExpressionField : IntellisenseExpressionFieldWithIcon };
+      } else {
+        if (showIntellisense && isOneOf) {
+          return { field: DefaultFields.IntellisenseTextField };
+        } else if (showIntellisense && !isOneOf) {
+          return { field: IntellisenseTextFieldWithIcon };
+        } else if (!showIntellisense && !isOneOf) {
+          return { field: StringFieldWithIcon };
+        }
+        return {
+          field: DefaultFields.StringField,
+        };
+      }
     }
 
     if (Array.isArray(schema.enum)) {

--- a/Composer/packages/adaptive-form/src/utils/resolveFieldWidget.ts
+++ b/Composer/packages/adaptive-form/src/utils/resolveFieldWidget.ts
@@ -61,7 +61,7 @@ export function resolveFieldWidget(params: {
     if (expression && typeof value === 'string') {
       // The schema has two types of expressions: "equalsExpression" and "expression".
       // "equalsExpression" inputs start with "=". For those we want to have access to the adaptive expressions built-in functions and have intellisense surface it, thus using IntellisenseExpressionField.
-      // "expression" inputs don't leverage the built-in functions. For those, we only want to show IntellisenseTextField.
+      // "expression" inputs don't leverage the built-in functions. For those, we only want to show a regular text field (that could potentially leverage Intellisense for results other than built-in expression functions).
       if (value.startsWith('=')) {
         return { field: isOneOf ? DefaultFields.IntellisenseExpressionField : IntellisenseExpressionFieldWithIcon };
       } else {


### PR DESCRIPTION
## Description

**resolveFieldWidget** assumed that all expressions start with "=". But there are two types of expressions:

- **equalsExpression**
- **expression**

As such, schema types that were **oneOf** between **expression** (not **equalsExpression**) and a list of non string types were enable to resolve when the input was a string. Such an example is **condition**:

```

"condition": {
      "$role": "expression",
      "title": "Boolean condition",
      "description": "Boolean constant or expression to evaluate.",
      "oneOf": [
        {
          "$ref": "#/definitions/expression"
        },
        {
          "type": "boolean",
         "title": "Boolean",
          "description": "Boolean value.",
          "default": true,
          "examples": [
            false
          ]
        }
      ]
    },

```

This PR addresses this issue by resolving to a regular input field when the type is an **expression**.

## Task Item

fixes #4479 

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
![image](https://user-images.githubusercontent.com/66701106/97047459-dcf9c480-152d-11eb-97c1-4602a09e9ca4.png)
