### PR TITLE
fix: use Common links in LG page only

### DIFF
--- a/Composer/packages/client/src/components/Page.tsx
+++ b/Composer/packages/client/src/components/Page.tsx
@@ -97,6 +97,7 @@ type IPageProps = {
   useNewTree?: boolean;
   navLinks?: INavTreeItem[];
   pageMode: PageMode;
+  showCommonLinks?: boolean;
 };
 
 const Page: React.FC<IPageProps> = (props) => {
@@ -112,6 +113,7 @@ const Page: React.FC<IPageProps> = (props) => {
     shouldShowEditorError = true,
     useNewTree,
     pageMode,
+    showCommonLinks = false,
   } = props;
 
   return (
@@ -134,7 +136,7 @@ const Page: React.FC<IPageProps> = (props) => {
                   showMenu: false,
                   showQnAMenu: title === 'QnA',
                   showErrors: false,
-                  showCommonLinks: true,
+                  showCommonLinks,
                 }}
                 onSelect={(link) => {
                   navigateTo(buildURL(pageMode, link));

--- a/Composer/packages/client/src/pages/language-generation/LGPage.tsx
+++ b/Composer/packages/client/src/pages/language-generation/LGPage.tsx
@@ -57,6 +57,7 @@ const LGPage: React.FC<RouteComponentProps<{
 
   return (
     <Page
+      showCommonLinks
       useNewTree
       data-testid="LGPage"
       mainRegionName={formatMessage('LG editor')}


### PR DESCRIPTION
## Description

The Common links should only show up in the LG page; this wires a prop through so we can make that work.

## Task Item

#minor

## Screenshots
![image](https://user-images.githubusercontent.com/61990921/100942500-5501c580-34b0-11eb-965e-49757df9e134.png)
![image](https://user-images.githubusercontent.com/61990921/100942514-5d5a0080-34b0-11eb-953d-40e14bc28cf3.png)
![image](https://user-images.githubusercontent.com/61990921/100942527-6519a500-34b0-11eb-8c33-b5ad0a883873.png)

