### PR TITLE
fix: Allow choose Orchestrator recognizer type when lu file is empty

### DIFF
--- a/Composer/packages/client/src/recoilModel/Recognizers.tsx
+++ b/Composer/packages/client/src/recoilModel/Recognizers.tsx
@@ -76,7 +76,7 @@ export const getMultiLanguagueRecognizerDialog = (
 
 export const getLuisRecognizerDialogs = (target: string, luFiles: LuFile[]) => {
   return luFiles
-    .filter((item) => !item.empty && getBaseName(item.id) === target)
+    .filter((item) => getBaseName(item.id) === target)
     .map((item) => ({ id: `${item.id}.lu.dialog`, content: LuisRecognizerTemplate(target, item.id) }));
 };
 

--- a/Composer/packages/server/src/models/bot/botProject.ts
+++ b/Composer/packages/server/src/models/bot/botProject.ts
@@ -471,17 +471,20 @@ export class BotProject implements IBotProject {
   public buildFiles = async ({ luisConfig, qnaConfig, luResource = [], qnaResource = [] }: IBuildConfig) => {
     if (this.settings) {
       const luFiles: FileInfo[] = [];
-      luResource.forEach(({ id }) => {
+      const emptyFiles = {};
+      luResource.forEach(({ id, isEmpty }) => {
         const fileName = `${id}.lu`;
         const f = this.files.get(fileName);
+        if (isEmpty) emptyFiles[fileName] = true;
         if (f) {
           luFiles.push(f);
         }
       });
       const qnaFiles: FileInfo[] = [];
-      qnaResource.forEach(({ id }) => {
+      qnaResource.forEach(({ id, isEmpty }) => {
         const fileName = `${id}.qna`;
         const f = this.files.get(fileName);
+        if (isEmpty) emptyFiles[fileName] = true;
         if (f) {
           qnaFiles.push(f);
         }
@@ -492,7 +495,7 @@ export class BotProject implements IBotProject {
         { ...luisConfig, subscriptionKey: qnaConfig.subscriptionKey, qnaRegion: qnaConfig.qnaRegion },
         this.settings.downsampling
       );
-      await this.builder.build(luFiles, qnaFiles, Array.from(this.files.values()) as FileInfo[]);
+      await this.builder.build(luFiles, qnaFiles, Array.from(this.files.values()) as FileInfo[], emptyFiles);
     }
   };
 

--- a/Composer/packages/server/src/models/bot/builder.ts
+++ b/Composer/packages/server/src/models/bot/builder.ts
@@ -76,7 +76,12 @@ export class Builder {
     this.interruptionFolderPath = Path.join(this.generatedFolderPath, INTERRUPTION);
   }
 
-  public build = async (luFiles: FileInfo[], qnaFiles: FileInfo[], allFiles: FileInfo[]) => {
+  public build = async (
+    luFiles: FileInfo[],
+    qnaFiles: FileInfo[],
+    allFiles: FileInfo[],
+    emptyFiles: { [key: string]: boolean }
+  ) => {
     try {
       await this.createGeneratedDir();
       //do cross train before publish
@@ -92,7 +97,7 @@ export class Builder {
       }
       await this.runLuBuild(luBuildFiles);
       await this.runQnaBuild(interruptionQnaFiles);
-      await this.runOrchestratorBuild(orchestratorBuildFiles);
+      await this.runOrchestratorBuild(orchestratorBuildFiles, emptyFiles);
     } catch (error) {
       throw new Error(error.message ?? error.text ?? 'Error publishing to LUIS or QNA.');
     }
@@ -141,8 +146,8 @@ export class Builder {
    * 4) Generate settings file for runtime containing model and snapshot paths and place in /generated folder
    * @param luFiles LU Files needed to build snapshot data
    */
-  public runOrchestratorBuild = async (luFiles: FileInfo[]) => {
-    if (!luFiles.length) return;
+  public runOrchestratorBuild = async (luFiles: FileInfo[], emptyFiles: { [key: string]: boolean }) => {
+    if (!luFiles.filter((file) => !emptyFiles[file.name]).length) return;
 
     const nlrList = await this.runOrchestratorNlrList();
     const defaultNLR = nlrList.default;

--- a/Composer/packages/ui-plugins/orchestrator/src/index.ts
+++ b/Composer/packages/ui-plugins/orchestrator/src/index.ts
@@ -30,10 +30,6 @@ const config: PluginConfig = {
             alert(formatMessage(`NO LU OR QNA FILE WITH NAME { id }`, { id: currentDialog.id }));
           }
 
-          if (luFile?.empty) {
-            alert(formatMessage(`LU FILE IS EMPTY WITH NAME { id }`, { id: currentDialog.id }));
-          }
-
           shellApi.updateRecognizer(projectId, currentDialog.id, SDKKinds.OrchestratorRecognizer);
           return `${currentDialog.id}.lu.qna`;
         },


### PR DESCRIPTION
## Description
**Why we can't choose Orchestrator type in the previous design**

When the dialog recognizer type is CrossTrainedRecognizerSet, the value of the recognize field in dialog is '{fileBasename}.{locale}.lu.qna'. So we don't know the the dialog recognizer type from the recognize field in the dialog directly. 

When we choose the Orchestrator type, we will update the {fileBasename}.{locale}.lu.dialog content. We will write the Orchestrator type to this file. Composer then will use the recognize field from the dialog and the type from it's recognizer file to determine if it is Orchestrator type.

But in the previous design, we will not create a recognizer file for empty lu file and in order to avoid users to choose the Orchestrator type when the lu file is empty, we add a warning here.

**fix**

Generate the luis recognizer for empty file. But the file will not been add to the crosstrained recognizer file
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
closes #5126
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
