### PR TITLE
fix: Excluded luconfig.json from project load

### DIFF
--- a/Composer/packages/server/src/models/bot/botProject.ts
+++ b/Composer/packages/server/src/models/bot/botProject.ts
@@ -752,7 +752,14 @@ export class BotProject implements IBotProject {
       // deployment process
       const root = this.dataDir;
       const paths = await this.fileStorage.glob(
-        [pattern, '!(generated/**)', '!(runtime/**)', '!(scripts/**)', '!(settings/appsettings.json)'],
+        [
+          pattern,
+          '!(generated/**)',
+          '!(runtime/**)',
+          '!(scripts/**)',
+          '!(settings/appsettings.json)',
+          '!(**/luconfig.json)',
+        ],
         root
       );
 


### PR DESCRIPTION
## Description

Excluding luconfig.json from file loading to prevent duplicate conflicts for multiple form dialogs generated.

## Task Item

#minor 

## Screenshots
N/A