### PR TITLE
fix: make sure LGOption has the correct LG file id in LGField

### DIFF
--- a/Composer/packages/ui-plugins/lg/src/LgField.tsx
+++ b/Composer/packages/ui-plugins/lg/src/LgField.tsx
@@ -45,7 +45,12 @@ const LgField: React.FC<FieldProps<string>> = (props) => {
 
   const lgTemplateRef = LgTemplateRef.parse(value);
   const lgName = lgTemplateRef ? lgTemplateRef.name : new LgMetaData(lgType, designerId || '').toString();
-  const lgFileId = `${currentDialog.lgFile}.${locale}`;
+
+  const relatedLgFile = lgFiles.find(
+    (file) => file.templates.find((template) => template.name === lgName) !== undefined
+  );
+
+  const lgFileId = relatedLgFile ? relatedLgFile.id : `${currentDialog.lgFile}.${locale}`;
   const lgFile = lgFiles && lgFiles.find((file) => file.id === lgFileId);
 
   const updateLgTemplate = useCallback(


### PR DESCRIPTION
closes #4955 
In generative dialog, the lg file in the dialog only contains some import statements. 
The issues is caused by LGOption contains the wrong file id. Once it is passed to language server, it will throw unexpected duplicated definition error. Also, it will also make the sendResponse node uneditable.

To fix this, we need add a lookup function to find out the correct lg file id which contains current template id.

After the fix, the error will disappear and the body is editable.
![image](https://user-images.githubusercontent.com/17074777/100251721-0a48f080-2f7a-11eb-8737-62f04ea40797.png)

