### PR TITLE
fix: show intent value in the "Trigger phrases" field of a RegEx intent

### DIFF
--- a/Composer/packages/adaptive-form/src/components/fields/RegexIntentField.tsx
+++ b/Composer/packages/adaptive-form/src/components/fields/RegexIntentField.tsx
@@ -7,12 +7,10 @@ import React, { useState, useEffect } from 'react';
 import { FieldProps, useShellApi, MicrosoftIDialog } from '@bfc/extension-client';
 import { RegexRecognizer } from '@bfc/shared';
 
-import { useFormData } from '../../hooks';
-
 import { StringField } from './StringField';
 
-function getRegexIntentPattern(formData: MicrosoftIDialog, intent: string): string {
-  const recognizer = formData.recognizer as RegexRecognizer;
+function getRegexIntentPattern(dialogContent: MicrosoftIDialog, intent: string): string {
+  const recognizer = dialogContent.recognizer as RegexRecognizer;
   let pattern = '';
 
   if (!recognizer) {
@@ -28,15 +26,14 @@ function getRegexIntentPattern(formData: MicrosoftIDialog, intent: string): stri
 
 const RegexIntentField: React.FC<FieldProps> = ({ value: intentName, ...rest }) => {
   const { currentDialog, shellApi } = useShellApi();
-  const formData = useFormData();
-  const [localValue, setLocalValue] = useState(getRegexIntentPattern(formData, intentName));
+  const [localValue, setLocalValue] = useState(getRegexIntentPattern(currentDialog?.content, intentName));
 
   // if the intent name changes or intent names in the regex patterns
   // we need to reset the local value
   useEffect(() => {
-    const pattern = getRegexIntentPattern(formData, intentName);
+    const pattern = getRegexIntentPattern(currentDialog?.content, intentName);
     setLocalValue(pattern);
-  }, [intentName, (formData.recognizer as RegexRecognizer)?.intents.map((i) => i.intent)]);
+  }, [intentName, currentDialog?.content]);
 
   const handleIntentChange = (pattern?: string) => {
     setLocalValue(pattern ?? '');


### PR DESCRIPTION
## Description
closes #4653 

Fix the problem that intent value not shown when the recognizer is RegexRecognizer.

![image](https://user-images.githubusercontent.com/8528761/98192928-fc91e380-1f56-11eb-8614-991b81ce9fc4.png)


Reference: https://github.com/microsoft/BotFramework-Composer/pull/4383/files#r517765615

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
