### PR TITLE
fix: use URL to select sidebar icons and fix pathname in header

### DIFF
--- a/Composer/packages/client/__tests__/navItem.test.tsx
+++ b/Composer/packages/client/__tests__/navItem.test.tsx
@@ -10,7 +10,7 @@ import { renderWithRecoil } from './testUtils';
 describe('<Header />', () => {
   it('should render a nav item', async () => {
     const { findByText } = renderWithRecoil(
-      <NavItem exact showTooltip disabled={false} iconName={''} labelName={'some nav item'} to={'/'} />
+      <NavItem showTooltip disabled={false} iconName={''} labelName={'some nav item'} to={'/'} />
     );
 
     await findByText(/some nav item/);

--- a/Composer/packages/client/src/components/AppComponents/SideBar.tsx
+++ b/Composer/packages/client/src/components/AppComponents/SideBar.tsx
@@ -92,7 +92,6 @@ export const SideBar = () => {
               <NavItem
                 key={'NavLeftBar' + index}
                 disabled={link.disabled}
-                exact={link.exact}
                 iconName={link.iconName}
                 labelName={link.labelName}
                 match={link.match}
@@ -110,7 +109,6 @@ export const SideBar = () => {
             <NavItem
               key={'NavLeftBar' + index}
               disabled={link.disabled}
-              exact={link.exact}
               iconName={link.iconName}
               labelName={link.labelName}
               showTooltip={showTooltips(link)}

--- a/Composer/packages/client/src/components/Header.tsx
+++ b/Composer/packages/client/src/components/Header.tsx
@@ -147,7 +147,7 @@ export const Header = () => {
   useEffect(() => {
     // hide it on the /home page, but make sure not to hide on /bot/stuff/home in case someone names a dialog "home"
     setStartBotsWidgetVisible(!pathname.endsWith('/home') || pathname.includes('/bot/'));
-  }, [location]);
+  }, [pathname]);
 
   const onUpdateAvailableClick = useCallback(() => {
     setAppUpdateShowing(true);

--- a/Composer/packages/client/src/components/NavItem.tsx
+++ b/Composer/packages/client/src/components/NavItem.tsx
@@ -73,19 +73,17 @@ const icon = (active: boolean, disabled: boolean) =>
 
 /**
  * @param to The string URI to link to. Supports relative and absolute URIs.
- * @param exact The uri is exactly the same as the anchor’s href.
  * @param iconName The link's icon.
  * @param labelName The link's text.
  * @param disabled If true, the Link will be unavailable.
  */
 export interface INavItemProps {
   to: string;
-  exact: boolean;
   iconName: string;
   labelName: string;
   disabled: boolean;
   showTooltip: boolean;
-  match?: string;
+  match?: RegExp;
 }
 
 export const NavItem: React.FC<INavItemProps> = (props) => {
@@ -98,7 +96,7 @@ export const NavItem: React.FC<INavItemProps> = (props) => {
 
   const linkTo = useRouterCache(to);
 
-  const active = pathname.startsWith(to) || !!(match && pathname.indexOf(match) > -1);
+  const active = (pathname.startsWith(to) || match?.test(pathname)) ?? false;
 
   const addRef = useCallback((ref) => onboardingAddCoachMarkRef({ [`nav${labelName.replace(' ', '')}`]: ref }), []);
 

--- a/Composer/packages/client/src/utils/hooks.ts
+++ b/Composer/packages/client/src/utils/hooks.ts
@@ -49,7 +49,7 @@ export const useLinks = () => {
   const designPageLocation = useRecoilValue(designPageLocationState(projectId));
   const pluginPages = useRecoilValue(pluginPagesSelector);
   const schemas = useRecoilValue(schemasState(projectId));
-  const openedDialogId = designPageLocation.dialogId || 'Main';
+  const openedDialogId = designPageLocation.dialogId;
   const showFormDialog = useFeatureFlag('FORM_DIALOG');
 
   const pageLinks = useMemo(() => {

--- a/Composer/packages/client/src/utils/pageLinks.ts
+++ b/Composer/packages/client/src/utils/pageLinks.ts
@@ -25,58 +25,55 @@ export const topLinks = (
       to: '/home',
       iconName: 'Home',
       labelName: formatMessage('Home'),
-      exact: true,
       disabled: false,
     },
     {
       to: linkBase + `dialogs/${openedDialogId}`,
       iconName: 'SplitObject',
       labelName: formatMessage('Design'),
-      exact: false,
       disabled: !botLoaded,
+      match: /(bot\/[0-9.]+)$|(bot\/[0-9.]+\/skill\/[0-9.]+)$/,
     },
     {
       to: linkBase + `language-generation/${openedDialogId}`,
       iconName: 'Robot',
       labelName: formatMessage('Bot Responses'),
-      exact: false,
       disabled: !botLoaded,
+      match: /language-generation\/[a-zA-Z0-9_-]+$/,
     },
     {
       to: linkBase + `language-understanding/${openedDialogId}`,
       iconName: 'People',
       labelName: formatMessage('User Input'),
-      exact: false,
       disabled: !botLoaded,
+      match: /language-understanding\/[a-zA-Z0-9_-]+$/,
     },
     {
       to: linkBase + `knowledge-base/${openedDialogId}`,
       iconName: 'QnAIcon',
       labelName: formatMessage('QnA'),
-      exact: true,
       disabled: !botLoaded,
+      match: /knowledge-base\/[a-zA-Z0-9_-]+$/,
     },
     {
       to: `/bot/${rootProjectId || projectId}/diagnostics`,
       iconName: 'Warning',
       labelName: formatMessage('Diagnostics'),
-      exact: true,
       disabled: !botLoaded,
-      match: 'diagnostics',
+      match: /diagnostics/,
     },
     {
       to: `/bot/${projectId}/publish`,
       iconName: 'CloudUpload',
       labelName: formatMessage('Publish'),
-      exact: true,
       disabled: !botLoaded,
     },
     {
       to: `/bot/${projectId}/botProjectsSettings`,
       iconName: 'BotProjectsSettings',
       labelName: formatMessage('Projects Settings'),
-      exact: true,
       disabled: !botLoaded,
+      match: /botProjectsSettings\/[0-9.]+$/,
     },
     ...(showFormDialog
       ? [
@@ -84,7 +81,6 @@ export const topLinks = (
             to: `/bot/${projectId}/forms`,
             iconName: 'Table',
             labelName: formatMessage('Forms (preview)'),
-            exact: false,
             disabled: !botLoaded,
           },
         ]
@@ -102,7 +98,6 @@ export const topLinks = (
         to: `/bot/${projectId}/plugin/${p.id}/${p.bundleId}`,
         iconName: p.icon ?? 'StatusCircleQuestionMark',
         labelName: p.label,
-        exact: true,
         disabled: !projectId,
       });
     });
@@ -116,7 +111,6 @@ export const bottomLinks = [
     to: `/settings`,
     iconName: 'Settings',
     labelName: formatMessage('Composer Settings'),
-    exact: false,
     disabled: false,
   },
 ];


### PR DESCRIPTION
## Description

This rewrites some of the logic of how we decide which sidebar icon to highlight; detecting that a URL matches its "to" link doesn't work when there's a "skill/<skill ID>" in the way. Instead, this uses some simple regexes to detect the page mode.

This also fixes a minor issue where the "Start Bots" button was showing up in the header on the home screen.

## Task Item

closes #4918

## Screenshots

![image](https://user-images.githubusercontent.com/61990921/99852351-acf60f00-2b35-11eb-9eb1-a0da996bbea7.png)

