### PR TITLE
fix: the generated recognizer files is messy when the dialog name has the same prefix

### DIFF
--- a/Composer/packages/client/src/recoilModel/Recognizers.tsx
+++ b/Composer/packages/client/src/recoilModel/Recognizers.tsx
@@ -7,7 +7,7 @@ import { useRecoilState, useSetRecoilState } from 'recoil';
 import { useRecoilValue } from 'recoil';
 import isEqual from 'lodash/isEqual';
 
-import { getExtension } from '../utils/fileUtil';
+import { getBaseName, getExtension } from '../utils/fileUtil';
 
 import * as luUtil from './../utils/luUtil';
 import * as buildUtil from './../utils/buildUtil';
@@ -55,7 +55,7 @@ export const getMultiLanguagueRecognizerDialog = (
   const multiLanguageRecognizer = MultiLanguageRecognizerTemplate(target, fileType);
 
   files.forEach((item) => {
-    if (item.empty || !item.id.startsWith(target)) return;
+    if (item.empty || getBaseName(item.id) !== target) return;
     const locale = getExtension(item.id);
     const fileName = `${item.id}.${fileType}`;
     multiLanguageRecognizer.recognizers[locale] = fileName;
@@ -69,7 +69,7 @@ export const getMultiLanguagueRecognizerDialog = (
 
 export const getLuisRecognizerDialogs = (target: string, luFiles: LuFile[]) => {
   return luFiles
-    .filter((item) => !item.empty && item.id.startsWith(target))
+    .filter((item) => !item.empty && getBaseName(item.id) === target)
     .map((item) => ({ id: `${item.id}.lu.dialog`, content: LuisRecognizerTemplate(target, item.id) }));
 };
 
@@ -147,8 +147,8 @@ export const Recognizer = React.memo((props: { projectId: string }) => {
       .filter((dialog) => !dialog.isFormDialog)
       .filter((dialog) => isCrossTrainedRecognizerSet(dialog) || isLuisRecognizer(dialog))
       .forEach((dialog) => {
-        const filtedLus = luFiles.filter((item) => item.id.startsWith(dialog.id));
-        const filtedQnas = qnaFiles.filter((item) => item.id.startsWith(dialog.id));
+        const filtedLus = luFiles.filter((item) => getBaseName(item.id) === dialog.id);
+        const filtedQnas = qnaFiles.filter((item) => getBaseName(item.id) === dialog.id);
         const {
           isCrossTrain,
           luisRecognizers,


### PR DESCRIPTION
## Description
Can't use startsWith here, if the dialog name is a.dialog and ab.dialog, the filter for lu files will be wrong

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
closes #4705
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
