### PR TITLE
chore: cherry pick #4997 to v1.2.2

### DIFF
--- a/Composer/packages/client/src/recoilModel/dispatchers/__tests__/lg.test.tsx
+++ b/Composer/packages/client/src/recoilModel/dispatchers/__tests__/lg.test.tsx
@@ -38,7 +38,7 @@ jest.mock('../../parsers/lgWorker', () => {
 });
 const lgFiles = [
   {
-    id: 'common.en-us',
+    id: 'a.en-us',
     content: `\r\n# Hello\r\n-hi`,
     templates: [{ name: 'Hello', body: '-hi', parameters: [] }],
     diagnostics: [],
@@ -87,7 +87,7 @@ describe('Lg dispatcher', () => {
   it('should create a lg template', async () => {
     await act(async () => {
       await dispatcher.createLgTemplate({
-        id: 'common.en-us',
+        id: 'a.en-us',
         template: getLgTemplate('Test', '-add'),
         projectId,
       });
@@ -98,7 +98,7 @@ describe('Lg dispatcher', () => {
 
   it('should update a lg file', async () => {
     await act(async () => {
-      await dispatcher.updateLgFile({ id: 'common.en-us', content: `test`, projectId });
+      await dispatcher.updateLgFile({ id: 'a.en-us', content: `test`, projectId });
     });
 
     expect(renderedComponent.current.lgFiles[0].content).toBe(`test`);
@@ -107,7 +107,7 @@ describe('Lg dispatcher', () => {
   it('should update a lg template', async () => {
     await act(async () => {
       await dispatcher.updateLgTemplate({
-        id: 'common.en-us',
+        id: 'a.en-us',
         templateName: 'Hello',
         template: getLgTemplate('Hello', '-TemplateValue'),
         projectId,
@@ -120,7 +120,7 @@ describe('Lg dispatcher', () => {
   it('should remove a lg template', async () => {
     await act(async () => {
       await dispatcher.removeLgTemplate({
-        id: 'common.en-us',
+        id: 'a.en-us',
         templateName: 'Hello',
         projectId,
       });
@@ -132,7 +132,7 @@ describe('Lg dispatcher', () => {
   it('should remove lg templates', async () => {
     await act(async () => {
       await dispatcher.removeLgTemplates({
-        id: 'common.en-us',
+        id: 'a.en-us',
         templateNames: ['Hello'],
         projectId,
       });


### PR DESCRIPTION
## Description

Bug introduced in #4669, root caused is a long time LG parsing. when editing common.lg, all LG files in this bot will be parse again. when the bot has many lgFiles or some of them is large. The time of re-parsing them could be seconds.
at this moment, if go to another page, composer is reading a middle state, which cause a mangled editing version in LG Editor.

Fix it by split re-parse all to another async thread.

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
refs #4997
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
