### PR TITLE
fix: QnA list render slow issue

### DIFF
--- a/Composer/packages/client/src/pages/knowledge-base/table-view.tsx
+++ b/Composer/packages/client/src/pages/knowledge-base/table-view.tsx
@@ -433,8 +433,8 @@ const TableView: React.FC<TableViewProps> = (props) => {
         isResizable: true,
         data: 'string',
         onRender: (item: QnASectionItem, index) => {
-          const questions = item.Questions;
           const isExpanded = expandedIndex === index;
+          const questions = isExpanded ? item.Questions : item.Questions.slice(0, 1);
           const isSourceSectionInDialog = item.fileId.endsWith('.source') && !dialogId.endsWith('.source');
           const isAllowEdit = dialogId !== 'all' && !isSourceSectionInDialog;
           const isCreatingQnA =
@@ -452,14 +452,16 @@ const TableView: React.FC<TableViewProps> = (props) => {
                 const isQuestionEmpty = question.content === '';
                 const isOnlyQuestion = questions.length === 1 && qIndex === 0;
                 return (
-                  <div key={question.id} style={{ display: isExpanded ? 'block' : qIndex === 0 ? 'block' : 'none' }}>
+                  <div key={question.id}>
                     <EditableField
                       key={question.id}
                       ariaLabel={formatMessage(`Question is {content}`, { content: question.content })}
                       depth={0}
                       disabled={isAllowEdit}
                       enableIcon={isExpanded}
-                      extraContent={qIndex === 0 && !isExpanded && !isQuestionEmpty ? ` (${questions.length})` : ''}
+                      extraContent={
+                        qIndex === 0 && !isExpanded && !isQuestionEmpty ? ` (${item.Questions.length})` : ''
+                      }
                       iconProps={{
                         iconName: 'Cancel',
                       }}


### PR DESCRIPTION
## Description

Previously, questions are all rendered, even rows are collapsed, expand is set question components 'hide'/'show'. That cause perf issue when QnA is large. benchmark from low performance laptop:
1. when table list first page ( top 10 QnA pairs ), questions amount more than 1000, scroll on list will feel 1s delay.
2. when questions amount less than 500, UX still feel smoothy.
3. when each pairs don't have much alternative questions, more than 10000 line qna file still smooth, UX works fine.

So the bottleneck is rendered too many hide question components in viewport. and the amount of QnA pairs will not cause perf issue. 

Fix it by render only one question when row collapsed.
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
close #4849 
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots
![image](https://user-images.githubusercontent.com/49866537/99503640-6aa7c300-29b9-11eb-9cd2-d4b517d574dd.png)

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
