### PR TITLE
fix: data flow for publish page

### DIFF
--- a/Composer/packages/client/src/pages/publish/Publish.tsx
+++ b/Composer/packages/client/src/pages/publish/Publish.tsx
@@ -90,7 +90,7 @@ const Publish: React.FC<RouteComponentProps<{ projectId: string; targetName?: st
   const [showNotifications, setShowNotifications] = useState<Record<string, boolean>>({});
   // fill Settings, status, publishType, publish target for bot from botProjectMeta, publishHistory
   const { botSettingList, statusList, botPublishTypesList } = useMemo(() => {
-    return generateComputedData(botProjectData, publish);
+    return generateComputedData(botProjectData, publishHistoryList);
   }, [botProjectData, publishHistoryList]);
 
   const [botStatusList, setBotStatusList] = useState<IBotStatus[]>(statusList);

--- a/Composer/packages/client/src/pages/publish/Publish.tsx
+++ b/Composer/packages/client/src/pages/publish/Publish.tsx
@@ -52,7 +52,7 @@ const generateComputedData = (botProjectData, publishHistoryList) => {
       name: bot.name,
       publishTargets: [],
     };
-    const publishHistory = publishHistoryList.find((item) => item.projectId === bot.projectId);
+    const publishHistory = publishHistoryList.find((item) => item.projectId === bot.projectId)?.publishHistory;
     if (publishTargets.length > 0) {
       botStatus.publishTarget = publishTargets[0].name as string;
       botStatus.publishTargets = publishTargets;

--- a/Composer/packages/client/src/pages/publish/Publish.tsx
+++ b/Composer/packages/client/src/pages/publish/Publish.tsx
@@ -27,7 +27,7 @@ import { getPendingNotificationCardProps, getPublishedNotificationCardProps } fr
 import { PullDialog } from './pullDialog';
 
 const publishStatusInterval = 10000;
-const generateComputedData = (botProjectData, publishHistoryList) => {
+const generateComputedData = (botProjectData, publishHistoryList, currentBotPublishTargetList) => {
   const botSettingList: { projectId: string; setting: DialogSetting }[] = [];
   const statusList: IBotStatus[] = [];
   const botPublishTypesList: { projectId: string; publishTypes: PublishType[] }[] = [];
@@ -54,7 +54,12 @@ const generateComputedData = (botProjectData, publishHistoryList) => {
     };
     const publishHistory = publishHistoryList.find((item) => item.projectId === bot.projectId)?.publishHistory;
     if (publishTargets.length > 0) {
-      botStatus.publishTarget = publishTargets[0].name as string;
+      const currentPublishTarget =
+        currentBotPublishTargetList &&
+        currentBotPublishTargetList.find((targetMap) => targetMap.projectId === botStatus.id);
+      botStatus.publishTarget = (currentPublishTarget && currentPublishTarget.publishTarget
+        ? currentPublishTarget.publishTarget
+        : publishTargets[0].name) as string;
       botStatus.publishTargets = publishTargets;
       if (publishHistory[botStatus.publishTarget] && publishHistory[botStatus.publishTarget].length > 0) {
         const history = publishHistory[botStatus.publishTarget][0];
@@ -88,9 +93,12 @@ const Publish: React.FC<RouteComponentProps<{ projectId: string; targetName?: st
   const [publishDisabled, setPublishDisabled] = useState(false);
 
   const [showNotifications, setShowNotifications] = useState<Record<string, boolean>>({});
+  const [currentBotPublishTargetList, setCurrentBotPublishTargetList] = useState<
+    { projectId: string; publishTarget: string }[]
+  >([]);
   // fill Settings, status, publishType, publish target for bot from botProjectMeta, publishHistory
   const { botSettingList, statusList, botPublishTypesList } = useMemo(() => {
-    return generateComputedData(botProjectData, publishHistoryList);
+    return generateComputedData(botProjectData, publishHistoryList, currentBotPublishTargetList);
   }, [botProjectData, publishHistoryList]);
 
   const [botStatusList, setBotStatusList] = useState<IBotStatus[]>(statusList);
@@ -255,6 +263,13 @@ const Publish: React.FC<RouteComponentProps<{ projectId: string; targetName?: st
     });
   }, [botProjectData.length]);
 
+  useEffect(() => {
+    return () => {
+      Object.keys(statusIntervals).forEach((key) => {
+        clearInterval(statusIntervals[key]);
+      });
+    };
+  });
   const rollbackToVersion = (version: IStatus, item: IBotStatus) => {
     const setting = botSettingList.find((botSetting) => botSetting.projectId === item.id)?.setting;
     const selectedTarget = item.publishTargets?.find((target) => target.name === item.publishTarget);
@@ -356,6 +371,22 @@ const Publish: React.FC<RouteComponentProps<{ projectId: string; targetName?: st
   };
   const changePublishTarget = (publishTarget, currentBotStatus) => {
     const target = currentBotStatus.publishTargets.find((t) => t.name === publishTarget);
+    if (currentBotPublishTargetList.some((targetMap) => targetMap.projectId === currentBotStatus.id)) {
+      setCurrentBotPublishTargetList(
+        currentBotPublishTargetList.map((targetMap) => {
+          if (targetMap.projectId === currentBotStatus.id) {
+            targetMap.publishTarget = publishTarget;
+          }
+          return targetMap;
+        })
+      );
+    } else {
+      setCurrentBotPublishTargetList([
+        ...currentBotPublishTargetList,
+        { projectId: currentBotStatus.id, publishTarget },
+      ]);
+    }
+
     getPublishHistory(currentBotStatus.id, target);
   };
 

--- a/Composer/packages/client/src/pages/publish/Publish.tsx
+++ b/Composer/packages/client/src/pages/publish/Publish.tsx
@@ -212,7 +212,11 @@ const Publish: React.FC<RouteComponentProps<{ projectId: string; targetName?: st
       }
       const latestPublishItem = botPublishHistory[0];
       // stop polling if status is 200 or 500
-      if (latestPublishItem.status === 200 || latestPublishItem.status === 500) {
+      if (latestPublishItem.status === 202) {
+        if (!statusIntervals.some((i) => i[bot.id])) {
+          setStatusIntervals([...statusIntervals, { [bot.id]: getUpdatedStatus(selectedTarget, bot.id) }]);
+        }
+      } else if (latestPublishItem.status === 200 || latestPublishItem.status === 500) {
         const interval = statusIntervals.find((i) => i[bot.id]);
         if (interval) {
           clearInterval(interval[bot.id]);
@@ -259,7 +263,9 @@ const Publish: React.FC<RouteComponentProps<{ projectId: string; targetName?: st
         return;
       }
       const target = botStatus.publishTargets.find((t) => t.name === botStatus.publishTarget);
-      getPublishHistory(botStatus.id, target);
+      getPublishHistory(botStatus.id, target).then(() => {
+        getPublishStatus(botStatus.id, target);
+      });
     });
   }, [botProjectData.length]);
 

--- a/Composer/packages/client/src/recoilModel/selectors/project.ts
+++ b/Composer/packages/client/src/recoilModel/selectors/project.ts
@@ -50,6 +50,20 @@ export const localBotsWithoutErrorsSelector = selector({
   },
 });
 
+export const localBotPublishHistorySelector = selector({
+  key: 'localBotPublishHistorySelector',
+  get: ({ get }) => {
+    const botProjectIds = get(localBotsWithoutErrorsSelector);
+    const result = botProjectIds.map((projectId: string) => {
+      const publishHistory = get(publishHistoryState(projectId));
+      return {
+        projectId,
+        publishHistory,
+      };
+    });
+    return result;
+  },
+});
 export const localBotsDataSelector = selector({
   key: 'localBotsDataSelector',
   get: ({ get }) => {
@@ -130,7 +144,6 @@ export const botProjectSpaceSelector = selector({
       });
 
       const diagnostics = BotIndexer.validate({ ...botAssets, isRemote, isRootBot });
-      const publishHistory = get(publishHistoryState(projectId));
       const publishTypes = get(publishTypesState(projectId));
 
       return {
@@ -145,7 +158,6 @@ export const botProjectSpaceSelector = selector({
         diagnostics,
         buildEssentials,
         isPvaSchema,
-        publishHistory,
         publishTypes,
         lgImports,
         luImports,


### PR DESCRIPTION
## Description

### Adjust data flow for publish page.
- Add publishHistory recoil value
- UseMemo to involve publishType, publishHistory & settings
- Reduce `useEffect` use.

### Result
- Data flow is clearer.  
- Data change is unidirectional.
- Avoid data reset possiblity.


### validated scenario 
- publish multi-bot 
- bot is still publishing status when reload page, if bot is publishing status
- change publish target, publish history work well
- bot list displayed right when switching from other page

## Task Item

fix #5214 

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
