### PR TITLE
fix: Export to zip is missing files and folders

### DIFF
--- a/Composer/packages/server/src/models/storage/localDiskStorage.ts
+++ b/Composer/packages/server/src/models/storage/localDiskStorage.ts
@@ -8,6 +8,7 @@ import path from 'path';
 import glob from 'globby';
 import archiver from 'archiver';
 import rimraf from 'rimraf';
+import { FileExtensions } from '@botframework-composer/types';
 
 import { IFileStorage, Stat, MakeDirectoryOptions } from './interface';
 
@@ -99,13 +100,16 @@ export class LocalDiskStorage implements IFileStorage {
       '/settings/',
       '/generated/',
       '/knowledge-base/',
+      '/recognizers/',
+      '/form-dialogs/',
+      '/scripts/',
     ];
 
     const directoriesToInclude = defaultDirectories.filter((elem) => {
       return exclusions?.directories == undefined || exclusions?.directories?.indexOf(elem) == -1;
     });
 
-    const defaultFiles = ['*.botproject', '*.dialog'];
+    const defaultFiles = [`*${FileExtensions.BotProject}`, `*${FileExtensions.Dialog}`, 'README.md', '.gitignore'];
 
     const filesToInclude = defaultFiles.filter((elem) => {
       return exclusions?.files == undefined || exclusions?.files?.indexOf(elem) == -1;


### PR DESCRIPTION
## Description

When bot is exported to zip, recognizers, form-dialogs, scripts, bot project file and a README.md are missing.

## Task Item

closes #5019 
