### PR TITLE
fix: Added custom iframe styling for pva publish

### DIFF
--- a/Composer/packages/client/src/pages/publish/createPublishTarget.tsx
+++ b/Composer/packages/client/src/pages/publish/createPublishTarget.tsx
@@ -18,7 +18,7 @@ import { userSettingsState } from '../../recoilModel';
 import { PluginHost } from '../../components/PluginHost/PluginHost';
 import { PluginAPI } from '../../plugins/api';
 
-import { label, customPublishUISurface } from './styles';
+import { label, defaultPublishSurface, pvaPublishSurface } from './styles';
 
 interface CreatePublishTargetProps {
   closeDialog: () => void;
@@ -104,9 +104,20 @@ const CreatePublishTarget: React.FC<CreatePublishTargetProps> = (props) => {
 
   const publishTargetContent = useMemo(() => {
     if (selectedTarget?.bundleId) {
+      let publishSurfaceStyles;
+      switch (selectedTarget.extensionId) {
+        case 'pva-publish-composer':
+          publishSurfaceStyles = pvaPublishSurface;
+          break;
+
+        default:
+          publishSurfaceStyles = defaultPublishSurface;
+          break;
+      }
+
       // render custom plugin view
       return (
-        <div css={customPublishUISurface}>
+        <div css={publishSurfaceStyles}>
           <PluginHost bundleId={selectedTarget.bundleId} pluginName={selectedTarget.extensionId} pluginType="publish" />
         </div>
       );

--- a/Composer/packages/client/src/pages/publish/styles.ts
+++ b/Composer/packages/client/src/pages/publish/styles.ts
@@ -116,6 +116,10 @@ export const targetSelected = css`
   font-size: ${FontSizes.small};
 `;
 
-export const customPublishUISurface = css`
+export const defaultPublishSurface = css`
   height: 230px;
+`;
+
+export const pvaPublishSurface = css`
+  height: 350px;
 `;


### PR DESCRIPTION
## Description

The pva publish iframe was too small, truncating the view and ruining the experience.

#minor

## Screenshots

**Before:**

![publish-style-before](https://user-images.githubusercontent.com/3452012/97049978-6f4f9780-1531-11eb-8b2e-20b296799edb.PNG)


**After:**


![publish-style-after](https://user-images.githubusercontent.com/3452012/97049988-72e31e80-1531-11eb-926f-9af76fa134d7.PNG)
