### PR TITLE
fix: make copy, move and paste work for one bot instead of cross bots

### DIFF
--- a/Composer/packages/client/src/components/ProjectTree/ExpandableNode.tsx
+++ b/Composer/packages/client/src/components/ProjectTree/ExpandableNode.tsx
@@ -21,6 +21,8 @@ const summaryStyle = css`
   display: flex;
   padding-left: 12px;
   padding-top: 6px;
+  outline: none;
+  border: none;
 `;
 
 const nodeStyle = (depth: number) => css`

--- a/Composer/packages/client/src/components/ProjectTree/ExpandableNode.tsx
+++ b/Composer/packages/client/src/components/ProjectTree/ExpandableNode.tsx
@@ -21,8 +21,6 @@ const summaryStyle = css`
   display: flex;
   padding-left: 12px;
   padding-top: 6px;
-  outline: none;
-  border: none;
 `;
 
 const nodeStyle = (depth: number) => css`

--- a/Composer/packages/client/src/components/ProjectTree/ProjectTree.tsx
+++ b/Composer/packages/client/src/components/ProjectTree/ProjectTree.tsx
@@ -316,7 +316,7 @@ export const ProjectTree: React.FC<Props> = ({
           {
             label: formatMessage('Settings'),
             onClick: () => {
-              navigateTo(createBotSettingUrl(bot.projectId, link.skillId));
+              navigateTo(createBotSettingUrl(link.projectId, link.skillId));
             },
           },
         ]

--- a/Composer/packages/client/src/recoilModel/atoms/appState.ts
+++ b/Composer/packages/client/src/recoilModel/atoms/appState.ts
@@ -102,7 +102,7 @@ export const onboardingState = atom<{
   },
 });
 
-export const clipboardActionsState = atom<any[]>({
+export const clipboardActionsState = atomFamily<any[], string>({
   key: getFullyQualifiedKey('clipboardActions'),
   default: [],
 });

--- a/Composer/packages/client/src/recoilModel/dispatchers/__tests__/editor.test.tsx
+++ b/Composer/packages/client/src/recoilModel/dispatchers/__tests__/editor.test.tsx
@@ -15,7 +15,7 @@ describe('Editor dispatcher', () => {
   beforeEach(() => {
     const useRecoilTestHook = () => {
       const [visualEditorState, setVisualEditorState] = useRecoilState(visualEditorSelectionState);
-      const [clipboardState, setClipboardActionsState] = useRecoilState(clipboardActionsState);
+      const [clipboardState, setClipboardActionsState] = useRecoilState(clipboardActionsState('test'));
       const currentDispatcher = useRecoilValue(dispatcherState);
 
       return {
@@ -30,7 +30,7 @@ describe('Editor dispatcher', () => {
     const { result } = renderRecoilHook(useRecoilTestHook, {
       states: [
         { recoilState: visualEditorSelectionState, initialValue: [{ action1: 'initialVisualEditorValue' }] },
-        { recoilState: clipboardActionsState, initialValue: [{ action1: 'initialClipboardVal' }] },
+        { recoilState: clipboardActionsState('test'), initialValue: [{ action1: 'initialClipboardVal' }] },
       ],
       dispatcher: {
         recoilState: dispatcherState,
@@ -45,7 +45,7 @@ describe('Editor dispatcher', () => {
 
   it('should set clipboard state correctly', () => {
     act(() => {
-      dispatcher.setVisualEditorClipboard([{ action2: 'updatedVal' }]);
+      dispatcher.setVisualEditorClipboard([{ action2: 'updatedVal' }], 'test');
     });
     expect(renderedComponent.current.clipboardState).toEqual([{ action2: 'updatedVal' }]);
   });

--- a/Composer/packages/client/src/recoilModel/dispatchers/editor.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/editor.ts
@@ -7,9 +7,11 @@ import { CallbackInterface, useRecoilCallback } from 'recoil';
 import { clipboardActionsState, visualEditorSelectionState } from '../atoms/appState';
 
 export const editorDispatcher = () => {
-  const setVisualEditorClipboard = useRecoilCallback(({ set }: CallbackInterface) => (clipboardActions: any[]) => {
-    set(clipboardActionsState, [...clipboardActions]);
-  });
+  const setVisualEditorClipboard = useRecoilCallback(
+    ({ set }: CallbackInterface) => (clipboardActions: any[], projectId: string) => {
+      set(clipboardActionsState(projectId), [...clipboardActions]);
+    }
+  );
 
   const setVisualEditorSelection = useRecoilCallback(({ set }: CallbackInterface) => (selection: string[]) => {
     set(visualEditorSelectionState, [...selection]);

--- a/Composer/packages/client/src/shell/useShell.ts
+++ b/Composer/packages/client/src/shell/useShell.ts
@@ -94,7 +94,7 @@ export function useShell(source: EventSource, projectId: string): Shell {
   const isRootBot = rootBotProjectId === projectId;
 
   const userSettings = useRecoilValue(userSettingsState);
-  const clipboardActions = useRecoilValue(clipboardActionsState);
+  const clipboardActions = useRecoilValue(clipboardActionsState(projectId));
   const featureFlags = useRecoilValue(featureFlagsState);
   const {
     updateDialog,
@@ -221,7 +221,7 @@ export function useShell(source: EventSource, projectId: string): Shell {
     onFocusEvent: focusEvent,
     onFocusSteps: focusSteps,
     onSelect: setVisualEditorSelection,
-    onCopy: setVisualEditorClipboard,
+    onCopy: (clipboardActions) => setVisualEditorClipboard(clipboardActions, projectId),
     createDialog: (actionsSeed) => {
       return new Promise((resolve) => {
         createDialogBegin(


### PR DESCRIPTION
## Description
1. make the copy move and paste work for just in bot.
2. update the setting link in context menu

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
closes #4921 


<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots
![copy](https://user-images.githubusercontent.com/39758135/99933618-90a4dd00-2d96-11eb-902e-42c5a2078535.gif)
<!---
Please include screenshots or gifs if your PR include UX changes.
--->
