### PR TITLE
fix: plugin hosts are not able to load

### DIFF
--- a/Composer/packages/server/src/server.ts
+++ b/Composer/packages/server/src/server.ts
@@ -124,7 +124,10 @@ export async function start(electronContext?: ElectronContext): Promise<number |
   });
 
   app.get(`${BASEURL}/plugin-host.html`, (req, res) => {
-    res.render(path.resolve(clientDirectory, 'plugin-host.ejs'), { __nonce__: req.__nonce__ });
+    res.render(path.resolve(clientDirectory, 'plugin-host.ejs'), {
+      __nonce__: req.__nonce__,
+      __csrf__: authService.csrfToken,
+    });
   });
 
   app.get('*', (req, res) => {


### PR DESCRIPTION
## Description

A csrf token was not present when rendering the plugin host causing it to error.

## Task Item

#minor
