### PR TITLE
fix: skill bot missing skill diagnostics

### DIFF
--- a/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
@@ -467,6 +467,8 @@ export const openLocalSkill = async (callbackHelpers, pathToBot: string, storage
     isRemote: false,
   });
   set(botNameIdentifierState(projectData.id), botNameIdentifier);
+  const currentBotProjectFileIndexed: BotProjectFile = botFiles.botProjectSpaceFiles[0];
+  set(botProjectFileState(projectData.id), currentBotProjectFileIndexed);
 
   return {
     projectId: projectData.id,

--- a/Composer/packages/lib/indexers/src/botIndexer.ts
+++ b/Composer/packages/lib/indexers/src/botIndexer.ts
@@ -152,7 +152,7 @@ const checkSkillSetting = (assets: { dialogs: DialogInfo[]; botProjectFile: BotP
         const skillName = getSkillNameFromSetting(skillId) || skillId;
         diagnostics.push(
           new Diagnostic(
-            `The skill '${skillName}' does not exist in in appsettings.json`,
+            `The skill '${skillName}' does not exist in bot project file`,
             dialog.id,
             DiagnosticSeverity.Error
           )


### PR DESCRIPTION
## Description

The bug is caused not set botProjectFileState for skill bot when do open local skill.

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
close #5211
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots
<img width="826" alt="image" src="https://user-images.githubusercontent.com/49866537/101449655-24b0a000-3964-11eb-9380-47fa175013a9.png">

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
