### PR TITLE
fix: prevent create root dialog (PVA scenario)

### DIFF
--- a/Composer/packages/client/src/pages/design/createDialogModal.tsx
+++ b/Composer/packages/client/src/pages/design/createDialogModal.tsx
@@ -14,7 +14,7 @@ import { DialogWrapper, DialogTypes } from '@bfc/ui-shared';
 import { DialogCreationCopy } from '../../constants';
 import { StorageFolder } from '../../recoilModel/types';
 import { FieldConfig, useForm } from '../../hooks/useForm';
-import { actionsSeedState, schemasState, validateDialogsSelectorFamily } from '../../recoilModel';
+import { actionsSeedState, botDisplayNameState, schemasState, validateDialogsSelectorFamily } from '../../recoilModel';
 import TelemetryClient from '../../telemetry/TelemetryClient';
 
 import { name, description, styles as wizardStyles } from './styles';
@@ -38,8 +38,8 @@ export const CreateDialogModal: React.FC<CreateDialogModalProps> = (props) => {
 
   const schemas = useRecoilValue(schemasState(projectId));
   const dialogs = useRecoilValue(validateDialogsSelectorFamily(projectId));
+  const botName = useRecoilValue(botDisplayNameState(projectId));
   const actionsSeed = useRecoilValue(actionsSeedState(projectId));
-
   const { shellApi, ...shellData } = useShellApi();
   const { defaultRecognizer } = useRecognizerConfig();
 
@@ -55,6 +55,10 @@ export const CreateDialogModal: React.FC<CreateDialogModalProps> = (props) => {
 
         if (dialogs.some((dialog) => dialog.id.toLowerCase() === value.toLowerCase())) {
           return formatMessage('Duplicate dialog name');
+        }
+
+        if (botName.toLowerCase() === value.toLowerCase()) {
+          return formatMessage('Duplicate root dialog name');
         }
       },
       defaultValue: '',


### PR DESCRIPTION
## Description

PVA bot's root dialog has different name with bot name, when create a botName dialog, current check will pass because there is no duplicate dialog name. that mess up PVA bot structure.

The solution add a check prevent root dialog (bot name dialog). that both work for normal composer bot and PVA bot.


<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
close #5304 
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots
<img width="1038" alt="image" src="https://user-images.githubusercontent.com/49866537/101860439-c6c0ca00-3ba8-11eb-92f7-6741a5cd3761.png">

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
