### PR TITLE
fix: does not allow to delete root bot

### DIFF
--- a/Composer/packages/client/src/components/ProjectTree/ProjectTree.tsx
+++ b/Composer/packages/client/src/components/ProjectTree/ProjectTree.tsx
@@ -305,13 +305,17 @@ export const ProjectTree: React.FC<Props> = ({
           isActive={doesLinkMatch(link, selectedLink)}
           link={link}
           menu={[
-            {
-              label: formatMessage('Remove this dialog'),
-              icon: 'Delete',
-              onClick: (link) => {
-                onDeleteDialog(link.dialogId ?? '');
-              },
-            },
+            ...(!dialog.isRoot
+              ? [
+                  {
+                    label: formatMessage('Remove this dialog'),
+                    icon: 'Delete',
+                    onClick: (link) => {
+                      onDeleteDialog(link.dialogId ?? '');
+                    },
+                  },
+                ]
+              : []),
             ...(showEditSchema
               ? [
                   {

--- a/Composer/packages/server/src/controllers/formDialog.ts
+++ b/Composer/packages/server/src/controllers/formDialog.ts
@@ -85,9 +85,19 @@ const deleteDialog = async (req: Request, res: Response) => {
 
   const currentProject = await BotProjectService.getProjectById(projectId, user);
   if (currentProject !== undefined) {
-    await currentProject.deleteFormDialog(dialogId);
-    const updatedProject = await BotProjectService.getProjectById(projectId, user);
-    res.status(200).json({ id: projectId, ...updatedProject.getProject() });
+    try {
+      const rootDialogId = currentProject.rootDialogId;
+      if (rootDialogId === dialogId) {
+        throw new Error('root dialog is not allowed to delete');
+      }
+      await currentProject.deleteFormDialog(dialogId);
+      const updatedProject = await BotProjectService.getProjectById(projectId, user);
+      res.status(200).json({ id: projectId, ...updatedProject.getProject() });
+    } catch (e) {
+      res.status(400).json({
+        message: e.message,
+      });
+    }
   } else {
     res.status(404).json({
       message: `Could not delete form dialog. Project ${projectId} not found.`,


### PR DESCRIPTION
## Description
delete root dialog button is hidden and add checks on server side.
## Task Item
Closes #4626 

## Screenshots
![微信图片_20201104195522](https://user-images.githubusercontent.com/24380525/98108916-b5b0d900-1ed7-11eb-8c58-54e258ec1194.png)

![微信图片_20201104195703](https://user-images.githubusercontent.com/24380525/98109086-f7418400-1ed7-11eb-9eed-7076768c2447.png)
