### PR TITLE
fix: Remove LUIS key error if LUIS not used

### DIFF
--- a/Composer/packages/lib/indexers/src/botIndexer.ts
+++ b/Composer/packages/lib/indexers/src/botIndexer.ts
@@ -60,7 +60,7 @@ const checkSetting = (assets: {
       luFiles
         .filter(({ id }) => getBaseName(id) === luFileId)
         .forEach((item) => {
-          if (!item.empty && (dialogItem.luProvider !== undefined || dialogItem.luProvider === SDKKinds.LuisRecognizer))
+          if (!item.empty && (dialogItem.luProvider === undefined || dialogItem.luProvider === SDKKinds.LuisRecognizer))
             useLUIS = true;
         });
     }


### PR DESCRIPTION
## Description
This is a fix to fix #4971 - there was a mistake in LU check.  Was meant to say if `luProvider` is undefined or `luProvider` is LUIS, then this dialog is using LUIS.

## Task Item
closes #4953
