### PR TITLE
fix: the parameter lufile name is not correct when removing lu intent

### DIFF
--- a/Composer/packages/client/src/recoilModel/dispatchers/lu.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/lu.ts
@@ -261,7 +261,6 @@ export const luDispatcher = () => {
       const { set, snapshot } = callbackHelpers;
       const luFiles = await snapshot.getPromise(luFilesState(projectId));
       const { luFeatures } = await snapshot.getPromise(settingsState(projectId));
-
       const file = luFiles.find((temp) => temp.id === id);
       if (!file) return luFiles;
       try {

--- a/Composer/packages/client/src/recoilModel/dispatchers/lu.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/lu.ts
@@ -261,6 +261,7 @@ export const luDispatcher = () => {
       const { set, snapshot } = callbackHelpers;
       const luFiles = await snapshot.getPromise(luFilesState(projectId));
       const { luFeatures } = await snapshot.getPromise(settingsState(projectId));
+
       const file = luFiles.find((temp) => temp.id === id);
       if (!file) return luFiles;
       try {


### PR DESCRIPTION
## Description
Delete dialog will also delete lu file. Then luis key is not needed. This works as expected. But delete trigger, if the referred intent is the last one in the lu file. Then luis key is not needed either. The bug is: lu file name missing locale.

## Task Item
Closes #4950 
## Screenshots
![trigger](https://user-images.githubusercontent.com/24380525/100097240-6c7cf500-2e97-11eb-910d-8f94479972c8.gif)
