### PR TITLE
fix: Add APPINSIGHTS_INSTRUMENTATIONKEY to getBuildEnvironment

### DIFF
--- a/Composer/packages/server/scripts/build.js
+++ b/Composer/packages/server/scripts/build.js
@@ -6,6 +6,7 @@ const path = require('path');
 function getBuildEnvironment() {
   return {
     QNA_SUBSCRIPTION_KEY: process.env.QNA_SUBSCRIPTION_KEY,
+    APPINSIGHTS_INSTRUMENTATIONKEY: process.env.APPINSIGHTS_INSTRUMENTATIONKEY,
   };
 }
 

--- a/Composer/packages/server/src/services/telemetry.ts
+++ b/Composer/packages/server/src/services/telemetry.ts
@@ -1,17 +1,31 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+import fs from 'fs';
 
 import * as AppInsights from 'applicationinsights';
 import { TelemetryEventName, TelemetryEvents, TelemetryEventTypes, TelemetryEvent } from '@bfc/shared';
 
 import { APPINSIGHTS_INSTRUMENTATIONKEY, piiProperties } from '../constants';
 import { useElectronContext } from '../utility/electronContext';
+import { Path } from '../utility/path';
 
 import { SettingsService } from './settings';
 
+const buildEnvPath = Path.join(__dirname, '../../env.json');
+
+function getBuildEnvironment() {
+  if (fs.existsSync(buildEnvPath)) {
+    return JSON.parse(fs.readFileSync(buildEnvPath, 'utf-8'));
+  }
+
+  return {};
+}
+
+const instrumentationKey = APPINSIGHTS_INSTRUMENTATIONKEY || getBuildEnvironment()?.APPINSIGHTS_INSTRUMENTATIONKEY;
+
 let client;
-if (APPINSIGHTS_INSTRUMENTATIONKEY) {
-  AppInsights.setup(APPINSIGHTS_INSTRUMENTATIONKEY)
+if (instrumentationKey) {
+  AppInsights.setup(instrumentationKey)
     // turn off extra instrumentation
     .setAutoCollectConsole(false)
     .setAutoCollectDependencies(false)


### PR DESCRIPTION
## Description
Adds missing `APPINSIGHTS_INSTRUMENTATIONKEY` to the `getBuildEnvironment` method.

## Task Item
#minor