### PR TITLE
fix: Fixed undefined deref on new property.

### DIFF
--- a/Composer/packages/server/src/services/featureFlags.ts
+++ b/Composer/packages/server/src/services/featureFlags.ts
@@ -37,7 +37,7 @@ export class FeatureFlagService {
     defaultFeatureFlagKeys.forEach((key: string) => {
       const currentFlag = FeatureFlagService.currentFeatureFlagMap[key];
       const defaultFlag = FeatureFlagService.defaultFeatureFlags[key];
-      if (currentFlag.isHidden !== defaultFlag.isHidden) {
+      if (currentFlag && defaultFlag && currentFlag.isHidden !== defaultFlag.isHidden) {
         FeatureFlagService.currentFeatureFlagMap[key].isHidden = FeatureFlagService.defaultFeatureFlags[key].isHidden;
         saveNeeded = true;
       }


### PR DESCRIPTION
## Description

Feature flags won't load if there is a mismatch between default and current structure.

## Task Item

Closes #5229 
Closes #5102 

## Screenshots

