### PR TITLE
fix: optionalize check for template creation flag

### DIFF
--- a/Composer/packages/client/src/recoilModel/selectors/projectTemplates.ts
+++ b/Composer/packages/client/src/recoilModel/selectors/projectTemplates.ts
@@ -19,7 +19,7 @@ export const filteredTemplatesSelector = selector({
         filteredTemplates.splice(vaTemplateIndex, 1);
       }
     }
-    if (!featureFlags.REMOTE_TEMPLATE_CREATION_EXPERIENCE.enabled) {
+    if (!featureFlags?.REMOTE_TEMPLATE_CREATION_EXPERIENCE?.enabled) {
       filteredTemplates = filteredTemplates.filter((template: BotTemplate) => {
         if (template.path) {
           return template;


### PR DESCRIPTION
## Description

Starting up Composer was failing for me because it was looking for this "enabled" prop on a flag that didn't exist. This changes that one line to match a similar case above.

## Task Item
#minor
