### PR TITLE
chore: allow setting oneauth version via env variable when installing

### DIFF
--- a/Composer/packages/electron-server/scripts/installOneAuth.js
+++ b/Composer/packages/electron-server/scripts/installOneAuth.js
@@ -21,7 +21,7 @@ const { log } = require('./common');
  */
 
 let packageName = null;
-const packageVersion = '1.14.0';
+const packageVersion = process.env.ONEAUTH_VERSION || '1.14.0';
 
 switch (process.platform) {
   case 'darwin':
@@ -55,6 +55,7 @@ async function downloadPackage() {
   log.info('Starting download.');
   await ensureDir(outDir);
   try {
+    log.info(`cd ${outDir} && npm pack ${packageName}@${packageVersion}`);
     execSync(`cd ${outDir} && npm pack ${packageName}@${packageVersion}`, { encoding: 'utf-8' });
   } catch (err) {
     process.exit(1);

--- a/Composer/packages/electron-server/scripts/installOneAuth.js
+++ b/Composer/packages/electron-server/scripts/installOneAuth.js
@@ -21,7 +21,7 @@ const { log } = require('./common');
  */
 
 let packageName = null;
-const packageVersion = process.env.ONEAUTH_VERSION || '1.14.0';
+const packageVersion = process.env.ONEAUTH_VERSION || '1.15.0';
 
 switch (process.platform) {
   case 'darwin':


### PR DESCRIPTION
## Description

Uses env variable to install a specific version of oneauth or falls back to 1.15.0

## Task Item


#minor
