### PR TITLE
fix: Memory leak & UI adjust for publish page

### DIFF
--- a/Composer/packages/client/src/pages/publish/Publish.tsx
+++ b/Composer/packages/client/src/pages/publish/Publish.tsx
@@ -230,18 +230,6 @@ const Publish: React.FC<RouteComponentProps<{ projectId: string; targetName?: st
     setBotStatusList(statusList);
   }, [botProjectData.length]);
 
-  useEffect(() => {
-    setSelectedBots(
-      selectedBots.map((selectedBot) => {
-        const bot = botStatusList.find((botStatus) => botStatus.id === selectedBot.id);
-        if (bot) {
-          selectedBot = { ...bot, comment: '', message: '', status: undefined, time: '' };
-        }
-        return selectedBot;
-      })
-    );
-  }, [botStatusList]);
-
   const rollbackToVersion = (version: IStatus, item: IBotStatus) => {
     const setting = botSettingList.find((botSetting) => botSetting.projectId === item.id)?.setting;
     const selectedTarget = item.publishTargets?.find((target) => target.name === item.publishTarget);
@@ -351,6 +339,15 @@ const Publish: React.FC<RouteComponentProps<{ projectId: string; targetName?: st
       return botStatus;
     });
     setBotStatusList(newBotStatusItems);
+    setSelectedBots(
+      selectedBots.map((selectedBot) => {
+        const bot = newBotStatusItems.find((botStatus) => botStatus.id === selectedBot.id);
+        if (bot) {
+          selectedBot = { ...bot, comment: '', message: '', status: undefined, time: '' };
+        }
+        return selectedBot;
+      })
+    );
   };
 
   return (

--- a/Composer/packages/client/src/pages/publish/PublishDialog.tsx
+++ b/Composer/packages/client/src/pages/publish/PublishDialog.tsx
@@ -23,9 +23,7 @@ export const PublishDialog = (props) => {
       fieldName: 'name',
       minWidth: 70,
       maxWidth: 90,
-      isResizable: true,
       isMultiline: true,
-      isCollapsible: true,
       data: 'string',
       onRender: (item: IBotStatus) => {
         return <span>{item.name}</span>;
@@ -39,9 +37,7 @@ export const PublishDialog = (props) => {
       fieldName: 'publishTarget',
       minWidth: 70,
       maxWidth: 90,
-      isResizable: true,
       isMultiline: true,
-      isCollapsible: true,
       data: 'string',
       onRender: (item: IBotStatus) => {
         return <span>{item.publishTarget}</span>;

--- a/Composer/packages/client/src/pages/publish/PublishDialog.tsx
+++ b/Composer/packages/client/src/pages/publish/PublishDialog.tsx
@@ -23,9 +23,12 @@ export const PublishDialog = (props) => {
       fieldName: 'name',
       minWidth: 70,
       maxWidth: 90,
+      isResizable: true,
+      isMultiline: true,
+      isCollapsible: true,
       data: 'string',
       onRender: (item: IBotStatus) => {
-        return <div css={{ alignItems: 'center', display: 'flex', height: '32px' }}>{item.name}</div>;
+        return <span>{item.name}</span>;
       },
       isPadded: true,
     },
@@ -36,21 +39,12 @@ export const PublishDialog = (props) => {
       fieldName: 'publishTarget',
       minWidth: 70,
       maxWidth: 90,
+      isResizable: true,
+      isMultiline: true,
+      isCollapsible: true,
       data: 'string',
       onRender: (item: IBotStatus) => {
-        return (
-          <div
-            css={{
-              backgroundColor: '#DDF3DB',
-              alignItems: 'center',
-              display: 'flex',
-              height: '32px',
-              paddingLeft: '8px',
-            }}
-          >
-            {item.publishTarget}
-          </div>
-        );
+        return <span>{item.publishTarget}</span>;
       },
       isPadded: true,
     },
@@ -111,7 +105,12 @@ export const PublishDialog = (props) => {
       }}
     >
       <Fragment>
-        <DetailsList checkboxVisibility={CheckboxVisibility.hidden} columns={columns} items={showItems} />
+        <DetailsList
+          styles={{ root: { selectors: { '.ms-DetailsRow-fields': { display: 'flex', alignItems: 'center' } } } }}
+          checkboxVisibility={CheckboxVisibility.hidden}
+          columns={columns}
+          items={showItems}
+        />
 
         <DialogFooter>
           <DefaultButton

--- a/Composer/packages/client/src/pages/publish/PublishDialog.tsx
+++ b/Composer/packages/client/src/pages/publish/PublishDialog.tsx
@@ -106,10 +106,10 @@ export const PublishDialog = (props) => {
     >
       <Fragment>
         <DetailsList
-          styles={{ root: { selectors: { '.ms-DetailsRow-fields': { display: 'flex', alignItems: 'center' } } } }}
           checkboxVisibility={CheckboxVisibility.hidden}
           columns={columns}
           items={showItems}
+          styles={{ root: { selectors: { '.ms-DetailsRow-fields': { display: 'flex', alignItems: 'center' } } } }}
         />
 
         <DialogFooter>


### PR DESCRIPTION
## Description

- fix memory leak 
- delete backgroud color for publish dialog

## Task Item

#minor 

## Screenshots

![image](https://user-images.githubusercontent.com/5860999/100206594-83782180-2f41-11eb-94a8-6dad18a6286f.png)
