### PR TITLE
fix: scrolling issue in propertyeditor

### DIFF
--- a/Composer/packages/client/src/pages/design/styles.ts
+++ b/Composer/packages/client/src/pages/design/styles.ts
@@ -64,8 +64,8 @@ export const assetTree = css`
 export const editorContainer = css`
   display: flex;
   flex-direction: column;
-  height: 100%;
-  flex-grow: 4;
+  height: 0;
+  flex-grow: 1;
 `;
 
 export const editorWrapper = css`


### PR DESCRIPTION
## Description
let flex box to calculate the height by itself
![scroll](https://user-images.githubusercontent.com/39758135/100075434-e488f200-2e7a-11eb-9f13-82e4cdc6dca2.gif)

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
closes #4949
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
