### PR TITLE
feat: Disable stop all operations while start operations is being performed

### DIFF
--- a/Composer/cypress/integration/LuisDeploy.spec.ts
+++ b/Composer/cypress/integration/LuisDeploy.spec.ts
@@ -35,6 +35,6 @@ context('Luis Deploy', () => {
       response: 'fixture:luPublish/success',
     });
     cy.findByText('Try again').click();
-    cy.findByTitle(/^Stop all bots/).click();
+    cy.findByTitle(/^Starting bots../);
   });
 });

--- a/Composer/packages/client/src/components/BotRuntimeController/BotController.tsx
+++ b/Composer/packages/client/src/components/BotRuntimeController/BotController.tsx
@@ -50,16 +50,6 @@ const disabledStyle = css`
 
 const startPanelsContainer = css`
   display: flex;
-  flex-direction: 'row';
-
-  @keyframes spin {
-    0% {
-      transform: rotate(0deg);
-    }
-    100% {
-      transform: rotate(360deg);
-    }
-  }
 `;
 
 const transparentBackground = 'rgba(255, 255, 255, 0.5)';

--- a/Composer/packages/client/src/components/BotRuntimeController/BotController.tsx
+++ b/Composer/packages/client/src/components/BotRuntimeController/BotController.tsx
@@ -175,7 +175,6 @@ const BotController: React.FC = () => {
               height: '36px',
               flexDirection: 'row',
               padding: '0 7px',
-              border: 'none',
               width: '100%',
             },
             rootHovered: {

--- a/Composer/packages/client/src/components/BotRuntimeController/BotController.tsx
+++ b/Composer/packages/client/src/components/BotRuntimeController/BotController.tsx
@@ -9,7 +9,7 @@ import { IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
 import { useRecoilValue } from 'recoil';
 import formatMessage from 'format-message';
 import { css } from '@emotion/core';
-import { NeutralColors } from '@uifabric/fluent-theme';
+import { NeutralColors, CommunicationColors } from '@uifabric/fluent-theme';
 import { Spinner, SpinnerSize } from 'office-ui-fabric-react/lib/Spinner';
 
 import {
@@ -29,7 +29,7 @@ const iconSectionContainer = css`
   display: flex;
   align-items: flex-end;
   flex-direction: row;
