### PR TITLE
fix: Flow Editor 'onResize' handler not working

### DIFF
--- a/Composer/packages/adaptive-flow/src/adaptive-flow-renderer/components/ElementMeasurer.tsx
+++ b/Composer/packages/adaptive-flow/src/adaptive-flow-renderer/components/ElementMeasurer.tsx
@@ -20,12 +20,12 @@ export const ElementMeasurer: React.FC<ElementMeasurerProps> = ({ children, styl
   return (
     <Measure
       scroll
-      onResize={({ bounds }) => {
+      onResize={({ scroll }) => {
         /**
          * As a parent node, <Measure /> mounted before children mounted.
          * Avoid flickering issue by filtering out the first onResize event.
          */
-        const { width, height } = bounds ?? { width: 0, height: 0 };
+        const { width, height } = scroll ?? { width: 0, height: 0 };
         if (width === 0 && height === 0) return;
         onResize(new Boundary(width, height));
       }}


### PR DESCRIPTION
## Description
#minor 
Follows #4672 

In #4672, we use `scroll` rather than `bounds` to measure node size. This change broke the layouter of Flow Editor.
This PR fixes the issue by reading `scroll` instead of `bounds` in the `onResize` handler.

**Wrong layout**:
![image](https://user-images.githubusercontent.com/8528761/98511284-76033c00-229f-11eb-8a7a-26029ea16009.png)
**Correct layout**:
![image](https://user-images.githubusercontent.com/8528761/98511377-8fa48380-229f-11eb-94da-6d5205d24627.png)

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
