### PR TITLE
fix: preserve selection when selecting right to left

### DIFF
--- a/Composer/packages/adaptive-form/src/components/fields/StringField.tsx
+++ b/Composer/packages/adaptive-form/src/components/fields/StringField.tsx
@@ -54,7 +54,7 @@ export const StringField: React.FC<FieldProps<string>> = function StringField(pr
 
   useEffect(() => {
     if (cursorPosition !== undefined && cursorPosition > -1 && textFieldRef.current) {
-      textFieldRef.current.setSelectionRange(cursorPosition, cursorPosition);
+      textFieldRef.current.setSelectionRange(cursorPosition, textFieldRef.current.selectionEnd || cursorPosition);
     }
   }, [cursorPosition]);
 


### PR DESCRIPTION
## Description

Preserves selection state when using shift+left arrow.

## Task Item

fixes #5125

## Screenshots

![Screen Recording 2020-12-07 at 03 02 12 PM](https://user-images.githubusercontent.com/3619060/101415721-3da24e00-389d-11eb-8cc9-5fcc18541956.gif)

