### PR TITLE
fix: title problem

### DIFF
--- a/Composer/packages/adaptive-form/src/components/FormTitle.tsx
+++ b/Composer/packages/adaptive-form/src/components/FormTitle.tsx
@@ -97,7 +97,7 @@ const FormTitle: React.FC<FormTitleProps> = (props) => {
   const initialValue = useMemo(() => {
     const designerName = formData.$designer?.name;
 
-    return designerName || uiLabel || schema.title;
+    return designerName ?? uiLabel ?? schema.title;
   }, [formData.$designer?.name, uiLabel, schema.title]);
 
   const getHelpLinkLabel = (): string => {

--- a/Composer/packages/client/src/pages/design/VisualEditor.tsx
+++ b/Composer/packages/client/src/pages/design/VisualEditor.tsx
@@ -94,7 +94,7 @@ const VisualEditor: React.FC<VisualEditorProps> = (props) => {
       }
     });
     return sdkSchema;
-  }, [formConfig, schemas]);
+  }, [formConfig, schemas, dialogId]);
 
   useEffect(() => {
     const dialog = dialogs.find((d) => d.id === dialogId);


### PR DESCRIPTION
## Description
Changes:
1. 'Backspacing intent name to empty' won't reset Form title for now.
2. Fix the Flow nodes' title by updating memo deps.

Note that when backspacing form title to empty, Form's title is synced to empty as requested but Flow node's title keeps fallback to the title from sdk.schema to make sure the flow logic is readable.
![image](https://user-images.githubusercontent.com/8528761/101336217-28d1b480-38b5-11eb-8e89-31ffb185e956.png)

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
closes #5123 
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
