### PR TITLE
fix: Sorting OneOfField options / better default type

### DIFF
--- a/Composer/packages/adaptive-form/src/components/fields/OneOfField/__tests__/utils.test.ts
+++ b/Composer/packages/adaptive-form/src/components/fields/OneOfField/__tests__/utils.test.ts
@@ -71,13 +71,13 @@ describe('getOptions', () => {
       const { options } = getOptions(schema, definitions);
       const optionKeys = options.map((o) => o.key);
       expect(optionKeys).toEqual([
-        'my awesome string',
-        'boolean',
+        'string',
         'number',
+        'boolean',
+        'my awesome string',
         'an enum',
         'dropdown',
         'another type',
-        'string',
         'unknown',
       ]);
     });

--- a/Composer/packages/adaptive-form/src/components/fields/OneOfField/__tests__/utils.test.ts
+++ b/Composer/packages/adaptive-form/src/components/fields/OneOfField/__tests__/utils.test.ts
@@ -22,9 +22,9 @@ describe('getOptions', () => {
     it('returns all of the types, sorted', () => {
       const { options } = getOptions(schema, {});
       expect(options).toEqual([
-        makeOption(schema, 'boolean'),
-        makeOption(schema, 'number'),
         makeOption(schema, 'string'),
+        makeOption(schema, 'number'),
+        makeOption(schema, 'boolean'),
       ]);
     });
   });

--- a/Composer/packages/adaptive-form/src/components/fields/OneOfField/utils.ts
+++ b/Composer/packages/adaptive-form/src/components/fields/OneOfField/utils.ts
@@ -25,6 +25,18 @@ function getOptionLabel(schema: JSONSchema7): string {
   return type || 'unknown';
 }
 
+const typePriorityWeights = {
+  string: 5,
+  number: 4,
+  boolean: 3,
+  array: 2,
+  object: 1,
+};
+
+const sortOptionsByTypeWeights = ({ key: type1 }, { key: type2 }): number => {
+  return (typePriorityWeights[type1] || 0) < (typePriorityWeights[type2] || 0) ? 1 : -1;
+};
+
 export function getOptions(
   schema: JSONSchema7,
   definitions?: SchemaDefinitions
@@ -40,7 +52,7 @@ export function getOptions(
       data: { schema: { ...schema, type: t }, icon: getFieldIconText(t) },
     }));
 
-    options.sort(({ text: t1 }, { text: t2 }) => (t1 > t2 ? 1 : -1));
+    options.sort(sortOptionsByTypeWeights);
 
     return { options, isNested };
   }
@@ -63,6 +75,8 @@ export function getOptions(
         }
       })
       .filter(Boolean) as IDropdownOption[];
+
+    options.sort(sortOptionsByTypeWeights);
 
     const expression = (resolvedOneOf as JSONSchema7[]).find(({ $role }) => $role === 'expression');
     const merged = merge({}, omit(schema, 'oneOf'), expression);

--- a/Composer/packages/adaptive-form/src/components/fields/OneOfField/utils.ts
+++ b/Composer/packages/adaptive-form/src/components/fields/OneOfField/utils.ts
@@ -34,7 +34,7 @@ const typePriorityWeights = {
 };
 
 const sortOptionsByTypeWeights = ({ key: type1 }, { key: type2 }): number => {
-  return (typePriorityWeights[type1] || 0) < (typePriorityWeights[type2] || 0) ? 1 : -1;
+  return (typePriorityWeights[type1] || 0) > (typePriorityWeights[type2] || 0) ? -1 : 1;
 };
 
 export function getOptions(


### PR DESCRIPTION
## Description

"object" was the default type for fields accepting **valueExpression**, such as **Microsoft.SetProperty**.
This was due to the fact that the default type is simply the first one mentioned in the schema:

![image](https://user-images.githubusercontent.com/66701106/98161876-4d410800-1e95-11eb-85ef-111ef0c0a95e.png)

As such the dropdown for fields using **valueExpression** was listing in that order: object -> array -> string -> boolean -> number, with object being the default.

One solution to this problem could be to modify the ordering in the schema.

The approach taken in this PR instead is to have a mappings of type to weights to give more priority to certain types (such as string) and order based of that.


## Task Item

closes #4654

## Screenshots

![image](https://user-images.githubusercontent.com/66701106/98161684-03582200-1e95-11eb-8c53-53d9d1bd9fae.png)

