### PR TITLE
fix: DetailsList hijacks EditableField navigation keys such as arrows, home/end, page up/down and Mac combos

### DIFF
--- a/Composer/packages/client/src/components/EditableField.tsx
+++ b/Composer/packages/client/src/components/EditableField.tsx
@@ -103,12 +103,12 @@ const EditableField: React.FC<EditableFieldProps> = (props) => {
   const [hasFocus, setHasFocus] = useState<boolean>(false);
   const [hasBeenEdited, setHasBeenEdited] = useState<boolean>(false);
   const [multiline, setMultiline] = useState<boolean>(true);
-  const rootRef = useRef<HTMLDivElement | null>(null);
+  const rootElmRef = useRef<HTMLDivElement | null>(null);
 
   // This effect prevents host DetailsList's FocusZone from stealing the focus and consuming the navigation keys.
   React.useEffect(() => {
-    if (rootRef.current && hasFocus) {
-      const inputElm = rootRef.current.querySelector<HTMLElement>(multiline ? 'textarea' : 'input');
+    if (rootElmRef.current && hasFocus) {
+      const inputElm = rootElmRef.current.querySelector<HTMLElement>(multiline ? 'textarea' : 'input');
 
       const keydownHandler = (e: KeyboardEvent) => {
         if (allowedNavigationKeys.includes(e.key)) {
@@ -120,7 +120,7 @@ const EditableField: React.FC<EditableFieldProps> = (props) => {
 
       return () => inputElm?.removeEventListener('keydown', keydownHandler);
     }
-  }, [hasFocus]);
+  }, [hasFocus, multiline]);
 
   const formConfig: FieldConfig<{ value: string }> = {
     value: {
@@ -216,7 +216,7 @@ const EditableField: React.FC<EditableFieldProps> = (props) => {
   return (
     <Fragment>
       <div
-        ref={rootRef}
+        ref={rootElmRef}
         css={[defaultContainerStyle(hasFocus, hasEditingErrors), containerStyles]}
         data-test-id={'EditableFieldContainer'}
       >

--- a/Composer/packages/client/src/components/EditableField.tsx
+++ b/Composer/packages/client/src/components/EditableField.tsx
@@ -103,24 +103,6 @@ const EditableField: React.FC<EditableFieldProps> = (props) => {
   const [hasFocus, setHasFocus] = useState<boolean>(false);
   const [hasBeenEdited, setHasBeenEdited] = useState<boolean>(false);
   const [multiline, setMultiline] = useState<boolean>(true);
-  const rootElmRef = useRef<HTMLDivElement | null>(null);
-
-  // This effect prevents host DetailsList's FocusZone from stealing the focus and consuming the navigation keys.
-  React.useEffect(() => {
-    if (rootElmRef.current && hasFocus) {
-      const inputElm = rootElmRef.current.querySelector<HTMLElement>(multiline ? 'textarea' : 'input');
-
-      const keydownHandler = (e: KeyboardEvent) => {
-        if (allowedNavigationKeys.includes(e.key)) {
-          e.stopPropagation();
-        }
-      };
-
-      inputElm?.addEventListener('keydown', keydownHandler);
-
-      return () => inputElm?.removeEventListener('keydown', keydownHandler);
-    }
-  }, [hasFocus, multiline]);
 
   const formConfig: FieldConfig<{ value: string }> = {
     value: {
@@ -195,6 +177,10 @@ const EditableField: React.FC<EditableFieldProps> = (props) => {
   // single line, press Enter to submit
   // multipe line, press Enter to submit, Shift+Enter get a new line,
   const handleOnKeyDown = (e) => {
+    // This prevents host DetailsList's FocusZone from stealing the focus and consuming the navigation keys.
+    if (allowedNavigationKeys.includes(e.key)) {
+      e.stopPropagation();
+    }
     const enterOnField = e.key === 'Enter' && hasFocus;
     const multilineEnter = multiline ? !e.shiftKey : true;
     if (enterOnField && multilineEnter) {
@@ -216,7 +202,6 @@ const EditableField: React.FC<EditableFieldProps> = (props) => {
   return (
     <Fragment>
       <div
-        ref={rootElmRef}
         css={[defaultContainerStyle(hasFocus, hasEditingErrors), containerStyles]}
         data-test-id={'EditableFieldContainer'}
       >


### PR DESCRIPTION
## Description

DetailsList internal FocusZone hijacks the key events from TextBoxes within to change the focus and that's making text editing cumbersome.

## Task Item

fixes #5207

## Screenshots

![EditableField](https://user-images.githubusercontent.com/1483492/101588342-087c2580-399b-11eb-8daf-a7b390306ef8.gif)
