### PR TITLE
fix: update incompatible Trigger redirect url & icon size

### DIFF
--- a/Composer/packages/adaptive-flow/src/adaptive-flow-renderer/components/ElementMeasurer.tsx
+++ b/Composer/packages/adaptive-flow/src/adaptive-flow-renderer/components/ElementMeasurer.tsx
@@ -20,12 +20,12 @@ export const ElementMeasurer: React.FC<ElementMeasurerProps> = ({ children, styl
   return (
     <Measure
       scroll
-      onResize={({ bounds }) => {
+      onResize={({ scroll }) => {
         /**
          * As a parent node, <Measure /> mounted before children mounted.
          * Avoid flickering issue by filtering out the first onResize event.
          */
-        const { width, height } = bounds ?? { width: 0, height: 0 };
+        const { width, height } = scroll ?? { width: 0, height: 0 };
         if (width === 0 && height === 0) return;
         onResize(new Boundary(width, height));
       }}

--- a/Composer/packages/adaptive-flow/src/adaptive-flow-renderer/components/ElementMeasurer.tsx
+++ b/Composer/packages/adaptive-flow/src/adaptive-flow-renderer/components/ElementMeasurer.tsx
@@ -20,12 +20,12 @@ export const ElementMeasurer: React.FC<ElementMeasurerProps> = ({ children, styl
   return (
     <Measure
       scroll
-      onResize={({ scroll }) => {
+      onResize={({ bounds }) => {
         /**
          * As a parent node, <Measure /> mounted before children mounted.
          * Avoid flickering issue by filtering out the first onResize event.
          */
-        const { width, height } = scroll ?? { width: 0, height: 0 };
+        const { width, height } = bounds ?? { width: 0, height: 0 };
         if (width === 0 && height === 0) return;
         onResize(new Boundary(width, height));
       }}

--- a/Composer/packages/client/src/components/ProjectTree/TriggerCreationModal.tsx
+++ b/Composer/packages/client/src/components/ProjectTree/TriggerCreationModal.tsx
@@ -95,7 +95,7 @@ const optionRow = {
 export const warningIcon = {
   marginLeft: 5,
   color: '#BE880A',
-  fontSize: 8,
+  fontSize: 12,
 };
 
 // -------------------- Validation Helpers -------------------- //

--- a/Composer/packages/client/src/pages/design/DesignPage.tsx
+++ b/Composer/packages/client/src/pages/design/DesignPage.tsx
@@ -707,7 +707,7 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
                           onCancel={() => {
                             setWarningIsVisible(false);
                           }}
-                          onOk={() => navigateTo(`/bot/${projectId}`)}
+                          onOk={() => navigateTo(`/bot/${projectId}/dialogs/${dialogId}`)}
                         />
                       )
                     ) : (


### PR DESCRIPTION
## Description
#minor
1. Follows #4652, redirect to the specific dialog url instead of main dialog.
    ![image](https://user-images.githubusercontent.com/8528761/98510781-abf3f080-229e-11eb-8dd8-8760433af286.png)

2. Follows #4630, increase icon size to 12px (5px -> 8px -> 12px).
    ![image](https://user-images.githubusercontent.com/8528761/98510817-bca46680-229e-11eb-893e-bde757802e7a.png)

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
