### PR TITLE
fix: Fixed pva publish base url bug

### DIFF
--- a/extensions/pvaPublish/src/node/constants.ts
+++ b/extensions/pvaPublish/src/node/constants.ts
@@ -1,5 +1,5 @@
 const COMPOSER_1P_APP_ID = 'ce48853e-0605-4f77-8746-d70ac63cc6bc';
-const API_VERSION = 'v1';
+export const API_VERSION = 'v1';
 
 export const AUTH_CREDENTIALS = {
   INT: {
@@ -23,7 +23,7 @@ export const AUTH_CREDENTIALS = {
 };
 
 export const BASE_URLS = {
-  INT: `https://bots.int.customercareintelligence.net/api/botmanagement/${API_VERSION}`,
-  PPE: `https://bots.ppe.customercareintelligence.net/api/botmanagement/${API_VERSION}`,
-  PROD: `https://powerva.microsoft.com/api/botmanagement/${API_VERSION}`,
+  INT: `https://bots.int.customercareintelligence.net/`,
+  PPE: `https://bots.ppe.customercareintelligence.net/`,
+  PROD: `https://powerva.microsoft.com/`,
 };

--- a/extensions/pvaPublish/src/node/publish.ts
+++ b/extensions/pvaPublish/src/node/publish.ts
@@ -16,6 +16,7 @@ import {
 } from './types';
 import { getAuthCredentials, getBaseUrl } from './utils';
 import { logger } from './logger';
+import { API_VERSION } from './constants';
 
 // in-memory history that allows us to get the status of the most recent job
 const publishHistory: PublishHistory = {};
@@ -84,7 +85,7 @@ export const publish = async (
     const length = zipReadStream.readableLength;
 
     // initiate the publish job
-    let url = `${base}/environments/${envId}/bots/${botId}/composer/publishoperations?deleteMissingDependencies=${deleteMissingDependencies}`;
+    let url = `${base}api/botmanagement/${API_VERSION}/environments/${envId}/bots/${botId}/composer/publishoperations?deleteMissingDependencies=${deleteMissingDependencies}`;
     if (comment) {
       url += `&comment=${encodeURIComponent(comment)}`;
     }
@@ -160,7 +161,7 @@ export const getStatus = async (
     const accessToken = await getAccessToken(creds);
 
     // check the status for the publish job
-    const url = `${base}/environments/${envId}/bots/${botId}/composer/publishoperations/${operationId}`;
+    const url = `${base}api/botmanagement/${API_VERSION}/environments/${envId}/bots/${botId}/composer/publishoperations/${operationId}`;
     const res = await fetch(url, {
       method: 'GET',
       headers: {
@@ -216,7 +217,7 @@ export const history = async (
     const accessToken = await getAccessToken(creds);
 
     // get the publish history for the bot
-    const url = `${base}/environments/${envId}/bots/${botId}/composer/publishoperations`;
+    const url = `${base}api/botmanagement/${API_VERSION}/environments/${envId}/bots/${botId}/composer/publishoperations`;
     const res = await fetch(url, {
       method: 'GET',
       headers: getAuthHeaders(accessToken, tenantId),
@@ -250,7 +251,7 @@ export const pull = async (
     const accessToken = await getAccessToken(creds);
 
     // fetch zip containing bot content
-    const url = `${base}/environments/${envId}/bots/${botId}/composer/content`;
+    const url = `${base}api/botmanagement/${API_VERSION}/environments/${envId}/bots/${botId}/composer/content`;
     const options: RequestInit = {
       method: 'GET',
       headers: getAuthHeaders(accessToken, tenantId),


### PR DESCRIPTION
## Description

The `baseUrl` that is provided from PVA in the publishing profile configuration has the form:

`https://bots.int.customercareintelligence.net/`

with just the host name. So I adjusted the constant base URLs to adhere to this shape.

#minor
