### PR TITLE
fix: skill bot path bug

### DIFF
--- a/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
@@ -85,6 +85,7 @@ import { setRootBotSettingState } from '../setting';
 
 import { crossTrainConfigState } from './../../atoms/botState';
 import { recognizersSelectorFamily } from './../../selectors/recognizers';
+import { getAbsolutePath } from '../../../utils/fileUtil';
 
 export const resetBotStates = async ({ reset }: CallbackInterface, projectId: string) => {
   const botStates = Object.keys(botstates);
@@ -609,7 +610,7 @@ const openRootBotAndSkills = async (callbackHelpers: CallbackInterface, data, st
         if (!skill.remote && skill.workspace) {
           const rootBotPath = location;
           const skillPath = skill.workspace;
-          const absoluteSkillPath = path.resolve(rootBotPath, skillPath);
+          const absoluteSkillPath = path.join(rootBotPath, skillPath);
           skillPromise = openLocalSkill(callbackHelpers, absoluteSkillPath, storageId, nameIdentifier);
         } else if (skill.manifest) {
           skillPromise = openRemoteSkill(callbackHelpers, skill.manifest, nameIdentifier);
@@ -715,7 +716,7 @@ export const checkIfBotExistsInBotProjectFile = async (
       }
     } else {
       if (workspace) {
-        const absolutePathOfSkill = path.resolve(rootBotLocation, workspace);
+        const absolutePathOfSkill = path.join(rootBotLocation, workspace);
         if (pathOrManifest === absolutePathOfSkill) {
           return true;
         }

--- a/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
@@ -85,7 +85,6 @@ import { setRootBotSettingState } from '../setting';
 
 import { crossTrainConfigState } from './../../atoms/botState';
 import { recognizersSelectorFamily } from './../../selectors/recognizers';
-import { getAbsolutePath } from '../../../utils/fileUtil';
 
 export const resetBotStates = async ({ reset }: CallbackInterface, projectId: string) => {
   const botStates = Object.keys(botstates);

--- a/Composer/packages/client/src/utils/fileUtil.ts
+++ b/Composer/packages/client/src/utils/fileUtil.ts
@@ -121,5 +121,7 @@ export const getFileNameFromPath = (param: string, ext: string | undefined = und
 };
 
 export const getAbsolutePath = (basePath: string, relativePath: string) => {
+  // note: in windows, path.resolve result will prefix with /
+  // https://github.com/jinder/path/issues/18
   return path.resolve(basePath, relativePath);
 };


### PR DESCRIPTION
## Description
Fix two bug on skill bot path in windows.
1. add duplicate path bot do not throw error.
2. load skill bot not found

the root cause is  path.resolve result will prefix with /

e.g 1
```
path.resolve('', 'C:/<path>') 
``` 
will get 
```
/C:/<path>
````
it suppose to get
```
C:/<path>
````

e.g 2
```
path.resolve('C:/<path>', 'a/b/c') 
``` 
will get 
```
/C:/<path>/a/b/c
````
it suppose to get
```
C:/<path>/a/b/c
````

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item

#minor
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
