### PR TITLE
fix: dismiss open bot loading screen

### DIFF
--- a/Composer/packages/client/src/recoilModel/dispatchers/project.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/project.ts
@@ -245,7 +245,6 @@ export const projectDispatcher = () => {
         if (navigate) {
           navigateToBot(callbackHelpers, projectId, mainDialog);
         }
-        set(botOpeningState, false);
 
         if (typeof callback === 'function') {
           callback(projectId);
@@ -255,6 +254,7 @@ export const projectDispatcher = () => {
         removeRecentProject(callbackHelpers, path);
         handleProjectFailure(callbackHelpers, ex);
         navigateTo('/home');
+      } finally {
         set(botOpeningState, false);
       }
     }

--- a/Composer/packages/server/src/services/telemetry.ts
+++ b/Composer/packages/server/src/services/telemetry.ts
@@ -69,7 +69,7 @@ if (instrumentationKey) {
 
       // remove PII
       for (const property of piiProperties) {
-        if (data.baseData.properties[property]) {
+        if (typeof data.baseData.properties[property] !== 'undefined') {
           delete data.baseData.properties[property];
         }
       }

--- a/Composer/packages/server/src/services/telemetry.ts
+++ b/Composer/packages/server/src/services/telemetry.ts
@@ -69,7 +69,7 @@ if (instrumentationKey) {
 
       // remove PII
       for (const property of piiProperties) {
-        if (typeof data.baseData.properties[property] !== 'undefined') {
+        if (data.baseData.properties[property] !== undefined) {
           delete data.baseData.properties[property];
         }
       }


### PR DESCRIPTION
## Description
Moved `set(botOpeningState, false);` to the `finally` block in the `try/catch` so the loading screen will always be dismissed.

## Task Item
#minor
