### PR TITLE
fix: Fixed reference to build environment variables

### DIFF
--- a/Composer/packages/server/src/models/utilities/parser.ts
+++ b/Composer/packages/server/src/models/utilities/parser.ts
@@ -17,7 +17,7 @@ const debug = log.extend('helper-parser');
 
 const BuildEnvPath = Path.join(__dirname, '../../env.json');
 
-function getBuildEnvironment() {
+export function getBuildEnvironment() {
   if (fs.existsSync(BuildEnvPath)) {
     return JSON.parse(fs.readFileSync(BuildEnvPath, 'utf-8'));
   }

--- a/Composer/packages/server/src/services/telemetry.ts
+++ b/Composer/packages/server/src/services/telemetry.ts
@@ -6,9 +6,9 @@ import { TelemetryEventName, TelemetryEvents, TelemetryEventTypes, TelemetryEven
 
 import { APPINSIGHTS_INSTRUMENTATIONKEY, piiProperties } from '../constants';
 import { useElectronContext } from '../utility/electronContext';
+import { getBuildEnvironment } from '../models/utilities/parser';
 
 import { SettingsService } from './settings';
-import { getBuildEnvironment } from '../models/utilities/parser';
 
 const instrumentationKey = APPINSIGHTS_INSTRUMENTATIONKEY || getBuildEnvironment()?.APPINSIGHTS_INSTRUMENTATIONKEY;
 

--- a/Composer/packages/server/src/services/telemetry.ts
+++ b/Composer/packages/server/src/services/telemetry.ts
@@ -1,25 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-import fs from 'fs';
 
 import * as AppInsights from 'applicationinsights';
 import { TelemetryEventName, TelemetryEvents, TelemetryEventTypes, TelemetryEvent } from '@bfc/shared';
 
 import { APPINSIGHTS_INSTRUMENTATIONKEY, piiProperties } from '../constants';
 import { useElectronContext } from '../utility/electronContext';
-import { Path } from '../utility/path';
 
 import { SettingsService } from './settings';
-
-const buildEnvPath = Path.join(__dirname, '../../env.json');
-
-function getBuildEnvironment() {
-  if (fs.existsSync(buildEnvPath)) {
-    return JSON.parse(fs.readFileSync(buildEnvPath, 'utf-8'));
-  }
-
-  return {};
-}
+import { getBuildEnvironment } from '../models/utilities/parser';
 
 const instrumentationKey = APPINSIGHTS_INSTRUMENTATIONKEY || getBuildEnvironment()?.APPINSIGHTS_INSTRUMENTATIONKEY;
 


### PR DESCRIPTION
## Description
Fixed an incorrect reference to the `env.json` file that contains the `APPINSIGHTS_INSTRUMENTATIONKEY`.

## Task Item
#minor
