### PR TITLE
fix: region is not set correctly when generating luis settings file name in luis build call

### DIFF
--- a/Composer/packages/server/src/models/bot/builder.ts
+++ b/Composer/packages/server/src/models/bot/builder.ts
@@ -217,6 +217,7 @@ export class Builder {
       suffix: config.suffix,
       keptVersionCount: 10,
       isStaging: false,
+      region: config.region,
     });
 
     await this.luBuilder.writeDialogAssets(buildResult, {


### PR DESCRIPTION
## Description

Composer is calling luis build api to publish luis models and generate luis settings file. But currently in composer, the config.region is not passed into luis build api that makes the luis settings file name `luis.settings.{environment}.{region}.json` consumed the default westus region even if users are specifying other regions.

## Task Item

Closes #4663 
