### PR TITLE
fix: Removed some extraneous characters from the downloaded pva zip name

### DIFF
--- a/Composer/packages/server/src/externalContentProvider/powerVirtualAgentsProvider.ts
+++ b/Composer/packages/server/src/externalContentProvider/powerVirtualAgentsProvider.ts
@@ -109,7 +109,7 @@ export class PowerVirtualAgentsProvider extends ExternalContentProvider<PowerVir
       // write the zip to disk
       if (result && result.body) {
         ensureDirSync(this.tempBotAssetsDir);
-        const zipPath = join(this.tempBotAssetsDir, `bot-assets-${Date.now()}.zip-}`);
+        const zipPath = join(this.tempBotAssetsDir, `bot-assets-${Date.now()}.zip`);
         const writeStream = createWriteStream(zipPath);
         await new Promise((resolve, reject) => {
           writeStream.once('finish', resolve);


### PR DESCRIPTION
Some extra, unwanted characters were being added to the end of the downloaded .zip from PVA. This PR removes those characters.

#minor

