### PR TITLE
fix: UX improvement to form dialogs and updated library

### DIFF
--- a/Composer/packages/client/src/Onboarding/Onboarding.tsx
+++ b/Composer/packages/client/src/Onboarding/Onboarding.tsx
@@ -5,9 +5,9 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { navigate } from '@reach/router';
 import formatMessage from 'format-message';
 import { useRecoilValue } from 'recoil';
+import { OpenConfirmModal } from '@bfc/ui-shared';
 
 import onboardingStorage from '../utils/onboardingStorage';
-import { OpenConfirmModal } from '../components/Modal/ConfirmDialog';
 import { useLocation } from '../utils/hooks';
 import { dispatcherState, onboardingState, botProjectIdsState, validateDialogsSelectorFamily } from '../recoilModel';
 

--- a/Composer/packages/client/src/pages/botProject/DeleteBotButton.tsx
+++ b/Composer/packages/client/src/pages/botProject/DeleteBotButton.tsx
@@ -11,8 +11,8 @@ import { Button } from 'office-ui-fabric-react/lib/Button';
 import { Text } from 'office-ui-fabric-react/lib/Text';
 import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
 import { NeutralColors, SharedColors } from '@uifabric/fluent-theme';
+import { OpenConfirmModal } from '@bfc/ui-shared';
 
-import { OpenConfirmModal } from '../../components/Modal/ConfirmDialog';
 import { navigateTo } from '../../utils/navigation';
 import { dispatcherState } from '../../recoilModel';
 

--- a/Composer/packages/client/src/pages/botProject/runtime-settings/RuntimeSettings.tsx
+++ b/Composer/packages/client/src/pages/botProject/runtime-settings/RuntimeSettings.tsx
@@ -14,6 +14,7 @@ import { Link } from 'office-ui-fabric-react/lib/Link';
 import { RouteComponentProps } from '@reach/router';
 import { useRecoilValue } from 'recoil';
 import { Spinner } from 'office-ui-fabric-react/lib/Spinner';
+import { OpenConfirmModal } from '@bfc/ui-shared';
 
 import {
   dispatcherState,
@@ -23,7 +24,6 @@ import {
   settingsState,
   isEjectRuntimeExistState,
 } from '../../../recoilModel';
-import { OpenConfirmModal } from '../../../components/Modal/ConfirmDialog';
 import { LoadingSpinner } from '../../../components/LoadingSpinner';
 
 import { EjectModal } from './ejectModal';

--- a/Composer/packages/client/src/pages/design/DesignPage.tsx
+++ b/Composer/packages/client/src/pages/design/DesignPage.tsx
@@ -13,6 +13,7 @@ import { ActionButton } from 'office-ui-fabric-react/lib/Button';
 import { JsonEditor } from '@bfc/code-editor';
 import { EditorExtension, PluginConfig } from '@bfc/extension-client';
 import { useRecoilValue, useRecoilState } from 'recoil';
+import { OpenConfirmModal } from '@bfc/ui-shared';
 
 import { LeftRightSplit } from '../../components/Split/LeftRightSplit';
 import { LoadingSpinner } from '../../components/LoadingSpinner';
@@ -20,7 +21,6 @@ import { DialogDeleting } from '../../constants';
 import { createSelectedPath, deleteTrigger as DialogdeleteTrigger, getDialogData } from '../../utils/dialogUtil';
 import { Conversation } from '../../components/Conversation';
 import { dialogStyle } from '../../components/Modal/dialogStyle';
-import { OpenConfirmModal } from '../../components/Modal/ConfirmDialog';
 import { ProjectTree, TreeLink } from '../../components/ProjectTree/ProjectTree';
 import { Toolbar, IToolbarItem } from '../../components/Toolbar';
 import { createDiagnosticsPageUrl, getFocusPath, navigateTo, createBotSettingUrl } from '../../utils/navigation';

--- a/Composer/packages/client/src/pages/form-dialog/FormDialogPage.tsx
+++ b/Composer/packages/client/src/pages/form-dialog/FormDialogPage.tsx
@@ -155,7 +155,7 @@ const FormDialogPage: React.FC<Props> = React.memo((props: Props) => {
         );
       }
     }