-  background: #3393dd;
+  background: ${CommunicationColors.tint10};
 
   :before {
     content: '';
@@ -168,13 +168,14 @@ const BotController: React.FC = () => {
           menuAs={() => null}
           styles={{
             root: {
-              backgroundColor: '#3393dd',
+              backgroundColor: CommunicationColors.tint10,
               display: 'flex',
               alignItems: 'center',
               minWidth: '229px',
               height: '36px',
               flexDirection: 'row',
               padding: '0 7px',
+              border: `1px solid ${CommunicationColors.tint10}`,
               width: '100%',
             },
             rootHovered: {
@@ -182,7 +183,7 @@ const BotController: React.FC = () => {
             },
             rootDisabled: {
               opacity: 0.6,
-              backgroundColor: '#3393dd',
+              backgroundColor: CommunicationColors.tint10,
               color: `${NeutralColors.white}`,
               border: 'none',
               font: '62px',
@@ -214,11 +215,11 @@ const BotController: React.FC = () => {
               root: {
                 color: NeutralColors.white,
                 height: '36px',
-                background: isControllerHidden ? '#3393DD' : transparentBackground,
+                background: isControllerHidden ? CommunicationColors.tint10 : transparentBackground,
                 selectors: {
                   ':disabled .ms-Button-icon': {
                     opacity: 0.6,
-                    backgroundColor: '#3393DD',
+                    backgroundColor: CommunicationColors.tint10,
                     color: `${NeutralColors.white}`,
                   },
                 },

--- a/Composer/packages/client/src/components/BotRuntimeController/BotController.tsx
+++ b/Composer/packages/client/src/components/BotRuntimeController/BotController.tsx
@@ -94,11 +94,11 @@ const BotController: React.FC = () => {
     setDisableOnStartBotsWidget(false);
   }, [projectCollection, errors]);
 
-  const running = useMemo(() => projectCollection.find(({ status }) => status === BotStatus.connected), [
+  const botStartComplete = useMemo(() => projectCollection.find(({ status }) => status === BotStatus.connected), [
     projectCollection,
   ]);
 
-  const botsStarting = useMemo(
+  const areBotsStarting = useMemo(
     () =>
       !!projectCollection.find(({ status }) => {
         return (
@@ -115,7 +115,7 @@ const BotController: React.FC = () => {
   const { startAllBots, stopAllBots } = useBotOperations();
 
   const handleClick = () => {
-    if (!running) {
+    if (!botStartComplete) {
       startAllBots();
     } else {
       stopAllBots();
@@ -127,7 +127,7 @@ const BotController: React.FC = () => {
   };
 
   const buttonText = useMemo(() => {
-    if (botsStarting) {
+    if (areBotsStarting) {
       setStatusIconClass(undefined);
       return formatMessage('Starting bots.. ({running}/{total} running)', {
         running: runningBots.projectIds.length,
@@ -135,7 +135,7 @@ const BotController: React.FC = () => {
       });
     }
 
-    if (running) {
+    if (botStartComplete) {
       setStatusIconClass('CircleStopSolid');
       return formatMessage('Stop all bots ({running}/{total} running)', {
         running: runningBots.projectIds.length,
@@ -145,7 +145,7 @@ const BotController: React.FC = () => {
 
     setStatusIconClass('Play');
     return formatMessage('Start all bots');
-  }, [runningBots, running, botsStarting]);
+  }, [runningBots, botStartComplete, areBotsStarting]);
 
   const items = useMemo<IContextualMenuItem[]>(() => {
     return projectCollection.map(({ name: displayName, projectId }) => ({
@@ -166,7 +166,7 @@ const BotController: React.FC = () => {
           primary
           aria-roledescription={formatMessage('Bot Controller')}
           ariaDescription={buttonText}
-          disabled={disableStartBots || botsStarting}
+          disabled={disableStartBots || areBotsStarting}
           iconProps={{
             iconName: statusIconClass,
             styles: {
@@ -202,7 +202,7 @@ const BotController: React.FC = () => {
           title={buttonText}
           onClick={handleClick}
         >
-          {botsStarting && (
+          {areBotsStarting && (
             <Spinner
               size={SpinnerSize.small}
               styles={{

--- a/Composer/packages/client/src/components/Header.tsx
+++ b/Composer/packages/client/src/components/Header.tsx
@@ -9,7 +9,7 @@ import { TeachingBubble } from 'office-ui-fabric-react/lib/TeachingBubble';
 import { DirectionalHint } from 'office-ui-fabric-react/lib/Callout';
 import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
 import { useCallback, useState, Fragment, useMemo, useEffect } from 'react';
-import { NeutralColors, SharedColors, FontSizes } from '@uifabric/fluent-theme';
+import { NeutralColors, SharedColors, FontSizes, CommunicationColors } from '@uifabric/fluent-theme';
 import { useRecoilValue } from 'recoil';
 import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
 
@@ -56,7 +56,7 @@ const botName = css`
   font-size: 16px;
   color: #fff;
   border-radius: 19px;
-  background: #3393dd;
+  background: ${CommunicationColors.tint10};
   padding-left: 10px;
   padding-right: 10px;
   cursor: pointer;

--- a/Composer/packages/client/src/components/__tests__/BotRuntimeController/BotController.test.tsx
+++ b/Composer/packages/client/src/components/__tests__/BotRuntimeController/BotController.test.tsx
@@ -111,4 +111,17 @@ describe('<BotController />', () => {
 
     expect(mockStart).toHaveBeenCalled();
   });
+
+  it('should show that bots are starting', async () => {
+    const initRecoilState = ({ set }) => {
+      const projectIds = ['123a.234', '456a.234', '789a.234', '1323.sdf'];
+      set(botProjectIdsState, projectIds);
+      set(botStatusState(projectIds[0]), BotStatus.published);
+      set(botStatusState(projectIds[1]), BotStatus.publishing);
+      set(botStatusState(projectIds[2]), BotStatus.connected);
+      set(botStatusState(projectIds[3]), BotStatus.queued);
+    };
+    const { findByText } = renderWithRecoil(<BotController />, initRecoilState);
+    await findByText('Starting bots.. (1/4 running)');
+  });
 });

--- a/Composer/packages/client/src/pages/design/DesignPage.tsx
+++ b/Composer/packages/client/src/pages/design/DesignPage.tsx
@@ -428,7 +428,7 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
     },
     {
       key: 'OpenSkill',
-      label: formatMessage('Open a new skill'),
+      label: formatMessage('Open an existing skill'),
       onClick: () => {
         setCreationFlowType('Skill');
         setCreationFlowStatus(CreationFlowStatus.OPEN);

--- a/Composer/packages/client/src/pages/setting/SettingsPage.tsx
+++ b/Composer/packages/client/src/pages/setting/SettingsPage.tsx
@@ -6,8 +6,6 @@ import { jsx, css } from '@emotion/core';
 import { useMemo, useEffect } from 'react';
 import formatMessage from 'format-message';
 import { RouteComponentProps } from '@reach/router';
-import { FontIcon } from 'office-ui-fabric-react/lib/Icon';
-import { Text } from 'office-ui-fabric-react/lib/Text';
 import { useRecoilValue } from 'recoil';
 
 import {
@@ -18,8 +16,6 @@ import {
   settingsState,
   currentProjectIdState,
 } from '../../recoilModel';
-import { OpenConfirmModal } from '../../components/Modal/ConfirmDialog';
-import { navigateTo } from '../../utils/navigation';
 import { Page } from '../../components/Page';
 import { INavTreeItem } from '../../components/NavTree';
 import { useLocation } from '../../utils/hooks';

--- a/Composer/packages/client/src/pages/setting/SettingsPage.tsx
+++ b/Composer/packages/client/src/pages/setting/SettingsPage.tsx
@@ -173,50 +173,6 @@ const SettingPage: React.FC<RouteComponentProps> = () => {
     });
   };
 
-  const toolbarItems: IToolbarItem[] = [
-    {
-      type: 'dropdown',
-      text: formatMessage('Edit'),
-      align: 'left',
-      dataTestid: 'EditFlyout',
-      buttonProps: {
-        iconProps: { iconName: 'Edit' },
-      },
-      menuProps: {
-        items: [
-          {
-            key: 'edit.deleteBot',
-            text: formatMessage('Delete Bot'),
-            onClick: openDeleteBotModal,
-          },
-          {
-            key: 'edit.deleteLanguage',
-            text: formatMessage('Delete language'),
-            onClick: () => {
-              delLanguageDialogBegin(projectId, () => {});
-            },
-          },
-        ],
-      },
-    },
-
-    {
-      type: 'action',
-      text: formatMessage('Add language'),
-      buttonProps: {
-        iconProps: {
-          iconName: 'CirclePlus',
-        },
-        onClick: () => {
-          addLanguageDialogBegin(projectId, () => {});
-        },
-      },
-      align: 'left',
-      dataTestid: 'AddLanguageFlyout',
-      disabled: false,
-    },
-  ];
-
   const title = useMemo(() => {
     const page = links.find((l) => location.pathname.includes(l.url));
     if (page) {
@@ -240,7 +196,7 @@ const SettingPage: React.FC<RouteComponentProps> = () => {
       navRegionName={formatMessage('Settings menu')}
       pageMode={'settings'}
       title={title}
-      toolbarItems={toolbarItems}
+      toolbarItems={[]}
       onRenderHeaderContent={onRenderHeaderContent}
     >
       <AddLanguageModal

--- a/Composer/packages/client/src/pages/setting/SettingsPage.tsx
+++ b/Composer/packages/client/src/pages/setting/SettingsPage.tsx
@@ -9,7 +9,6 @@ import { RouteComponentProps } from '@reach/router';
 import { FontIcon } from 'office-ui-fabric-react/lib/Icon';
 import { Text } from 'office-ui-fabric-react/lib/Text';
 import { useRecoilValue } from 'recoil';
-import { IToolbarItem } from '@bfc/ui-shared';
 
 import {
   dispatcherState,
@@ -44,10 +43,7 @@ const getProjectLink = (path: string, id?: string) => {
 
 const SettingPage: React.FC<RouteComponentProps> = () => {
   const {
-    deleteBot: deleteBotProject,
-    addLanguageDialogBegin,
     addLanguageDialogCancel,
-    delLanguageDialogBegin,
     delLanguageDialogCancel,
     addLanguages,
     deleteLanguages,
@@ -91,73 +87,6 @@ const SettingPage: React.FC<RouteComponentProps> = () => {
       navigate('/settings/application');
     }
   }, [projectId]);
-
-  const openDeleteBotModal = async () => {
-    const boldWarningText = formatMessage(
-      'Warning: the action you are about to take cannot be undone. Going further will delete this bot and any related files in the bot project folder.'
-    );
-    const warningText = formatMessage('External resources will not be changed.');
-    const title = formatMessage('Delete Bot');
-    const checkboxLabel = formatMessage('I want to delete this bot');
-    const settings = {
-      onRenderContent: () => {
-        return (
-          <div
-            style={{
-              background: '#ffddcc',
-              display: 'flex',
-              flexDirection: 'row',
-              marginBottom: '24px',
-            }}
-          >
-            <FontIcon
-              iconName="Warning12"
-              style={{
-                color: '#DD4400',
-                fontSize: 36,
-                padding: '32px',
-              }}
-            />
-            <div
-              style={{
-                display: 'flex',
-                flexDirection: 'column',
-              }}
-            >
-              <Text
-                block
-                style={{
-                  fontWeight: 'bold',
-                  marginTop: '24px',
-                  marginRight: '24px',
-                  marginBottom: '24px',
-                }}
-              >
-                {boldWarningText}
-              </Text>
-              <Text
-                block
-                style={{
-                  marginRight: '24px',
-                  marginBottom: '24px',
-                }}
-              >
-                {warningText}
-              </Text>
-            </div>
-          </div>
-        );
-      },
-      disabled: true,
-      checkboxLabel,
-      confirmBtnText: formatMessage('Delete'),
-    };
-    const res = await OpenConfirmModal(title, null, settings);
-    if (res) {
-      await deleteBotProject(projectId);
-      navigateTo('home');
-    }
-  };
 
   const onAddLangModalSubmit = async (formData) => {
     await addLanguages({


### PR DESCRIPTION
## Description
**Add support for disabling stop all operations while bots are starting.**
@sangwoohaan 
<img width="645" alt="Screen Shot 2020-12-03 at 12 26 50 AM" src="https://user-images.githubusercontent.com/13004779/101068785-01de5000-354e-11eb-9cf1-5ffbd61e4c41.png">

**Changed copy to add an existing skill in context menu**


**Removed toolbar from application settings page**
![Screen Shot 2020-12-03 at 12 17 20 PM](https://user-images.githubusercontent.com/13004779/101083623-a74eef00-3561-11eb-99f4-f34007722712.png)



#minor
