### PR TITLE
fix: publish url on left navigation list

### DIFF
--- a/Composer/packages/client/src/utils/pageLinks.ts
+++ b/Composer/packages/client/src/utils/pageLinks.ts
@@ -63,7 +63,7 @@ export const topLinks = (
       match: /diagnostics/,
     },
     {
-      to: `/bot/${projectId}/publish`,
+      to: `/bot/${rootProjectId || projectId}/publish`,
       iconName: 'CloudUpload',
       labelName: formatMessage('Publish'),
       disabled: !botLoaded,


### PR DESCRIPTION
## Description

publish page link on left navigation list is not correct.
## Task Item
Closes #4982
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
