### PR TITLE
fix: Start bots optimization

### DIFF
--- a/extensions/localPublish/src/index.ts
+++ b/extensions/localPublish/src/index.ts
@@ -263,7 +263,8 @@ class LocalPublisher implements PublishPlugin<PublishConfig> {
             encoding: 'utf-8',
           })
         );
-        if (!settings.runtime?.key || settings.runtime?.key !== project.settings.runtime?.key) {
+        // TODO: Understand why this is required as it would never hit this function if runtime is ejected
+        if (settings.runtime?.key && (settings.runtime?.key !== project.settings.runtime?.key)) {
           // in order to change runtime type
           await removeDirAndFiles(this.getBotRuntimeDir(botId));
           // copy runtime template in folder


### PR DESCRIPTION
## Description
This PR handles an unnecessary check that forces us to clear the hosted bots folder. Copy the bot again. Rebuild all the dependnacies every run.

@luhan2017 @VanyLaw can u help me evaluate if this change is OK. I have tried ejecting C# runtime and non ejected scenarios all of them seem to work fine. It seems to have been introduced here https://github.com/microsoft/BotFramework-Composer/pull/3198/files#diff-8bc80526cd9185a7138ca77498899908f213e41c98bfc7852a05a9e3c4fca37cR247

Fixes #5191 