### PR TITLE
fix: Show panel only if previous status is not restart all bots

### DIFF
--- a/Composer/packages/client/src/components/BotRuntimeController/BotController.tsx
+++ b/Composer/packages/client/src/components/BotRuntimeController/BotController.tsx
@@ -130,7 +130,9 @@ const BotController: React.FC = () => {
     }
 
     if (botStartComplete) {
-      hideController(false);
+      if (statusIconClass !== 'Refresh') {
+        hideController(false);
+      }
       setStatusIconClass('Refresh');
       return formatMessage('Restart all bots ({running}/{total} running)', {
         running: runningBots.projectIds.length,


### PR DESCRIPTION
Prevent reopening the start bots panel when updating LG. This is to avoid the scenario to show the panel every time the selector updates and the botsStartedFlag gets set

#minor