-  }, [formDialogError, formDialogGenerationProgressing]);
+  }, [formDialogError, formDialogGenerationProgressing, schemaId]);
 
   const updateItem = React.useCallback(
     (id: string, content: string) => {

--- a/Composer/packages/client/src/pages/form-dialog/FormDialogPage.tsx
+++ b/Composer/packages/client/src/pages/form-dialog/FormDialogPage.tsx
@@ -8,15 +8,17 @@ import { Stack } from 'office-ui-fabric-react/lib/Stack';
 import { Text } from 'office-ui-fabric-react/lib/Text';
 import * as React from 'react';
 import { useRecoilValue } from 'recoil';
+import { OpenConfirmModal } from '@bfc/ui-shared';
 
-import { OpenConfirmModal } from '../../components/Modal/ConfirmDialog';
 import { LeftRightSplit } from '../../components/Split/LeftRightSplit';
 import {
   dispatcherState,
+  formDialogErrorState,
   formDialogGenerationProgressingState,
   formDialogLibraryTemplatesState,
   formDialogSchemaIdsState,
 } from '../../recoilModel';
+import { createNotification } from '../../recoilModel/dispatchers/notification';
 
 import CreateFormDialogSchemaModal from './CreateFormDialogSchemaModal';
 import { FormDialogSchemaList } from './FormDialogSchemaList';
@@ -32,6 +34,7 @@ type Props = RouteComponentProps<{ projectId: string; schemaId: string }>;
 const FormDialogPage: React.FC<Props> = React.memo((props: Props) => {
   const { projectId = '', schemaId = '' } = props;
   const formDialogSchemaIds = useRecoilValue(formDialogSchemaIdsState(projectId));
+  const formDialogError = useRecoilValue(formDialogErrorState);
   const formDialogLibraryTemplates = useRecoilValue(formDialogLibraryTemplatesState);
   const formDialogGenerationProgressing = useRecoilValue(formDialogGenerationProgressingState);
   const {
@@ -41,8 +44,12 @@ const FormDialogPage: React.FC<Props> = React.memo((props: Props) => {
     updateFormDialogSchema,
     navigateToGeneratedDialog,
     loadFormDialogSchemaTemplates,
+    addNotification,
+    deleteNotification,
   } = useRecoilValue(dispatcherState);
 
+  const generationStartedRef = React.useRef(false);
+  const generationPendingNotificationIdRef = React.useRef<string | undefined>();
   const { 0: createSchemaDialogOpen, 1: setCreateSchemaDialogOpen } = React.useState(false);
 
   React.useEffect(() => {
@@ -65,7 +72,7 @@ const FormDialogPage: React.FC<Props> = React.memo((props: Props) => {
   const deleteItem = React.useCallback(
     async (id: string) => {
       const res = await OpenConfirmModal(
-        formatMessage('Delete form dialog schema'),
+        formatMessage('Delete form dialog schema?'),
         formatMessage('Are you sure you want to remove form dialog schema "{id}"?', { id })
       );
       if (res) {
@@ -81,6 +88,15 @@ const FormDialogPage: React.FC<Props> = React.memo((props: Props) => {
   const generateDialog = React.useCallback(
     (schemaId: string) => {
       if (schemaId) {
+        generationStartedRef.current = true;
+
+        const notification = createNotification({
+          title: formatMessage('Generating your dialog using "{schemaId}" schema, please wait...', { schemaId }),
+          type: 'pending',
+        });
+        generationPendingNotificationIdRef.current = notification.id;
+        addNotification(notification);
+
         generateFormDialog({ projectId, schemaId });
       }
     },
@@ -95,6 +111,51 @@ const FormDialogPage: React.FC<Props> = React.memo((props: Props) => {
     },
     [navigateToGeneratedDialog, projectId]
   );
+
+  React.useEffect(() => {
+    // Check to see if generation was in progress.
+    if (generationStartedRef.current && !formDialogGenerationProgressing) {
+      generationStartedRef.current = false;
+
+      if (generationPendingNotificationIdRef.current) {
+        deleteNotification(generationPendingNotificationIdRef.current);
+      }
+
+      // If the generation was started and now it's over check for errors.
+      if (!formDialogError) {
+        // No error, show success message.
+        addNotification(
+          createNotification({
+            type: 'success',
+            title: formatMessage('Dialog generation was successful.'),
+            description: formatMessage('Your dialog was generated successfully.'),
+            link: { label: formatMessage('View dialog'), onClick: () => schemaId && viewDialog(schemaId) },
+          })
+        );
+      } else {
+        // error, show failed message with error.
+        addNotification(
+          createNotification({
+            type: 'error',
+            title: formatMessage('Dialog generation failed.'),
+            description: formDialogError.message,
+          })
+        );
+      }
+    } else {
+      // There is an error but it's not about generation.
+      // Show failed message with error.
+      if (formDialogError) {
+        addNotification(
+          createNotification({
+            type: 'error',
+            title: formatMessage('Form dialog error'),
+            description: formDialogError.message,
+          })
+        );
+      }
+    }
+  }, [formDialogError, formDialogGenerationProgressing]);
 
   const updateItem = React.useCallback(
     (id: string, content: string) => {

--- a/Composer/packages/client/src/pages/form-dialog/FormDialogSchemaList.tsx
+++ b/Composer/packages/client/src/pages/form-dialog/FormDialogSchemaList.tsx
@@ -5,6 +5,7 @@ import styled from '@emotion/styled';
 import { NeutralColors } from '@uifabric/fluent-theme';
 import { DefaultPalette } from '@uifabric/styling';
 import formatMessage from 'format-message';
+import get from 'lodash/get';
 import debounce from 'lodash/debounce';
 import { CommandBarButton, IconButton } from 'office-ui-fabric-react/lib/Button';
 import { FocusZone, FocusZoneDirection } from 'office-ui-fabric-react/lib/FocusZone';
@@ -19,7 +20,14 @@ import { formDialogSchemaDialogExistsSelector, formDialogSchemaState } from '../
 
 import { FormDialogSchemaListHeader } from './FormDialogSchemaListHeader';
 
-const isEmptyObject = (objStr: string) => objStr === '{}';
+const isEmptyObject = (objStr: string) => {
+  if (!objStr) {
+    return true;
+  }
+
+  const properties = get(JSON.parse(objStr), 'properties', undefined);
+  return !properties;
+};
 
 const Root = styled(Stack)<{
   loading: boolean;
@@ -214,7 +222,7 @@ export const FormDialogSchemaList: React.FC<FormDialogSchemaListProps> = React.m
   const delayedSetQuery = debounce((newValue) => setQuery(newValue), 300);
 
   const filteredItems = React.useMemo(() => {
-    return items.filter((item) => item.toLowerCase().indexOf(query.toLowerCase()) !== -1);
+    return query ? items.filter((item) => item.toLowerCase().indexOf(query.toLowerCase()) !== -1) : items;
   }, [query, items]);
 
   const onFilter = (_e?: React.ChangeEvent<HTMLInputElement>, newValue?: string): void => {

--- a/Composer/packages/client/src/pages/form-dialog/FormDialogSchemaListHeader.tsx
+++ b/Composer/packages/client/src/pages/form-dialog/FormDialogSchemaListHeader.tsx
@@ -2,18 +2,35 @@
 // Licensed under the MIT License.
 
 import styled from '@emotion/styled';
+import { FontSizes, NeutralColors } from '@uifabric/fluent-theme';
 import formatMessage from 'format-message';
 import { IconButton } from 'office-ui-fabric-react/lib/Button';
+import { Icon, IIconStyleProps, IIconStyles } from 'office-ui-fabric-react/lib/Icon';
 import { Label } from 'office-ui-fabric-react/lib/Label';
+import { Link } from 'office-ui-fabric-react/lib/Link';
 import { ProgressIndicator } from 'office-ui-fabric-react/lib/ProgressIndicator';
 import { ISearchBoxProps, ISearchBoxStyles, SearchBox } from 'office-ui-fabric-react/lib/SearchBox';
 import { Stack } from 'office-ui-fabric-react/lib/Stack';
+import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
 import { classNamesFunction } from 'office-ui-fabric-react/lib/Utilities';
 import * as React from 'react';
 
 const TitleBar = styled(Stack)({
   flex: 1,
   height: 45,
+});
+
+const helpIconStyles = classNamesFunction<IIconStyleProps, IIconStyles>()({
+  root: {
+    width: '16px',
+    minWidth: '16px',
+    height: '16px',
+    color: NeutralColors.gray160,
+    fontSize: FontSizes.size12,
+    marginBottom: '-2px',
+    paddingLeft: '4px',
+    paddingTop: '4px',
+  },
 });
 
 const Title = styled(Label)({});
@@ -61,6 +78,22 @@ export const FormDialogSchemaListHeader = (props: ListHeaFormDialogSchemaListHea
         ) : (
           <Title>
             {formatMessage('Schemas')}
+            <TooltipHost
+              content={
+                <span>
+                  <span>{formatMessage('A schema, or form, is the list of properties your bot will collect.')}</span>
+                  <Link
+                    href="https://aka.ms/AAailpe#creating-and-connecting-a-form-dialog"
+                    styles={{ root: { marginLeft: 4 } }}
+                    target="_blank"
+                  >
+                    {formatMessage('Learn more about your property schema')}
+                  </Link>
+                </span>
+              }
+            >
+              <Icon iconName="Unknown" styles={helpIconStyles} />
+            </TooltipHost>
             {loading && <LoadingIndicator />}
           </Title>
         )}

--- a/Composer/packages/client/src/pages/form-dialog/VisualFormDialogSchemaEditor.tsx
+++ b/Composer/packages/client/src/pages/form-dialog/VisualFormDialogSchemaEditor.tsx
@@ -34,7 +34,6 @@ const Root = styled(Stack)<{
             width: '100%',
             height: '100%',
             background: 'rgba(255,255,255, 0.6)',
-            zIndex: 1,
           },
         }
       : null

--- a/Composer/packages/client/src/recoilModel/atoms/appState.ts
+++ b/Composer/packages/client/src/recoilModel/atoms/appState.ts
@@ -235,6 +235,11 @@ export const formDialogGenerationProgressingState = atom({
   default: false,
 });
 
+export const formDialogErrorState = atom<(Error & { kind: 'templateFetch' | 'generation' | 'deletion' }) | undefined>({
+  key: getFullyQualifiedKey('formDialogError'),
+  default: undefined,
+});
+
 export const pageElementState = atom<{ [page in PageMode]?: { [key: string]: any } }>({
   key: getFullyQualifiedKey('pageElement'),
   default: {

--- a/Composer/packages/client/src/recoilModel/dispatchers/formDialogs.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/formDialogs.ts
@@ -9,7 +9,7 @@ import { CallbackInterface, useRecoilCallback } from 'recoil';
 
 import httpClient from '../../utils/httpUtil';
 import {
-  applicationErrorState,
+  formDialogErrorState,
   formDialogGenerationProgressingState,
   formDialogLibraryTemplatesState,
 } from '../atoms/appState';
@@ -39,7 +39,9 @@ export const formDialogsDispatcher = () => {
   });
 
   const loadFormDialogSchemaTemplates = useRecoilCallback((callbackHelpers: CallbackInterface) => async () => {
-    const { set, snapshot } = callbackHelpers;
+    const { set, reset, snapshot } = callbackHelpers;
+    reset(formDialogErrorState);
+
     const templates = await snapshot.getPromise(formDialogLibraryTemplatesState);
     // If templates are already loaded, don't reload.
     if (templates.length) {
@@ -54,17 +56,20 @@ export const formDialogsDispatcher = () => {
       }));
 
       set(formDialogLibraryTemplatesState, templates);
-    } catch (error) {
-      set(applicationErrorState, {
-        message: error.message,
-        summary: formatMessage('Load form dialog schema templates Error'),
+    } catch (ex) {
+      set(formDialogErrorState, {
+        ...ex,
+        message: formatMessage('Load form dialog schema templates Error'),
+        kind: 'templateFetch',
       });
     }
   });
 
   const generateFormDialog = useRecoilCallback(
     (callbackHelpers: CallbackInterface) => async ({ projectId, schemaId }) => {
-      const { set, snapshot } = callbackHelpers;
+      const { set, reset, snapshot } = callbackHelpers;
+      reset(formDialogErrorState);
+
       const { reloadProject } = await snapshot.getPromise(dispatcherState);
       try {
         set(formDialogGenerationProgressingState, true);
@@ -78,10 +83,13 @@ export const formDialogsDispatcher = () => {
           name: schemaId,
         });
         await reloadProject(response.data.id);
-      } catch (error) {
-        set(applicationErrorState, {
-          message: error.message,
-          summary: formatMessage('Generating form dialog using "{ schemaId }" schema failed.', { schemaId }),
+      } catch (ex) {
+        set(formDialogErrorState, {
+          ...ex,
+          message: formatMessage('Generating form dialog using "{ schemaId }" schema failed. Please try again later.', {
+            schemaId,
+          }),
+          kind: 'generation',
         });
       } finally {
         set(formDialogGenerationProgressingState, false);
@@ -91,7 +99,8 @@ export const formDialogsDispatcher = () => {
 
   const removeFormDialog = useRecoilCallback(
     (callbackHelpers: CallbackInterface) => async ({ projectId, dialogId }) => {
-      const { set, snapshot } = callbackHelpers;
+      const { set, reset, snapshot } = callbackHelpers;
+      reset(formDialogErrorState);
 
       const dialog = await snapshot.getPromise(dialogState({ projectId, dialogId }));
       const { reloadProject } = await snapshot.getPromise(dispatcherState);
@@ -103,10 +112,11 @@ export const formDialogsDispatcher = () => {
 
         await httpClient.delete(`/formDialogs/${projectId}/${dialogId}`);
         await reloadProject(projectId);
-      } catch (error) {
-        set(applicationErrorState, {
-          message: error.message,
-          summary: formatMessage('Deleting "{ dialogId }" failed.', { dialogId }),
+      } catch (ex) {
+        set(formDialogErrorState, {
+          ...ex,
+          message: formatMessage('Deleting "{ dialogId }" failed.', { dialogId }),
+          kind: 'deletion',
         });
       }
     }

--- a/Composer/packages/client/src/recoilModel/dispatchers/formDialogs.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/formDialogs.ts
@@ -60,7 +60,7 @@ export const formDialogsDispatcher = () => {
     } catch (ex) {
       set(formDialogErrorState, {
         ...ex,
-        message: formatMessage('Load form dialog schema templates Error'),
+        message: formatMessage('Fetching form dialog schema templates failed.'),
         kind: 'templateFetch',
       });
     }

--- a/Composer/packages/client/src/shell/useShell.ts
+++ b/Composer/packages/client/src/shell/useShell.ts
@@ -13,6 +13,7 @@ import {
 } from '@botframework-composer/types';
 import { useRecoilValue } from 'recoil';
 import formatMessage from 'format-message';
+import { OpenConfirmModal } from '@bfc/ui-shared';
 
 import httpClient from '../utils/httpUtil';
 import { updateRegExIntent, renameRegExIntent, updateIntentTrigger } from '../utils/dialogUtil';
@@ -40,7 +41,6 @@ import {
 import { undoFunctionState } from '../recoilModel/undo/history';
 import { skillsStateSelector } from '../recoilModel/selectors';
 import { navigateTo } from '../utils/navigation';
-import { OpenConfirmModal } from '../components/Modal/ConfirmDialog';
 
 import { useLgApi } from './lgApi';
 import { useLuApi } from './luApi';

--- a/Composer/packages/form-dialogs/package.json
+++ b/Composer/packages/form-dialogs/package.json
@@ -18,7 +18,8 @@
     "lint:fix": "yarn lint --fix"
   },
   "dependencies": {
-    "react-beautiful-dnd": "^13.0.0"
+    "react-beautiful-dnd": "^13.0.0",
+    "@bfc/ui-shared": "*"
   },
   "peerDependencies": {
     "recoil": "^0.0.13",

--- a/Composer/packages/form-dialogs/src/components/property/PropertyListItem.tsx
+++ b/Composer/packages/form-dialogs/src/components/property/PropertyListItem.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { OpenConfirmModal } from '@bfc/ui-shared';
 import styled from '@emotion/styled';
 import { FluentTheme } from '@uifabric/fluent-theme';
 import { useId } from '@uifabric/react-hooks';
@@ -14,7 +15,7 @@ import { Draggable, DraggableProvidedDragHandleProps } from 'react-beautiful-dnd
 import { useRecoilValue } from 'recoil';
 import { activePropertyIdAtom, formDialogPropertyAtom, formDialogPropertyValidSelector } from 'src/atoms/appState';
 import { useHandlers } from 'src/atoms/handlers';
-import { FormDialogProperty, FormDialogPropertyPayload, FormDialogPropertyKind } from 'src/atoms/types';
+import { FormDialogProperty, FormDialogPropertyKind, FormDialogPropertyPayload } from 'src/atoms/types';
 import { getPropertyTypeDisplayName } from 'src/atoms/utils';
 import { FormDialogPropertyCard } from 'src/components/property/FormDialogPropertyCard';
 import { RequiredPriorityIndicator } from 'src/components/property/RequiredPriorityIndicator';
@@ -173,8 +174,14 @@ export const PropertyListItem = React.memo((props: Props) => {
     [activatePropertyId]
   );
 
-  const onRemove = React.useCallback(() => {
-    if (confirm(formatMessage('Are you sure you want to remove "{propertyName}"?', { propertyName: property.name }))) {
+  const onRemove = React.useCallback(async () => {
+    const res = await OpenConfirmModal(
+      formatMessage('Delete property?'),
+      property.name
+        ? formatMessage('Are you sure you want to remove "{propertyName}"?', { propertyName: property.name })
+        : formatMessage('Are you sure you want to remove this property?')
+    );
+    if (res) {
       removeProperty({ id: propertyId });
     }
   }, [removeProperty, propertyId]);

--- a/Composer/packages/form-dialogs/src/components/tags/TagInput.tsx
+++ b/Composer/packages/form-dialogs/src/components/tags/TagInput.tsx
@@ -95,10 +95,15 @@ export const TagInput = (props: TagInputProps) => {
 
   const addTag = (value: string) => {
     const clonedTags = [...tags];
-    if (clonedTags.indexOf(value) === -1) {
-      clonedTags.push(value);
-      onChange(clonedTags);
-    }
+    // Extract comma separated tags
+    const enteredTags = csvToArray(value).filter((t) => !!t);
+
+    // Remove repetitive tags
+    const newTags = enteredTags.filter((et) => !clonedTags.includes(et));
+
+    clonedTags.push(...newTags);
+    onChange(clonedTags);
+
     setInput('');
   };
 
@@ -109,7 +114,6 @@ export const TagInput = (props: TagInputProps) => {
   };
 
   const onPaste = (event: React.ClipboardEvent<HTMLInputElement>) => {
-    setInput('');
     event.preventDefault();
 
     const pasteData = event.clipboardData;
@@ -118,10 +122,8 @@ export const TagInput = (props: TagInputProps) => {
       return;
     }
 
-    const text = pasteData.getData('text/plain');
-    const tags = csvToArray(text);
-
-    onChange(tags);
+    const value = pasteData.getData('text/plain');
+    addTag(value);
   };
 
   const onInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/Composer/packages/lib/shared/src/featureFlagUtils/index.ts
+++ b/Composer/packages/lib/shared/src/featureFlagUtils/index.ts
@@ -6,7 +6,7 @@ import { FeatureFlagMap } from '@botframework-composer/types';
 
 export const getDefaultFeatureFlags = (): FeatureFlagMap => ({
   FORM_DIALOG: {
-    displayName: formatMessage('Show Form Dialog'),
+    displayName: formatMessage('Form dialogs'),
     description: formatMessage(
       'Automatically generate dialogs that collect information from a user to manage conversations.'
     ),

--- a/Composer/packages/lib/ui-shared/src/components/ConfirmDialog.tsx
+++ b/Composer/packages/lib/ui-shared/src/components/ConfirmDialog.tsx
@@ -9,10 +9,12 @@ import { PrimaryButton, DefaultButton } from 'office-ui-fabric-react/lib/Button'
 import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
 import ReactDOM from 'react-dom';
 import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
-import { SharedColors } from '@uifabric/fluent-theme';
 import formatMessage from 'format-message';
 
-import { dialogStyle } from './dialogStyle';
+const dialogStyle = {
+  normal: 'NORMAL',
+  console: 'CONSOLE',
+};
 
 // -------------------- Styles -------------------- //
 const normalStyle = css`
@@ -33,46 +35,35 @@ const consoleStyle = css`
   white-space: pre-line;
 `;
 
-export const builtInStyles = {
+const builtInStyles = {
   [dialogStyle.normal]: normalStyle,
   [dialogStyle.console]: consoleStyle,
 };
 
-export const dialog = {
+const dialog = {
   title: {
     fontWeight: FontWeights.bold,
   },
 };
 
-export const dialogModal = {
+const dialogModal = {
   main: {
     maxWidth: '600px !important',
   },
 };
 
-export const confirmationContainer = css`
+const confirmationContainer = css`
   display: flex;
   flex-direction: column;
 `;
 
-export const confirmation = css`
-  padding: 15px;
-  margin-bottom: 20px;
-  white-space: pre-line;
-  background: ${SharedColors.red10};
-`;
-
-export const confirmationContent = css`
-  width: 500px;
-`;
-
 // -------------------- ConfirmDialog -------------------- //
 
-interface ConfirmDialogProps {
+type ConfirmDialogProps = {
   onCancel: () => void;
   onConfirm: () => void;
   setting: any;
-}
+};
 
 const ConfirmDialog: React.FC<ConfirmDialogProps> = (props) => {
   const { setting, onCancel, onConfirm } = props;

--- a/Composer/packages/lib/ui-shared/src/components/index.ts
+++ b/Composer/packages/lib/ui-shared/src/components/index.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export * from './ListOverview';
-export * from './PropertyAssignment';
 export * from './DialogWrapper';
-export * from './Toolbar';
+export * from './ListOverview';
 export * from './LoadingSpinner';
+export * from './ConfirmDialog';
+export * from './PropertyAssignment';
+export * from './Toolbar';

--- a/Composer/packages/server/package.json
+++ b/Composer/packages/server/package.json
@@ -65,7 +65,7 @@
     "@botframework-composer/types": "*",
     "@microsoft/bf-dialog": "4.11.0-dev.20201025.69cf2b9",
     "@microsoft/bf-dispatcher": "^4.11.0-beta.20201016.393c6b2",
-    "@microsoft/bf-generate-library": "^4.10.0-daily.20201203.191380",
+    "@microsoft/bf-generate-library": "^4.10.0-daily.20201205.191993",
     "@microsoft/bf-lu": "^4.11.0-rc.20201030.a9f9b96",
     "@microsoft/bf-orchestrator": "4.11.0-beta.20201203.cd29e25",
     "applicationinsights": "^1.8.7",

--- a/Composer/yarn.lock
+++ b/Composer/yarn.lock
@@ -3111,10 +3111,10 @@
     ts-md5 "^1.2.6"
     tslib "^1.10.0"
 
-"@microsoft/bf-generate-library@^4.10.0-daily.20201203.191380":
-  version "4.10.0-daily.20201203.191380"
-  resolved "https://botbuilder.myget.org/F/botframework-cli/npm/@microsoft/bf-generate-library/-/@microsoft/bf-generate-library-4.10.0-daily.20201203.191380.tgz#8987c2e95c077abc82f6bdf93cabccdfa82cede9"
-  integrity sha1-iYfC6VwHeryC9r35PKvM36gs7ek=
+"@microsoft/bf-generate-library@^4.10.0-daily.20201205.191993":
+  version "4.10.0-daily.20201205.191993"
+  resolved "https://botbuilder.myget.org/F/botframework-cli/npm/@microsoft/bf-generate-library/-/@microsoft/bf-generate-library-4.10.0-daily.20201205.191993.tgz#d482a19322f3607c3c2c852f75cb0b1d505e808b"
+  integrity sha1-1IKhkyLzYHw8LIUvdcsLHVBegIs=
   dependencies:
     "@microsoft/bf-lu" rc
     adaptive-expressions "^4.11.0"

--- a/docs/preview features/form-dialogs.md
+++ b/docs/preview features/form-dialogs.md
@@ -13,7 +13,7 @@ Follow these steps to enable Forms (preview) in Composer:
 1. Install [Bot Framework Composer](https://docs.microsoft.com/composer/install-composer#build-composer-from-source) and run it.
 1. From the **Home** page, select **New** to create a new bot or open an existing bot. A bot needs to be open in order to use the Forms feature in Composer.
 1. Next, select **Settings** from the Composer menu, then **Application settings** in the navigation pane.
-1. In the **Preview features** section, select the **Show Form Dialog** checkbox.
+1. In the **Preview features** section, select the **Form dialogs** checkbox.
 
 You can now select **Forms (preview)** from the Composer menu.
 
@@ -62,9 +62,9 @@ When your schema is complete, generate a new dialog from it. Once your new dialo
 >
 > - **Missing**: Fires when the property value is missing. The bot sends a message to the user asking for a value and expects a response. The **Missing()** trigger is created only for required properties.
 > - **Help**: Fires when the bot is expecting a value for this property and user instead asks for help. The bot sends a message that describes the values acceptable for this property.
-> - **Clear**: Fires when the user asks to clear this property. The bot sends a confirmation message and deletes the property. 
-> - **Show**: Fires when the user asks to show this property. The bot sends a message that shows the property name and value. 
-> - **Change**: Fires when the user asks to change this property. The bot sends a message asking the user what value they like to use instead. 
+> - **Clear**: Fires when the user asks to clear this property. The bot sends a confirmation message and deletes the property.
+> - **Show**: Fires when the user asks to show this property. The bot sends a message that shows the property name and value.
+> - **Change**: Fires when the user asks to change this property. The bot sends a message asking the user what value they like to use instead.
 > - **Choose**: Fires when the user gives a value that is similar to multiple acceptable values. The bot sends a message asking the user to choose betweeen the possible value. The **Choose** trigger is created only for properties that have acceptable values that are similar.
 > - **Add**: Fires when the user specifies a property value, either when expected by the bot in response to a **Missing** trigger or unexpected by the bot. The bot sends a message confirming the value, if unexpected, and sets the property.
 > - **Remove**: Fires when the user asks to remove a value. The bot sends a message confirming the value and sets the property.


### PR DESCRIPTION
## Description

1. Adds notification to form dialog generation: progress, fail, success.
2. Adds help text to schemas, fixes minor search issue for schemas.
3. Adds back export for form dialog schema.
4. Replace native browser "confirm" with Composer confirm dialog (moved to ui-shared)
    Note: using native browser confirm freezes electron UI on windows.
5. Fixes disable state for "clear all" and "generate dialog"
6. Fixes text for feature flags view and in the documentation.

## Task Item

closes #5153
closes #5143
closes #5141
closes #5138