### PR TITLE
fix: let newly created Action be focused automatically

### DIFF
--- a/Composer/packages/adaptive-flow/__tests__/adaptive-flow-editor/stubs/ShellApiStub.ts
+++ b/Composer/packages/adaptive-flow/__tests__/adaptive-flow-editor/stubs/ShellApiStub.ts
@@ -10,7 +10,7 @@ const fnPromise = () => Promise.resolve({} as any);
 export const ShellApiStub: ShellApi = {
   getDialog: fn,
   saveDialog: fn,
-  saveData: fn,
+  saveData: fnPromise,
   navTo: fn,
   onFocusSteps: fn,
   onFocusEvent: fn,

--- a/Composer/packages/adaptive-flow/src/adaptive-flow-editor/hooks/useEditorEventApi.ts
+++ b/Composer/packages/adaptive-flow/src/adaptive-flow-editor/hooks/useEditorEventApi.ts
@@ -170,19 +170,20 @@ export const useEditorEventApi = (
         if (eventData.$kind === MenuEventTypes.Paste) {
           handler = (e) => {
             insertActions(path, data, e.id, e.position, clipboardActions).then((dialog) => {
-              onChange(dialog);
-              onFocusSteps([`${e.id}[${e.position || 0}]`]);
+              return onChange(dialog).then(() => {
+                onFocusSteps([`${e.id}[${e.position || 0}]`]);
+                announce(ScreenReaderMessage.ActionCreated);
+              });
             });
-
-            announce(ScreenReaderMessage.ActionCreated);
           };
         } else {
           handler = (e) => {
             const newAction = dialogFactory.create(e.$kind);
             insertAction(path, data, e.id, e.position, newAction).then((dialog) => {
-              onChange(dialog);
-              onFocusSteps([`${e.id}[${e.position || 0}]`]);
-              announce(ScreenReaderMessage.ActionCreated);
+              return onChange(dialog).then(() => {
+                onFocusSteps([`${e.id}[${e.position || 0}]`]);
+                announce(ScreenReaderMessage.ActionCreated);
+              });
             });
           };
         }

--- a/Composer/packages/client/src/shell/useShell.ts
+++ b/Composer/packages/client/src/shell/useShell.ts
@@ -193,8 +193,9 @@ export function useShell(source: EventSource, projectId: string): Shell {
         projectId,
       };
       dialogMapRef.current[dialogId] = updatedDialog;
-      updateDialog(payload);
-      commitChanges();
+      return updateDialog(payload).then(() => {
+        commitChanges();
+      });
     },
     updateRegExIntent: updateRegExIntentHandler,
     renameRegExIntent: renameRegExIntentHandler,

--- a/Composer/packages/types/src/shell.ts
+++ b/Composer/packages/types/src/shell.ts
@@ -121,7 +121,7 @@ export type ActionContextApi = {
 };
 
 export type DialogEditingContextApi = {
-  saveData: <T = any>(newData: T, updatePath?: string) => void;
+  saveData: <T = any>(newData: T, updatePath?: string) => Promise<void>;
   onFocusSteps: (stepIds: string[], focusedTab?: string) => void;
   onFocusEvent: (eventId: string) => void;
   onSelect: (ids: string[]) => void;


### PR DESCRIPTION
## Description
closes #4616 

**Problem**:
New action not focused automatically

**Root cause**:
Related to $designer.id encoded URL.
The focusPath is calculated based on old dialog data where $designerId is for wrong Action.

**Solution**:
Let `saveData()` return a Promise, postpone the calculation of next focused Action to after dialog updated.
It will correct the behavior of:
1. Create new Action via flyout menu
2. Paste Action from clipboard

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
