### PR TITLE
fix: help link

### DIFF
--- a/Composer/packages/client/src/recoilModel/dispatchers/publisher.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/publisher.ts
@@ -35,7 +35,7 @@ const missingDotnetVersionError = {
   message: formatMessage('To run this bot, Composer needs .NET Core SDK.'),
   linkAfterMessage: {
     text: formatMessage('Learn more.'),
-    url: 'https://docs.microsoft.com/en-us/composer/setup-yarn',
+    url: 'https://aka.ms/install-composer',
   },
   link: {
     text: formatMessage('Install Microsoft .NET Core SDK'),

--- a/Composer/packages/lib/shared/src/featureFlagUtils/index.ts
+++ b/Composer/packages/lib/shared/src/featureFlagUtils/index.ts
@@ -30,7 +30,7 @@ export const getDefaultFeatureFlags = (): FeatureFlagMap => ({
   },
   PACKAGE_MANAGER: {
     displayName: formatMessage('Package manager'),
-    description: formatMessage('Discover and use components that can be installed into your bot.'),
+    description: formatMessage('Discover and use components that can be installed into your bot'),
     isHidden: false,
     enabled: false,
     documentationLink: 'https://aka.ms/composer-package-manager-readme',


### PR DESCRIPTION
## Description

Replaced the 404 link (https://docs.microsoft.com/en-us/composer/setup-yarn)
To: https://aka.ms/install-composer

Fixed the double full stop issue in the Package manager texts.

![image](https://user-images.githubusercontent.com/32497439/101815584-9b6cab00-3ad4-11eb-9cce-31705c8670e5.png)


## Task Item
fixes #5273