### PR TITLE
fix: Fixes electron-based form dialog generation 

### DIFF
--- a/Composer/packages/server/src/controllers/formDialog.ts
+++ b/Composer/packages/server/src/controllers/formDialog.ts
@@ -21,7 +21,7 @@ const getTemplateDirs = async () => {
   if (templatesRootDir && templatesRootDir.length) {
     for (const dirName of await fs.readdir(templatesRootDir)) {
       const dir = path.join(templatesRootDir, dirName);
-      if ((await fs.lstat(dir)).isDirectory()) {
+      if ((await fs.lstat(dir)).isDirectory() && dir.endsWith('standard')) {
         // Add templates subdirectories as templates
         dirs.push(dir);
       }


### PR DESCRIPTION
## Description

bf-generate-library searches templates directories for main.dialog in a certain order (requires standard to be first), but was finding it under "professional" templates first.

This PR only sends in "standard" for template directory to generation library since professional and swagger are not being used anyways to make sure library only searches standard templates.

## Task Item

closes #5146 
closes #5148 
closes #5139 
closes #5147