### PR TITLE
feat: Adds LUIS name to settings

### DIFF
--- a/Composer/packages/client/src/components/TextFieldWithCustomButton.tsx
+++ b/Composer/packages/client/src/components/TextFieldWithCustomButton.tsx
@@ -4,38 +4,14 @@
 /** @jsx jsx */
 import { jsx, css } from '@emotion/core';
 import React, { useState, useRef, Fragment, useEffect } from 'react';
-import { TextField, ITextField } from 'office-ui-fabric-react/lib/TextField';
-import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
+import { TextField, ITextField, ITextFieldProps } from 'office-ui-fabric-react/lib/TextField';
+import { IRenderFunction } from 'office-ui-fabric-react/lib/Utilities';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import { ActionButton } from 'office-ui-fabric-react/lib/Button';
 import { SharedColors } from '@uifabric/fluent-theme';
 import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
 import { FontSizes } from '@uifabric/fluent-theme';
 import { NeutralColors } from '@uifabric/fluent-theme';
-
-const unknownIconStyle = (required) => {
-  return {
-    root: {
-      selectors: {
-        '&::before': {
-          content: required ? " '*'" : '',
-          color: SharedColors.red10,
-          paddingRight: 3,
-        },
-      },
-    },
-  };
-};
-
-const labelContainer = css`
-  display: flex;
-  flex-direction: row;
-`;
-
-const customerLabel = css`
-  font-size: ${FontSizes.size12};
-  margin-right: 5px;
-`;
 
 const disabledTextFieldStyle = {
   root: {
@@ -93,6 +69,7 @@ type TextFieldWithCustomButtonProps = {
   value: string;
   onBlur?: (value) => void;
   onChange?: (e, value) => void;
+  onRenderLabel?: IRenderFunction<ITextFieldProps>;
   required: boolean;
   id?: string;
 };
@@ -107,15 +84,8 @@ const errorElement = (errorText: string) => {
   );
 };
 
-const onRenderLabel = (props) => {
-  return (
-    <div css={labelContainer}>
-      <div css={customerLabel}> {props.label} </div>
-      <TooltipHost content={props.label}>
-        <Icon iconName="Unknown" styles={unknownIconStyle(props.required)} />
-      </TooltipHost>
-    </div>
-  );
+const defaultRenderLabel = (props, defaultRender) => {
+  return defaultRender(props);
 };
 
 export const TextFieldWithCustomButton: React.FC<TextFieldWithCustomButtonProps> = (props) => {
@@ -131,6 +101,7 @@ export const TextFieldWithCustomButton: React.FC<TextFieldWithCustomButtonProps>
     onBlur,
     errorMessage,
     id = '',
+    onRenderLabel = defaultRenderLabel,
   } = props;
   const [isDisabled, setDisabled] = useState<boolean>(!value);
   const textFieldComponentRef = useRef<ITextField>(null);

--- a/Composer/packages/client/src/pages/botProject/RootBotExternalService.tsx
+++ b/Composer/packages/client/src/pages/botProject/RootBotExternalService.tsx
@@ -21,6 +21,7 @@ import {
   luFilesState,
   qnaFilesState,
   validateDialogsSelectorFamily,
+  botDisplayNameState,
 } from '../../recoilModel';
 import settingStorage from '../../utils/dialogSettingStorage';
 import { rootBotProjectIdSelector } from '../../recoilModel/selectors/project';
@@ -145,8 +146,11 @@ export const RootBotExternalService: React.FC<RootBotExternalServiceProps> = (pr
   const dialogs = useRecoilValue(validateDialogsSelectorFamily(projectId));
   const luFiles = useRecoilValue(luFilesState(projectId));
   const qnaFiles = useRecoilValue(qnaFilesState(projectId));
+  const botName = useRecoilValue(botDisplayNameState(projectId));
   const isLUISKeyNeeded = isLUISMandatory(dialogs, luFiles);
   const isQnAKeyNeeded = isQnAKeyMandatory(dialogs, qnaFiles);
+
+  const rootLuisName = get(settings, 'luis.name', '') || botName;
 
   const [luisKeyErrorMsg, setLuisKeyErrorMsg] = useState<string>('');
   const [luisRegionErrorMsg, setLuisRegionErrorMsg] = useState<string>('');
@@ -155,6 +159,7 @@ export const RootBotExternalService: React.FC<RootBotExternalServiceProps> = (pr
   const [localRootLuisKey, setLocalRootLuisKey] = useState<string>(rootLuisKey ?? '');
   const [localRootQnAKey, setLocalRootQnAKey] = useState<string>(rootqnaKey ?? '');
   const [localRootLuisRegion, setLocalRootLuisRegion] = useState<string>(rootLuisRegion ?? '');
+  const [localRootLuisName, setLocalRootLuisName] = useState<string>(rootLuisName ?? '');
 
   const luisKeyFieldRef = React.useRef<HTMLInputElement>(null);
   const qnaKeyFieldRef = React.useRef<HTMLInputElement>(null);
@@ -192,6 +197,17 @@ export const RootBotExternalService: React.FC<RootBotExternalServiceProps> = (pr
       qnaKeyFieldRef.current.scrollIntoView({ behavior: 'smooth' });
     }
   }, [scrollToSectionId]);
+
+  const handleRootLUISNameOnChange = (e, value) => {
+    setLocalRootLuisName(value);
+  };
+
+  const handleRootLUISNameOnBlur = () => {
+    setSettings(projectId, {
+      ...mergedSettings,
+      luis: { ...mergedSettings.luis, name: localRootLuisName },
+    });
+  };
 
   const handleRootLUISKeyOnChange = (e, value) => {
     if (value) {
@@ -273,6 +289,17 @@ export const RootBotExternalService: React.FC<RootBotExternalServiceProps> = (pr
     <CollapsableWrapper title={formatMessage('External services')} titleStyle={titleStyle}>
       <div css={externalServiceContainerStyle}>
         <TextField
+          aria-labelledby={'LUIS name'}
+          data-testId={'rootLUISName'}
+          id={'luisName'}
+          label={formatMessage('LUIS name')}
+          placeholder={'Enter LUIS name'}
+          value={localRootLuisName}
+          onBlur={handleRootLUISNameOnBlur}
+          onChange={handleRootLUISNameOnChange}
+          onRenderLabel={onRenderLabel}
+        />
+        <TextField
           aria-labelledby={'LUIS key'}
           data-testId={'rootLUISKey'}
           errorMessage={isLUISKeyNeeded ? errorElement(luisKeyErrorMsg) : ''}
@@ -280,7 +307,7 @@ export const RootBotExternalService: React.FC<RootBotExternalServiceProps> = (pr
           label={formatMessage('LUIS key')}
           placeholder={'Enter LUIS key'}
           required={isLUISKeyNeeded}
-          styles={customError}
+          styles={mergeStyleSets({ root: { marginTop: 10 } }, customError)}
           value={localRootLuisKey}
           onBlur={handleRootLuisKeyOnBlur}
           onChange={handleRootLUISKeyOnChange}

--- a/Composer/packages/client/src/recoilModel/dispatchers/__tests__/mocks/mockProjectResponse.json
+++ b/Composer/packages/client/src/recoilModel/dispatchers/__tests__/mocks/mockProjectResponse.json
@@ -8655,7 +8655,7 @@
     "defaultLanguage": "en-us",
     "languages": ["en-us"],
     "luis": {
-      "name": "",
+      "name": "EmptyBot-1",
       "authoringKey": "",
       "authoringEndpoint": "",
       "endpointKey": "",

--- a/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
@@ -145,6 +145,13 @@ const mergeLocalStorage = (projectId: string, settings: DialogSetting) => {
   return mergedSettings;
 };
 
+const mergeLuisName = (settings: DialogSetting, botName: string) => {
+  const mergedSettings = cloneDeep(settings);
+  const luisName = objectGet(mergedSettings, 'luis.name', '') || botName;
+  objectSet(mergedSettings, 'luis.name', luisName);
+  return mergedSettings;
+};
+
 export const mergePropertiesManagedByRootBot = (projectId: string, rootBotProjectId, settings: DialogSetting) => {
   const localSetting = settingStorage.get(rootBotProjectId);
   const mergedSettings = cloneDeep(settings);
@@ -172,8 +179,9 @@ export const getSensitiveProperties = (settings: DialogSetting) => {
   return sensitiveProperties;
 };
 
-export const getMergedSettings = (projectId, settings): DialogSetting => {
-  const mergedSettings = mergeLocalStorage(projectId, settings);
+export const getMergedSettings = (projectId, settings, botName): DialogSetting => {
+  let mergedSettings = mergeLocalStorage(projectId, settings);
+  mergedSettings = mergeLuisName(mergedSettings, botName);
   if (Array.isArray(mergedSettings.skill)) {
     const skillsArr = mergedSettings.skill.map((skillData) => ({ ...skillData }));
     mergedSettings.skill = convertSkillsToDictionary(skillsArr);
@@ -210,7 +218,7 @@ export const navigateToSkillBot = (rootProjectId: string, skillId: string, mainD
 
 export const loadProjectData = (data) => {
   const { files, botName, settings, id: projectId } = data;
-  const mergedSettings = getMergedSettings(projectId, settings);
+  const mergedSettings = getMergedSettings(projectId, settings, botName);
   const storedLocale = languageStorage.get(botName)?.locale;
   const locale = settings.languages.includes(storedLocale) ? storedLocale : settings.defaultLanguage;
   const indexedFiles = indexer.index(files, botName, locale, mergedSettings);


### PR DESCRIPTION
## Description
Add luis name field on Settings page. During bot project initialization, if luis name is empty, it will initialize luis name with bot name and save it into settingsState.

## Task Item
Closes #5044
## Screenshots
![luisname](https://user-images.githubusercontent.com/24380525/100843069-c2175a00-34b4-11eb-9357-d735651f1fea.gif)
