### PR TITLE
fix: Test/Start buttons unable to click.

### DIFF
--- a/Composer/packages/client/src/components/Notifications/NotificationContainer.tsx
+++ b/Composer/packages/client/src/components/Notifications/NotificationContainer.tsx
@@ -3,6 +3,7 @@
 
 /** @jsx jsx */
 import { jsx, css } from '@emotion/core';
+import { isEmpty } from 'lodash';
 import { useRecoilValue } from 'recoil';
 
 import { dispatcherState } from '../../recoilModel';
@@ -22,8 +23,10 @@ const container = css`
 // -------------------- NotificationContainer -------------------- //
 
 export const NotificationContainer = () => {
-  const notifications = useRecoilValue(notificationsSelector);
+  const notifications = useRecoilValue(notificationsSelector).filter(({ hidden }) => !hidden);
   const { deleteNotification, hideNotification } = useRecoilValue(dispatcherState);
+
+  if (isEmpty(notifications)) return null;
 
   return (
     <div css={container} role="presentation">

--- a/Composer/packages/client/src/components/Notifications/NotificationContainer.tsx
+++ b/Composer/packages/client/src/components/Notifications/NotificationContainer.tsx
@@ -3,7 +3,7 @@
 
 /** @jsx jsx */
 import { jsx, css } from '@emotion/core';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { useRecoilValue } from 'recoil';
 
 import { dispatcherState } from '../../recoilModel';


### PR DESCRIPTION
## Description

When create notification card dismissed, the empty notification panel will still cover on buttons such as Test/Start/Show code. Introduced in #4484 
<img width="396" alt="image" src="https://user-images.githubusercontent.com/49866537/98083665-aae54c80-1eb5-11eb-9067-5bc92e40e38d.png">
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
close #4644 
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<img width="1222" alt="image" src="https://user-images.githubusercontent.com/49866537/98083128-d3b91200-1eb4-11eb-97be-7da8e358df68.png">

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
