### PR TITLE
fix: force node extensions to only require commonjs

### DIFF
--- a/extensions/authTest/webpack.config.js
+++ b/extensions/authTest/webpack.config.js
@@ -12,5 +12,6 @@ module.exports = {
   },
   resolve: {
     extensions: ['.js', '.ts', '.tsx', '.json'],
+    mainFields: ['main'],
   },
 };

--- a/extensions/azurePublish/webpack.config.js
+++ b/extensions/azurePublish/webpack.config.js
@@ -18,5 +18,6 @@ module.exports = {
   },
   resolve: {
     extensions: ['.js', '.ts', '.tsx', '.json'],
+    mainFields: ['main'],
   },
 };

--- a/extensions/githubAuth/webpack.config.js
+++ b/extensions/githubAuth/webpack.config.js
@@ -12,5 +12,6 @@ module.exports = {
   },
   resolve: {
     extensions: ['.js', '.ts', '.tsx', '.json'],
+    mainFields: ['main'],
   },
 };

--- a/extensions/localPublish/webpack.config.js
+++ b/extensions/localPublish/webpack.config.js
@@ -18,5 +18,6 @@ module.exports = {
   },
   resolve: {
     extensions: ['.js', '.ts', '.tsx', '.json'],
+    mainFields: ['main'],
   },
 };

--- a/extensions/mockRemotePublish/webpack.config.js
+++ b/extensions/mockRemotePublish/webpack.config.js
@@ -15,5 +15,6 @@ module.exports = {
   },
   resolve: {
     extensions: ['.js', '.ts', '.tsx', '.json'],
+    mainFields: ['main'],
   },
 };

--- a/extensions/mongoStorage/webpack.config.js
+++ b/extensions/mongoStorage/webpack.config.js
@@ -15,5 +15,6 @@ module.exports = {
   },
   resolve: {
     extensions: ['.js', '.ts', '.tsx', '.json'],
+    mainFields: ['main'],
   },
 };

--- a/extensions/runtimes/webpack.config.js
+++ b/extensions/runtimes/webpack.config.js
@@ -18,5 +18,6 @@ module.exports = {
   },
   resolve: {
     extensions: ['.js', '.ts', '.tsx', '.json'],
+    mainFields: ['main'],
   },
 };

--- a/extensions/sample-ui-plugin/webpack.config.js
+++ b/extensions/sample-ui-plugin/webpack.config.js
@@ -44,6 +44,7 @@ module.exports = [
     },
     resolve: {
       extensions: ['.js', '.ts', '.tsx', '.json'],
+      mainFields: ['main'],
     },
   },
 ];

--- a/extensions/samples/webpack.config.js
+++ b/extensions/samples/webpack.config.js
@@ -18,5 +18,6 @@ module.exports = {
   },
   resolve: {
     extensions: ['.js', '.ts', '.tsx', '.json'],
+    mainFields: ['main'],
   },
 };

--- a/extensions/vacore/webpack.config.js
+++ b/extensions/vacore/webpack.config.js
@@ -18,5 +18,6 @@ module.exports = {
   },
   resolve: {
     extensions: ['.js', '.ts', '.tsx', '.json'],
+    mainFields: ['main'],
   },
 };

--- a/extensions/webRoute/webpack.config.js
+++ b/extensions/webRoute/webpack.config.js
@@ -12,5 +12,6 @@ module.exports = {
   },
   resolve: {
     extensions: ['.js', '.ts', '.tsx', '.json'],
+    mainFields: ['main'],
   },
 };


### PR DESCRIPTION
## Description

Setting `mainFields` to ['main'] forces webpack to only resolve a package's main module, bypassing loading it's `module`.
[Webpack docs](https://webpack.js.org/configuration/resolve/#resolvemainfields)

## Task Item

#minor
