### PR TITLE
fix: update E2E tests to use new menu names

### DIFF
--- a/Composer/cypress/integration/LeftNavBar.spec.ts
+++ b/Composer/cypress/integration/LeftNavBar.spec.ts
@@ -14,7 +14,7 @@ context('Left Nav Bar', () => {
     cy.url().should('include', 'language-generation');
     cy.findByTestId('LeftNav-CommandBarButtonUser Input').click();
     cy.url().should('include', 'language-understanding');
-    cy.findByTestId('LeftNav-CommandBarButtonSettings').click();
+    cy.findByTestId('LeftNav-CommandBarButtonComposer Settings').click();
     cy.url().should('include', 'setting');
   });
 });

--- a/Composer/cypress/integration/LuisDeploy.spec.ts
+++ b/Composer/cypress/integration/LuisDeploy.spec.ts
@@ -12,7 +12,7 @@ context('Luis Deploy', () => {
   });
 
   it('can deploy luis success', () => {
-    cy.visitPage('Bot Projects');
+    cy.visitPage('Project Settings');
     cy.findAllByTestId('rootLUISKey').type('12345678', { delay: 200 });
     cy.findAllByTestId('rootLUISRegion').type('westus', { delay: 200 });
     cy.visitPage('User Input');

--- a/Composer/cypress/integration/Onboarding.spec.ts
+++ b/Composer/cypress/integration/Onboarding.spec.ts
@@ -7,7 +7,7 @@ context('Onboarding', () => {
     cy.createBot('TodoSample', 'Onboarding');
     cy.visitPage('Design');
     //enable onboarding setting
-    cy.visitPage('Settings');
+    cy.visitPage('Composer Settings');
     cy.findByTestId('ProjectTree').within(() => {
       cy.findByText('Application Settings').click();
     });

--- a/Composer/packages/client/src/utils/pageLinks.ts
+++ b/Composer/packages/client/src/utils/pageLinks.ts
@@ -74,7 +74,7 @@ export const topLinks = (
     {
       to: `/bot/${projectId}/botProjectsSettings`,
       iconName: 'BotProjectsSettings',
-      labelName: formatMessage('Projects Settings'),
+      labelName: formatMessage('Project Settings'),
       exact: true,
       disabled: !botLoaded,
     },


### PR DESCRIPTION
## Description

We need to make sure our E2E tests get updated when interface names do.

## Task Item

#minor