### PR TITLE
chore: cherry pick #4961 to v1.2.2

### DIFF
--- a/Composer/packages/server/src/models/bot/builder.ts
+++ b/Composer/packages/server/src/models/bot/builder.ts
@@ -21,7 +21,7 @@ const GENERATEDFOLDER = 'generated';
 const SETTINGS = 'settings';
 const INTERRUPTION = 'interruption';
 const SAMPLE_SIZE_CONFIGURATION = 2;
-const CrossTrainConfigName = 'cross-train.config';
+const CrossTrainConfigName = 'cross-train.config.json';
 
 export type SingleConfig = {
   rootDialog: boolean;


### PR DESCRIPTION
## Description
- The cross train config is from the settings/cross-train.config.json, but sever use wrong config name(cross-train.config), so crossTrain get the empty config content.

In this PR:
1. use the correct config file name.

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
refs #4961
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
