### PR TITLE
feat: Implement pull from publish target

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -88,7 +88,12 @@
         "DEBUG": "composer*",
         "COMPOSER_ENABLE_ONEAUTH": "false"
       },
-      "outputCapture": "std"
+      "outputCapture": "std",
+      "outFiles": [
+        "${workspaceRoot}/Composer/packages/electron-server/build/**/*.js",
+        "${workspaceRoot}/Composer/packages/server/build/**/*.js",
+        "${workspaceRoot}/extensions/**/*.js"
+      ]
     },
     {
       "name": "Debug current jest test",

--- a/Composer/packages/client/__tests__/pages/publish/Publish.test.tsx
+++ b/Composer/packages/client/__tests__/pages/publish/Publish.test.tsx
@@ -46,6 +46,7 @@ const state = {
         publish: true,
         status: true,
         rollback: true,
+        pull: true,
       },
     },
   ],

--- a/Composer/packages/client/src/pages/publish/Publish.tsx
+++ b/Composer/packages/client/src/pages/publish/Publish.tsx
@@ -30,6 +30,7 @@ import { PublishDialog } from './publishDialog';
 import { ContentHeaderStyle, HeaderText, ContentStyle, contentEditor, overflowSet, targetSelected } from './styles';
 import { CreatePublishTarget } from './createPublishTarget';
 import { PublishStatusList, IStatus } from './publishStatusList';
