### PR TITLE
fix: do not stub __dirname for node extensions

### DIFF
--- a/extensions/azurePublish/webpack.config.js
+++ b/extensions/azurePublish/webpack.config.js
@@ -5,6 +5,9 @@ module.exports = {
   mode: 'production',
   devtool: 'source-map',
   target: 'node',
+  node: {
+    __dirname: false,
+  },
   output: {
     path: resolve(__dirname, 'lib'),
     filename: 'index.js',

--- a/extensions/azurePublish/yarn.lock
+++ b/extensions/azurePublish/yarn.lock
@@ -1054,6 +1054,11 @@ array-back@^4.0.0, array-back@^4.0.1:
   resolved "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/array-back/-/array-back-4.0.1.tgz#9b80312935a52062e1a233a9c7abeb5481b30e90"
   integrity sha1-m4AxKTWlIGLhojOpx6vrVIGzDpA=
 
+array-differ@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/array-differ/-/array-differ-3.0.0.tgz#3cbb3d0f316810eafcc47624734237d6aee4ae6b"
+  integrity sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==
+
 array-union@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"

--- a/extensions/localPublish/webpack.config.js
+++ b/extensions/localPublish/webpack.config.js
@@ -5,6 +5,9 @@ module.exports = {
   mode: 'production',
   devtool: 'source-map',
   target: 'node',
+  node: {
+    __dirname: false,
+  },
   output: {
     path: resolve(__dirname, 'lib'),
     filename: 'index.js',

--- a/extensions/localPublish/yarn.lock
+++ b/extensions/localPublish/yarn.lock
@@ -192,11 +192,6 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-base64-js@^1.0.2:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
-  integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
-
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -444,11 +439,6 @@ has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
-
-ieee754@^1.1.4:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
-  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 ignore@^5.1.4:
   version "5.1.8"

--- a/extensions/runtimes/webpack.config.js
+++ b/extensions/runtimes/webpack.config.js
@@ -5,6 +5,9 @@ module.exports = {
   mode: 'production',
   devtool: 'source-map',
   target: 'node',
+  node: {
+    __dirname: false,
+  },
   output: {
     path: resolve(__dirname, 'lib'),
     filename: 'index.js',

--- a/extensions/samples/webpack.config.js
+++ b/extensions/samples/webpack.config.js
@@ -5,6 +5,9 @@ module.exports = {
   mode: 'production',
   devtool: 'source-map',
   target: 'node',
+  node: {
+    __dirname: false,
+  },
   output: {
     path: resolve(__dirname, 'lib'),
     filename: 'index.js',

--- a/extensions/vacore/webpack.config.js
+++ b/extensions/vacore/webpack.config.js
@@ -5,6 +5,9 @@ module.exports = {
   mode: 'production',
   devtool: 'source-map',
   target: 'node',
+  node: {
+    __dirname: false,
+  },
   output: {
     path: resolve(__dirname, 'lib'),
     filename: 'index.js',

--- a/extensions/vacore/yarn.lock
+++ b/extensions/vacore/yarn.lock
@@ -319,11 +319,6 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-base64-js@^1.0.2:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
-  integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
-
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -763,11 +758,6 @@ human-signals@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
-
-ieee754@^1.1.4:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
-  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 ignore@^5.1.4:
   version "5.1.8"


### PR DESCRIPTION
## Description

Allows node extensions bundled by webpack to use `__dirname` appropriately.

## Task Item

#minor
