### PR TITLE
fix: Fixes linux icons on the taskbar

### DIFF
--- a/Composer/packages/electron-server/src/electronWindow.ts
+++ b/Composer/packages/electron-server/src/electronWindow.ts
@@ -8,7 +8,6 @@ import { app, BrowserWindow, screen, shell } from 'electron';
 
 import { isLinux } from './utility/platform';
 import { isDevelopment } from './utility/env';
-import { getUnpackedAsarPath } from './utility/getUnpackedAsarPath';
 import logger from './utility/logger';
 const log = logger.extend('electron-window');
 
@@ -43,7 +42,7 @@ export default class ElectronWindow {
     if (isLinux() && !isDevelopment) {
       // workaround for broken .AppImage icons since electron-builder@21.0.1 removed .AppImage desktop integration
       // (https://github.com/electron-userland/electron-builder/releases/tag/v21.0.1)
-      browserWindowOptions.icon = join(getUnpackedAsarPath(), 'resources/composerIcon_1024x1024.png');
+      browserWindowOptions.icon = join(__dirname, '../resources/composerIcon_1024x1024.png');
     }
     this.currentBrowserWindow = new BrowserWindow(browserWindowOptions);
     this.currentBrowserWindow.on('page-title-updated', (ev) => ev.preventDefault()); // preserve explicit window title

--- a/Composer/packages/electron-server/src/main.ts
+++ b/Composer/packages/electron-server/src/main.ts
@@ -249,6 +249,7 @@ async function run() {
     const getMainWindow = () => ElectronWindow.getInstance().browserWindow;
     const { startApp, updateStatus } = await initSplashScreen({
       getMainWindow,
+      icon: join(__dirname, '../resources/composerIcon_1024x1024.png'),
       color: 'rgb(0, 120, 212)',
       logo: `file://${microsoftLogoPath}`,
       productName: 'Bot Framework Composer',

--- a/Composer/packages/electron-server/src/main.ts
+++ b/Composer/packages/electron-server/src/main.ts
@@ -7,21 +7,21 @@ import { AppUpdaterSettings, UserSettings } from '@bfc/shared';
 import { app, ipcMain } from 'electron';
 import { UpdateInfo } from 'electron-updater';
 import fixPath from 'fix-path';
-import { mkdirp } from 'fs-extra';
 import formatMessage from 'format-message';
+import { mkdirp } from 'fs-extra';
 
 import { initAppMenu } from './appMenu';
 import { AppUpdater } from './appUpdater';
+import { OneAuthService } from './auth/oneAuthService';
 import { composerProtocol } from './constants';
 import ElectronWindow from './electronWindow';
 import { initSplashScreen } from './splash/splashScreen';
 import { isDevelopment } from './utility/env';
 import { getUnpackedAsarPath } from './utility/getUnpackedAsarPath';
-import { loadLocale, getAppLocale, updateAppLocale } from './utility/locale';
+import { getAppLocale, loadLocale, updateAppLocale } from './utility/locale';
 import log from './utility/logger';
-import { isMac, isWindows } from './utility/platform';
+import { isLinux, isMac, isWindows } from './utility/platform';
 import { parseDeepLinkUrl } from './utility/url';
-import { OneAuthService } from './auth/oneAuthService';
 
 const env = log.extend('env');
 env('%O', process.env);
@@ -50,6 +50,10 @@ const getBaseUrl = () => {
 // set production flag
 if (app.isPackaged) {
   process.env.NODE_ENV = 'production';
+  // Windows and Mac use the window title as the app name, but some linux distributions use package name, this will fix that.
+  if (isLinux()) {
+    app.setName('Bot Framework Composer');
+  }
 }
 log(`${process.env.NODE_ENV} environment detected.`);
 


### PR DESCRIPTION
## Description

Fixes linux icons on the taskbar, tested on Ubuntu.

## Task Item

#minor

## Screenshots
![Screenshot from 2020-11-13 11-57-09](https://user-images.githubusercontent.com/1483492/99115681-ad2b6300-25a7-11eb-99a5-1110301a9cab.png)


