### PR TITLE
fix: Form dialog hidden fixed feature flags

### DIFF
--- a/Composer/packages/lib/shared/src/featureFlagUtils/index.ts
+++ b/Composer/packages/lib/shared/src/featureFlagUtils/index.ts
@@ -28,7 +28,7 @@ export const getDefaultFeatureFlags = (): FeatureFlagMap => ({
   FORM_DIALOG: {
     displayName: formatMessage('Show Form Dialog'),
     description: formatMessage('Show form dialog editor in the canvas'),
-    isHidden: false,
+    isHidden: true,
     enabled: false,
   },
 });

--- a/Composer/packages/server/src/services/featureFlags.ts
+++ b/Composer/packages/server/src/services/featureFlags.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
@@ -21,69 +22,64 @@ export class FeatureFlagService {
   private static updateFeatureFlags = () => {
     const currentFeatureFlagKeys = Object.keys(FeatureFlagService.currentFeatureFlagMap);
     const defaultFeatureFlagKeys = Object.keys(FeatureFlagService.defaultFeatureFlags);
-    const keysToAdd: string[] = [];
-    const keysToUpdateHidden: string[] = [];
 
-    defaultFeatureFlagKeys.forEach((key: string) => {
-      if (!currentFeatureFlagKeys.includes(key)) {
-        keysToAdd.push(key);
-      } else if (
-        currentFeatureFlagKeys.includes(key) &&
-        FeatureFlagService.currentFeatureFlagMap[key as FeatureFlagKey].isHidden !==
-          FeatureFlagService.defaultFeatureFlags[key as FeatureFlagKey].isHidden
-      ) {
-        keysToUpdateHidden.push(key);
-      }
+    // apply defaults to the loaded feature flags
+    Object.keys(FeatureFlagService.currentFeatureFlagMap).forEach((key) => {
+      FeatureFlagService.currentFeatureFlagMap[key] = {
+        ...FeatureFlagService.defaultFeatureFlags[key],
+        ...FeatureFlagService.currentFeatureFlagMap[key],
+      };
     });
 
-    const keysToRemove = currentFeatureFlagKeys.filter((key: string) => {
-      if (!defaultFeatureFlagKeys.includes(key)) {
-        return key;
-      }
-    });
+    let saveNeeded = false;
+
+    // add any new keys defined in the defaults that aren't in current
+    const keysToAdd = defaultFeatureFlagKeys.filter((key: string) => !currentFeatureFlagKeys.includes(key));
 
     keysToAdd.forEach((key: string) => {
       FeatureFlagService.currentFeatureFlagMap[key] = FeatureFlagService.defaultFeatureFlags[key];
+      saveNeeded = true;
     });
+
+    // remove any keys no longer in default that are in current
+    const keysToRemove = currentFeatureFlagKeys.filter((key: string) => !defaultFeatureFlagKeys.includes(key));
 
     keysToRemove.forEach((key: string) => {
       delete FeatureFlagService.currentFeatureFlagMap[key];
+      saveNeeded = true;
     });
 
-    keysToUpdateHidden.forEach((key: string) => {
-      FeatureFlagService.currentFeatureFlagMap[key as FeatureFlagKey].isHidden =
-        FeatureFlagService.defaultFeatureFlags[key as FeatureFlagKey].isHidden;
-    });
+    // set any hidden feature flags from the process
+    // process should override value for hidden features flags
+    Object.keys(FeatureFlagService.currentFeatureFlagMap)
+      .filter((key) => FeatureFlagService.currentFeatureFlagMap[key as FeatureFlagKey].isHidden)
+      .forEach((key) => {
+        const enabled = FeatureFlagService.currentFeatureFlagMap[key as FeatureFlagKey].enabled;
+        const processEnvEnabled = key in process.env;
 
-    const hiddenFeatureFlagUpdated = FeatureFlagService.updateHiddenFeatureFlags();
+        if (enabled !== processEnvEnabled) {
+          FeatureFlagService.currentFeatureFlagMap[key as FeatureFlagKey].enabled = processEnvEnabled;
+          saveNeeded = true;
+        }
+      });
 
-    if (
-      keysToRemove?.length > 0 ||
-      keysToAdd?.length > 0 ||
-      keysToUpdateHidden?.length > 0 ||
-      hiddenFeatureFlagUpdated
-    ) {
-      Store.set(storeKey, FeatureFlagService.currentFeatureFlagMap);
+    if (saveNeeded) {
+      FeatureFlagService.saveFeatureFlags();
     }
   };
 
-  private static updateHiddenFeatureFlags = (): boolean => {
-    const hiddenFeatureFlagKeys = Object.keys(FeatureFlagService.currentFeatureFlagMap).filter((key: string) => {
-      if (FeatureFlagService.currentFeatureFlagMap[key as FeatureFlagKey].isHidden) {
-        return key;
-      }
-    });
+  private static saveFeatureFlags() {
+    const saveFeatureFlagMap: FeatureFlagMap = {} as FeatureFlagMap;
 
-    let result = false;
-    hiddenFeatureFlagKeys.forEach((key: string) => {
-      if (process.env[key] && process.env[key] !== FeatureFlagService.currentFeatureFlagMap[key]) {
-        FeatureFlagService.currentFeatureFlagMap[key as FeatureFlagKey].enabled =
-          process.env[key]?.toLowerCase() === 'true';
-        result = true;
-      }
+    // only save user data to avoid replacing values from defaults like displayName
+    Object.keys(FeatureFlagService.currentFeatureFlagMap).forEach((key) => {
+      saveFeatureFlagMap[key] = {
+        enabled: FeatureFlagService.currentFeatureFlagMap[key].enabled,
+        isHidden: FeatureFlagService.currentFeatureFlagMap[key].isHidden,
+      };
     });
-    return result;
-  };
+    Store.set(storeKey, saveFeatureFlagMap);
+  }
 
   public static getFeatureFlags(): FeatureFlagMap {
     FeatureFlagService.initialize();
@@ -92,7 +88,7 @@ export class FeatureFlagService {
 
   public static updateFeatureFlag(newFeatureFlags: FeatureFlagMap) {
     FeatureFlagService.currentFeatureFlagMap = newFeatureFlags;
-    Store.set(storeKey, newFeatureFlags);
+    FeatureFlagService.saveFeatureFlags();
   }
 
   public static getFeatureFlagValue(featureFlagKey: FeatureFlagKey): boolean {

--- a/Composer/packages/server/src/services/featureFlags.ts
+++ b/Composer/packages/server/src/services/featureFlags.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 

--- a/Composer/packages/server/src/services/featureFlags.ts
+++ b/Composer/packages/server/src/services/featureFlags.ts
@@ -33,20 +33,20 @@ export class FeatureFlagService {
     let saveNeeded = false;
 
     // add any new keys defined in the defaults that aren't in current
-    const keysToAdd = defaultFeatureFlagKeys.filter((key: string) => !currentFeatureFlagKeys.includes(key));
-
-    keysToAdd.forEach((key: string) => {
-      FeatureFlagService.currentFeatureFlagMap[key] = FeatureFlagService.defaultFeatureFlags[key];
-      saveNeeded = true;
-    });
+    defaultFeatureFlagKeys
+      .filter((key: string) => !currentFeatureFlagKeys.includes(key))
+      .forEach((key: string) => {
+        FeatureFlagService.currentFeatureFlagMap[key] = FeatureFlagService.defaultFeatureFlags[key];
+        saveNeeded = true;
+      });
 
     // remove any keys no longer in default that are in current
-    const keysToRemove = currentFeatureFlagKeys.filter((key: string) => !defaultFeatureFlagKeys.includes(key));
-
-    keysToRemove.forEach((key: string) => {
-      delete FeatureFlagService.currentFeatureFlagMap[key];
-      saveNeeded = true;
-    });
+    currentFeatureFlagKeys
+      .filter((key: string) => !defaultFeatureFlagKeys.includes(key))
+      .forEach((key: string) => {
+        delete FeatureFlagService.currentFeatureFlagMap[key];
+        saveNeeded = true;
+      });
 
     // set any hidden feature flags from the process
     // process should override value for hidden features flags


### PR DESCRIPTION
## Description

Hiding form dialogs feature switch for composer 1.2 (hidden:true in the defaults)
There were issues with the feature switch service that caused hidden:true to not hide the switch.

I refactored to fix the following:
- filter statements were returning values and not booleans
- hidden switches needed to follow the process.env for enabled
- hidden switches that were updated weren't properly causing the storage to save again
- the display name and description shouldn't be saved as user data
- the defaults were only applied if the key was not present, needed to merge defaults and currents per key

## Task Item

Fixes #4621 

## Screenshots

![image](https://user-images.githubusercontent.com/28762486/98165424-bd9e5800-1e9a-11eb-8c64-6be9cfab3943.png)

![image](https://user-images.githubusercontent.com/28762486/98165452-ca22b080-1e9a-11eb-8c54-e383c9bd7b2d.png)

