### PR TITLE
fix: Intellisense doesn't disappear when tabbing out of a field 

### DIFF
--- a/Composer/packages/intellisense/src/components/Intellisense.tsx
+++ b/Composer/packages/intellisense/src/components/Intellisense.tsx
@@ -97,19 +97,19 @@ export const Intellisense = React.memo(
         }
       };
 
-      const keyupHandler = (event: KeyboardEvent) => {
-        if (event.key === 'Escape' && focused) {
+      const keydownHandler = (event: KeyboardEvent) => {
+        if ((event.key === 'Escape' || event.key === 'Tab') && focused) {
           setShowCompletionList(false);
           onBlur && onBlur(id);
         }
       };
 
       document.body.addEventListener('click', outsideClickHandler);
-      document.body.addEventListener('keyup', keyupHandler);
+      document.body.addEventListener('keydown', keydownHandler);
 
       return () => {
         document.body.removeEventListener('click', outsideClickHandler);
-        document.body.removeEventListener('keyup', keyupHandler);
+        document.body.removeEventListener('keydown', keydownHandler);
       };
     }, [focused, onBlur]);
 


### PR DESCRIPTION
## Description

- onBlur when pressing Tab
- using keydown instead of keyup so that Intellisense doesn't disappear from the next field being tabbed to

## Task Item

closes #4573


