### PR TITLE
fix: click show skill manifest no response in form editor

### DIFF
--- a/Composer/packages/client/src/components/Modal/DisplayManifestModal.tsx
+++ b/Composer/packages/client/src/components/Modal/DisplayManifestModal.tsx
@@ -67,7 +67,6 @@ export const DisplayManifestModal: React.FC<DisplayManifestModalProps> = ({
   const userSettings = useRecoilValue(userSettingsState);
   useEffect(() => onDismiss, []);
 
-  console.log();
   const selectedSkill = useMemo(() => {
     if (skillNameIdentifier) {
       return skills[skillNameIdentifier];

--- a/Composer/packages/client/src/components/Modal/DisplayManifestModal.tsx
+++ b/Composer/packages/client/src/components/Modal/DisplayManifestModal.tsx
@@ -16,7 +16,7 @@ import { IDialogContentStyles } from 'office-ui-fabric-react/lib/Dialog';
 import { IModalStyles } from 'office-ui-fabric-react/lib/Modal';
 import { useRecoilValue } from 'recoil';
 
-import { skillNameIdentifierByProjectIdSelector, skillsStateSelector, userSettingsState } from '../../recoilModel';
+import { skillsStateSelector, userSettingsState } from '../../recoilModel';
 
 // -------------------- Styles -------------------- //
 
@@ -53,23 +53,21 @@ const dragOptions: IDragOptions = {
 interface DisplayManifestModalProps {
   isDraggable?: boolean;
   isModeless?: boolean;
-  skillNameIdentifier?: string | null;
+  skillNameIdentifier: string;
   onDismiss: () => void;
-  projectId: string;
 }
 
 export const DisplayManifestModal: React.FC<DisplayManifestModalProps> = ({
   isDraggable = true,
   isModeless = true,
-  projectId,
+  skillNameIdentifier,
   onDismiss,
 }) => {
   const skills = useRecoilValue(skillsStateSelector);
   const userSettings = useRecoilValue(userSettingsState);
-  const skillsByProjectId = useRecoilValue(skillNameIdentifierByProjectIdSelector);
-  const skillNameIdentifier = skillsByProjectId[projectId];
   useEffect(() => onDismiss, []);
 
+  console.log();
   const selectedSkill = useMemo(() => {
     if (skillNameIdentifier) {
       return skills[skillNameIdentifier];

--- a/Composer/packages/client/src/pages/design/DesignPage.tsx
+++ b/Composer/packages/client/src/pages/design/DesignPage.tsx
@@ -44,7 +44,7 @@ import {
   skillNameIdentifierByProjectIdSelector,
   SkillInfo,
   projectMetaDataState,
-  displayManifestModalOnProjectIdSelector,
+  displaySkillManifestState,
 } from '../../recoilModel';
 import { CreateQnAModal } from '../../components/QnA';
 import { triggerNotSupported } from '../../utils/dialogValidator';
@@ -133,7 +133,7 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
   const schemas = useRecoilValue(schemasState(skillId ?? projectId));
   const dialogs = useRecoilValue(validateDialogsSelectorFamily(skillId ?? projectId));
   const skills = useRecoilValue(skillsStateSelector);
-  const displaySkillManifestOnProjectId = useRecoilValue(displayManifestModalOnProjectIdSelector);
+  const displaySkillManifestNameIdentifier = useRecoilValue(displaySkillManifestState);
   const skillsByProjectId = useRecoilValue(skillNameIdentifierByProjectIdSelector);
   const projectDialogsMap = useRecoilValue(projectDialogsMapSelector);
   const { startSingleBot, stopSingleBot } = useBotOperations();
@@ -697,7 +697,7 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
 
     const skillNameIdentifier = skillsByProjectId[skillId];
     if (!skillNameIdentifier) return;
-    displayManifestModal(skillNameIdentifier, skillId);
+    displayManifestModal(skillNameIdentifier);
   };
 
   const handleErrorClick = (projectId: string, skillId: string, diagnostic: Diagnostic) => {
@@ -864,10 +864,10 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
           onSubmit={handleCreateQnA}
         />
 
-        {displaySkillManifestOnProjectId && (
+        {displaySkillManifestNameIdentifier && (
           <DisplayManifestModal
-            projectId={displaySkillManifestOnProjectId}
-            onDismiss={() => dismissManifestModal(displaySkillManifestOnProjectId)}
+            skillNameIdentifier={displaySkillManifestNameIdentifier}
+            onDismiss={() => dismissManifestModal()}
           />
         )}
         {brokenSkillInfo && (

--- a/Composer/packages/client/src/recoilModel/atoms/appState.ts
+++ b/Composer/packages/client/src/recoilModel/atoms/appState.ts
@@ -264,3 +264,8 @@ export const exportSkillModalInfoState = atom<undefined | string>({
   key: getFullyQualifiedKey('exportSkillModalInfo'),
   default: undefined,
 });
+
+export const displaySkillManifestState = atom<undefined | string>({
+  key: getFullyQualifiedKey('displaySkillManifest'),
+  default: undefined,
+});

--- a/Composer/packages/client/src/recoilModel/atoms/botState.ts
+++ b/Composer/packages/client/src/recoilModel/atoms/botState.ts
@@ -19,7 +19,7 @@ import {
   RecognizerFile,
   Skill,
 } from '@bfc/shared';
-import { atomFamily } from 'recoil';
+import { atom, atomFamily } from 'recoil';
 
 import { BotRuntimeError, DesignPageLocation } from '../../recoilModel/types';
 import FilePersistence from '../persistence/FilePersistence';
@@ -226,9 +226,9 @@ export const onAddSkillDialogCompleteState = atomFamily<any, string>({
   default: { func: undefined },
 });
 
-export const displaySkillManifestState = atomFamily<any, string>({
+export const displaySkillManifestState = atom({
   key: getFullyQualifiedKey('displaySkillManifest'),
-  default: undefined,
+  default: '',
 });
 
 export const showAddLanguageModalState = atomFamily<boolean, string>({

--- a/Composer/packages/client/src/recoilModel/atoms/botState.ts
+++ b/Composer/packages/client/src/recoilModel/atoms/botState.ts
@@ -19,7 +19,7 @@ import {
   RecognizerFile,
   Skill,
 } from '@bfc/shared';
-import { atom, atomFamily } from 'recoil';
+import { atomFamily } from 'recoil';
 
 import { BotRuntimeError, DesignPageLocation } from '../../recoilModel/types';
 import FilePersistence from '../persistence/FilePersistence';
@@ -224,11 +224,6 @@ export const focusPathState = atomFamily<string, string>({
 export const onAddSkillDialogCompleteState = atomFamily<any, string>({
   key: getFullyQualifiedKey('onAddSkillDialogComplete'),
   default: { func: undefined },
-});
-
-export const displaySkillManifestState = atom({
-  key: getFullyQualifiedKey('displaySkillManifest'),
-  default: '',
 });
 
 export const showAddLanguageModalState = atomFamily<boolean, string>({

--- a/Composer/packages/client/src/recoilModel/dispatchers/__tests__/skill.test.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/__tests__/skill.test.ts
@@ -71,7 +71,7 @@ describe('skill dispatcher', () => {
       const onAddSkillDialogComplete = useRecoilValue(onAddSkillDialogCompleteState(projectId));
       const settings = useRecoilValue(settingsState(projectId));
       const showAddSkillDialogModal = useRecoilValue(showAddSkillDialogModalState(projectId));
-      const displaySkillManifest = useRecoilValue(displaySkillManifestState(projectId));
+      const displaySkillManifest = useRecoilValue(displaySkillManifestState);
       const skills = useRecoilValue(skillsStateSelector);
       const [botEndpoints, setBotEndpoints] = useRecoilState(botEndpointsState);
       const currentDispatcher = useRecoilValue(dispatcherState);
@@ -111,7 +111,7 @@ describe('skill dispatcher', () => {
         { recoilState: onAddSkillDialogCompleteState(projectId), initialValue: { func: undefined } },
         { recoilState: settingsState(projectId), initialValue: {} },
         { recoilState: showAddSkillDialogModalState(projectId), initialValue: false },
-        { recoilState: displaySkillManifestState(projectId), initialValue: undefined },
+        { recoilState: displaySkillManifestState, initialValue: '' },
         { recoilState: currentProjectIdState, initialValue: projectId },
         { recoilState: botProjectIdsState, initialValue: [projectId, ...skillIds] },
         { recoilState: settingsState(projectId), initialValue: {} },
@@ -171,14 +171,14 @@ describe('skill dispatcher', () => {
 
   it('displayManifestModal', async () => {
     await act(async () => {
-      dispatcher.displayManifestModal('foo', projectId);
+      dispatcher.displayManifestModal('foo');
     });
     expect(renderedComponent.current.displaySkillManifest).toEqual('foo');
   });
 
   it('dismissManifestModal', async () => {
     await act(async () => {
-      dispatcher.dismissManifestModal(projectId);
+      dispatcher.dismissManifestModal();
     });
     expect(renderedComponent.current.displaySkillManifest).toBeUndefined();
   });

--- a/Composer/packages/client/src/recoilModel/dispatchers/__tests__/skill.test.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/__tests__/skill.test.ts
@@ -12,7 +12,6 @@ import {
   onAddSkillDialogCompleteState,
   settingsState,
   showAddSkillDialogModalState,
-  displaySkillManifestState,
   botProjectFileState,
   botNameIdentifierState,
   locationState,
@@ -20,7 +19,7 @@ import {
   botDisplayNameState,
 } from '../../atoms/botState';
 import { dispatcherState } from '../../DispatcherWrapper';
-import { botEndpointsState, botProjectIdsState, currentProjectIdState } from '../../atoms';
+import { botEndpointsState, botProjectIdsState, currentProjectIdState, displaySkillManifestState } from '../../atoms';
 import { Dispatcher } from '..';
 import { skillsStateSelector } from '../../selectors';
 
@@ -111,7 +110,7 @@ describe('skill dispatcher', () => {
         { recoilState: onAddSkillDialogCompleteState(projectId), initialValue: { func: undefined } },
         { recoilState: settingsState(projectId), initialValue: {} },
         { recoilState: showAddSkillDialogModalState(projectId), initialValue: false },
-        { recoilState: displaySkillManifestState, initialValue: '' },
+        { recoilState: displaySkillManifestState, initialValue: undefined },
         { recoilState: currentProjectIdState, initialValue: projectId },
         { recoilState: botProjectIdsState, initialValue: [projectId, ...skillIds] },
         { recoilState: settingsState(projectId), initialValue: {} },

--- a/Composer/packages/client/src/recoilModel/dispatchers/skill.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/skill.ts
@@ -108,7 +108,7 @@ export const skillDispatcher = () => {
   });
 
   const dismissManifestModal = useRecoilCallback(({ set }: CallbackInterface) => () => {
-    set(displaySkillManifestState, '');
+    set(displaySkillManifestState, undefined);
   });
 
   return {

--- a/Composer/packages/client/src/recoilModel/dispatchers/skill.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/skill.ts
@@ -103,12 +103,12 @@ export const skillDispatcher = () => {
     }
   );
 
-  const displayManifestModal = useRecoilCallback(({ set }: CallbackInterface) => (id: string, projectId: string) => {
-    set(displaySkillManifestState(projectId), id);
+  const displayManifestModal = useRecoilCallback(({ set }: CallbackInterface) => (id: string) => {
+    set(displaySkillManifestState, id);
   });
 
-  const dismissManifestModal = useRecoilCallback(({ set }: CallbackInterface) => (projectId: string) => {
-    set(displaySkillManifestState(projectId), undefined);
+  const dismissManifestModal = useRecoilCallback(({ set }: CallbackInterface) => () => {
+    set(displaySkillManifestState, '');
   });
 
   return {

--- a/Composer/packages/client/src/recoilModel/selectors/skills.ts
+++ b/Composer/packages/client/src/recoilModel/selectors/skills.ts
@@ -12,7 +12,6 @@ import {
   projectMetaDataState,
   locationState,
   botProjectIdsState,
-  displaySkillManifestState,
 } from '../atoms';
 
 export const skillsProjectIdSelector = selector({
@@ -78,17 +77,5 @@ export const skillNameIdentifierByProjectIdSelector = selector({
       return result;
     }, {});
     return skills;
-  },
-});
-
-// Display manifest modal if return is projectId
-export const displayManifestModalOnProjectIdSelector = selector({
-  key: 'displayManifestModalOnProjectIdSelector',
-  get: ({ get }) => {
-    const botProjects = get(botProjectIdsState);
-    const displaySkillManifestOnProjects = botProjects.filter((projectId) => {
-      return get(displaySkillManifestState(projectId));
-    });
-    return displaySkillManifestOnProjects[0];
   },
 });

--- a/Composer/packages/client/src/shell/useShell.ts
+++ b/Composer/packages/client/src/shell/useShell.ts
@@ -236,7 +236,7 @@ export function useShell(source: EventSource, projectId: string): Shell {
     undo,
     redo,
     commitChanges,
-    displayManifestModal: (skillId) => displayManifestModal(skillId, projectId),
+    displayManifestModal: (skillId) => displayManifestModal(skillId),
     isFeatureEnabled: (featureFlagKey: FeatureFlagKey): boolean => featureFlags?.[featureFlagKey]?.enabled ?? false,
     updateDialogSchema: async (dialogSchema: DialogSchemaFile) => {
       updateDialogSchema(dialogSchema, projectId);


### PR DESCRIPTION
## Description

Current `displaySkillManifestState` is a atomFamily `{ projectId: skillINameIdentify }`
but skill is shared cross current workspace, by projectId only increases difficulty to locate this state, for example, the shell api call from form editor only have `skillNameIdentify`, do not know this skill is on which projectId. 

By update it to a single atom `string` state, caller do not need pass `projectId`. 

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item

#minor

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots
<img width="464" alt="image" src="https://user-images.githubusercontent.com/49866537/100197157-e616f080-2f34-11eb-9509-cfd64b6ba5ee.png">

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
