### PR TITLE
fix: Dialog creation, trigger creation error resolved

### DIFF
--- a/Composer/packages/client/src/components/ProjectTree/ProjectTree.tsx
+++ b/Composer/packages/client/src/components/ProjectTree/ProjectTree.tsx
@@ -224,6 +224,10 @@ export const ProjectTree: React.FC<Props> = ({
 
   const jsonSchemaFilesByProjectId = useRecoilValue(jsonSchemaFilesByProjectIdSelector);
 
+  const createSubtree = useCallback(() => {
+    return projectCollection.map(createBotSubtree);
+  }, [projectCollection]);
+
   if (rootProjectId == null) {
     // this should only happen before a project is loaded in, so it won't last very long
     return <LoadingSpinner />;
@@ -658,7 +662,7 @@ export const ProjectTree: React.FC<Props> = ({
     }
   };
 
-  const projectTree = projectCollection.map(createBotSubtree);
+  const projectTree = createSubtree();
 
   return (
     <div

--- a/Composer/packages/client/src/recoilModel/dispatchers/multilang.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/multilang.ts
@@ -20,6 +20,7 @@ import {
   onDelLanguageDialogCompleteState,
   showDelLanguageModalState,
   botDisplayNameState,
+  qnaFilesState,
 } from './../atoms/botState';
 
 const copyLanguageResources = (files: any[], fromLanguage: string, toLanguages: string[]): any[] => {
@@ -90,12 +91,14 @@ export const multilangDispatcher = () => {
       const { set, snapshot } = callbackHelpers;
       const prevlgFiles = await snapshot.getPromise(lgFilesState(projectId));
       const prevluFiles = await snapshot.getPromise(luFilesState(projectId));
+      const prevQnaFiles = await snapshot.getPromise(qnaFilesState(projectId));
       const prevSettings = await snapshot.getPromise(settingsState(projectId));
       const onAddLanguageDialogComplete = (await snapshot.getPromise(onAddLanguageDialogCompleteState(projectId))).func;
 
       // copy files from default language
       const lgFiles = copyLanguageResources(prevlgFiles, defaultLang, languages);
       const luFiles = copyLanguageResources(prevluFiles, defaultLang, languages);
+      const qnaFiles = copyLanguageResources(prevQnaFiles, defaultLang, languages);
 
       const settings: any = cloneDeep(prevSettings);
       if (Array.isArray(settings.languages)) {
@@ -112,6 +115,8 @@ export const multilangDispatcher = () => {
 
       set(lgFilesState(projectId), [...prevlgFiles, ...lgFiles]);
       set(luFilesState(projectId), [...prevluFiles, ...luFiles]);
+      set(qnaFilesState(projectId), [...prevQnaFiles, ...qnaFiles]);
+
       set(settingsState(projectId), settings);
 
       if (typeof onAddLanguageDialogComplete === 'function') {

--- a/Composer/packages/client/src/shell/useShell.ts
+++ b/Composer/packages/client/src/shell/useShell.ts
@@ -261,10 +261,15 @@ export function useShell(source: EventSource, projectId: string): Shell {
     confirm: OpenConfirmModal,
   };
 
-  const currentDialog = useMemo(() => dialogs.find((d) => d.id === dialogId) ?? stubDialog(), [
-    dialogs,
-    dialogId,
-  ]) as DialogInfo;
+  const currentDialog = useMemo(() => {
+    let result: any = dialogs.find((d) => d.id === dialogId) ?? dialogs.find((dialog) => dialog.isRoot);
+    if (!result) {
+      // Should not hit here as the seed content should atleast be the root dialog if no current dialog
+      result = stubDialog();
+    }
+    return result;
+  }, [dialogs, dialogId]);
+
   const editorData = useMemo(() => {
     return source === 'PropertyEditor'
       ? getDialogData(dialogsMap, dialogId, focused || selected || '')


### PR DESCRIPTION
## Description
Dialog creation uses the currently selected dialog to seed the data for the new dialog. With the new bot project work we can have urls to the bot name and not redirected to the main dialog always. Essentially, this PR makes sure if no dialog is selected we get the seed data from root dialog.

Fixes #4821 