### PR TITLE
chore: cherry pick get history always return empty array

### DIFF
--- a/Composer/packages/server/src/controllers/publisher.ts
+++ b/Composer/packages/server/src/controllers/publisher.ts
@@ -172,7 +172,7 @@ export const PublishController = {
 
     if (profile && extensionImplementsMethod(extensionName, 'history')) {
       // get the externally defined method
-      const pluginMethod = ExtensionContext.extensions.publish[extensionName].methods.history;
+      const pluginMethod = ExtensionContext.extensions.publish[extensionName].methods.getHistory;
       if (typeof pluginMethod === 'function') {
         const configuration = {
           profileName: profile.name,

--- a/Composer/packages/server/src/controllers/publisher.ts
+++ b/Composer/packages/server/src/controllers/publisher.ts
@@ -37,7 +37,7 @@ export const PublishController = {
             extensionId: plugin.extensionId,
             bundleId: plugin.bundleId,
             features: {
-              history: typeof methods.history === 'function',
+              history: typeof methods.getHistory === 'function',
               publish: typeof methods.publish === 'function',
               status: typeof methods.getStatus === 'function',
               rollback: typeof methods.rollback === 'function',
@@ -170,7 +170,7 @@ export const PublishController = {
     // get the publish plugin key
     const extensionName = profile ? profile.type : '';
 
-    if (profile && extensionImplementsMethod(extensionName, 'history')) {
+    if (profile && extensionImplementsMethod(extensionName, 'getHistory')) {
       // get the externally defined method
       const pluginMethod = ExtensionContext.extensions.publish[extensionName].methods.getHistory;
       if (typeof pluginMethod === 'function') {

--- a/extensions/pvaPublish/src/node/index.ts
+++ b/extensions/pvaPublish/src/node/index.ts
@@ -9,7 +9,7 @@ function initialize(registration: ExtensionRegistration) {
     name: 'pva-publish-composer',
     description: 'Publish bot to Power Virtual Agents (Preview)',
     bundleId: 'publish',
-    history,
+    getHistory: history,
     getStatus,
     publish,
     pull,


### PR DESCRIPTION
## Description

cherry pick get history always return empty array

## Task Item

#minor

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