+import { PullDialog } from './pullDialog';
 
 const Publish: React.FC<RouteComponentProps<{ projectId: string; targetName?: string }>> = (props) => {
   const selectedTargetName = props.targetName;
@@ -56,6 +57,7 @@ const Publish: React.FC<RouteComponentProps<{ projectId: string; targetName?: st
 
   const [showLog, setShowLog] = useState(false);
   const [publishDialogHidden, setPublishDialogHidden] = useState(true);
+  const [pullDialogHidden, setPullDialogHidden] = useState(true);
 
   // items to show in the list
   const [thisPublishHistory, setThisPublishHistory] = useState<IStatus[]>([]);
@@ -86,6 +88,16 @@ const Publish: React.FC<RouteComponentProps<{ projectId: string; targetName?: st
     [projectId, publishTypes]
   );
 
+  const isPullSupported = useMemo(() => {
+    if (selectedTarget) {
+      const type = publishTypes?.find((t) => t.name === selectedTarget.type);
+      if (type?.features?.pull) {
+        return true;
+      }
+    }
+    return false;
+  }, [projectId, publishTypes, selectedTarget]);
+
   const toolbarItems: IToolbarItem[] = [
     {
       type: 'action',
@@ -112,6 +124,19 @@ const Publish: React.FC<RouteComponentProps<{ projectId: string; targetName?: st
       align: 'left',
       dataTestid: 'publishPage-Toolbar-Publish',
       disabled: selectedTargetName !== 'all' ? false : true,
+    },
+    {
+      type: 'action',
+      text: formatMessage('Pull from selected profile'),
+      buttonProps: {
+        iconProps: {
+          iconName: 'CloudDownload',
+        },
+        onClick: () => setPullDialogHidden(false),
+      },
+      align: 'left',
+      dataTestid: 'publishPage-Toolbar-Pull',
+      disabled: !isPullSupported,
     },
     {
       type: 'action',
@@ -402,6 +427,9 @@ const Publish: React.FC<RouteComponentProps<{ projectId: string; targetName?: st
           onDismiss={() => setPublishDialogHidden(true)}
           onSubmit={publish}
         />
+      )}
+      {!pullDialogHidden && (
+        <PullDialog projectId={projectId} selectedTarget={selectedTarget} onDismiss={() => setPullDialogHidden(true)} />
       )}
       {showLog && <LogDialog version={selectedVersion} onDismiss={() => setShowLog(false)} />}
       <Toolbar toolbarItems={toolbarItems} />

--- a/Composer/packages/client/src/pages/publish/pullDialog.tsx
+++ b/Composer/packages/client/src/pages/publish/pullDialog.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /** @jsx jsx */
 import { jsx, css } from '@emotion/core';
 import { PublishTarget } from '@botframework-composer/types';
@@ -6,11 +9,12 @@ import { Dialog, DialogFooter } from 'office-ui-fabric-react/lib/Dialog';
 import { PrimaryButton } from 'office-ui-fabric-react/lib/Button';
 import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
 import React, { useCallback, useEffect, useState } from 'react';
+import { useRecoilValue } from 'recoil';
 
 import { createNotification } from '../../recoilModel/dispatchers/notification';
 import { ImportSuccessNotification } from '../../components/ImportModal/ImportSuccessNotification';
-import { useRecoilValue } from 'recoil';
 import { dispatcherState, locationState } from '../../recoilModel';
+
 import { PullStatus } from './pullStatus';
 
 type PullDialogProps = {
@@ -44,7 +48,6 @@ export const PullDialog: React.FC<PullDialogProps> = (props) => {
         setStatus('downloading');
 
         try {
-          console.log('doing the pull');
           // wait for pull result from server
           const res = await fetch(`/api/publish/${projectId}/pull/${selectedTarget.name}`, {
             method: 'POST',
@@ -97,15 +100,14 @@ export const PullDialog: React.FC<PullDialogProps> = (props) => {
 
   switch (status) {
     case 'connecting':
-      return <PullStatus state={'connecting'} publishTarget={selectedTarget} />;
+      return <PullStatus publishTarget={selectedTarget} state={'connecting'} />;
 
     case 'downloading':
-      return <PullStatus state={'downloading'} publishTarget={selectedTarget} />;
+      return <PullStatus publishTarget={selectedTarget} state={'downloading'} />;
 
     case 'error':
       return (
         <Dialog
-          hidden={false}
           dialogContentProps={{
             title: formatMessage('Something went wrong'),
             styles: {
@@ -114,6 +116,7 @@ export const PullDialog: React.FC<PullDialogProps> = (props) => {
               },
             },
           }}
+          hidden={false}
         >
           <p>
             {formatMessage('There was an unexpected error pulling from publish profile ')}

--- a/Composer/packages/client/src/pages/publish/pullDialog.tsx
+++ b/Composer/packages/client/src/pages/publish/pullDialog.tsx
@@ -1,0 +1,132 @@
+/** @jsx jsx */
+import { jsx, css } from '@emotion/core';
+import { PublishTarget } from '@botframework-composer/types';
+import formatMessage from 'format-message';
+import { Dialog, DialogFooter } from 'office-ui-fabric-react/lib/Dialog';
+import { PrimaryButton } from 'office-ui-fabric-react/lib/Button';
+import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
+import React, { useCallback, useEffect, useState } from 'react';
+
+import { createNotification } from '../../recoilModel/dispatchers/notification';
+import { ImportSuccessNotification } from '../../components/ImportModal/ImportSuccessNotification';
+import { useRecoilValue } from 'recoil';
+import { dispatcherState, locationState } from '../../recoilModel';
+import { PullStatus } from './pullStatus';
+
+type PullDialogProps = {
+  onDismiss: () => void;
+  projectId: string;
+  selectedTarget: PublishTarget | undefined;
+};
+
+type PullDialogStatus = 'connecting' | 'downloading' | 'error';
+
+const boldText = css`
+  font-weight: ${FontWeights.semibold};
+  word-break: break-work;
+`;
+
+const CONNECTING_STATUS_DISPLAY_TIME = 2000;
+
+export const PullDialog: React.FC<PullDialogProps> = (props) => {
+  const { onDismiss, projectId, selectedTarget } = props;
+  const [status, setStatus] = useState<PullDialogStatus>('connecting');
+  const [error, setError] = useState<string>('');
+  const { addNotification, openProject } = useRecoilValue(dispatcherState);
+  const botLocation = useRecoilValue(locationState(projectId));
+
+  // TODO: pull needs to be broken down into a previous auth step so the UI can reflect status
+  // properly like in import flow
+  const pull = useCallback(() => {
+    if (selectedTarget) {
+      const doPull = async () => {
+        // show progress dialog
+        setStatus('downloading');
+
+        try {
+          console.log('doing the pull');
+          // wait for pull result from server
+          const res = await fetch(`/api/publish/${projectId}/pull/${selectedTarget.name}`, {
+            method: 'POST',
+          });
+          if (res.status && res.status === 200) {
+            const { backupLocation } = await res.json();
+            // show notification indicating success and close dialog
+            const notification = createNotification({
+              type: 'success',
+              title: '',
+              onRenderCardContent: ImportSuccessNotification({
+                importedToExisting: true,
+                location: backupLocation,
+              }),
+            });
+            addNotification(notification);
+            // reload the bot project to update the authoring canvas
+            openProject(botLocation, undefined, false);
+            onDismiss();
+            return;
+          }
+
+          // not what we expected
+          const { message } = await res.json();
+          setError(formatMessage('Something happened while attempting to pull: ') + message);
+          setStatus('error');
+        } catch (e) {
+          // something bad happened
+          setError(e);
+          setStatus('error');
+        }
+      };
+      doPull();
+    }
+  }, [projectId, selectedTarget]);
+
+  useEffect(() => {
+    if (status === 'connecting') {
+      // start the pull
+      setTimeout(() => {
+        pull();
+      }, CONNECTING_STATUS_DISPLAY_TIME);
+    }
+  }, [status]);
+
+  const onCancelOrDone = useCallback(() => {
+    setStatus('connecting');
+    onDismiss();
+  }, [onDismiss]);
+
+  switch (status) {
+    case 'connecting':
+      return <PullStatus state={'connecting'} publishTarget={selectedTarget} />;
+
+    case 'downloading':
+      return <PullStatus state={'downloading'} publishTarget={selectedTarget} />;
+
+    case 'error':
+      return (
+        <Dialog
+          hidden={false}
+          dialogContentProps={{
+            title: formatMessage('Something went wrong'),
+            styles: {
+              content: {
+                fontSize: 16,
+              },
+            },
+          }}
+        >
+          <p>
+            {formatMessage('There was an unexpected error pulling from publish profile ')}
+            <span css={boldText}>{selectedTarget?.name}</span>
+          </p>
+          <p css={boldText}>{typeof error === 'object' ? JSON.stringify(error, undefined, 2) : error}</p>
+          <DialogFooter>
+            <PrimaryButton text={formatMessage('Ok')} onClick={onCancelOrDone} />
+          </DialogFooter>
+        </Dialog>
+      );
+
+    default:
+      return <div style={{ display: 'none' }}></div>;
+  }
+};

--- a/Composer/packages/client/src/pages/publish/pullFailedDialog.tsx
+++ b/Composer/packages/client/src/pages/publish/pullFailedDialog.tsx
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/** @jsx jsx */
+import { css, jsx } from '@emotion/core';
+import { generateUniqueId } from '@bfc/shared';
+import formatMessage from 'format-message';
+import { PrimaryButton } from 'office-ui-fabric-react/lib/components/Button';
+import { Dialog, DialogFooter } from 'office-ui-fabric-react/lib/Dialog';
+import React from 'react';
+import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
+
+type PulledFailedDialogProps = {
+  error: Error | string;
+  onDismiss: () => void;
+  selectedTargetName?: string;
+};
+
+const boldText = css`
+  font-weight: ${FontWeights.semibold};
+  word-break: break-work;
+`;
+
+const Bold = ({ children }) => (
+  <span key={generateUniqueId()} css={boldText}>
+    {children}
+  </span>
+);
+
+export const PullFailedDialog: React.FC<PulledFailedDialogProps> = (props) => {
+  const { error, onDismiss, selectedTargetName } = props;
+
+  return (
+    <Dialog
+      dialogContentProps={{
+        title: formatMessage('Something went wrong'),
+        styles: {
+          content: {
+            fontSize: 16,
+          },
+        },
+      }}
+      hidden={false}
+    >
+      <p>
+        {formatMessage.rich(
+          'There was an unexpected error pulling from publish profile <b>{ selectedTargetName }</b>',
+          { b: Bold, selectedTargetName }
+        )}
+      </p>
+      <p css={boldText}>{typeof error === 'object' ? JSON.stringify(error, undefined, 2) : error}</p>
+      <DialogFooter>
+        <PrimaryButton text={formatMessage('Ok')} onClick={onDismiss} />
+      </DialogFooter>
+    </Dialog>
+  );
+};

--- a/Composer/packages/client/src/pages/publish/pullStatus.tsx
+++ b/Composer/packages/client/src/pages/publish/pullStatus.tsx
@@ -6,10 +6,11 @@ import { css, jsx } from '@emotion/core';
 import * as React from 'react';
 import { RouteComponentProps } from '@reach/router';
 import { Dialog, DialogType, IDialogContentProps } from 'office-ui-fabric-react/lib/Dialog';
-import { ProgressIndicator } from 'office-ui-fabric-react/lib/ProgressIndicator';
+import { IProgressIndicatorStyles, ProgressIndicator } from 'office-ui-fabric-react/lib/ProgressIndicator';
 import formatMessage from 'format-message';
 import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
 import { PublishTarget } from '@botframework-composer/types';
+import { generateUniqueId } from '@bfc/shared';
 
 import compIcon from '../../images/composerIcon.svg';
 import pvaIcon from '../../images/pvaIcon.svg';
@@ -45,11 +46,32 @@ const contentProps: IDialogContentProps = {
   },
 };
 
+const serviceIcon = css`
+  width: 33px;
+`;
+
 const boldBlueText = css`
   font-weight: ${FontWeights.semibold};
   color: #106ebe;
   word-break: break-work;
 `;
+
+const iconContainer = css`
+  display: flex;
+  justify-content: center;
+`;
+
+const progressLabel = css`
+  font-size: 16px;
+  white-space: normal;
+`;
+
+const dataTransferStyle = css`
+  margin: 0 16px;
+  width: 78px;
+`;
+
+const centeredProgressIndicatorStyles: Partial<IProgressIndicatorStyles> = { itemName: { textAlign: 'center' } };
 
 function getServiceIcon(targetType?: KnownPublishTargets) {
   let icon;
@@ -59,8 +81,8 @@ function getServiceIcon(targetType?: KnownPublishTargets) {
         <img
           alt={formatMessage('PowerVirtualAgents Logo')}
           aria-label={formatMessage('PowerVirtualAgents Logo')}
+          css={serviceIcon}
           src={pvaIcon}
-          style={{ width: '33px' }}
         />
       );
       break;
@@ -75,12 +97,18 @@ function getServiceIcon(targetType?: KnownPublishTargets) {
       <img
         alt={formatMessage('Data transferring between services')}
         aria-label={formatMessage('Data transferring between services')}
+        css={dataTransferStyle}
         src={dataTransferLine}
-        style={{ margin: '0 16px', width: '78px' }}
       />
     </React.Fragment>
   );
 }
+
+const Bold = ({ children }) => (
+  <span key={generateUniqueId()} css={boldBlueText}>
+    {children}
+  </span>
+);
 
 export const PullStatus: React.FC<RouteComponentProps & PullStatusProps> = (props) => {
   const { publishTarget, state } = props;
@@ -89,18 +117,19 @@ export const PullStatus: React.FC<RouteComponentProps & PullStatusProps> = (prop
     <img
       alt={formatMessage('Composer Logo')}
       aria-label={formatMessage('Composer Logo')}
+      css={serviceIcon}
       src={compIcon}
-      style={{ width: '33px' }}
     />
   );
 
   switch (state) {
     case 'connecting': {
       const label = (
-        <p style={{ fontSize: 16, whiteSpace: 'normal' }}>
-          {formatMessage('Connecting to ')}
-          <span css={boldBlueText}>{publishTarget?.name}</span>
-          {formatMessage(' to import bot content...')}
+        <p css={progressLabel}>
+          {formatMessage.rich('Connecting to <b>{ targetName }</b> to import bot content...', {
+            b: Bold,
+            targetName: publishTarget?.name,
+          })}
         </p>
       );
       return (
@@ -111,18 +140,18 @@ export const PullStatus: React.FC<RouteComponentProps & PullStatusProps> = (prop
           modalProps={{ isBlocking: true }}
           styles={{ main: { height: 263 } }}
         >
-          <span style={{ display: 'flex', justifyContent: 'center' }}>
+          <span css={iconContainer}>
             {getServiceIcon(publishTarget?.type as KnownPublishTargets)}
             {composerIcon}
           </span>
-          <ProgressIndicator label={label} styles={{ itemName: { textAlign: 'center' } }} />
+          <ProgressIndicator label={label} styles={centeredProgressIndicatorStyles} />
         </Dialog>
       );
     }
 
     case 'downloading': {
       const label = (
-        <p style={{ fontSize: 16, whiteSpace: 'normal' }}>
+        <p css={progressLabel}>
           {formatMessage('Importing bot content from {targetName}...', { targetName: publishTarget?.name })}
         </p>
       );
@@ -134,16 +163,16 @@ export const PullStatus: React.FC<RouteComponentProps & PullStatusProps> = (prop
           modalProps={{ isBlocking: true }}
           styles={{ main: { height: 263 } }}
         >
-          <span style={{ display: 'flex', justifyContent: 'center' }}>
+          <span css={iconContainer}>
             {getServiceIcon(publishTarget?.type as KnownPublishTargets)}
             {composerIcon}
           </span>
-          <ProgressIndicator label={label} styles={{ itemName: { textAlign: 'center' } }} />
+          <ProgressIndicator label={label} styles={centeredProgressIndicatorStyles} />
         </Dialog>
       );
     }
 
     default:
-      return <div style={{ display: 'none' }}></div>;
+      throw new Error(`PullStatus trying to render for unexpected status: ${state}`);
   }
 };

--- a/Composer/packages/client/src/pages/publish/pullStatus.tsx
+++ b/Composer/packages/client/src/pages/publish/pullStatus.tsx
@@ -1,0 +1,149 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/** @jsx jsx */
+import { css, jsx } from '@emotion/core';
+import * as React from 'react';
+import { RouteComponentProps } from '@reach/router';
+import { Dialog, DialogType, IDialogContentProps } from 'office-ui-fabric-react/lib/Dialog';
+import { ProgressIndicator } from 'office-ui-fabric-react/lib/ProgressIndicator';
+import formatMessage from 'format-message';
+import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
+import { PublishTarget } from '@botframework-composer/types';
+
+import compIcon from '../../images/composerIcon.svg';
+import pvaIcon from '../../images/pvaIcon.svg';
+import dataTransferLine from '../../images/dataTransferLine.svg';
+
+type KnownPublishTargets = 'pva-publish-composer';
+
+type PullState = 'connecting' | 'downloading';
+
+type PullStatusProps = {
+  publishTarget: PublishTarget | undefined;
+  state: PullState;
+};
+
+const contentProps: IDialogContentProps = {
+  type: DialogType.normal,
+  styles: {
+    header: {
+      display: 'none',
+    },
+    content: {
+      height: '100%',
+    },
+    inner: {
+      height: '100%',
+    },
+    innerContent: {
+      display: 'flex',
+      flexFlow: 'column nowrap',
+      height: '100%',
+      justifyContent: 'center',
+    },
+  },
+};
+
+const boldBlueText = css`
+  font-weight: ${FontWeights.semibold};
+  color: #106ebe;
+  word-break: break-work;
+`;
+
+export const PullStatus: React.FC<RouteComponentProps & PullStatusProps> = (props) => {
+  const { publishTarget, state } = props;
+
+  const composerIcon = (
+    <img
+      alt={formatMessage('Composer Logo')}
+      aria-label={formatMessage('Composer Logo')}
+      src={compIcon}
+      style={{ width: '33px' }}
+    />
+  );
+
+  switch (state) {
+    case 'connecting': {
+      const label = (
+        <p style={{ fontSize: 16, whiteSpace: 'normal' }}>
+          {formatMessage('Connecting to ')}
+          <span css={boldBlueText}>{publishTarget?.name}</span>
+          {formatMessage(' to import bot content...')}
+        </p>
+      );
+      return (
+        <Dialog
+          dialogContentProps={contentProps}
+          hidden={false}
+          minWidth={560}
+          styles={{ main: { height: 263 } }}
+          modalProps={{ isBlocking: true }}
+        >
+          <span style={{ display: 'flex', justifyContent: 'center' }}>
+            {getServiceIcon(publishTarget?.type as KnownPublishTargets)}
+            {composerIcon}
+          </span>
+          <ProgressIndicator label={label} styles={{ itemName: { textAlign: 'center' } }} />
+        </Dialog>
+      );
+    }
+
+    case 'downloading': {
+      const label = (
+        <p style={{ fontSize: 16, whiteSpace: 'normal' }}>
+          {formatMessage('Importing bot content from {targetName}...', { targetName: publishTarget?.name })}
+        </p>
+      );
+      return (
+        <Dialog
+          dialogContentProps={contentProps}
+          hidden={false}
+          minWidth={560}
+          styles={{ main: { height: 263 } }}
+          modalProps={{ isBlocking: true }}
+        >
+          <span style={{ display: 'flex', justifyContent: 'center' }}>
+            {getServiceIcon(publishTarget?.type as KnownPublishTargets)}
+            {composerIcon}
+          </span>
+          <ProgressIndicator label={label} styles={{ itemName: { textAlign: 'center' } }} />
+        </Dialog>
+      );
+    }
+
+    default:
+      return <div style={{ display: 'none' }}></div>;
+  }
+};
+
+function getServiceIcon(targetType?: KnownPublishTargets) {
+  let icon;
+  switch (targetType) {
+    case 'pva-publish-composer':
+      icon = (
+        <img
+          alt={formatMessage('PowerVirtualAgents Logo')}
+          aria-label={formatMessage('PowerVirtualAgents Logo')}
+          src={pvaIcon}
+          style={{ width: '33px' }}
+        />
+      );
+      break;
+
+    // don't draw anything, just render the Composer icon
+    default:
+      return undefined;
+  }
+  return (
+    <React.Fragment>
+      {icon}
+      <img
+        alt={formatMessage('Data transferring between services')}
+        aria-label={formatMessage('Data transferring between services')}
+        src={dataTransferLine}
+        style={{ margin: '0 16px', width: '78px' }}
+      />
+    </React.Fragment>
+  );
+}

--- a/Composer/packages/client/src/pages/publish/pullStatus.tsx
+++ b/Composer/packages/client/src/pages/publish/pullStatus.tsx
@@ -51,72 +51,6 @@ const boldBlueText = css`
   word-break: break-work;
 `;
 
-export const PullStatus: React.FC<RouteComponentProps & PullStatusProps> = (props) => {
-  const { publishTarget, state } = props;
-
-  const composerIcon = (
-    <img
-      alt={formatMessage('Composer Logo')}
-      aria-label={formatMessage('Composer Logo')}
-      src={compIcon}
-      style={{ width: '33px' }}
-    />
-  );
-
-  switch (state) {
-    case 'connecting': {
-      const label = (
-        <p style={{ fontSize: 16, whiteSpace: 'normal' }}>
-          {formatMessage('Connecting to ')}
-          <span css={boldBlueText}>{publishTarget?.name}</span>
-          {formatMessage(' to import bot content...')}
-        </p>
-      );
-      return (
-        <Dialog
-          dialogContentProps={contentProps}
-          hidden={false}
-          minWidth={560}
-          styles={{ main: { height: 263 } }}
-          modalProps={{ isBlocking: true }}
-        >
-          <span style={{ display: 'flex', justifyContent: 'center' }}>
-            {getServiceIcon(publishTarget?.type as KnownPublishTargets)}
-            {composerIcon}
-          </span>
-          <ProgressIndicator label={label} styles={{ itemName: { textAlign: 'center' } }} />
-        </Dialog>
-      );
-    }
-
-    case 'downloading': {
-      const label = (
-        <p style={{ fontSize: 16, whiteSpace: 'normal' }}>
-          {formatMessage('Importing bot content from {targetName}...', { targetName: publishTarget?.name })}
-        </p>
-      );
-      return (
-        <Dialog
-          dialogContentProps={contentProps}
-          hidden={false}
-          minWidth={560}
-          styles={{ main: { height: 263 } }}
-          modalProps={{ isBlocking: true }}
-        >
-          <span style={{ display: 'flex', justifyContent: 'center' }}>
-            {getServiceIcon(publishTarget?.type as KnownPublishTargets)}
-            {composerIcon}
-          </span>
-          <ProgressIndicator label={label} styles={{ itemName: { textAlign: 'center' } }} />
-        </Dialog>
-      );
-    }
-
-    default:
-      return <div style={{ display: 'none' }}></div>;
-  }
-};
-
 function getServiceIcon(targetType?: KnownPublishTargets) {
   let icon;
   switch (targetType) {
@@ -147,3 +81,69 @@ function getServiceIcon(targetType?: KnownPublishTargets) {
     </React.Fragment>
   );
 }
+
+export const PullStatus: React.FC<RouteComponentProps & PullStatusProps> = (props) => {
+  const { publishTarget, state } = props;
+
+  const composerIcon = (
+    <img
+      alt={formatMessage('Composer Logo')}
+      aria-label={formatMessage('Composer Logo')}
+      src={compIcon}
+      style={{ width: '33px' }}
+    />
+  );
+
+  switch (state) {
+    case 'connecting': {
+      const label = (
+        <p style={{ fontSize: 16, whiteSpace: 'normal' }}>
+          {formatMessage('Connecting to ')}
+          <span css={boldBlueText}>{publishTarget?.name}</span>
+          {formatMessage(' to import bot content...')}
+        </p>
+      );
+      return (
+        <Dialog
+          dialogContentProps={contentProps}
+          hidden={false}
+          minWidth={560}
+          modalProps={{ isBlocking: true }}
+          styles={{ main: { height: 263 } }}
+        >
+          <span style={{ display: 'flex', justifyContent: 'center' }}>
+            {getServiceIcon(publishTarget?.type as KnownPublishTargets)}
+            {composerIcon}
+          </span>
+          <ProgressIndicator label={label} styles={{ itemName: { textAlign: 'center' } }} />
+        </Dialog>
+      );
+    }
+
+    case 'downloading': {
+      const label = (
+        <p style={{ fontSize: 16, whiteSpace: 'normal' }}>
+          {formatMessage('Importing bot content from {targetName}...', { targetName: publishTarget?.name })}
+        </p>
+      );
+      return (
+        <Dialog
+          dialogContentProps={contentProps}
+          hidden={false}
+          minWidth={560}
+          modalProps={{ isBlocking: true }}
+          styles={{ main: { height: 263 } }}
+        >
+          <span style={{ display: 'flex', justifyContent: 'center' }}>
+            {getServiceIcon(publishTarget?.type as KnownPublishTargets)}
+            {composerIcon}
+          </span>
+          <ProgressIndicator label={label} styles={{ itemName: { textAlign: 'center' } }} />
+        </Dialog>
+      );
+    }
+
+    default:
+      return <div style={{ display: 'none' }}></div>;
+  }
+};

--- a/Composer/packages/client/src/recoilModel/dispatchers/project.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/project.ts
@@ -32,6 +32,7 @@ import { logMessage, setError } from './../dispatchers/shared';
 import {
   checkIfBotExistsInBotProjectFile,
   createNewBotFromTemplate,
+  fetchProjectDataById,
   flushExistingTasks,
   getSkillNameIdentifier,
   handleProjectFailure,
@@ -369,6 +370,13 @@ export const projectDispatcher = () => {
     await initBotState(callbackHelpers, projectData, botFiles);
   };
 
+  /** Resets the file persistence of a project, and then reloads the bot state. */
+  const reloadExistingProject = useRecoilCallback((callbackHelpers: CallbackInterface) => async (projectId: string) => {
+    callbackHelpers.reset(filePersistenceState(projectId));
+    const { projectData, botFiles } = await fetchProjectDataById(projectId);
+    await initBotState(callbackHelpers, projectData, botFiles);
+  });
+
   return {
     openProject,
     createNewBot,
@@ -386,5 +394,6 @@ export const projectDispatcher = () => {
     addRemoteSkillToBotProject,
     replaceSkillInBotProject,
     reloadProject,
+    reloadExistingProject,
   };
 };

--- a/Composer/packages/client/src/recoilModel/types.ts
+++ b/Composer/packages/client/src/recoilModel/types.ts
@@ -37,6 +37,7 @@ export interface PublishType {
   features: {
     history: boolean;
     publish: boolean;
+    pull: boolean;
     rollback: boolean;
     status: boolean;
   };

--- a/Composer/packages/server/src/controllers/project.ts
+++ b/Composer/packages/server/src/controllers/project.ts
@@ -2,13 +2,12 @@
 // Licensed under the MIT License.
 
 import * as fs from 'fs';
-import { existsSync } from 'fs';
 
 import { Request, Response } from 'express';
 import { Archiver } from 'archiver';
 import { ExtensionContext } from '@bfc/extension';
 import { SchemaMerger } from '@microsoft/bf-dialog/lib/library/schemaMerger';
-import { ensureDir, remove } from 'fs-extra';
+import { remove } from 'fs-extra';
 
 import log from '../logger';
 import { BotProjectService } from '../services/project';

--- a/Composer/packages/server/src/controllers/project.ts
+++ b/Composer/packages/server/src/controllers/project.ts
@@ -497,24 +497,7 @@ async function backupProject(req: Request, res: Response) {
   const project = await BotProjectService.getProjectById(projectId, user);
   if (project !== undefined) {
     try {
-      // ensure there isn't an older backup directory hanging around
-      const projectDirName = Path.basename(project.dir);
-      const backupPath = Path.join(process.env.COMPOSER_BACKUP_DIR as string, projectDirName);
-      await ensureDir(process.env.COMPOSER_BACKUP_DIR as string);
-      if (existsSync(backupPath)) {
-        log('%s already exists. Deleting before backing up.', backupPath);
-        await remove(backupPath);
-        log('Existing backup folder deleted successfully.');
-      }
-
-      // clone the bot project to the backup directory
-      const location: LocationRef = {
-        storageId: 'default',
-        path: backupPath,
-      };
-      log('Backing up project at %s to %s', project.dir, backupPath);
-      await project.cloneFiles(location);
-      log('Project backed up successfully.');
+      const backupPath = await BotProjectService.backupProject(project);
       res.status(200).json({ path: backupPath });
     } catch (e) {
       log('Failed to backup project %s: %O', projectId, e);

--- a/Composer/packages/server/src/controllers/publisher.ts
+++ b/Composer/packages/server/src/controllers/publisher.ts
@@ -356,8 +356,6 @@ export const PublishController = {
             return res.status(500).json({ message: 'Could not get .zip from publishing target.' });
           }
 
-          // TODO: stop current bot project from running?
-
           // backup the current bot project contents
           const backupLocation = await BotProjectService.backupProject(currentProject);
 
@@ -368,7 +366,7 @@ export const PublishController = {
           log('Extracting pulled assets into temp template folder %s ', templateDir);
           await extractZip(results.zipPath, { dir: templateDir });
 
-          // TODO: abstract away the template copying logic so that the code can be shared between project and publisher controllers
+          // TODO (toanzian): abstract away the template copying logic so that the code can be shared between project and publisher controllers
           // (see copyTemplateToExistingProject())
           log('Cleaning up bot content at %s before copying pulled content over.', currentProject.dir);
           await currentProject.fileStorage.rmrfDir(currentProject.dir);

--- a/Composer/packages/server/src/controllers/publisher.ts
+++ b/Composer/packages/server/src/controllers/publisher.ts
@@ -1,15 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { join } from 'path';
+
 import merge from 'lodash/merge';
 import { ExtensionContext } from '@bfc/extension';
 import { defaultPublishConfig } from '@bfc/shared';
-import { join } from 'path';
 import { ensureDirSync, remove } from 'fs-extra';
 import extractZip from 'extract-zip';
 
 import { BotProjectService } from '../services/project';
-import { authService } from '../services/auth';
+import { authService } from '../services/auth/auth';
 import AssetService from '../services/asset';
 import logger from '../logger';
 import { LocationRef } from '../models/bot/interface';

--- a/Composer/packages/server/src/controllers/publisher.ts
+++ b/Composer/packages/server/src/controllers/publisher.ts
@@ -339,16 +339,16 @@ export const PublishController = {
       if (typeof pluginMethod === 'function') {
         try {
           // call the method
-          const results = (await pluginMethod.call(
+          const results = await pluginMethod.call(
             null,
             configuration,
             currentProject,
             user,
             authService.getAccessToken.bind(authService)
-          )) as { zipPath?: string; eTag: string; status: number; error?: any };
+          );
           if (results.status === 500) {
             // something went wrong
-            console.error(results.error?.message);
+            log('Error while trying to pull: %s', results.error?.message);
             return res.status(500).send(results.error?.message);
           }
           if (!results.zipPath) {
@@ -379,7 +379,7 @@ export const PublishController = {
             path: currentProject.dir,
           };
           log('Copying content from template at %s to %s', templateDir, currentProject.dir);
-          await AssetService.manager.copyProjectTemplateDirTo(
+          await AssetService.manager.copyRemoteProjectTemplateTo(
             templateDir,
             locationRef,
             user,

--- a/Composer/packages/server/src/controllers/publisher.ts
+++ b/Composer/packages/server/src/controllers/publisher.ts
@@ -4,8 +4,21 @@
 import merge from 'lodash/merge';
 import { ExtensionContext } from '@bfc/extension';
 import { defaultPublishConfig } from '@bfc/shared';
+import { join } from 'path';
+import { ensureDirSync, remove } from 'fs-extra';
+import extractZip from 'extract-zip';
 
 import { BotProjectService } from '../services/project';
+import { authService } from '../services/auth';
+import AssetService from '../services/asset';
+import logger from '../logger';
+import { LocationRef } from '../models/bot/interface';
+
+const log = logger.extend('publisher-controller');
+
+function extensionImplementsMethod(extensionName: string, methodName: string): boolean {
+  return extensionName && ExtensionContext.extensions.publish[extensionName]?.methods[methodName];
+}
 
 export const PublishController = {
   getTypes: async (req, res) => {
@@ -27,6 +40,7 @@ export const PublishController = {
               publish: typeof methods.publish === 'function',
               status: typeof methods.getStatus === 'function',
               rollback: typeof methods.rollback === 'function',
+              pull: typeof methods.pull === 'function',
             },
           };
         })
@@ -45,9 +59,9 @@ export const PublishController = {
 
     const profiles = allTargets.filter((t) => t.name === target);
     const profile = profiles.length ? profiles[0] : undefined;
-    const method = profile ? profile.type : undefined; // get the publish plugin key
+    const extensionName = profile ? profile.type : ''; // get the publish plugin key
 
-    if (profile && method && ExtensionContext?.extensions?.publish[method]?.methods?.publish) {
+    if (profile && extensionImplementsMethod(extensionName, 'publish')) {
       // append config from client(like sensitive settings)
       const configuration = {
         profileName: profile.name,
@@ -56,11 +70,18 @@ export const PublishController = {
       };
 
       // get the externally defined method
-      const pluginMethod = ExtensionContext.extensions.publish[method].methods.publish;
+      const pluginMethod = ExtensionContext.extensions.publish[extensionName].methods.publish;
 
       try {
         // call the method
-        const results = await pluginMethod.call(null, configuration, currentProject, metadata, user);
+        const results = await pluginMethod.call(
+          null,
+          configuration,
+          currentProject,
+          metadata,
+          user,
+          authService.getAccessToken.bind(authService)
+        );
 
         // copy status into payload for ease of access in client
         const response = {
@@ -79,7 +100,7 @@ export const PublishController = {
     } else {
       res.status(400).json({
         statusCode: '400',
-        message: `${method} is not a valid publishing target type. There may be a missing plugin.`,
+        message: `${extensionName} is not a valid publishing target type. There may be a missing plugin.`,
       });
     }
   },
@@ -95,10 +116,10 @@ export const PublishController = {
     const profiles = allTargets.filter((t) => t.name === target);
     const profile = profiles.length ? profiles[0] : undefined;
     // get the publish plugin key
-    const method = profile ? profile.type : undefined;
-    if (profile && method && ExtensionContext.extensions.publish[method]?.methods?.getStatus) {
+    const extensionName = profile ? profile.type : '';
+    if (profile && extensionImplementsMethod(extensionName, 'getStatus')) {
       // get the externally defined method
-      const pluginMethod = ExtensionContext.extensions.publish[method].methods.getStatus;
+      const pluginMethod = ExtensionContext.extensions.publish[extensionName].methods.getStatus;
 
       if (typeof pluginMethod === 'function') {
         const configuration = {
@@ -107,7 +128,17 @@ export const PublishController = {
         };
 
         // call the method
-        const results = await pluginMethod.call(null, configuration, currentProject, user);
+        const results = await pluginMethod.call(
+          null,
+          configuration,
+          currentProject,
+          user,
+          authService.getAccessToken.bind(authService)
+        );
+        // update the eTag if the publish was completed and an eTag is provided
+        if (results.status === 200 && results.result?.eTag) {
+          BotProjectService.setProjectLocationData(projectId, { eTag: results.result.eTag });
+        }
         // copy status into payload for ease of access in client
         const response = {
           ...results.result,
@@ -121,7 +152,7 @@ export const PublishController = {
 
     res.status(400).json({
       statusCode: '400',
-      message: `${method} is not a valid publishing target type. There may be a missing plugin.`,
+      message: `${extensionName} is not a valid publishing target type. There may be a missing plugin.`,
     });
   },
   history: async (req, res) => {
@@ -136,11 +167,11 @@ export const PublishController = {
     const profiles = allTargets.filter((t) => t.name === target);
     const profile = profiles.length ? profiles[0] : undefined;
     // get the publish plugin key
-    const method = profile ? profile.type : undefined;
+    const extensionName = profile ? profile.type : '';
 
-    if (profile && method && ExtensionContext.extensions.publish[method]?.methods?.history) {
+    if (profile && extensionImplementsMethod(extensionName, 'history')) {
       // get the externally defined method
-      const pluginMethod = ExtensionContext.extensions.publish[method].methods.history;
+      const pluginMethod = ExtensionContext.extensions.publish[extensionName].methods.history;
       if (typeof pluginMethod === 'function') {
         const configuration = {
           profileName: profile.name,
@@ -148,7 +179,13 @@ export const PublishController = {
         };
 
         // call the method
-        const results = await pluginMethod.call(null, configuration, currentProject, user);
+        const results = await pluginMethod.call(
+          null,
+          configuration,
+          currentProject,
+          user,
+          authService.getAccessToken.bind(authService)
+        );
 
         // set status and return value as json
         return res.status(200).json(results);
@@ -157,7 +194,7 @@ export const PublishController = {
 
     res.status(400).json({
       statusCode: '400',
-      message: `${method} is not a valid publishing target type. There may be a missing plugin.`,
+      message: `${extensionName} is not a valid publishing target type. There may be a missing plugin.`,
     });
   },
   rollback: async (req, res) => {
@@ -174,9 +211,9 @@ export const PublishController = {
     const profiles = allTargets.filter((t) => t.name === target);
     const profile = profiles.length ? profiles[0] : undefined;
     // get the publish plugin key
-    const method = profile ? profile.type : undefined;
+    const extensionName = profile ? profile.type : '';
 
-    if (profile && method && ExtensionContext.extensions.publish[method]?.methods?.rollback) {
+    if (profile && extensionImplementsMethod(extensionName, 'rollback')) {
       // append config from client(like sensitive settings)
       const configuration = {
         profileName: profile.name,
@@ -184,7 +221,7 @@ export const PublishController = {
         ...JSON.parse(profile.configuration),
       };
       // get the externally defined method
-      const pluginMethod = ExtensionContext.extensions.publish[method].methods.rollback;
+      const pluginMethod = ExtensionContext.extensions.publish[extensionName].methods.rollback;
       if (typeof pluginMethod === 'function') {
         try {
           // call the method
@@ -209,15 +246,15 @@ export const PublishController = {
 
     res.status(400).json({
       statusCode: '400',
-      message: `${method} is not a valid publishing target type. There may be a missing plugin.`,
+      message: `${extensionName} is not a valid publishing target type. There may be a missing plugin.`,
     });
   },
   removeLocalRuntimeData: async (req, res) => {
     const projectId = req.params.projectId;
     const profile = defaultPublishConfig;
-    const method = profile.type;
-    if (profile && method && ExtensionContext.extensions.publish[method]?.methods?.stopBot) {
-      const pluginMethod = ExtensionContext.extensions.publish[method].methods.stopBot;
+    const extensionName = profile.type;
+    if (profile && extensionImplementsMethod(extensionName, 'stopBot')) {
+      const pluginMethod = ExtensionContext.extensions.publish[extensionName].methods.stopBot;
       if (typeof pluginMethod === 'function') {
         try {
           await pluginMethod.call(null, projectId);
@@ -229,8 +266,8 @@ export const PublishController = {
         }
       }
     }
-    if (profile && ExtensionContext.extensions.publish[method]?.methods?.removeRuntimeData) {
-      const pluginMethod = ExtensionContext.extensions.publish[method].methods.removeRuntimeData;
+    if (profile && extensionImplementsMethod(extensionName, 'removeRuntimeData')) {
+      const pluginMethod = ExtensionContext.extensions.publish[extensionName].methods.removeRuntimeData;
       if (typeof pluginMethod === 'function') {
         try {
           const result = await pluginMethod.call(null, projectId);
@@ -245,16 +282,16 @@ export const PublishController = {
     }
     res.status(400).json({
       statusCode: '400',
-      message: `${method} is not a valid publishing target type. There may be a missing plugin.`,
+      message: `${extensionName} is not a valid publishing target type. There may be a missing plugin.`,
     });
   },
 
   stopBot: async (req, res) => {
     const projectId = req.params.projectId;
     const profile = defaultPublishConfig;
-    const method = profile.type;
-    if (profile && method && ExtensionContext.extensions.publish[method]?.methods?.stopBot) {
-      const pluginMethod = ExtensionContext.extensions.publish[method].methods.stopBot;
+    const extensionName = profile.type;
+    if (profile && extensionImplementsMethod(extensionName, 'stopBot')) {
+      const pluginMethod = ExtensionContext.extensions.publish[extensionName].methods.stopBot;
       if (typeof pluginMethod === 'function') {
         try {
           await pluginMethod.call(null, projectId);
@@ -269,7 +306,110 @@ export const PublishController = {
     }
     res.status(400).json({
       statusCode: '400',
-      message: `${method} is not a valid publishing target type. There may be a missing plugin.`,
+      message: `${extensionName} is not a valid publishing target type. There may be a missing plugin.`,
     });
+  },
+
+  pull: async (req, res) => {
+    log('Starting pull');
+    const target = req.params.target;
+    const user = await ExtensionContext.getUserFromRequest(req);
+    const projectId = req.params.projectId;
+    const currentProject = await BotProjectService.getProjectById(projectId, user);
+
+    // deal with publishTargets not existing in settings
+    const publishTargets = currentProject.settings?.publishTargets || [];
+    const allTargets = [defaultPublishConfig, ...publishTargets];
+
+    const profiles = allTargets.filter((t) => t.name === target);
+    const profile = profiles.length ? profiles[0] : undefined;
+    const extensionName = profile ? profile.type : ''; // get the publish plugin key
+
+    if (profile && extensionImplementsMethod(extensionName, 'pull')) {
+      const configuration = {
+        profileName: profile.name,
+        fullSettings: merge({}, currentProject.settings),
+        ...JSON.parse(profile.configuration),
+      };
+
+      // get the externally defined method
+      const pluginMethod = ExtensionContext.extensions.publish[extensionName].methods.pull;
+
+      if (typeof pluginMethod === 'function') {
+        try {
+          // call the method
+          const results = (await pluginMethod.call(
+            null,
+            configuration,
+            currentProject,
+            user,
+            authService.getAccessToken.bind(authService)
+          )) as { zipPath?: string; eTag: string; status: number; error?: any };
+          if (results.status === 500) {
+            // something went wrong
+            console.error(results.error?.message);
+            return res.status(500).send(results.error?.message);
+          }
+          if (!results.zipPath) {
+            // couldn't get zip from publish target
+            return res.status(500).json({ message: 'Could not get .zip from publishing target.' });
+          }
+
+          // TODO: stop current bot project from running?
+
+          // backup the current bot project contents
+          const backupLocation = await BotProjectService.backupProject(currentProject);
+
+          // extract zip into new "template" directory
+          const baseDir = process.env.COMPOSER_TEMP_DIR as string;
+          const templateDir = join(baseDir, 'extractedTemplate-' + Date.now());
+          ensureDirSync(templateDir);
+          log('Extracting pulled assets into temp template folder %s ', templateDir);
+          await extractZip(results.zipPath, { dir: templateDir });
+
+          // TODO: abstract away the template copying logic so that the code can be shared between project and publisher controllers
+          // (see copyTemplateToExistingProject())
+          log('Cleaning up bot content at %s before copying pulled content over.', currentProject.dir);
+          await currentProject.fileStorage.rmrfDir(currentProject.dir);
+
+          // copy extracted template content into bot project
+          const locationRef: LocationRef = {
+            storageId: 'default',
+            path: currentProject.dir,
+          };
+          log('Copying content from template at %s to %s', templateDir, currentProject.dir);
+          await AssetService.manager.copyProjectTemplateDirTo(
+            templateDir,
+            locationRef,
+            user,
+            undefined // TODO: re-enable once we figure out path issue currentProject.settings?.defaultLanguage || 'en-us'
+          );
+          log('Copied template content successfully.');
+          // clean up the temporary template & zip directories -- fire and forget
+          remove(templateDir);
+          remove(results.zipPath);
+
+          // update eTag
+          log('Updating etag.');
+          BotProjectService.setProjectLocationData(projectId, { eTag: results.eTag });
+
+          log('Pull successful');
+
+          return res.status(200).json({
+            backupLocation,
+          });
+        } catch (err) {
+          return res.status(500).json({
+            message: err.message,
+          });
+        }
+      }
+      return res.status(501); // not implemented
+    } else {
+      return res.status(400).json({
+        statusCode: '400',
+        message: `${extensionName} is not a valid publishing target type. There may be a missing plugin.`,
+      });
+    }
   },
 };

--- a/Composer/packages/server/src/router/api.ts
+++ b/Composer/packages/server/src/router/api.ts
@@ -66,6 +66,7 @@ router.post('/publish/:projectId/publish/:target', PublishController.publish);
 router.get('/publish/:projectId/history/:target', PublishController.history);
 router.post('/publish/:projectId/rollback/:target', PublishController.rollback);
 router.post('/publish/:projectId/stopPublish/:target', PublishController.stopBot);
+router.post('/publish/:projectId/pull/:target', PublishController.pull);
 
 router.get('/publish/:method', PublishController.publish);
 

--- a/Composer/packages/server/src/services/project.ts
+++ b/Composer/packages/server/src/services/project.ts
@@ -374,7 +374,7 @@ export class BotProjectService {
     try {
       // ensure there isn't an older backup directory hanging around
       const projectDirName = Path.basename(project.dir);
-      const backupPath = Path.join(process.env.COMPOSER_BACKUP_DIR as string, projectDirName);
+      const backupPath = Path.join(process.env.COMPOSER_BACKUP_DIR as string, `${projectDirName}.${Date.now()}`);
       await ensureDir(process.env.COMPOSER_BACKUP_DIR as string);
       if (existsSync(backupPath)) {
         log('%s already exists. Deleting before backing up.', backupPath);

--- a/Composer/packages/server/src/services/project.ts
+++ b/Composer/packages/server/src/services/project.ts
@@ -7,6 +7,7 @@ import flatten from 'lodash/flatten';
 import { luImportResolverGenerator, ResolverResource } from '@bfc/shared';
 import extractMemoryPaths from '@bfc/indexers/lib/dialogUtils/extractMemoryPaths';
 import { UserIdentity } from '@bfc/extension';
+import { ensureDir, existsSync, remove } from 'fs-extra';
 
 import { BotProject } from '../models/bot/botProject';
 import { LocationRef } from '../models/bot/interface';
@@ -366,6 +367,32 @@ export class BotProjectService {
       return projectId;
     } else {
       return '';
+    }
+  };
+
+  public static backupProject = async (project: BotProject): Promise<string> => {
+    try {
+      // ensure there isn't an older backup directory hanging around
+      const projectDirName = Path.basename(project.dir);
+      const backupPath = Path.join(process.env.COMPOSER_BACKUP_DIR as string, projectDirName);
+      await ensureDir(process.env.COMPOSER_BACKUP_DIR as string);
+      if (existsSync(backupPath)) {
+        log('%s already exists. Deleting before backing up.', backupPath);
+        await remove(backupPath);
+        log('Existing backup folder deleted successfully.');
+      }
+
+      // clone the bot project to the backup directory
+      const location: LocationRef = {
+        storageId: 'default',
+        path: backupPath,
+      };
+      log('Backing up project at %s to %s', project.dir, backupPath);
+      await project.cloneFiles(location);
+      log('Project backed up successfully.');
+      return location.path;
+    } catch (e) {
+      throw new Error(`Failed to backup project ${project.id}: ${e}`);
     }
   };
 }

--- a/Composer/packages/types/src/publish.ts
+++ b/Composer/packages/types/src/publish.ts
@@ -6,10 +6,12 @@ import type { JSONSchema7 } from 'json-schema';
 import type { IBotProject } from './server';
 import type { UserIdentity } from './user';
 import type { ILuisConfig, IQnAConfig } from './settings';
+import { AuthParameters } from './auth';
 
 export type PublishResult = {
   message: string;
   comment?: string;
+  eTag?: string;
   log?: string;
   id?: string;
   time?: Date;
@@ -22,21 +24,52 @@ export type PublishResponse = {
   result: PublishResult;
 };
 
+export type PullResponse = {
+  error?: any;
+  eTag?: string;
+  status: number;
+  zipPath?: string;
+};
+
+type GetAccessToken = (params: AuthParameters) => Promise<string>;
+
 // TODO: Add types for project, metadata
 export type PublishPlugin<Config = any> = {
   name: string;
   description: string;
 
   // methods plugins should support
-  publish: (config: Config, project: IBotProject, metadata: any, user?: UserIdentity) => Promise<PublishResponse>;
-  getStatus?: (config: Config, project: IBotProject, user?: UserIdentity) => Promise<PublishResponse>;
-  getHistory?: (config: Config, project: IBotProject, user?: UserIdentity) => Promise<PublishResult[]>;
+  publish: (
+    config: Config,
+    project: IBotProject,
+    metadata: any,
+    user?: UserIdentity,
+    getAccessToken?: GetAccessToken
+  ) => Promise<PublishResponse>;
+  getStatus?: (
+    config: Config,
+    project: IBotProject,
+    user?: UserIdentity,
+    getAccessToken?: GetAccessToken
+  ) => Promise<PublishResponse>;
+  getHistory?: (
+    config: Config,
+    project: IBotProject,
+    user?: UserIdentity,
+    getAccessToken?: GetAccessToken
+  ) => Promise<PublishResult[]>;
   rollback?: (
     config: Config,
     project: IBotProject,
     rollbackToVersion: string,
     user?: UserIdentity
   ) => Promise<PublishResponse>;
+  pull?: (
+    config: Config,
+    project: IBotProject,
+    user?: UserIdentity,
+    getAccessToken?: GetAccessToken
+  ) => Promise<PullResponse>;
 
   // other properties
   schema?: JSONSchema7;

--- a/Composer/yarn.lock
+++ b/Composer/yarn.lock
@@ -4184,6 +4184,13 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@types/yauzl@^2.9.1":
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-2.9.1.tgz#d10f69f9f522eef3cf98e30afb684a1e1ec923af"
+  integrity sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==
+  dependencies:
+    "@types/node" "*"
+
 "@typescript-eslint/eslint-plugin@2.34.0":
   version "2.34.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.34.0.tgz#6f8ce8a46c7dea4a6f1d171d2bb8fbae6dac2be9"
@@ -9768,6 +9775,17 @@ extract-stack@^1.0.0:
   resolved "https://botbuilder.myget.org/F/botbuilder-declarative/npm/extract-stack/-/extract-stack-1.0.0.tgz#b97acaf9441eea2332529624b732fc5a1c8165fa"
   integrity sha1-uXrK+UQe6iMyUpYktzL8WhyBZfo=
 
+extract-zip@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-2.0.1.tgz#663dca56fe46df890d5f131ef4a06d22bb8ba13a"
+  integrity sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==
+  dependencies:
+    debug "^4.1.1"
+    get-stream "^5.1.0"
+    yauzl "^2.10.0"
+  optionalDependencies:
+    "@types/yauzl" "^2.9.1"
+
 extract-zip@^1.0.3, extract-zip@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.7.0.tgz#556cc3ae9df7f452c493a0cfb51cc30277940927"
@@ -14116,6 +14134,11 @@ no-case@^2.2.0:
   dependencies:
     lower-case "^1.1.1"
 
+node-fetch@2.6.1, node-fetch@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
 node-fetch@^1.0.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
@@ -14128,11 +14151,6 @@ node-fetch@^2.1.2, node-fetch@^2.6.0, node-fetch@~2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
-
-node-fetch@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
-  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-forge@^0.10.0:
   version "0.10.0"

--- a/extensions/pvaPublish/package.json
+++ b/extensions/pvaPublish/package.json
@@ -9,7 +9,7 @@
     "test:ui": "jest --config jest.config.ui.js"
   },
   "composer": {
-    "enabled": false,
+    "enabled": true,
     "bundles": [
       {
         "id": "publish",

--- a/extensions/pvaPublish/src/node/index.ts
+++ b/extensions/pvaPublish/src/node/index.ts
@@ -1,6 +1,6 @@
 import { ExtensionRegistration } from '@bfc/extension';
 
-import { getStatus, history, publish } from './publish';
+import { getStatus, history, publish, pull } from './publish';
 import { setLogger } from './logger';
 
 function initialize(registration: ExtensionRegistration) {
@@ -12,10 +12,9 @@ function initialize(registration: ExtensionRegistration) {
     history,
     getStatus,
     publish,
-    // TODO: add 'pull' once ready,
+    pull,
   };
 
-  // @ts-expect-error (TODO: remove once auth is integrated and added to publish method signature)
   registration.addPublishMethod(extension);
 }
 

--- a/extensions/pvaPublish/src/node/publish.ts
+++ b/extensions/pvaPublish/src/node/publish.ts
@@ -269,7 +269,7 @@ export const pull = async (
       // where we will store the bot .zip
       const zipDir = join(process.env.COMPOSER_TEMP_DIR as string, 'pva-publish');
       ensureDirSync(zipDir);
-      const zipPath = join(zipDir, 'bot-assets.zip');
+      const zipPath = join(zipDir, `bot-assets-${Date.now()}.zip`);
       const writeStream = createWriteStream(zipPath);
       await new Promise((resolve, reject) => {
         writeStream.once('finish', resolve);


### PR DESCRIPTION
## Description

This PR enables the ability for publishing extensions to implement the "pull" method to provide updated bot content from a remote source.

## Task Item

Fixes #4385

## Screenshots

![image](https://user-images.githubusercontent.com/3452012/98874924-07091d00-2430-11eb-84e6-4ca11320bccc.png)

![image](https://user-images.githubusercontent.com/3452012/98874964-1a1bed00-2430-11eb-97f6-4a998dff50d9.png)

![image](https://user-images.githubusercontent.com/3452012/98875205-91ea1780-2430-11eb-81e7-c0a548693cc5.png)

![image](https://user-images.githubusercontent.com/3452012/98875225-97dff880-2430-11eb-879f-d2676ac94545.png)

![image](https://user-images.githubusercontent.com/3452012/98875065-53ecf380-2430-11eb-99e7-e15f94a873b5.png)



