### PR TITLE
feat: Add data collection dialog and settings

### DIFF
--- a/Composer/packages/client/src/App.tsx
+++ b/Composer/packages/client/src/App.tsx
@@ -16,19 +16,16 @@ initializeIcons(undefined, { disableWarnings: true });
 
 export const App: React.FC = () => {
   const { appLocale } = useRecoilValue(userSettingsState);
-  const { fetchFeatureFlags } = useRecoilValue(dispatcherState);
+  const { fetchExtensions, fetchFeatureFlags, fetchServerSettings } = useRecoilValue(dispatcherState);
+
   useEffect(() => {
     loadLocale(appLocale);
   }, [appLocale]);
 
   useEffect(() => {
-    fetchFeatureFlags();
-  }, []);
-
-  const { fetchExtensions } = useRecoilValue(dispatcherState);
-
-  useEffect(() => {
     fetchExtensions();
+    fetchFeatureFlags();
+    fetchServerSettings();
   }, []);
 
   return (

--- a/Composer/packages/client/src/components/AppComponents/Assistant.tsx
+++ b/Composer/packages/client/src/components/AppComponents/Assistant.tsx
@@ -7,17 +7,24 @@ import { Suspense, Fragment } from 'react';
 import React from 'react';
 
 import { isElectron } from './../../utils/electronUtil';
-import { onboardingState } from './../../recoilModel';
+import { ServerSettingsState, onboardingState } from './../../recoilModel';
 
 const Onboarding = React.lazy(() => import('./../../Onboarding/Onboarding'));
 const AppUpdater = React.lazy(() => import('./../AppUpdater').then((module) => ({ default: module.AppUpdater })));
+const DataCollectionDialog = React.lazy(() => import('./../DataCollectionDialog'));
 
 export const Assistant = () => {
+  const { telemetry } = useRecoilValue(ServerSettingsState);
   const onboarding = useRecoilValue(onboardingState);
   const renderAppUpdater = isElectron();
+
+  const renderDataCollectionDialog = telemetry?.allowDataCollection === null;
+  const renderOnboarding = !renderDataCollectionDialog && !onboarding.complete;
+
   return (
     <Fragment>
-      <Suspense fallback={<div />}>{!onboarding.complete && <Onboarding />}</Suspense>
+      <Suspense fallback={<div />}>{renderDataCollectionDialog && <DataCollectionDialog />}</Suspense>
+      <Suspense fallback={<div />}>{renderOnboarding && <Onboarding />}</Suspense>
       <Suspense fallback={<div />}>{renderAppUpdater && <AppUpdater />}</Suspense>
     </Fragment>
   );

--- a/Composer/packages/client/src/components/DataCollectionDialog.tsx
+++ b/Composer/packages/client/src/components/DataCollectionDialog.tsx
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import formatMessage from 'format-message';
+import { DefaultButton, PrimaryButton } from 'office-ui-fabric-react/lib/Button';
+import { Dialog, DialogFooter } from 'office-ui-fabric-react/lib/Dialog';
+import { Link } from 'office-ui-fabric-react/lib/Link';
+import React from 'react';
+import { useRecoilValue } from 'recoil';
+
+import { dispatcherState } from '../recoilModel';
+
+const DataCollectionDialog: React.FC = () => {
+  const { setAllowDataCollection } = useRecoilValue(dispatcherState);
+
+  const handleDismiss = () => {
+    setAllowDataCollection(false);
+  };
+
+  const handleAgree = () => {
+    setAllowDataCollection(true);
+  };
+
+  return (
+    <Dialog
+      hidden={false}
+      modalProps={{
+        isBlocking: true,
+      }}
+      title={formatMessage('Help us improve?')}
+      onDismiss={handleDismiss}
+    >
+      <p>
+        {formatMessage(
+          'Composer includes a telemetry feature that collects usage information. It is important that the Composer team understands how the tool is being used so that it can be improved.'
+        )}
+      </p>
+      <p>{formatMessage('You can turn data collection on or off at any time in the Application Settings.')}</p>
+      <p>
+        <Link
+          aria-label={formatMessage('Privacy statement')}
+          href={'https://privacy.microsoft.com/privacystatement'}
+          target={'_blank'}
+        >
+          {formatMessage('Privacy statement')}
+        </Link>
+      </p>
+      <DialogFooter>
+        <DefaultButton text={formatMessage('Not now')} onClick={handleDismiss} />
+        <PrimaryButton text={formatMessage('Yes, collect data')} onClick={handleAgree} />
+      </DialogFooter>
+    </Dialog>
+  );
+};
+
+export default DataCollectionDialog;
+export { DataCollectionDialog };

--- a/Composer/packages/client/src/components/DataCollectionDialog.tsx
+++ b/Composer/packages/client/src/components/DataCollectionDialog.tsx
@@ -11,14 +11,14 @@ import { useRecoilValue } from 'recoil';
 import { dispatcherState } from '../recoilModel';
 
 const DataCollectionDialog: React.FC = () => {
-  const { setAllowDataCollection } = useRecoilValue(dispatcherState);
+  const { updateServerSettings } = useRecoilValue(dispatcherState);
 
-  const handleDismiss = () => {
-    setAllowDataCollection(false);
-  };
-
-  const handleAgree = () => {
-    setAllowDataCollection(true);
+  const handleDataCollectionChange = (allowDataCollection: boolean) => () => {
+    updateServerSettings({
+      telemetry: {
+        allowDataCollection,
+      },
+    });
   };
 
   return (
@@ -28,7 +28,7 @@ const DataCollectionDialog: React.FC = () => {
         isBlocking: true,
       }}
       title={formatMessage('Help us improve?')}
-      onDismiss={handleDismiss}
+      onDismiss={handleDataCollectionChange(false)}
     >
       <p>
         {formatMessage(
@@ -46,8 +46,8 @@ const DataCollectionDialog: React.FC = () => {
         </Link>
       </p>
       <DialogFooter>
-        <DefaultButton text={formatMessage('Not now')} onClick={handleDismiss} />
-        <PrimaryButton text={formatMessage('Yes, collect data')} onClick={handleAgree} />
+        <DefaultButton text={formatMessage('Not now')} onClick={handleDataCollectionChange(false)} />
+        <PrimaryButton text={formatMessage('Yes, collect data')} onClick={handleDataCollectionChange(true)} />
       </DialogFooter>
     </Dialog>
   );

--- a/Composer/packages/client/src/pages/setting/app-settings/AppSettings.tsx
+++ b/Composer/packages/client/src/pages/setting/app-settings/AppSettings.tsx
@@ -13,7 +13,7 @@ import { RouteComponentProps } from '@reach/router';
 import { useRecoilValue } from 'recoil';
 
 import { isElectron } from '../../../utils/electronUtil';
-import { onboardingState, userSettingsState, dispatcherState } from '../../../recoilModel';
+import { onboardingState, userSettingsState, dispatcherState, ServerSettingsState } from '../../../recoilModel';
 
 import { container, section } from './styles';
 import { SettingToggle } from './SettingToggle';
@@ -28,7 +28,8 @@ const ElectronSettings = lazy(() =>
 const AppSettings: React.FC<RouteComponentProps> = () => {
   const [calloutIsShown, showCallout] = useState(false);
 
-  const { onboardingSetComplete, updateUserSettings } = useRecoilValue(dispatcherState);
+  const { onboardingSetComplete, updateUserSettings, setAllowDataCollection } = useRecoilValue(dispatcherState);
+  const { telemetry } = useRecoilValue(ServerSettingsState);
   const userSettings = useRecoilValue(userSettingsState);
   const { complete } = useRecoilValue(onboardingState);
   const onOnboardingChange = useCallback(
@@ -46,6 +47,10 @@ const AppSettings: React.FC<RouteComponentProps> = () => {
 
   const onLocaleChange = (appLocale: string) => {
     updateUserSettings({ appLocale });
+  };
+
+  const handleDataCollectionChange = () => {
+    setAllowDataCollection(!telemetry?.allowDataCollection);
   };
 
   const renderElectronSettings = isElectron();
@@ -183,6 +188,18 @@ const AppSettings: React.FC<RouteComponentProps> = () => {
         <h2>{formatMessage('Application Updates')}</h2>
         <Suspense fallback={<div />}>{renderElectronSettings && <ElectronSettings />}</Suspense>
         <PreviewFeatureToggle />
+      </section>
+      <section css={section}>
+        <h2>{formatMessage('Data Collection')}</h2>
+        <SettingToggle
+          checked={!!telemetry?.allowDataCollection}
+          description={formatMessage(
+            'Composer includes a telemetry feature that collects usage information. It is important that the Composer team understands how the tool is being used so that it can be improved.'
+          )}
+          id="dataCollectionToggle"
+          title={formatMessage('Data collection')}
+          onToggle={handleDataCollectionChange}
+        />
       </section>
     </div>
   );

--- a/Composer/packages/client/src/pages/setting/app-settings/AppSettings.tsx
+++ b/Composer/packages/client/src/pages/setting/app-settings/AppSettings.tsx
@@ -28,7 +28,7 @@ const ElectronSettings = lazy(() =>
 const AppSettings: React.FC<RouteComponentProps> = () => {
   const [calloutIsShown, showCallout] = useState(false);
 
-  const { onboardingSetComplete, updateUserSettings, setAllowDataCollection } = useRecoilValue(dispatcherState);
+  const { onboardingSetComplete, updateUserSettings, updateServerSettings } = useRecoilValue(dispatcherState);
   const { telemetry } = useRecoilValue(ServerSettingsState);
   const userSettings = useRecoilValue(userSettingsState);
   const { complete } = useRecoilValue(onboardingState);
@@ -49,8 +49,12 @@ const AppSettings: React.FC<RouteComponentProps> = () => {
     updateUserSettings({ appLocale });
   };
 
-  const handleDataCollectionChange = () => {
-    setAllowDataCollection(!telemetry?.allowDataCollection);
+  const handleDataCollectionChange = (allowDataCollection) => {
+    updateServerSettings({
+      telemetry: {
+        allowDataCollection,
+      },
+    });
   };
 
   const renderElectronSettings = isElectron();

--- a/Composer/packages/client/src/pages/setting/app-settings/SettingToggle.tsx
+++ b/Composer/packages/client/src/pages/setting/app-settings/SettingToggle.tsx
@@ -16,7 +16,7 @@ interface ISettingToggleProps {
   checked?: boolean;
   description: React.ReactChild;
   id?: string;
-  image: string;
+  image?: string;
   onToggle: (checked: boolean) => void;
   title: string;
   hideToggle?: boolean;

--- a/Composer/packages/client/src/recoilModel/atoms/appState.ts
+++ b/Composer/packages/client/src/recoilModel/atoms/appState.ts
@@ -240,5 +240,9 @@ export const pageElementState = atom<{ [page in PageMode]?: { [key: string]: any
 
 export const ServerSettingsState = atom<ServerSettings>({
   key: getFullyQualifiedKey('serverSettings'),
-  default: {},
+  default: {
+    telemetry: {
+      allowDataCollection: false,
+    },
+  },
 });

--- a/Composer/packages/client/src/recoilModel/atoms/appState.ts
+++ b/Composer/packages/client/src/recoilModel/atoms/appState.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { atom, atomFamily } from 'recoil';
-import { FormDialogSchemaTemplate, FeatureFlagMap, BotTemplate, UserSettings } from '@bfc/shared';
+import { FormDialogSchemaTemplate, FeatureFlagMap, BotTemplate, UserSettings, ServerSettings } from '@bfc/shared';
 import { ExtensionMetadata } from '@bfc/extension-client';
 import formatMessage from 'format-message';
 
@@ -236,4 +236,9 @@ export const pageElementState = atom<{ [page in PageMode]?: { [key: string]: any
     lu: {},
     qna: {},
   },
+});
+
+export const ServerSettingsState = atom<ServerSettings>({
+  key: getFullyQualifiedKey('serverSettings'),
+  default: {},
 });

--- a/Composer/packages/client/src/recoilModel/dispatchers/__tests__/serverSettings.test.tsx
+++ b/Composer/packages/client/src/recoilModel/dispatchers/__tests__/serverSettings.test.tsx
@@ -41,7 +41,11 @@ describe('server setting dispatcher', () => {
 
   it('should set allowDataCollection to false', async () => {
     await act(async () => {
-      await dispatcher.setAllowDataCollection(false);
+      await dispatcher.updateServerSettings({
+        telemetry: {
+          allowDataCollection: false,
+        },
+      });
     });
 
     expect(renderedComponent.current.serverSettings.telemetry.allowDataCollection).toBe(false);
@@ -61,7 +65,11 @@ describe('server setting dispatcher', () => {
     (httpClient.post as jest.Mock).mockResolvedValue({});
 
     await act(async () => {
-      await dispatcher.setAllowDataCollection(true);
+      await dispatcher.updateServerSettings({
+        telemetry: {
+          allowDataCollection: true,
+        },
+      });
     });
 
     expect(renderedComponent.current.serverSettings.telemetry.allowDataCollection).toBe(true);

--- a/Composer/packages/client/src/recoilModel/dispatchers/__tests__/serverSettings.test.tsx
+++ b/Composer/packages/client/src/recoilModel/dispatchers/__tests__/serverSettings.test.tsx
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { useRecoilValue } from 'recoil';
+import { act } from '@botframework-composer/test-utils/lib/hooks';
+
+import { renderRecoilHook } from '../../../../__tests__/testUtils';
+import { ServerSettingsState } from '../../atoms';
+import { dispatcherState } from '../../../recoilModel/DispatcherWrapper';
+import { Dispatcher } from '..';
+import { serverSettingsDispatcher } from '../serverSettings';
+import httpClient from '../../../utils/httpUtil';
+
+jest.mock('../../../utils/httpUtil');
+
+describe('server setting dispatcher', () => {
+  let renderedComponent, dispatcher: Dispatcher;
+  beforeEach(() => {
+    const useRecoilTestHook = () => {
+      const serverSettings = useRecoilValue(ServerSettingsState);
+      const currentDispatcher = useRecoilValue(dispatcherState);
+
+      return {
+        serverSettings,
+        currentDispatcher,
+      };
+    };
+
+    const { result } = renderRecoilHook(useRecoilTestHook, {
+      states: [{ recoilState: ServerSettingsState, initialValue: {} }],
+      dispatcher: {
+        recoilState: dispatcherState,
+        initialValue: {
+          serverSettingsDispatcher,
+        },
+      },
+    });
+    renderedComponent = result;
+    dispatcher = renderedComponent.current.currentDispatcher;
+  });
+
+  it('should set allowDataCollection to false', async () => {
+    await act(async () => {
+      await dispatcher.setAllowDataCollection(false);
+    });
+
+    expect(renderedComponent.current.serverSettings.telemetry.allowDataCollection).toBe(false);
+    expect(httpClient.post).toBeCalledWith(
+      '/settings',
+      expect.objectContaining({
+        settings: {
+          telemetry: {
+            allowDataCollection: false,
+          },
+        },
+      })
+    );
+  });
+
+  it('should set allowDataCollection to true', async () => {
+    (httpClient.post as jest.Mock).mockResolvedValue({});
+
+    await act(async () => {
+      await dispatcher.setAllowDataCollection(true);
+    });
+
+    expect(renderedComponent.current.serverSettings.telemetry.allowDataCollection).toBe(true);
+    expect(httpClient.post).toBeCalledWith(
+      '/settings',
+      expect.objectContaining({
+        settings: {
+          telemetry: {
+            allowDataCollection: true,
+          },
+        },
+      })
+    );
+  });
+
+  it('should fetch settings from server', async () => {
+    (httpClient.get as jest.Mock).mockResolvedValue({
+      data: {
+        telemetry: {
+          allowDataCollection: null,
+        },
+      },
+    });
+
+    await act(async () => {
+      await dispatcher.fetchServerSettings();
+    });
+
+    expect(renderedComponent.current.serverSettings.telemetry.allowDataCollection).toBe(null);
+  });
+});

--- a/Composer/packages/client/src/recoilModel/dispatchers/index.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/index.ts
@@ -24,6 +24,7 @@ import { formDialogsDispatcher } from './formDialogs';
 import { botProjectFileDispatcher } from './botProjectFile';
 import { zoomDispatcher } from './zoom';
 import { recognizerDispatcher } from './recognizers';
+import { serverSettingsDispatcher } from './serverSettings';
 
 const createDispatchers = () => {
   return {
@@ -50,6 +51,7 @@ const createDispatchers = () => {
     ...botProjectFileDispatcher(),
     ...zoomDispatcher(),
     ...recognizerDispatcher(),
+    ...serverSettingsDispatcher(),
   };
 };
 

--- a/Composer/packages/client/src/recoilModel/dispatchers/serverSettings.tsx
+++ b/Composer/packages/client/src/recoilModel/dispatchers/serverSettings.tsx
@@ -1,0 +1,51 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { CallbackInterface, useRecoilCallback } from 'recoil';
+import { produce } from 'immer';
+
+import httpClient from '../../utils/httpUtil';
+import { ServerSettingsState } from '../atoms/appState';
+
+import { logMessage } from './shared';
+
+export const serverSettingsDispatcher = () => {
+  const setAllowDataCollection = useRecoilCallback(
+    (callbackHelpers: CallbackInterface) => async (allowDataCollection: boolean) => {
+      const { set, snapshot } = callbackHelpers;
+      try {
+        const currentSettings = await snapshot.getPromise(ServerSettingsState);
+
+        const settings = produce(currentSettings, (current) => ({
+          ...current,
+          telemetry: {
+            ...current.telemetry,
+            allowDataCollection,
+          },
+        }));
+
+        await httpClient.post('/settings', { settings });
+        set(ServerSettingsState, settings);
+      } catch (error) {
+        logMessage(callbackHelpers, `Error fetching data collection settings: ${error}`);
+      }
+    }
+  );
+
+  const fetchServerSettings = useRecoilCallback((callbackHelpers: CallbackInterface) => async () => {
+    const { set } = callbackHelpers;
+    try {
+      const { data: settings } = await httpClient.get('/settings');
+
+      set(ServerSettingsState, settings);
+    } catch (error) {
+      logMessage(callbackHelpers, `Error fetching data collection settings: ${error}`);
+    }
+  });
+
+  return {
+    fetchServerSettings,
+    setAllowDataCollection,
+  };
+};

--- a/Composer/packages/client/src/recoilModel/dispatchers/serverSettings.tsx
+++ b/Composer/packages/client/src/recoilModel/dispatchers/serverSettings.tsx
@@ -19,7 +19,7 @@ export const serverSettingsDispatcher = () => {
 
       set(ServerSettingsState, settings);
     } catch (error) {
-      logMessage(callbackHelpers, `Error fetching data collection settings: ${error}`);
+      logMessage(callbackHelpers, `Error fetching server settings: ${error}`);
     }
   });
 
@@ -33,7 +33,7 @@ export const serverSettingsDispatcher = () => {
         await httpClient.post('/settings', { settings });
         set(ServerSettingsState, settings);
       } catch (error) {
-        logMessage(callbackHelpers, `Error fetching data collection settings: ${error}`);
+        logMessage(callbackHelpers, `Error updating server settings: ${error}`);
       }
     }
   );

--- a/Composer/packages/client/src/recoilModel/dispatchers/serverSettings.tsx
+++ b/Composer/packages/client/src/recoilModel/dispatchers/serverSettings.tsx
@@ -30,8 +30,6 @@ export const serverSettingsDispatcher = () => {
         const currentSettings = await snapshot.getPromise(ServerSettingsState);
         const settings = merge({}, currentSettings, partialSettings);
 
-        console.log('bfc', { partialSettings, currentSettings, settings });
-
         await httpClient.post('/settings', { settings });
         set(ServerSettingsState, settings);
       } catch (error) {

--- a/Composer/packages/client/src/recoilModel/dispatchers/serverSettings.tsx
+++ b/Composer/packages/client/src/recoilModel/dispatchers/serverSettings.tsx
@@ -2,8 +2,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { ServerSettings } from '@bfc/shared';
 import { CallbackInterface, useRecoilCallback } from 'recoil';
-import { produce } from 'immer';
+import merge from 'lodash/merge';
 
 import httpClient from '../../utils/httpUtil';
 import { ServerSettingsState } from '../atoms/appState';
@@ -11,28 +12,6 @@ import { ServerSettingsState } from '../atoms/appState';
 import { logMessage } from './shared';
 
 export const serverSettingsDispatcher = () => {
-  const setAllowDataCollection = useRecoilCallback(
-    (callbackHelpers: CallbackInterface) => async (allowDataCollection: boolean) => {
-      const { set, snapshot } = callbackHelpers;
-      try {
-        const currentSettings = await snapshot.getPromise(ServerSettingsState);
-
-        const settings = produce(currentSettings, (current) => ({
-          ...current,
-          telemetry: {
-            ...current.telemetry,
-            allowDataCollection,
-          },
-        }));
-
-        await httpClient.post('/settings', { settings });
-        set(ServerSettingsState, settings);
-      } catch (error) {
-        logMessage(callbackHelpers, `Error fetching data collection settings: ${error}`);
-      }
-    }
-  );
-
   const fetchServerSettings = useRecoilCallback((callbackHelpers: CallbackInterface) => async () => {
     const { set } = callbackHelpers;
     try {
@@ -44,8 +23,25 @@ export const serverSettingsDispatcher = () => {
     }
   });
 
+  const updateServerSettings = useRecoilCallback(
+    (callbackHelpers: CallbackInterface) => async (partialSettings: Partial<ServerSettings>) => {
+      const { set, snapshot } = callbackHelpers;
+      try {
+        const currentSettings = await snapshot.getPromise(ServerSettingsState);
+        const settings = merge({}, currentSettings, partialSettings);
+
+        console.log('bfc', { partialSettings, currentSettings, settings });
+
+        await httpClient.post('/settings', { settings });
+        set(ServerSettingsState, settings);
+      } catch (error) {
+        logMessage(callbackHelpers, `Error fetching data collection settings: ${error}`);
+      }
+    }
+  );
+
   return {
     fetchServerSettings,
-    setAllowDataCollection,
+    updateServerSettings,
   };
 };

--- a/Composer/packages/server/src/controllers/__tests__/settings.test.ts
+++ b/Composer/packages/server/src/controllers/__tests__/settings.test.ts
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { Request, Response } from 'express';
+
+import { SettingsController } from '../settings';
+import { Store } from '../../store/store';
+
+Store.set = jest.fn();
+
+let mockRes: Response;
+
+beforeEach(() => {
+  mockRes = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    send: jest.fn().mockReturnThis(),
+  } as any;
+});
+
+describe('server settings', () => {
+  it('should update user settings', async () => {
+    const mockReq = {
+      params: {},
+      query: {},
+      body: {
+        settings: {
+          telemetry: {},
+        },
+      },
+    } as Request;
+    await SettingsController.updateUserSettings(mockReq, mockRes);
+    expect(mockRes.json).toHaveBeenCalledWith({ telemetry: {} });
+  });
+
+  it('should get user settings', async () => {
+    (Store.set as jest.Mock).mockReturnValue(null);
+    const mockReq = {
+      params: {},
+      query: {},
+      body: {},
+    } as Request;
+    await SettingsController.getUserSettings(mockReq, mockRes);
+    expect(mockRes.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        telemetry: expect.objectContaining({
+          allowDataCollection: null,
+        }),
+      })
+    );
+  });
+});

--- a/Composer/packages/server/src/controllers/settings.ts
+++ b/Composer/packages/server/src/controllers/settings.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { Request, Response } from 'express';
+
+import SettingsService from '../services/settings';
+
+async function getUserSettings(req: Request, res: Response) {
+  try {
+    const settings = SettingsService.getSettings();
+    return res.status(200).json(settings);
+  } catch (err) {
+    return res.status(500).json({
+      message: err instanceof Error ? err.message : err,
+    });
+  }
+}
+
+async function updateUserSettings(req: Request, res: Response) {
+  try {
+    const { settings } = req.body;
+    const updatedSettings = SettingsService.setSettings(settings);
+    return res.status(200).json(updatedSettings);
+  } catch (err) {
+    return res.status(500).json({
+      message: err instanceof Error ? err.message : err,
+    });
+  }
+}
+
+export const SettingsController = {
+  getUserSettings,
+  updateUserSettings,
+};

--- a/Composer/packages/server/src/router/api.ts
+++ b/Composer/packages/server/src/router/api.ts
@@ -17,6 +17,7 @@ import { AuthController } from '../controllers/auth';
 import { csrfProtection } from '../middleware/csrfProtection';
 import { ImportController } from '../controllers/import';
 import { StatusController } from '../controllers/status';
+import { SettingsController } from '../controllers/settings';
 
 import { UtilitiesController } from './../controllers/utilities';
 
@@ -106,6 +107,10 @@ router.post('/import/:source/authenticate', ImportController.authenticate);
 
 // Process status
 router.get('/status/:jobId', StatusController.getStatus);
+
+// User Server Settings
+router.get('/settings', SettingsController.getUserSettings);
+router.post('/settings', SettingsController.updateUserSettings);
 
 const errorHandler = (handler: RequestHandler) => (req: Request, res: Response, next: NextFunction) => {
   Promise.resolve(handler(req, res, next)).catch(next);

--- a/Composer/packages/server/src/services/settings.ts
+++ b/Composer/packages/server/src/services/settings.ts
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { ServerSettings } from '@bfc/shared';
+
+import { Store } from '../store/store';
+
+const KEY = 'settings';
+
+const DEFAULT_SETTINGS: ServerSettings = {
+  telemetry: {
+    allowDataCollection: null,
+  },
+};
+
+export class SettingsService {
+  public static getSettings(): ServerSettings {
+    return Store.get(KEY, DEFAULT_SETTINGS);
+  }
+
+  public static setSettings(settings: ServerSettings): ServerSettings {
+    Store.set(KEY, settings);
+    return settings;
+  }
+}
+
+export default SettingsService;

--- a/Composer/packages/types/src/index.ts
+++ b/Composer/packages/types/src/index.ts
@@ -14,4 +14,5 @@ export * from './sdk';
 export * from './server';
 export * from './settings';
 export * from './shell';
+export * from './telemetry';
 export * from './user';

--- a/Composer/packages/types/src/telemetry.ts
+++ b/Composer/packages/types/src/telemetry.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export type TelemetrySettings = {
+  allowDataCollection?: boolean | null;
+};
+
+export type ServerSettings = {
+  telemetry?: TelemetrySettings;
+};

--- a/Composer/packages/types/src/telemetry.ts
+++ b/Composer/packages/types/src/telemetry.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 export type TelemetrySettings = {
-  allowDataCollection: boolean | null;
+  allowDataCollection?: boolean | null;
 };
 
 export type ServerSettings = Partial<{ telemetry: TelemetrySettings }>;

--- a/Composer/packages/types/src/telemetry.ts
+++ b/Composer/packages/types/src/telemetry.ts
@@ -2,9 +2,7 @@
 // Licensed under the MIT License.
 
 export type TelemetrySettings = {
-  allowDataCollection?: boolean | null;
+  allowDataCollection: boolean | null;
 };
 
-export type ServerSettings = {
-  telemetry?: TelemetrySettings;
-};
+export type ServerSettings = Partial<{ telemetry: TelemetrySettings }>;


### PR DESCRIPTION
## Description
Adds a prompt when the user opens the app to opt-in or opt-out of data collection. It also adds the ability for them to change their data collection preferences in the Application Settings. 

## Task Item
Closes #4766

## Screenshots

### Data Collection Dialog
![image](https://user-images.githubusercontent.com/17039790/99467970-96587980-28e3-11eb-8b12-e05b0cd41f85.png)


### Data Collection Application Settings
![image](https://user-images.githubusercontent.com/17039790/99468007-a708ef80-28e3-11eb-9049-e2e53a93b627.png)
