### PR TITLE
fix: get history always return empty array

### DIFF
--- a/Composer/packages/server/src/controllers/publisher.ts
+++ b/Composer/packages/server/src/controllers/publisher.ts
@@ -172,7 +172,7 @@ export const PublishController = {
 
     if (profile && extensionImplementsMethod(extensionName, 'history')) {
       // get the externally defined method
-      const pluginMethod = ExtensionContext.extensions.publish[extensionName].methods.history;
+      const pluginMethod = ExtensionContext.extensions.publish[extensionName].methods.getHistory;
       if (typeof pluginMethod === 'function') {
         const configuration = {
           profileName: profile.name,

--- a/extensions/pvaPublish/src/node/index.ts
+++ b/extensions/pvaPublish/src/node/index.ts
@@ -9,7 +9,7 @@ function initialize(registration: IExtensionRegistration) {
     name: 'pva-publish-composer',
     description: 'Publish bot to Power Virtual Agents (Preview)',
     bundleId: 'publish',
-    history,
+    getHistory: history,
     getStatus,
     publish,
     pull,


### PR DESCRIPTION
## Description

fix getHistory always return empty array.
reason: the function defined in publishplugin interface is getHistory, not history.
![image](https://user-images.githubusercontent.com/21174180/99804215-9cfe1f80-2b75-11eb-9b9a-4cdc2f621c6f.png)

## Task Item

#minor 
## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
