### PR TITLE
fix:  missing cross train config

### DIFF
--- a/Composer/packages/server/src/models/bot/botProject.ts
+++ b/Composer/packages/server/src/models/bot/botProject.ts
@@ -481,7 +481,7 @@ export class BotProject implements IBotProject {
       luResource.forEach(({ id, isEmpty }) => {
         const fileName = `${id}.lu`;
         const f = this.files.get(fileName);
-        if (f && !isEmpty) {
+        if (f) {
           luFiles.push(f);
         }
       });

--- a/Composer/packages/server/src/models/bot/builder.ts
+++ b/Composer/packages/server/src/models/bot/builder.ts
@@ -25,7 +25,7 @@ const GENERATEDFOLDER = 'generated';
 const SETTINGS = 'settings';
 const INTERRUPTION = 'interruption';
 const SAMPLE_SIZE_CONFIGURATION = 2;
-const CrossTrainConfigName = 'cross-train.config';
+const CrossTrainConfigName = 'cross-train.config.json';
 
 export type SingleConfig = {
   rootDialog: boolean;


### PR DESCRIPTION
## Description

 

- The cross train config is from the settings/cross-train.config.json, but sever use wrong config name(cross-train.config), so crossTrain get the empty config content.

 

- CrossTain config contains the empty lu files, but sever filters the empty files. crosstrain api will throw error when no lu file find.

In this PR:
1. use the correct config file name.
2. don't filer the empty lu files. (The bf-lu will filter the empty files and the empty lu file will never generate the orcherator recognizer files)

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
closes #4960
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
