### PR TITLE
fix: "Show skill manifest" has double scroll bar

### DIFF
--- a/Composer/packages/client/src/components/Modal/DisplayManifestModal.tsx
+++ b/Composer/packages/client/src/components/Modal/DisplayManifestModal.tsx
@@ -38,6 +38,7 @@ const styles: { content: any; dialog: Partial<IDialogContentStyles>; modal: Part
       height: '800px !important',
       maxWidth: '80% !important',
       width: '600px !important',
+      overflowY: 'hidden',
     },
   },
 };

--- a/Composer/packages/client/src/recoilModel/dispatchers/project.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/project.ts
@@ -9,7 +9,7 @@ import { RootBotManagedProperties } from '@bfc/shared';
 import get from 'lodash/get';
 import { CallbackInterface, useRecoilCallback } from 'recoil';
 
-import { BotStatus } from '../../constants';
+import { BotStatus, QnABotTemplateId } from '../../constants';
 import settingStorage from '../../utils/dialogSettingStorage';
 import { getFileNameFromPath } from '../../utils/fileUtil';
 import httpClient from '../../utils/httpUtil';
@@ -26,9 +26,11 @@ import {
   botProjectIdsState,
   botProjectSpaceLoadedState,
   botStatusState,
+  createQnAOnState,
   currentProjectIdState,
   filePersistenceState,
   projectMetaDataState,
+  showCreateQnAFromUrlDialogState,
 } from '../atoms';
 import { dispatcherState } from '../DispatcherWrapper';
 import { rootBotProjectIdSelector } from '../selectors';
@@ -469,6 +471,12 @@ export const projectDispatcher = () => {
               isRootBot: true,
               isRemote: false,
             });
+            // if create from QnATemplate, continue creation flow.
+            if (templateId === QnABotTemplateId) {
+              callbackHelpers.set(createQnAOnState, { projectId, dialogId: mainDialog });
+              callbackHelpers.set(showCreateQnAFromUrlDialogState(projectId), true);
+            }
+
             projectIdCache.set(projectId);
             navigateToBot(callbackHelpers, projectId, mainDialog, urlSuffix);
             callbackHelpers.set(botOpeningMessage, '');

--- a/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
@@ -70,6 +70,7 @@ import {
   skillManifestsState,
   dialogIdsState,
   showCreateQnAFromUrlDialogState,
+  createQnAOnState,
 } from '../../atoms';
 import * as botstates from '../../atoms/botState';
 import { dispatcherState } from '../../DispatcherWrapper';
@@ -511,6 +512,7 @@ export const createNewBotFromTemplate = async (
   const mainDialog = await initBotState(callbackHelpers, projectData, botFiles);
   // if create from QnATemplate, continue creation flow.
   if (templateId === QnABotTemplateId) {
+    set(createQnAOnState, { projectId, dialogId: mainDialog });
     set(showCreateQnAFromUrlDialogState(projectId), true);
   }
 


### PR DESCRIPTION
## Description
Fix two issue:
1. "Show skill manifest" has double scroll bar
2. fix QnA bot creation flow, broken in feature/botprojects check in
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item

close #5167 

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots
1. "Show skill manifest" has double scroll bar
<img width="1133" alt="image" src="https://user-images.githubusercontent.com/49866537/101330195-4a2ea280-38ad-11eb-8e41-274ea1c6dd80.png">


2. fix QnA bot creation flow, broken in feature/botprojects check in
![Untitled7](https://user-images.githubusercontent.com/49866537/101329989-0c317e80-38ad-11eb-8d4d-973cd013f94e.gif)

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
