### PR TITLE
fix: Add delete form dialog to Composer server API

### DIFF
--- a/Composer/packages/server/src/controllers/formDialog.ts
+++ b/Composer/packages/server/src/controllers/formDialog.ts
@@ -77,8 +77,27 @@ const generate = async (req: Request, res: Response) => {
   }
 };
 
+const deleteDialog = async (req: Request, res: Response) => {
+  const projectId = req.params.projectId;
+  const dialogId = req.params.dialogId;
+
+  const user = await ExtensionContext.getUserFromRequest(req);
+
+  const currentProject = await BotProjectService.getProjectById(projectId, user);
+  if (currentProject !== undefined) {
+    await currentProject.deleteFormDialog(dialogId);
+    const updatedProject = await BotProjectService.getProjectById(projectId, user);
+    res.status(200).json({ id: projectId, ...updatedProject.getProject() });
+  } else {
+    res.status(404).json({
+      message: `Could not delete form dialog. Project ${projectId} not found.`,
+    });
+  }
+};
+
 export const FormDialogController = {
   getTemplateSchemas,
   generate,
   expandJsonSchemaProperty,
+  deleteDialog,
 };

--- a/Composer/packages/server/src/models/bot/botProject.ts
+++ b/Composer/packages/server/src/models/bot/botProject.ts
@@ -591,6 +591,17 @@ export class BotProject implements IBotProject {
     );
   }
 
+  public async deleteFormDialog(dialogId: string) {
+    const defaultLocale = this.settings?.defaultLanguage || defaultLanguage;
+    const dialogPath = defaultFilePath(this.name, defaultLocale, `${dialogId}${FileExtensions.Dialog}`);
+    const dirToDelete = Path.dirname(Path.resolve(this.dir, dialogPath));
+
+    // I check that the path is longer 3 to avoid deleting a drive and all its contents.
+    if (dirToDelete.length > 3 && this.fileStorage.exists(dirToDelete)) {
+      this.fileStorage.rmrfDir(dirToDelete);
+    }
+  }
+
   private async removeLocalRuntimeData(projectId) {
     const method = 'localpublish';
     if (ExtensionContext.extensions.publish[method]?.methods?.stopBot) {

--- a/Composer/packages/server/src/router/api.ts
+++ b/Composer/packages/server/src/router/api.ts
@@ -39,6 +39,7 @@ router.get('/projects/:projectId/export', ProjectController.exportProject);
 router.post('/formDialogs/expandJsonSchemaProperty', FormDialogController.expandJsonSchemaProperty);
 router.get('/formDialogs/templateSchemas', FormDialogController.getTemplateSchemas);
 router.post('/formDialogs/:projectId/generate', FormDialogController.generate);
+router.delete('/formDialogs/:projectId/:dialogId', FormDialogController.deleteDialog);
 
 // update the boilerplate content
 router.get('/projects/:projectId/boilerplateVersion', ProjectController.checkBoilerplateVersion);


### PR DESCRIPTION
## Description

Deleting a form dialog requires deleting form dialog assets which are all contained within a folder under dialogs.

## Task Item

#minor
#4505

## Screenshots

N/A