### PR TITLE
build: add option to force rebuild of extensions

### DIFF
--- a/Composer/scripts/compileExtensions.js
+++ b/Composer/scripts/compileExtensions.js
@@ -87,7 +87,7 @@ const compile = (name, extPath) => {
 
   console.log('[%s] compiling', name);
   console.log('[%s] yarn install', name);
-  execSync('yarn --force --production=false', { cwd: extPath, stdio: 'inherit' });
+  execSync('yarn --force --production=false --frozen-lockfile', { cwd: extPath, stdio: 'inherit' });
 
   if (hasBuild) {
     console.log('[%s] yarn build', name);
@@ -108,7 +108,7 @@ for (const entry of allExtensions) {
     if (!fs.existsSync(packageJSONPath)) {
       console.warn(`Ignore directory ${extPath} which is not a npm module.`);
       continue;
-    };
+    }
 
     const packageJSON = JSON.parse(fs.readFileSync(packageJSONPath));
     const lastModified = getLastModified(extPath);

--- a/Composer/scripts/compileExtensions.js
+++ b/Composer/scripts/compileExtensions.js
@@ -9,10 +9,16 @@ const path = require('path');
 // eslint-disable-next-line security/detect-child-process
 const { execSync } = require('child_process');
 
+const FORCE_BUILD = process.argv.includes('--force') || process.argv.includes('-f');
+
 const extensionsDir = process.env.COMPOSER_BUILTIN_EXTENSIONS_DIR || path.resolve(__dirname, '../../extensions');
 const buildCachePath = path.resolve(extensionsDir, '.build-cache.json');
 
 console.log('Compiling extensions in %s', extensionsDir);
+
+if (FORCE_BUILD) {
+  console.log('--force is true. Forcing a rebuild of all extensions.');
+}
 
 const allExtensions = fs.readdirSync(extensionsDir, { withFileTypes: true });
 
@@ -112,7 +118,7 @@ for (const entry of allExtensions) {
 
     const packageJSON = JSON.parse(fs.readFileSync(packageJSONPath));
     const lastModified = getLastModified(extPath);
-    if (missingMain(extPath, packageJSON) || hasChanges(entry.name, lastModified)) {
+    if (FORCE_BUILD || missingMain(extPath, packageJSON) || hasChanges(entry.name, lastModified)) {
       try {
         compile(entry.name, extPath);
         writeToCache(entry.name, lastModified);


### PR DESCRIPTION
## Description

`yarn build:extensions --force` will now force a rebuild of all the extensions.

## Task Item

#minor
