### PR TITLE
fix: the board in project tree on the ellipsis is taller

### DIFF
--- a/Composer/packages/client/src/components/ProjectTree/ExpandableNode.tsx
+++ b/Composer/packages/client/src/components/ProjectTree/ExpandableNode.tsx
@@ -24,6 +24,7 @@ const summaryStyle = css`
 `;
 
 const nodeStyle = (depth: number) => css`
+  margin-top: 2px;
   margin-left: ${depth * INDENT_PER_LEVEL}px;
 `;
 

--- a/Composer/packages/client/src/components/ProjectTree/treeItem.tsx
+++ b/Composer/packages/client/src/components/ProjectTree/treeItem.tsx
@@ -141,7 +141,7 @@ export const diagnosticLink = css`
 
 export const overflowSet = (isBroken: boolean) => css`
   width: 100%;
-  height: 100%;
+  height: 24px;
   box-sizing: border-box;
   line-height: 24px;
   justify-content: space-between;
@@ -149,8 +149,13 @@ export const overflowSet = (isBroken: boolean) => css`
   i {
     color: ${isBroken ? SharedColors.red20 : 'inherit'};
   }
-  margin-top: 2px;
 `;
+
+const moreButtonContainer = {
+  root: {
+    lineHeight: '1',
+  },
+};
 
 const statusIcon = {
   fontSize: 15,
@@ -398,7 +403,7 @@ const onRenderOverflowButton = (
   return (overflowItems: IContextualMenuItem[] | undefined) => {
     if (overflowItems == null) return null;
     return (
-      <TooltipHost content={moreLabel} directionalHint={DirectionalHint.rightCenter}>
+      <TooltipHost content={moreLabel} directionalHint={DirectionalHint.rightCenter} styles={moreButtonContainer}>
         <IconButton
           ariaLabel={moreLabel}
           className="dialog-more-btn"

--- a/Composer/packages/client/src/components/ProjectTree/treeItem.tsx
+++ b/Composer/packages/client/src/components/ProjectTree/treeItem.tsx
@@ -141,7 +141,7 @@ export const diagnosticLink = css`
 
 export const overflowSet = (isBroken: boolean) => css`
   width: 100%;
-  height: 24px;
+  height: 100%;
   box-sizing: border-box;
   line-height: 24px;
   justify-content: space-between;


### PR DESCRIPTION
## Description
The line-height from parent make the component height bigger than the container.

![image](https://user-images.githubusercontent.com/39758135/99941388-e97d7100-2da8-11eb-95fa-6cecbd27659b.png)

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
#minor
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
