### PR TITLE
fix: fix js runtime eject issue

### DIFF
--- a/extensions/localPublish/src/index.ts
+++ b/extensions/localPublish/src/index.ts
@@ -80,6 +80,8 @@ class LocalPublisher implements PublishPlugin<PublishConfig> {
           'azurewebapp'
         );
       } else if (project.settings.runtime.path && project.settings.runtime.command) {
+        const runtimePath =  path.isAbsolute(project.settings.runtime.path)? project.settings.runtime.path: path.resolve(project.dataDir, project.settings.runtime.path);
+        await runtime.build(runtimePath, project);
         await runtime.setSkillManifest(
           project.settings.runtime.path,
           project.fileStorage,

--- a/extensions/runtimes/src/index.ts
+++ b/extensions/runtimes/src/index.ts
@@ -166,11 +166,14 @@ export default async (composer: any): Promise<void> => {
       // install dev dependencies in production, make sure typescript is installed
       const { stderr: installErr } = await execAsync('npm install && npm install --only=dev', {
         cwd: runtimePath,
+        timeout: 120000,
       });
       if (installErr) {
         // in order to not throw warning, we just log all warning and error message
-        composer.log(installErr);
+        composer.log(`npm install timeout, ${installErr}`);
       }
+
+      // runtime build need typescript
       const { stderr: install2Err } = await execAsync('npm run build', {
         cwd: runtimePath,
       });
@@ -220,17 +223,6 @@ export default async (composer: any): Promise<void> => {
         // used to read bot project template from source (bundled in plugin)
         const excludeFolder = new Set<string>().add(path.resolve(sourcePath, 'node_modules'));
         await copyDir(sourcePath, localDisk, destPath, project.fileStorage, excludeFolder);
-        // install dev dependencies in production, make sure typescript is installed
-        const { stderr: initErr } = await execAsync('npm install && npm install --only=dev', {
-          cwd: destPath,
-        });
-        if (initErr) {
-          composer.log(initErr);
-        }
-        const { stderr: initErr2 } = await execAsync('npm run build', { cwd: destPath });
-        if (initErr2) {
-          throw new Error(initErr2);
-        }
         return destPath;
       } else {
         throw new Error(`Runtime already exists at ${destPath}`);


### PR DESCRIPTION
## Description

Fix JS runtime eject issue. 
**Cause**:  npm install timeout when ejecting. 
**Solution**: don't doing npm install in ejecting, just install and build before publish.

## Task Item

close #4011 

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
