### PR TITLE
fix: Azure functions deployment and code.zip size doubled issue

### DIFF
--- a/extensions/runtimes/src/index.ts
+++ b/extensions/runtimes/src/index.ts
@@ -79,7 +79,7 @@ export default async (composer: any): Promise<void> => {
       } else if (profile.type === 'azureFunctionsPublish') {
         csproj = 'Microsoft.BotFramework.Composer.Functions.csproj';
       }
-      const publishFolder = path.join(runtimePath, 'bin', 'Release', 'netcoreapp3.1');
+      const publishFolder = path.join(runtimePath, 'bin', 'release', 'publishTarget');
       const deployFilePath = path.join(runtimePath, '.deployment');
       const dotnetProjectPath = path.join(runtimePath, csproj);
 
@@ -94,10 +94,14 @@ export default async (composer: any): Promise<void> => {
       try {
         const configuration = JSON.parse(profile.configuration);
         const runtimeIdentifier = configuration.runtimeIdentifier;
+
+        // Don't set self-contained and runtimeIdentifier for AzureFunctions.
         let buildCommand = `dotnet publish "${dotnetProjectPath}" -c release -o "${publishFolder}" -v q`;
-        if (runtimeIdentifier) {
+
+        if (profile.type === 'azurePublish')
+        {
           // if runtime identifier set, make dotnet runtime to self contained, default runtime identifier is win-x64, please refer to https://docs.microsoft.com/en-us/dotnet/core/rid-catalog
-          buildCommand = `dotnet publish "${dotnetProjectPath}" -c release -o "${publishFolder}" -v q --self-contained true -r ${runtimeIdentifier}`;
+          buildCommand = `dotnet publish "${dotnetProjectPath}" -c release -o "${publishFolder}" -v q --self-contained true -r ${runtimeIdentifier ?? 'win-x64'}`;
         }
         const { stdout, stderr } = await execAsync(
           buildCommand,


### PR DESCRIPTION
## Description

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

This PR is to fix two issues:
1. Azure Function does not work with --self-contain publish with RID. So in this PR, we only enable --self-contain and RID in azure web app.
2. We found a bug that the build targets are duplicated in the publishing process, this is because we set the publish target folder to bin/release/netcoreapp3.1, this is the default folder that all the built stuff be placed in, and we add a -o parameter for the dotnet publish which points to the same folder, this will actually generated two duplicated built targets. One is in bin\release\netcoreapp3.1\ and the other is in bin\release\netcoreapp3.1\win-x64, which doubled the build target. 

## Task Item

fixes #5267 

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
