### PR TITLE
feat: Property Editor Header when botname is selected in Project tree

### DIFF
--- a/Composer/packages/adaptive-form/src/components/AdaptiveForm.tsx
+++ b/Composer/packages/adaptive-form/src/components/AdaptiveForm.tsx
@@ -11,13 +11,12 @@ import { FontSizes } from '@uifabric/fluent-theme';
 
 import AdaptiveFormContext from '../AdaptiveFormContext';
 
-import { PropertyEditorHeader, PropertyEditorHeaderProps } from './PropertyEditorHeader';
 import { SchemaField } from './SchemaField';
 import FormTitle from './FormTitle';
 import ErrorInfo from './ErrorInfo';
 import { LoadingTimeout } from './LoadingTimeout';
 
-export interface AdaptiveFormProps extends PropertyEditorHeaderProps {
+export interface AdaptiveFormProps {
   errors?: string | FormErrors | string[] | FormErrors[];
   schema?: JSONSchema7;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -28,12 +27,6 @@ export interface AdaptiveFormProps extends PropertyEditorHeaderProps {
   onChange: (value: any) => void;
 }
 
-const schemaErrorContainer = css`
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-`;
-
 const schemaLoadErrorStyle = css`
   display: flex;
   align-items: center;
@@ -43,54 +36,47 @@ const schemaLoadErrorStyle = css`
 `;
 
 export const AdaptiveForm: React.FC<AdaptiveFormProps> = function AdaptiveForm(props) {
-  const { errors, focusedTab, formData, schema, uiOptions, onChange, onFocusedTab, projectMetadata, botName } = props;
+  const { errors, focusedTab, formData, schema, uiOptions, onChange, onFocusedTab } = props;
 
-  if (!formData || !schema) {
-    const propertyHeaderComponent = <PropertyEditorHeader botName={botName} projectMetadata={projectMetadata} />;
-    let schemaLoadErrorComponent;
-    if (!formData && !schema) {
-      schemaLoadErrorComponent = (
-        <div css={schemaLoadErrorStyle}>
-          <LoadingTimeout timeout={2000}>
-            <p>
-              {formatMessage('{type} could not be loaded', {
-                type: formData ? formatMessage('Schema') : formatMessage('Dialog data'),
-              })}
-            </p>
-          </LoadingTimeout>
-        </div>
-      );
-    }
+  if (!formData && !schema) {
     return (
-      <div css={schemaErrorContainer}>
-        {propertyHeaderComponent}
-        {schemaLoadErrorComponent}
+      <div css={schemaLoadErrorStyle}>
+        <LoadingTimeout timeout={2000}>
+          <p>
+            {formatMessage('{type} could not be loaded', {
+              type: formData ? formatMessage('Schema') : formatMessage('Dialog data'),
+            })}
+          </p>
+        </LoadingTimeout>
       </div>
     );
   }
 
-  return (
-    <ErrorBoundary FallbackComponent={ErrorInfo}>
-      <AdaptiveFormContext.Provider value={{ focusedTab, onFocusedTab, baseSchema: schema }}>
-        <FormTitle
-          formData={formData}
-          id={formData.$designer?.id || 'unknown'}
-          schema={schema}
-          uiOptions={uiOptions}
-          onChange={(newData) => onChange({ ...formData, ...newData })}
-        />
-        <SchemaField
-          definitions={schema?.definitions}
-          depth={-1}
-          id={formData.$designer?.id ? `root[${formData.$designer?.id}]` : 'root'}
-          name="root"
-          rawErrors={errors}
-          schema={schema}
-          uiOptions={uiOptions}
-          value={formData}
-          onChange={onChange}
-        />
-      </AdaptiveFormContext.Provider>
-    </ErrorBoundary>
-  );
+  if (schema) {
+    return (
+      <ErrorBoundary FallbackComponent={ErrorInfo}>
+        <AdaptiveFormContext.Provider value={{ focusedTab, onFocusedTab, baseSchema: schema }}>
+          <FormTitle
+            formData={formData}
+            id={formData.$designer?.id || 'unknown'}
+            schema={schema}
+            uiOptions={uiOptions}
+            onChange={(newData) => onChange({ ...formData, ...newData })}
+          />
+          <SchemaField
+            definitions={schema?.definitions}
+            depth={-1}
+            id={formData.$designer?.id ? `root[${formData.$designer?.id}]` : 'root'}
+            name="root"
+            rawErrors={errors}
+            schema={schema}
+            uiOptions={uiOptions}
+            value={formData}
+            onChange={onChange}
+          />
+        </AdaptiveFormContext.Provider>
+      </ErrorBoundary>
+    );
+  }
+  return null;
 };

--- a/Composer/packages/adaptive-form/src/components/AdaptiveForm.tsx
+++ b/Composer/packages/adaptive-form/src/components/AdaptiveForm.tsx
@@ -7,21 +7,17 @@ import React from 'react';
 import { FormErrors, JSONSchema7, UIOptions } from '@bfc/extension-client';
 import ErrorBoundary from 'react-error-boundary';
 import formatMessage from 'format-message';
+import { FontSizes } from '@uifabric/fluent-theme';
 
 import AdaptiveFormContext from '../AdaptiveFormContext';
 
+import { PropertyEditorHeader, PropertyEditorHeaderProps } from './PropertyEditorHeader';
 import { SchemaField } from './SchemaField';
 import FormTitle from './FormTitle';
 import ErrorInfo from './ErrorInfo';
 import { LoadingTimeout } from './LoadingTimeout';
 
-const styles = {
-  errorLoading: css`
-    padding: 18px;
-  `,
-};
-
-export interface AdaptiveFormProps {
+export interface AdaptiveFormProps extends PropertyEditorHeaderProps {
   errors?: string | FormErrors | string[] | FormErrors[];
   schema?: JSONSchema7;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -32,18 +28,44 @@ export interface AdaptiveFormProps {
   onChange: (value: any) => void;
 }
 
+const schemaErrorContainer = css`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+`;
+
+const schemaLoadErrorStyle = css`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  font-size: ${FontSizes.size14};
+`;
+
 export const AdaptiveForm: React.FC<AdaptiveFormProps> = function AdaptiveForm(props) {
-  const { errors, focusedTab, formData, schema, uiOptions, onChange, onFocusedTab } = props;
+  const { errors, focusedTab, formData, schema, uiOptions, onChange, onFocusedTab, projectMetadata, botName } = props;
 
   if (!formData || !schema) {
-    return (
-      <LoadingTimeout timeout={2000}>
-        <div css={styles.errorLoading}>
-          {formatMessage('{type} could not be loaded', {
-            type: formData ? formatMessage('Schema') : formatMessage('Dialog data'),
-          })}
+    const propertyHeaderComponent = <PropertyEditorHeader botName={botName} projectMetadata={projectMetadata} />;
+    let schemaLoadErrorComponent;
+    if (!formData && !schema) {
+      schemaLoadErrorComponent = (
+        <div css={schemaLoadErrorStyle}>
+          <LoadingTimeout timeout={2000}>
+            <p>
+              {formatMessage('{type} could not be loaded', {
+                type: formData ? formatMessage('Schema') : formatMessage('Dialog data'),
+              })}
+            </p>
+          </LoadingTimeout>
         </div>
-      </LoadingTimeout>
+      );
+    }
+    return (
+      <div css={schemaErrorContainer}>
+        {propertyHeaderComponent}
+        {schemaLoadErrorComponent}
+      </div>
     );
   }
 

--- a/Composer/packages/adaptive-form/src/components/PropertyEditorHeader.tsx
+++ b/Composer/packages/adaptive-form/src/components/PropertyEditorHeader.tsx
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/** @jsx jsx */
+import { jsx } from '@emotion/core';
+import React, { useMemo } from 'react';
+import { css } from '@emotion/core';
+import { FontSizes, NeutralColors } from '@uifabric/fluent-theme';
+import formatMessage from 'format-message';
+import { Link } from 'office-ui-fabric-react/lib/Link';
+import { FontWeights } from '@uifabric/styling';
+
+const styles = {
+  errorLoading: css`
+    padding: 18px;
+  `,
+
+  banner: css`
+    border-top: 1px solid ${NeutralColors.gray10};
+    padding: 0 18px;
+    margin-bottom: 0px;
+    border-bottom: 1px solid ${NeutralColors.gray60};
+  `,
+
+  title: css`
+    font-weight: ${FontWeights.semibold};
+    margin: 5px 0px;
+  `,
+
+  subtitle: css`
+    display: block;
+    height: 15px;
+    line-height: 15px;
+    font-size: ${FontSizes.size12};
+    color: ${NeutralColors.gray130};
+    font-weight: ${FontWeights.semibold};
+  `,
+
+  description: css`
+    margin-top: 0;
+    margin-bottom: 10px;
+    white-space: pre-line;
+    font-size: ${FontSizes.size12};
+  `,
+
+  helplink: css`
+    margin-top: 15px;
+    font-size: ${FontSizes.size12};
+  `,
+};
+
+export type PropertyEditorHeaderProps = {
+  projectData: { isRootBot: boolean; isRemote: boolean };
+  botName: string;
+  description?: string;
+  helpLink?: string;
+};
+
+const PropertyEditorHeader: React.FC<PropertyEditorHeaderProps> = (props) => {
+  const {
+    projectData: { isRootBot, isRemote },
+    botName,
+    helpLink,
+  } = props;
+
+  const botTypeText = useMemo(() => {
+    if (isRootBot) {
+      return formatMessage('Root bot');
+    } else {
+      if (isRemote) {
+        return formatMessage('Remote Skill.');
+      }
+      return formatMessage('Local Skill.');
+    }
+  }, [isRemote, isRootBot]);
+
+  const botDescriptionText = useMemo(() => {
+    if (isRootBot) {
+      return formatMessage('Root bot of your project that greets users, and can call skills.');
+    } else {
+      if (isRemote) {
+        return formatMessage('This configures a data driven dialog via a collection of events and actions.');
+      }
+      return formatMessage('A skill bot that can be called from a host bot.');
+    }
+  }, [isRemote, isRootBot]);
+
+  return (
+    <div css={styles.banner}>
+      <h2 style={{ margin: '7px 0' }}>
+        {botName} {isRemote ? '(Remote)' : ''}
+        <span css={styles.subtitle}>{botTypeText}</span>
+      </h2>
+      <p css={styles.description}>{botDescriptionText}</p>
+      <p css={styles.helplink}>
+        {isRemote ? (
+          <Link
+            aria-label={formatMessage('Learn more about skill manifests')}
+            href={helpLink}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            {formatMessage('Learn more')}
+          </Link>
+        ) : null}
+      </p>
+    </div>
+  );
+};
+
+export { PropertyEditorHeader };

--- a/Composer/packages/adaptive-form/src/components/__tests__/PropertyEditorHeader.test.tsx
+++ b/Composer/packages/adaptive-form/src/components/__tests__/PropertyEditorHeader.test.tsx
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import React from 'react';
+import { render } from '@botframework-composer/test-utils';
+
+import { PropertyEditorHeader } from '../PropertyEditorHeader';
+
+describe('<PropertyEditorHeader />', () => {
+  it('renders property editor header without help link if not a remote bot', () => {
+    const metadata = {
+      isRootBot: true,
+      isRemote: false,
+    };
+
+    const { queryAllByText } = render(<PropertyEditorHeader botName={'echo-bot'} projectData={metadata} />);
+    expect(queryAllByText('Learn more')).toEqual([]);
+  });
+
+  it('renders property editor header for a root bot', () => {
+    const metadata = {
+      isRootBot: true,
+      isRemote: false,
+    };
+    const { findByText } = render(<PropertyEditorHeader botName={'echo-bot'} projectData={metadata} />);
+    expect(findByText('Root bot'));
+    expect(findByText('Root bot of your project that greets users, and can call skills.'));
+  });
+
+  it('renders property editor header for a local skill', () => {
+    const metadata = {
+      isRootBot: false,
+      isRemote: false,
+    };
+    const { findByText } = render(<PropertyEditorHeader botName={'echo-bot'} projectData={metadata} />);
+    expect(findByText('Local Skill'));
+  });
+
+  it('renders property editor header for a local skill', () => {
+    const metadata = {
+      isRootBot: false,
+      isRemote: true,
+    };
+    const helpLink = 'https://botframework-skill/manifest';
+    const { findByText } = render(
+      <PropertyEditorHeader botName={'echo-bot'} helpLink={helpLink} projectData={metadata} />
+    );
+    expect(findByText('Remote Skill'));
+    expect(findByText('Learn more'));
+  });
+});

--- a/Composer/packages/adaptive-form/src/components/__tests__/PropertyEditorHeader.test.tsx
+++ b/Composer/packages/adaptive-form/src/components/__tests__/PropertyEditorHeader.test.tsx
@@ -36,7 +36,7 @@ describe('<PropertyEditorHeader />', () => {
     expect(findByText('Local Skill'));
   });
 
-  it('renders property editor header for a local skill', () => {
+  it('renders property editor header for a remote skill', () => {
     const metadata = {
       isRootBot: false,
       isRemote: true,

--- a/Composer/packages/client/src/pages/design/DesignPage.tsx
+++ b/Composer/packages/client/src/pages/design/DesignPage.tsx
@@ -131,7 +131,7 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
   const [showAddSkillDialogModal, setAddSkillDialogModalVisibility] = useState(false);
   const visualEditorSelection = useRecoilValue(visualEditorSelectionState);
   const { undo, redo, commitChanges, clearUndo } = undoFunction;
-  const [canUndo, canRedo] = useRecoilValue(undoStatusSelectorFamily(projectId));
+  const [canUndo, canRedo] = useRecoilValue(undoStatusSelectorFamily(skillId ?? projectId));
 
   const {
     removeDialog,

--- a/Composer/packages/client/src/pages/design/DesignPage.tsx
+++ b/Composer/packages/client/src/pages/design/DesignPage.tsx
@@ -49,6 +49,7 @@ import {
   projectDialogsMapSelector,
   skillNameIdentifierByProjectIdSelector,
   SkillInfo,
+  projectMetaDataState,
 } from '../../recoilModel';
 import { CreateQnAModal } from '../../components/QnA';
 import { triggerNotSupported } from '../../utils/dialogValidator';
@@ -148,6 +149,7 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
   const visualEditorSelection = useRecoilValue(visualEditorSelectionState);
   const { undo, redo, commitChanges, clearUndo } = undoFunction;
   const [canUndo, canRedo] = useRecoilValue(undoStatusSelectorFamily(skillId ?? projectId));
+  const { isRemote: isRemoteSkill } = useRecoilValue(projectMetaDataState(skillId ?? projectId));
 
   const {
     removeDialog,
@@ -213,7 +215,6 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
       setSkillManifestFile(skills[skillNameIdentifier]);
     }
   }, [skills, skillId]);
-  const isRemoteSkill = !dialogId && !!skillManifestFile?.remote;
 
   useEffect(() => {
     const currentDialog = dialogs.find(({ id }) => id === dialogId) as DialogInfo | undefined;
@@ -729,10 +730,6 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
     if (!skillNameIdentifier) return;
     displayManifestModal(skillNameIdentifier, projectId);
   };
-
-  if (!dialogId && !skillId) {
-    return <LoadingSpinner />;
-  }
 
   const selectedTrigger = currentDialog?.triggers.find((t) => t.id === selected);
   const withWarning = triggerNotSupported(currentDialog, selectedTrigger);

--- a/Composer/packages/client/src/pages/design/DesignPage.tsx
+++ b/Composer/packages/client/src/pages/design/DesignPage.tsx
@@ -176,12 +176,6 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
     if (currentDialog) {
       setCurrentDialog(currentDialog);
     }
-    const rootDialog = dialogs.find(({ isRoot }) => isRoot);
-    if (!currentDialog && rootDialog) {
-      const { search } = location || {};
-      navigateTo(`/bot/${projectId}/dialogs/${rootDialog.id}${search}`);
-      return;
-    }
     setWarningIsVisible(true);
   }, [dialogId, dialogs, location]);
 
@@ -650,10 +644,6 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
     }
   };
 
-  if (!dialogId) {
-    return <LoadingSpinner />;
-  }
-
   const selectedTrigger = currentDialog?.triggers.find((t) => t.id === selected);
   const withWarning = triggerNotSupported(currentDialog, selectedTrigger);
 
@@ -757,7 +747,8 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
             onSubmit={() => setExportSkillModalVisible(false)}
           />
         )}
-        {triggerModalVisible && (
+
+        {triggerModalVisible && dialogId && (
           <TriggerCreationModal
             dialogId={dialogId}
             isOpen={triggerModalVisible}
@@ -766,7 +757,11 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
             onSubmit={onTriggerCreationSubmit}
           />
         )}
-        <CreateQnAModal dialogId={dialogId} projectId={projectId} qnaFiles={qnaFiles} onSubmit={handleCreateQnA} />
+
+        {dialogId && (
+          <CreateQnAModal dialogId={dialogId} projectId={projectId} qnaFiles={qnaFiles} onSubmit={handleCreateQnA} />
+        )}
+
         {displaySkillManifest && (
           <DisplayManifestModal
             projectId={projectId}

--- a/Composer/packages/client/src/pages/design/ManifestEditor.tsx
+++ b/Composer/packages/client/src/pages/design/ManifestEditor.tsx
@@ -10,7 +10,6 @@ import { LoadingTimeout } from '@bfc/adaptive-form/lib/components/LoadingTimeout
 import { FieldLabel } from '@bfc/adaptive-form/lib/components/FieldLabel';
 import ErrorInfo from '@bfc/adaptive-form/lib/components/ErrorInfo';
 import { FontSizes, NeutralColors } from '@uifabric/fluent-theme';
-import { Link } from 'office-ui-fabric-react/lib/Link';
 import { FontWeights } from '@uifabric/styling';
 import { DetailsList, DetailsListLayoutMode, SelectionMode } from 'office-ui-fabric-react/lib/DetailsList';
 import get from 'lodash/get';
@@ -18,6 +17,7 @@ import get from 'lodash/get';
 import { SkillInfo } from '../../recoilModel';
 
 import { formEditor } from './styles';
+import { PropertyEditorHeader } from './PropertyEditorHeader';
 
 const styles = {
   errorLoading: css`
@@ -102,24 +102,11 @@ export const ManifestEditor: React.FC<ManifestEditorProps> = (props) => {
   return (
     <div aria-label={formatMessage('manifest editor')} css={formEditor} data-testid="ManifestEditor" role="region">
       <ErrorBoundary FallbackComponent={ErrorInfo}>
-        <div css={styles.banner}>
-          <p css={styles.title}>
-            {formData.name} {'(Remote)'}
-          </p>
-          <p css={styles.subtitle}> {formatMessage('Remote skill')} </p>
-          <p css={styles.description}>{manifest.description}</p>
-          <p css={styles.helplink}>
-            <Link
-              aria-label={formatMessage('Learn more about skill manifests')}
-              href={helpLink}
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              {formatMessage('Learn more')}
-            </Link>
-          </p>
-        </div>
-
+        <PropertyEditorHeader
+          botName={formData.name}
+          helpLink={helpLink}
+          projectData={{ isRootBot: false, isRemote: true }}
+        />
         <div css={styles.body}>
           <section css={styles.section}>
             <FieldLabel

--- a/Composer/packages/client/src/pages/design/PropertyEditor.tsx
+++ b/Composer/packages/client/src/pages/design/PropertyEditor.tsx
@@ -3,7 +3,7 @@
 
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
-import React, { Fragment, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import AdaptiveForm, { resolveRef, getUIOptions } from '@bfc/adaptive-form';
 import { FormErrors, JSONSchema7, useFormConfig, useShellApi } from '@bfc/extension-client';
 import formatMessage from 'format-message';
@@ -12,11 +12,18 @@ import debounce from 'lodash/debounce';
 import get from 'lodash/get';
 import { MicrosoftAdaptiveDialog } from '@bfc/shared';
 import { useRecoilValue } from 'recoil';
+import { css } from '@emotion/core';
 
 import { botDisplayNameState, projectMetaDataState } from '../../recoilModel';
 
 import { PropertyEditorHeader } from './PropertyEditorHeader';
 import { formEditor } from './styles';
+
+const propertyEditorWrapperStyle = css`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+`;
 
 function resolveBaseSchema(schema: JSONSchema7, $kind: string): JSONSchema7 | undefined {
   const defSchema = schema.definitions?.[$kind];
@@ -126,7 +133,7 @@ const PropertyEditor: React.FC = () => {
   };
 
   return (
-    <Fragment>
+    <div css={propertyEditorWrapperStyle}>
       {!localData || !$schema ? <PropertyEditorHeader botName={botName} projectData={projectData} /> : null}
       <div aria-label={formatMessage('form editor')} css={formEditor} data-testid="PropertyEditor" role="region">
         <AdaptiveForm
@@ -139,7 +146,7 @@ const PropertyEditor: React.FC = () => {
           onFocusedTab={handleFocusTab}
         />
       </div>
-    </Fragment>
+    </div>
   );
 };
 

--- a/Composer/packages/client/src/pages/design/PropertyEditor.tsx
+++ b/Composer/packages/client/src/pages/design/PropertyEditor.tsx
@@ -11,6 +11,10 @@ import isEqual from 'lodash/isEqual';
 import debounce from 'lodash/debounce';
 import get from 'lodash/get';
 import { MicrosoftAdaptiveDialog } from '@bfc/shared';
+import { PropertyEditorHeader } from '@bfc/adaptive-form/lib/components/PropertyEditorHeader';
+import { useRecoilValue } from 'recoil';
+
+import { botDisplayNameState, projectMetaDataState } from '../../recoilModel';
 
 import { formEditor } from './styles';
 
@@ -26,8 +30,10 @@ function resolveBaseSchema(schema: JSONSchema7, $kind: string): JSONSchema7 | un
 
 const PropertyEditor: React.FC = () => {
   const { shellApi, ...shellData } = useShellApi();
-  const { currentDialog, focusPath, focusedSteps, focusedTab, schemas } = shellData;
+  const { currentDialog, focusPath, focusedSteps, focusedTab, schemas, projectId } = shellData;
   const { onFocusSteps } = shellApi;
+  const botName = useRecoilValue(botDisplayNameState(projectId));
+  const projectData = useRecoilValue(projectMetaDataState(projectId));
 
   const dialogData = useMemo(() => {
     if (currentDialog?.content) {
@@ -120,16 +126,19 @@ const PropertyEditor: React.FC = () => {
   };
 
   return (
-    <div aria-label={formatMessage('form editor')} css={formEditor} data-testid="PropertyEditor" role="region">
-      <AdaptiveForm
-        errors={errors}
-        focusedTab={focusedTab}
-        formData={localData}
-        schema={$schema}
-        uiOptions={$uiOptions}
-        onChange={handleDataChange}
-        onFocusedTab={handleFocusTab}
-      />
+    <div>
+      {!localData || !$schema ? <PropertyEditorHeader botName={botName} projectData={projectData} /> : null}
+      <div aria-label={formatMessage('form editor')} css={formEditor} data-testid="PropertyEditor" role="region">
+        <AdaptiveForm
+          errors={errors}
+          focusedTab={focusedTab}
+          formData={localData}
+          schema={$schema}
+          uiOptions={$uiOptions}
+          onChange={handleDataChange}
+          onFocusedTab={handleFocusTab}
+        />
+      </div>
     </div>
   );
 };

--- a/Composer/packages/client/src/pages/design/PropertyEditor.tsx
+++ b/Composer/packages/client/src/pages/design/PropertyEditor.tsx
@@ -3,7 +3,7 @@
 
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import AdaptiveForm, { resolveRef, getUIOptions } from '@bfc/adaptive-form';
 import { FormErrors, JSONSchema7, useFormConfig, useShellApi } from '@bfc/extension-client';
 import formatMessage from 'format-message';
@@ -11,11 +11,11 @@ import isEqual from 'lodash/isEqual';
 import debounce from 'lodash/debounce';
 import get from 'lodash/get';
 import { MicrosoftAdaptiveDialog } from '@bfc/shared';
-import { PropertyEditorHeader } from '@bfc/adaptive-form/lib/components/PropertyEditorHeader';
 import { useRecoilValue } from 'recoil';
 
 import { botDisplayNameState, projectMetaDataState } from '../../recoilModel';
 
+import { PropertyEditorHeader } from './PropertyEditorHeader';
 import { formEditor } from './styles';
 
 function resolveBaseSchema(schema: JSONSchema7, $kind: string): JSONSchema7 | undefined {
@@ -126,7 +126,7 @@ const PropertyEditor: React.FC = () => {
   };
 
   return (
-    <div>
+    <Fragment>
       {!localData || !$schema ? <PropertyEditorHeader botName={botName} projectData={projectData} /> : null}
       <div aria-label={formatMessage('form editor')} css={formEditor} data-testid="PropertyEditor" role="region">
         <AdaptiveForm
@@ -139,7 +139,7 @@ const PropertyEditor: React.FC = () => {
           onFocusedTab={handleFocusTab}
         />
       </div>
-    </div>
+    </Fragment>
   );
 };
 

--- a/Composer/packages/client/src/pages/design/PropertyEditorHeader.tsx
+++ b/Composer/packages/client/src/pages/design/PropertyEditorHeader.tsx
@@ -41,10 +41,10 @@ const styles = {
     margin-bottom: 10px;
     white-space: pre-line;
     font-size: ${FontSizes.size12};
+    margin-bottom: 10px;
   `,
 
   helplink: css`
-    margin-top: 15px;
     font-size: ${FontSizes.size12};
   `,
 };
@@ -52,7 +52,6 @@ const styles = {
 export type PropertyEditorHeaderProps = {
   projectData: { isRootBot: boolean; isRemote: boolean };
   botName: string;
-  description?: string;
   helpLink?: string;
 };
 

--- a/Composer/packages/client/src/pages/design/PropertyEditorHeader.tsx
+++ b/Composer/packages/client/src/pages/design/PropertyEditorHeader.tsx
@@ -15,7 +15,7 @@ const styles = {
     padding: 18px;
   `,
 
-  banner: css`
+  propertyEditorHeaderStyle: css`
     border-top: 1px solid ${NeutralColors.gray10};
     padding: 0 18px;
     margin-bottom: 0px;
@@ -65,7 +65,7 @@ const PropertyEditorHeader: React.FC<PropertyEditorHeaderProps> = (props) => {
 
   const botTypeText = useMemo(() => {
     if (isRootBot) {
-      return formatMessage('Root bot');
+      return formatMessage('Root bot.');
     } else {
       if (isRemote) {
         return formatMessage('Remote Skill.');
@@ -86,7 +86,7 @@ const PropertyEditorHeader: React.FC<PropertyEditorHeaderProps> = (props) => {
   }, [isRemote, isRootBot]);
 
   return (
-    <div css={styles.banner}>
+    <div css={styles.propertyEditorHeaderStyle}>
       <h2 style={{ margin: '7px 0' }}>
         {botName} {isRemote ? '(Remote)' : ''}
         <span css={styles.subtitle}>{botTypeText}</span>

--- a/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
@@ -382,14 +382,15 @@ export const openRemoteSkill = async (
     url: manifestUrl,
   });
 
-  //TODO: open remote url 404. isRemote set to false?
-  const manifestResponse = await httpClient.get(
-    `/projects/${projectId}/skill/retrieveSkillManifest?${stringified}&ignoreProjectValidation=true`
-  );
   set(projectMetaDataState(projectId), {
     isRootBot: false,
     isRemote: true,
   });
+
+  //TODO: open remote url 404. isRemote set to false?
+  const manifestResponse = await httpClient.get(
+    `/projects/${projectId}/skill/retrieveSkillManifest?${stringified}&ignoreProjectValidation=true`
+  );
 
   let uniqueSkillNameIdentifier = botNameIdentifier;
   if (!uniqueSkillNameIdentifier) {


### PR DESCRIPTION
This PR adds a header to the property  editor when the botname is clicked in the project tree and no dialogs are selected. Default routing to main dialog is stopped.
![nav](https://user-images.githubusercontent.com/13004779/98863978-0b2c3f00-241e-11eb-811c-6bcae0ffcb79.gif)
