### PR TITLE
fix: Cause Recognizers component to update after project reload

### DIFF
--- a/Composer/packages/client/src/recoilModel/Recognizers.tsx
+++ b/Composer/packages/client/src/recoilModel/Recognizers.tsx
@@ -11,7 +11,7 @@ import { getBaseName, getExtension } from '../utils/fileUtil';
 
 import * as luUtil from './../utils/luUtil';
 import * as buildUtil from './../utils/buildUtil';
-import { crossTrainConfigState, luFilesState, qnaFilesState, settingsState } from './atoms';
+import { crossTrainConfigState, luFilesState, qnaFilesState, settingsState, projectMetaDataState } from './atoms';
 import { dialogsSelectorFamily } from './selectors';
 import { recognizersSelectorFamily } from './selectors/recognizers';
 
@@ -146,9 +146,12 @@ export const Recognizer = React.memo((props: { projectId: string }) => {
   const luFiles = useRecoilValue(luFilesState(projectId));
   const qnaFiles = useRecoilValue(qnaFilesState(projectId));
   const settings = useRecoilValue(settingsState(projectId));
+  const { lastReloadedFromServer } = useRecoilValue(projectMetaDataState(projectId));
+
   const curRecognizers = useRecoilValue(recognizersSelectorFamily(projectId));
 
   useEffect(() => {
+    console.log('********* RECOGNIZERS UPDATED AND REUPDATING UPDATES');
     let recognizers: RecognizerFile[] = [];
     dialogs
       .filter((dialog) => isCrossTrainedRecognizerSet(dialog) || isLuisRecognizer(dialog))
@@ -179,7 +182,7 @@ export const Recognizer = React.memo((props: { projectId: string }) => {
     if (!isEqual([...recognizers].sort(), [...curRecognizers].sort())) {
       setRecognizers(recognizers);
     }
-  }, [dialogs, luFiles, qnaFiles]);
+  }, [dialogs, luFiles, qnaFiles, lastReloadedFromServer]);
 
   useEffect(() => {
     try {

--- a/Composer/packages/client/src/recoilModel/atoms/botState.ts
+++ b/Composer/packages/client/src/recoilModel/atoms/botState.ts
@@ -246,12 +246,16 @@ export const onDelLanguageDialogCompleteState = atomFamily<any, string>({
   default: { func: undefined },
 });
 
-export const projectMetaDataState = atomFamily<{ isRootBot: boolean; isRemote: boolean }, string>({
+export const projectMetaDataState = atomFamily<
+  { isRootBot: boolean; isRemote: boolean; lastReloadedFromServer: number | undefined },
+  string
+>({
   key: getFullyQualifiedKey('projectsMetaDataState'),
   default: () => {
     return {
       isRootBot: false,
       isRemote: false,
+      lastReloadedFromServer: undefined,
     };
   },
 });

--- a/Composer/packages/client/src/recoilModel/dispatchers/project.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/project.ts
@@ -182,6 +182,7 @@ export const projectDispatcher = () => {
         set(projectMetaDataState(projectId), {
           isRemote: false,
           isRootBot: false,
+          lastReloadedFromServer: Date.now(),
         });
         set(botProjectIdsState, (current) => [...current, projectId]);
         await dispatcher.addLocalSkillToBotProjectFile(projectId);
@@ -207,6 +208,7 @@ export const projectDispatcher = () => {
         set(projectMetaDataState(projectId), {
           isRootBot: true,
           isRemote: false,
+          lastReloadedFromServer: Date.now(),
         });
         projectIdCache.set(projectId);
 
@@ -245,6 +247,7 @@ export const projectDispatcher = () => {
       set(projectMetaDataState(projectId), {
         isRootBot: true,
         isRemote: false,
+        lastReloadedFromServer: Date.now(),
       });
       projectIdCache.set(projectId);
     } catch (ex) {
@@ -293,6 +296,7 @@ export const projectDispatcher = () => {
       set(projectMetaDataState(projectId), {
         isRootBot: true,
         isRemote: false,
+        lastReloadedFromServer: Date.now(),
       });
       projectIdCache.set(projectId);
       navigateToBot(callbackHelpers, projectId, mainDialog, urlSuffix);
@@ -365,6 +369,7 @@ export const projectDispatcher = () => {
         set(projectMetaDataState(projectId), {
           isRootBot: true,
           isRemote: false,
+          lastReloadedFromServer: Date.now(),
         });
         projectIdCache.set(projectId);
         navigateToBot(callbackHelpers, projectId, mainDialog);
@@ -468,6 +473,7 @@ export const projectDispatcher = () => {
             callbackHelpers.set(projectMetaDataState(projectId), {
               isRootBot: true,
               isRemote: false,
+              lastReloadedFromServer: Date.now(),
             });
             projectIdCache.set(projectId);
             navigateToBot(callbackHelpers, projectId, mainDialog, urlSuffix);

--- a/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
@@ -395,6 +395,7 @@ export const initBotState = async (callbackHelpers: CallbackInterface, data: any
 
   set(filePersistenceState(projectId), new FilePersistence(projectId));
   set(undoHistoryState(projectId), new UndoHistory(projectId));
+
   return mainDialog;
 };
 
@@ -428,6 +429,7 @@ export const openRemoteSkill = async (
   set(projectMetaDataState(projectId), {
     isRootBot: false,
     isRemote: true,
+    lastReloadedFromServer: Date.now(),
   });
 
   //TODO: open remote url 404. isRemote set to false?
@@ -464,6 +466,7 @@ export const openLocalSkill = async (callbackHelpers, pathToBot: string, storage
   set(projectMetaDataState(projectData.id), {
     isRootBot: false,
     isRemote: false,
+    lastReloadedFromServer: Date.now(),
   });
   set(botNameIdentifierState(projectData.id), botNameIdentifier);
 


### PR DESCRIPTION
## Description

Adds a lastReloadedFromServer member so that the Recognizers onEffect will fire to generate the new recognizer files for newly added dialogs.

HOWEVER, while the recognizer onEffect does fire, it does not generate the recogniezr files as expected.

## Task Item

Fixes #5034
