### PR TITLE
fix: undo/redo can't navigate to the correct position

### DIFF
--- a/Composer/packages/adaptive-flow/src/adaptive-flow-editor/hooks/useEditorEventApi.ts
+++ b/Composer/packages/adaptive-flow/src/adaptive-flow-editor/hooks/useEditorEventApi.ts
@@ -160,9 +160,10 @@ export const useEditorEventApi = (
       case NodeEventTypes.Delete:
         trackActionChange(eventData.id);
         handler = (e) => {
-          onChange(deleteSelectedAction(path, data, e.id));
-          onFocusSteps([]);
-          announce(ScreenReaderMessage.ActionDeleted);
+          onChange(deleteSelectedAction(path, data, e.id), undefined, async () => {
+            await onFocusSteps([]);
+            announce(ScreenReaderMessage.ActionDeleted);
+          });
         };
         break;
       case NodeEventTypes.Insert:
@@ -170,8 +171,8 @@ export const useEditorEventApi = (
         if (eventData.$kind === MenuEventTypes.Paste) {
           handler = (e) => {
             insertActions(path, data, e.id, e.position, clipboardActions).then((dialog) => {
-              return onChange(dialog).then(() => {
-                onFocusSteps([`${e.id}[${e.position || 0}]`]);
+              return onChange(dialog, undefined, async () => {
+                await onFocusSteps([`${e.id}[${e.position || 0}]`]);
                 announce(ScreenReaderMessage.ActionCreated);
               });
             });
@@ -180,8 +181,8 @@ export const useEditorEventApi = (
           handler = (e) => {
             const newAction = dialogFactory.create(e.$kind);
             insertAction(path, data, e.id, e.position, newAction).then((dialog) => {
-              return onChange(dialog).then(() => {
-                onFocusSteps([`${e.id}[${e.position || 0}]`]);
+              return onChange(dialog, undefined, async () => {
+                await onFocusSteps([`${e.id}[${e.position || 0}]`]);
                 announce(ScreenReaderMessage.ActionCreated);
               });
             });
@@ -200,9 +201,10 @@ export const useEditorEventApi = (
           const actionIds = getClipboardTargetsFromContext();
           trackActionListChange(actionIds);
           cutSelectedActions(path, data, actionIds).then(({ dialog, cutActions }) => {
-            onChange(dialog);
-            onFocusSteps([]);
-            onClipboardChange(cutActions);
+            onChange(dialog, undefined, async () => {
+              await onFocusSteps([]);
+              onClipboardChange(cutActions);
+            });
           });
           announce(ScreenReaderMessage.ActionsCut);
         };
@@ -260,18 +262,20 @@ export const useEditorEventApi = (
             placeholderPosition.arrayIndex,
             placeholderAction
           );
-          onChange(insertResult);
-          onFocusSteps([]);
-          announce(ScreenReaderMessage.ActionsMoved);
+          onChange(insertResult, undefined, async () => {
+            await onFocusSteps([]);
+            announce(ScreenReaderMessage.ActionsMoved);
+          });
         };
         break;
       case NodeEventTypes.DeleteSelection:
         handler = () => {
           const actionIds = getClipboardTargetsFromContext();
           trackActionListChange(actionIds);
-          onChange(deleteSelectedActions(path, data, actionIds));
-          onFocusSteps([]);
-          announce(ScreenReaderMessage.ActionsDeleted);
+          onChange(deleteSelectedActions(path, data, actionIds), undefined, async () => {
+            await onFocusSteps([]);
+            announce(ScreenReaderMessage.ActionsDeleted);
+          });
         };
         break;
       case NodeEventTypes.DisableSelection:

--- a/Composer/packages/client/src/recoilModel/dispatchers/navigation.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/navigation.ts
@@ -16,10 +16,7 @@ import { checkUrl, convertPathToUrl, getUrlSearch, navigateTo } from './../../ut
 
 export const navigationDispatcher = () => {
   const setDesignPageLocation = useRecoilCallback(
-    ({ set }: CallbackInterface) => async (
-      projectId: string,
-      { dialogId = '', selected = '', focused = '', promptTab }
-    ) => {
+    ({ set }: CallbackInterface) => (projectId: string, { dialogId = '', selected = '', focused = '', promptTab }) => {
       let focusPath = dialogId + '#';
       if (focused) {
         focusPath = dialogId + '#.' + focused;
@@ -56,7 +53,11 @@ export const navigationDispatcher = () => {
           ? convertPathToUrl(rootBotProjectId, skillId, dialogId)
           : convertPathToUrl(rootBotProjectId, skillId, dialogId, `selected=triggers[${trigger}]`);
       if (checkUrl(currentUri, rootBotProjectId, projectId, designPageLocation)) return;
-
+      set(designPageLocationState(projectId), {
+        dialogId: dialogId ?? '',
+        selected: trigger ?? '',
+        focused: '',
+      });
       navigateTo(currentUri);
     }
   );
@@ -85,6 +86,11 @@ export const navigationDispatcher = () => {
       const currentUri = convertPathToUrl(rootBotProjectId, skillId, dialogId, encodedSelectPath);
 
       if (checkUrl(currentUri, rootBotProjectId, skillId, designPageLocation)) return;
+      set(designPageLocationState(projectId), {
+        dialogId,
+        selected: selectPath,
+        focused: '',
+      });
       navigateTo(currentUri);
     }
   );
@@ -121,6 +127,13 @@ export const navigationDispatcher = () => {
         currentUri += `#${fragment}`;
       }
       if (checkUrl(currentUri, projectId, skillId, designPageLocation)) return;
+
+      set(designPageLocationState(projectId), {
+        dialogId,
+        selected: getSelected(focusPath) || selected,
+        focused: focusPath ?? '',
+        promptTab: Object.values(PromptTab).find((value) => fragment === value),
+      });
       navigateTo(currentUri);
     }
   );

--- a/Composer/packages/client/src/shell/useShell.ts
+++ b/Composer/packages/client/src/shell/useShell.ts
@@ -135,17 +135,17 @@ export function useShell(source: EventSource, projectId: string): Shell {
     updateDialog({ id, content: newDialog.content, projectId });
   }
 
-  function navigationTo(path, rest?) {
+  async function navigationTo(path, rest?) {
     if (rootBotProjectId == null) return;
-    navTo(projectId, path, rest);
+    await navTo(projectId, path, rest);
   }
 
-  function focusEvent(subPath) {
+  async function focusEvent(subPath) {
     if (rootBotProjectId == null) return;
-    selectTo(projectId, dialogId, subPath);
+    await selectTo(projectId, dialogId, subPath);
   }
 
-  function focusSteps(subPaths: string[] = [], fragment?: string) {
+  async function focusSteps(subPaths: string[] = [], fragment?: string) {
     let dataPath: string = subPaths[0];
 
     if (source === FORM_EDITOR) {
@@ -156,8 +156,7 @@ export function useShell(source: EventSource, projectId: string): Shell {
         dataPath = `${focused}.${dataPath}`;
       }
     }
-
-    focusTo(rootBotProjectId ?? projectId, projectId, dataPath, fragment ?? '');
+    await focusTo(rootBotProjectId ?? projectId, projectId, dataPath, fragment ?? '');
   }
 
   function updateFlowZoomRate(currentRate) {
@@ -178,7 +177,7 @@ export function useShell(source: EventSource, projectId: string): Shell {
         projectId,
       });
     },
-    saveData: (newData, updatePath) => {
+    saveData: (newData, updatePath, callback) => {
       let dataPath = '';
       if (source === FORM_EDITOR) {
         dataPath = updatePath || focused || '';
@@ -191,7 +190,10 @@ export function useShell(source: EventSource, projectId: string): Shell {
         projectId,
       };
       dialogMapRef.current[dialogId] = updatedDialog;
-      return updateDialog(payload).then(() => {
+      return updateDialog(payload).then(async () => {
+        if (typeof callback === 'function') {
+          await callback();
+        }
         commitChanges();
       });
     },

--- a/Composer/packages/types/src/shell.ts
+++ b/Composer/packages/types/src/shell.ts
@@ -121,10 +121,10 @@ export type ActionContextApi = {
 };
 
 export type DialogEditingContextApi = {
-  saveData: <T = any>(newData: T, updatePath?: string) => Promise<void>;
-  onFocusSteps: (stepIds: string[], focusedTab?: string) => void;
-  onFocusEvent: (eventId: string) => void;
-  onSelect: (ids: string[]) => void;
+  saveData: <T = any>(newData: T, updatePath?: string, callback?: () => void | Promise<void>) => Promise<void>;
+  onFocusSteps: (stepIds: string[], focusedTab?: string) => Promise<void>;
+  onFocusEvent: (eventId: string) => Promise<void>;
+  onSelect: (ids: string[]) => Promise<void>;
   onCopy: (clipboardActions: any[]) => void;
   undo: () => void;
   redo: () => void;

--- a/Composer/packages/types/src/shell.ts
+++ b/Composer/packages/types/src/shell.ts
@@ -124,7 +124,7 @@ export type DialogEditingContextApi = {
   saveData: <T = any>(newData: T, updatePath?: string, callback?: () => void | Promise<void>) => Promise<void>;
   onFocusSteps: (stepIds: string[], focusedTab?: string) => Promise<void>;
   onFocusEvent: (eventId: string) => Promise<void>;
-  onSelect: (ids: string[]) => Promise<void>;
+  onSelect: (ids: string[]) => void;
   onCopy: (clipboardActions: any[]) => void;
   undo: () => void;
   redo: () => void;


### PR DESCRIPTION
## Description
Editors use the designpage location to calculate some important values.
The data flow now is saveData -> commitChanges -> navigate. So undoHistory can't get the correct locations.

In this PR add callback for shellApi.saveData to make sure the navigate is before commit. Update the designPageLocation when navigate.

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
#minor
refs #4620

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots
![undo2](https://user-images.githubusercontent.com/39758135/98513833-77cefe80-22a3-11eb-999f-7481bcf7eae8.gif)

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
