### PR TITLE
fix: Made the default width of the Property Editor larger

### DIFF
--- a/Composer/packages/client/src/pages/design/DesignPage.tsx
+++ b/Composer/packages/client/src/pages/design/DesignPage.tsx
@@ -694,7 +694,7 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
             </div>
             <Conversation css={editorContainer}>
               <div css={editorWrapper}>
-                <LeftRightSplit initialLeftGridWidth="75%" minLeftPixels={500} minRightPixels={300}>
+                <LeftRightSplit initialLeftGridWidth="65%" minLeftPixels={500} minRightPixels={350}>
                   <div aria-label={formatMessage('Authoring canvas')} css={visualPanel} role="region">
                     {breadcrumbItems}
                     {dialogJsonVisible ? (


### PR DESCRIPTION
#minor

## Screenshots

**BEFORE**

![form-before-0](https://user-images.githubusercontent.com/3452012/98972056-cad4cb80-24c6-11eb-828b-91ef8d8edffe.PNG)

![form-before-1](https://user-images.githubusercontent.com/3452012/98972061-cd372580-24c6-11eb-99eb-bddd85d3982c.PNG)


**AFTER**

![form-after-0](https://user-images.githubusercontent.com/3452012/98972072-d1fbd980-24c6-11eb-8f47-b52f9e3b406f.PNG)

![form-after-1](https://user-images.githubusercontent.com/3452012/98972086-d58f6080-24c6-11eb-9912-21afe8bd9d29.PNG)

(Fullscreen)

![after-fs](https://user-images.githubusercontent.com/3452012/98972105-db854180-24c6-11eb-930f-4f200f35c953.PNG)
