### PR TITLE
fix: fixes form dialog generation on electron

### DIFF
--- a/Composer/packages/client/src/components/ProjectTree/ProjectTree.tsx
+++ b/Composer/packages/client/src/components/ProjectTree/ProjectTree.tsx
@@ -443,7 +443,7 @@ export const ProjectTree: React.FC<Props> = ({
         `}
         role="grid"
       >
-        <TreeItem showProps isSubItemActive={false} link={link} textWidth={leftSplitWidth - TREE_PADDING} />
+        <TreeItem hasChildren showProps isSubItemActive={false} link={link} textWidth={leftSplitWidth - TREE_PADDING} />
       </span>
     );
   };

--- a/Composer/packages/electron-server/scripts/copy-artifacts.js
+++ b/Composer/packages/electron-server/scripts/copy-artifacts.js
@@ -32,6 +32,7 @@ const sources = [
   {
     source: path.resolve(__dirname, '../../../node_modules/@microsoft/bf-generate-library/templates'),
     dest: 'form-dialog-templates',
+    opts: { force: true },
   },
   // oneauth
   oneauthSource(),


### PR DESCRIPTION
## Description

1. Copy artifacts was not copying the top level files in a given folder.
2. Removes extra spacing for form property names that dont have an icon in the project tree.

## Task Item

#minor
