### PR TITLE
fix: increase the size of 'warning' icon in Trigger modal

### DIFF
--- a/Composer/packages/client/src/components/ProjectTree/TriggerCreationModal.tsx
+++ b/Composer/packages/client/src/components/ProjectTree/TriggerCreationModal.tsx
@@ -95,7 +95,7 @@ const optionRow = {
 export const warningIcon = {
   marginLeft: 5,
   color: '#BE880A',
-  fontSize: 5,
+  fontSize: 8,
 };
 
 // -------------------- Validation Helpers -------------------- //


### PR DESCRIPTION
## Description
closes #4630 
![image](https://user-images.githubusercontent.com/8528761/98081361-e847db00-1eb1-11eb-85df-f05d250ccc30.png)

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
