### PR TITLE
fix: generate correct URLs for root bots

### DIFF
--- a/Composer/packages/client/src/components/ProjectTree/ProjectTree.tsx
+++ b/Composer/packages/client/src/components/ProjectTree/ProjectTree.tsx
@@ -279,7 +279,7 @@ export const ProjectTree: React.FC<Props> = ({
       displayName: dialog.displayName,
       isRoot: dialog.isRoot,
       projectId: rootProjectId,
-      skillId: skillId,
+      skillId: skillId === rootProjectId ? undefined : skillId,
       errorContent,
       warningContent,
     };
@@ -332,7 +332,7 @@ export const ProjectTree: React.FC<Props> = ({
   const renderTrigger = (item: any, dialog: DialogInfo, projectId: string): React.ReactNode => {
     const link: TreeLink = {
       projectId: rootProjectId,
-      skillId: projectId,
+      skillId: projectId === rootProjectId ? undefined : projectId,
       dialogId: dialog.id,
       trigger: item.index,
       displayName: item.displayName,


### PR DESCRIPTION
## Description

This fixes a small glitch in generating URLs for the links; dialogs and triggers that belong to the root of a botProject now generate links that look like the older non-botProject ones, which should fix some issues with undo/redo.

## Task Item

#minor

## Screenshots

![image](https://user-images.githubusercontent.com/61990921/97901926-ad974480-1cf1-11eb-9bab-9e4629892c57.png)

