### PR TITLE
fix: ui fix about publish & setting page

### DIFF
--- a/Composer/packages/client/src/pages/botProject/PublishTargets.tsx
+++ b/Composer/packages/client/src/pages/botProject/PublishTargets.tsx
@@ -59,6 +59,9 @@ const publishTargetsItemText = css`
   border-bottom: 1px solid ${NeutralColors.gray30};
   padding-top: 10px;
   padding-left: 10px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 `;
 
 const addPublishProfile = {
@@ -212,8 +215,12 @@ export const PublishTargets: React.FC<PublishTargetsProps> = (props) => {
           {publishTargets?.map((p, index) => {
             return (
               <div key={index} css={publishTargetsItem}>
-                <div css={publishTargetsItemText}>{p.name} </div>
-                <div css={publishTargetsItemText}>{p.type} </div>
+                <div css={publishTargetsItemText} title={p.name}>
+                  {p.name}
+                </div>
+                <div css={publishTargetsItemText} title={p.type}>
+                  {p.type}
+                </div>
                 <div css={publishTargetsEditButton}>
                   <ActionButton styles={editPublishProfile} onClick={async () => await onEdit(index, p)}>
                     {formatMessage('Edit')}

--- a/Composer/packages/client/src/pages/botProject/PublishTargets.tsx
+++ b/Composer/packages/client/src/pages/botProject/PublishTargets.tsx
@@ -38,7 +38,7 @@ const publishTargetsHeader = css`
 `;
 
 const publishTargetsHeaderText = css`
-  width: 200px;
+  width: 300px;
   font-size: ${FontSizes.medium};
   font-weight: ${FontWeights.semibold};
   border-bottom: 1px solid ${NeutralColors.gray30};

--- a/Composer/packages/client/src/pages/publish/BotStatusList.tsx
+++ b/Composer/packages/client/src/pages/publish/BotStatusList.tsx
@@ -102,7 +102,7 @@ export const BotStatusList: React.FC<IBotStatusListProps> = (props) => {
     if (!option) return null;
     const style = {
       ...(option.data && option.data.style),
-      maxWidth: '120px',
+      width: '80%',
       textOverflow: 'ellipsis',
       overflow: 'hidden',
       whiteSpace: 'nowrap',
@@ -174,8 +174,8 @@ export const BotStatusList: React.FC<IBotStatusListProps> = (props) => {
       name: formatMessage('Publish target'),
       className: 'publishTarget',
       fieldName: 'target',
-      minWidth: 114,
-      maxWidth: 134,
+      minWidth: 180,
+      maxWidth: 200,
       isRowHeader: true,
       isResizable: true,
       data: 'string',
@@ -185,7 +185,10 @@ export const BotStatusList: React.FC<IBotStatusListProps> = (props) => {
             defaultSelectedKey={item.publishTarget}
             options={publishTargetOptions(item)}
             placeholder={formatMessage('Select a publish target')}
-            styles={{ root: { width: '134px' } }}
+            styles={{
+              root: { width: '100%' },
+              dropdownItems: { selectors: { '.ms-Button-flexContainer': { width: '100%' } } },
+            }}
             onChange={(_, option?: IDropdownOption) => handleChangePublishTarget(item, option)}
             onRenderOption={onRenderOption}
           />

--- a/Composer/packages/client/src/pages/publish/BotStatusList.tsx
+++ b/Composer/packages/client/src/pages/publish/BotStatusList.tsx
@@ -100,7 +100,14 @@ export const BotStatusList: React.FC<IBotStatusListProps> = (props) => {
   };
   const onRenderOption = (option?: IDropdownOption): JSX.Element | null => {
     if (!option) return null;
-    return <div style={option.data && option.data.style}>{option.text}</div>;
+    const style = {
+      ...(option.data && option.data.style),
+      maxWidth: '120px',
+      textOverflow: 'ellipsis',
+      overflow: 'hidden',
+      whiteSpace: 'nowrap',
+    };
+    return <div style={style}>{option.text}</div>;
   };
   const onRenderStatus = (item: IBotStatus): JSX.Element | null => {
     if (!item.status) {

--- a/Composer/packages/client/src/pages/publish/Publish.tsx
+++ b/Composer/packages/client/src/pages/publish/Publish.tsx
@@ -171,6 +171,7 @@ const Publish: React.FC<RouteComponentProps<{ projectId: string; targetName?: st
   const getUpdatedStatus = (target, botProjectId): NodeJS.Timeout => {
     // TODO: this should use a backoff mechanism to not overload the server with requests
     // OR BETTER YET, use a websocket events system to receive updates... (SOON!)
+    getPublishStatus(botProjectId, target);
     return setInterval(async () => {
       getPublishStatus(botProjectId, target);
     }, publishStatusInterval);

--- a/Composer/packages/client/src/pages/publish/Publish.tsx
+++ b/Composer/packages/client/src/pages/publish/Publish.tsx
@@ -134,14 +134,22 @@ const Publish: React.FC<RouteComponentProps<{ projectId: string; targetName?: st
           data-testid="publishPage-Toolbar-Publish"
           disabled={publishDisabled || selectedBots.length === 0}
           onClick={() => setPublishDialogHidden(false)}
+          styles={{ root: { fontSize: '16px' } }}
         >
-          <svg fill="none" height="15" viewBox="0 0 16 15" width="16" xmlns="http://www.w3.org/2000/svg">
+          <svg
+            fill="none"
+            height="15"
+            viewBox="0 0 16 15"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+            css={{ margin: '0 4px' }}
+          >
             <path
               d="M16 4.28906V15H5V0H11.7109L16 4.28906ZM12 4H14.2891L12 1.71094V4ZM15 14V5H11V1H6V14H15ZM0 5H4V6H0V5ZM1 7H4V8H1V7ZM2 9H4V10H2V9Z"
               fill={selectedBots.length > 0 && !publishDisabled ? '#0078D4' : 'rgb(161, 159, 157)'}
             />
           </svg>
-          <span css={{ marginLeft: '8px' }}>{formatMessage('Publish selected bots')}</span>
+          <span css={{ margin: '0 4px' }}>{formatMessage('Publish selected bots')}</span>
         </ActionButton>
       ),
     },

--- a/Composer/packages/client/src/pages/publish/Publish.tsx
+++ b/Composer/packages/client/src/pages/publish/Publish.tsx
@@ -133,16 +133,16 @@ const Publish: React.FC<RouteComponentProps<{ projectId: string; targetName?: st
         <ActionButton
           data-testid="publishPage-Toolbar-Publish"
           disabled={publishDisabled || selectedBots.length === 0}
-          onClick={() => setPublishDialogHidden(false)}
           styles={{ root: { fontSize: '16px' } }}
+          onClick={() => setPublishDialogHidden(false)}
         >
           <svg
+            css={{ margin: '0 4px' }}
             fill="none"
             height="15"
             viewBox="0 0 16 15"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
-            css={{ margin: '0 4px' }}
           >
             <path
               d="M16 4.28906V15H5V0H11.7109L16 4.28906ZM12 4H14.2891L12 1.71094V4ZM15 14V5H11V1H6V14H15ZM0 5H4V6H0V5ZM1 7H4V8H1V7ZM2 9H4V10H2V9Z"


### PR DESCRIPTION
## Description

UI fix about publish & setting page.  text truncate  instead of overflow & set column width wider
- publish page
![dropdown-wider](https://user-images.githubusercontent.com/5860999/101588394-458afb00-3a21-11eb-8d29-8b9fd6699a26.gif)
![notificationStatus](https://user-images.githubusercontent.com/5860999/101595230-fd260a00-3a2d-11eb-87ea-f4b97d3d9320.gif)
- setting page
![image](https://user-images.githubusercontent.com/5860999/101581494-aad8ef00-3a15-11eb-9b02-dd5368c8e5a0.png)

## Task Item

fix #5246 

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->

