### PR TITLE
fix: Qna pairs are being duplicated in the Qna knowledge base

### DIFF
--- a/Composer/packages/server/src/models/bot/builder.ts
+++ b/Composer/packages/server/src/models/bot/builder.ts
@@ -430,19 +430,22 @@ export class Builder {
       culture: config.fallbackLocal,
     });
 
-    if (qnaContents) {
-      const subscriptionKeyEndpoint = `https://${config.qnaRegion}.api.cognitive.microsoft.com/qnamaker/v4.0`;
+    //we need to filter the source qna file out.
+    const filteredQnaContents = qnaContents?.filter((content) => !content.id.endsWith('.source'));
 
-      const buildResult = await this.qnaBuilder.build(qnaContents, config.subscriptionKey, config.botName, {
-        endpoint: subscriptionKeyEndpoint,
-        suffix: config.suffix,
-      });
+    if (!filteredQnaContents || filteredQnaContents.length === 0) return;
 
-      await this.qnaBuilder.writeDialogAssets(buildResult, {
-        force: true,
-        out: this.generatedFolderPath,
-      });
-    }
+    const subscriptionKeyEndpoint = `https://${config.qnaRegion}.api.cognitive.microsoft.com/qnamaker/v4.0`;
+
+    const buildResult = await this.qnaBuilder.build(filteredQnaContents, config.subscriptionKey, config.botName, {
+      endpoint: subscriptionKeyEndpoint,
+      suffix: config.suffix,
+    });
+
+    await this.qnaBuilder.writeDialogAssets(buildResult, {
+      force: true,
+      out: this.generatedFolderPath,
+    });
   }
 
   //delete files in generated folder


### PR DESCRIPTION
## Description
**Root cause**

we have source qna file and dialog qna file today. The dialog qna file will import the the source qna file. When we do a qna publish, the loader will add source file content to the qna content of the dialog, then publish all these two files to the Qna maker.

**fix**
do a filter to prevent publish source file to the service.

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
closes #5104
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots
![image](https://user-images.githubusercontent.com/39758135/101593720-5e001300-3a2b-11eb-9833-a807c7487c11.png)

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
