### PR TITLE
fix: account for undefined $designer in breadcrumb

### DIFF
--- a/Composer/packages/client/src/pages/design/DesignPage.tsx
+++ b/Composer/packages/client/src/pages/design/DesignPage.tsx
@@ -232,7 +232,7 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
       if (triggerIndex != null && trigger != null) {
         breadcrumbArray.push({
           key: 'trigger-' + triggerIndex,
-          label: trigger.$designer.name || getFriendlyName(trigger),
+          label: trigger.$designer?.name || getFriendlyName(trigger),
           link: {
             projectId: props.projectId,
             dialogId: props.dialogId,


### PR DESCRIPTION
## Description

Fixes an issue where the designer cannot load because a trigger does not have $designer.

## Task Item

fixes #4750
