### PR TITLE
fix: Bot publish to azure failed in cross train step

### DIFF
--- a/Composer/packages/server/src/models/bot/botProject.ts
+++ b/Composer/packages/server/src/models/bot/botProject.ts
@@ -193,6 +193,7 @@ export class BotProject implements IBotProject {
       skills: this.skills,
       diagnostics: this.diagnostics,
       settings: this.settings,
+      filesWithoutRecognizers: Array.from(this.files.values()).filter(({ name }) => !isRecognizer(name)),
     };
   };
 

--- a/extensions/azurePublish/package.json
+++ b/extensions/azurePublish/package.json
@@ -22,7 +22,7 @@
     "@bfc/indexers": "../../Composer/packages/lib/indexers",
     "@bfc/shared": "../../Composer/packages/lib/shared",
     "@botframework-composer/types": "0.0.1",
-    "@microsoft/bf-lu": "^4.11.0-rc.20201030.a9f9b96",
+    "@microsoft/bf-lu": "4.11.0-dev.20201005.7e5e1b8",
     "@microsoft/bf-luis-cli": "^4.10.0-dev.20200721.8bb21ac",
     "@types/archiver": "3.1.0",
     "@types/fs-extra": "8.1.0",

--- a/extensions/azurePublish/src/index.ts
+++ b/extensions/azurePublish/src/index.ts
@@ -127,7 +127,7 @@ export default async (composer: ExtensionRegistration): Promise<void> => {
      */
     private init = async (project: any, srcTemplate: string, resourcekey: string, runtime: any) => {
       // point to the declarative assets (possibly in remote storage)
-      const botFiles = project.getProject().files;
+      const botFiles = project.getProject().filesWithoutRecognizers;
       const botFolder = this.getBotFolder(resourcekey, this.mode);
       const runtimeFolder = this.getRuntimeFolder(resourcekey);
 

--- a/extensions/azurePublish/yarn.lock
+++ b/extensions/azurePublish/yarn.lock
@@ -233,6 +233,28 @@
     semver "^5.5.1"
     tslib "^1.10.0"
 
+"@microsoft/bf-lu@4.11.0-dev.20201005.7e5e1b8":
+  version "4.11.0-dev.20201005.7e5e1b8"
+  resolved "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@microsoft/bf-lu/-/@microsoft/bf-lu-4.11.0-dev.20201005.7e5e1b8.tgz#62f9a37bb8340456e41853e179f2941dab9dfc87"
+  integrity sha1-Yvmje7g0BFbkGFPhefKUHaud/Ic=
+  dependencies:
+    "@azure/cognitiveservices-luis-authoring" "4.0.0-preview.1"
+    "@azure/ms-rest-azure-js" "2.0.1"
+    "@types/node-fetch" "~2.5.5"
+    antlr4 "^4.7.2"
+    chalk "2.4.1"
+    console-stream "^0.1.1"
+    deep-equal "^1.0.1"
+    delay "^4.3.0"
+    fs-extra "^8.1.0"
+    get-stdin "^6.0.0"
+    globby "^10.0.1"
+    intercept-stdout "^0.1.2"
+    lodash "^4.17.19"
+    node-fetch "~2.6.0"
+    semver "^5.5.1"
+    tslib "^1.10.0"
+
 "@microsoft/bf-lu@^4.11.0-rc.20201030.a9f9b96":
   version "4.11.0-rc.20201030.a9f9b96"
   resolved "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@microsoft/bf-lu/-/@microsoft/bf-lu-4.11.0-rc.20201030.a9f9b96.tgz#9fcb2a18d66bcef74eabc98f06df4574215c402f"


### PR DESCRIPTION
## Description
the recognizer file is end with .dialog, in azurepublish plugin will regard them as dialog.
The bf-lu package version is updated in other PR, we need to preserve the old version. We didn't update the plugin's build logic

1. filter the recognizer file
2. update the bf-lu to old version

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
closes #4636
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots
![image](https://user-images.githubusercontent.com/39758135/98070656-816bf700-1e9c-11eb-8cb4-c842a717b50b.png)

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
