### PR TITLE
fix: luis key not initialized

### DIFF
--- a/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
@@ -584,7 +584,7 @@ const openRootBotAndSkills = async (callbackHelpers: CallbackInterface, data, st
     const skills: { [skillId: string]: BotProjectSpaceSkill } = currentBotProjectFile.skills;
 
     const totalProjectsCount = Object.keys(skills).length + 1;
-    if (totalProjectsCount > 0) {
+    if (totalProjectsCount > 1) {
       for (const nameIdentifier in skills) {
         const skill = skills[nameIdentifier];
         let skillPromise;
@@ -615,6 +615,9 @@ const openRootBotAndSkills = async (callbackHelpers: CallbackInterface, data, st
             });
         }
       }
+    } else {
+      //only contains rootBot
+      set(botProjectSpaceLoadedState, true);
     }
   } else {
     // Should never hit here as all projects should have a botproject file


### PR DESCRIPTION
## Description
if the bot project only contains a root bot. The botProjectSpaceLoaded is not set to true.
## Task Item
Closes #4845 

## Screenshots
![newnew](https://user-images.githubusercontent.com/24380525/99503446-2caa9f00-29b9-11eb-8821-4756ae05b4bf.gif)
