### PR TITLE
fix: update script button overlaps with publish target content in setting page

### DIFF
--- a/Composer/packages/client/src/pages/botProject/runtime-settings/RuntimeSettings.tsx
+++ b/Composer/packages/client/src/pages/botProject/runtime-settings/RuntimeSettings.tsx
@@ -38,6 +38,7 @@ import {
   customerLabel,
   iconStyle,
   textOr,
+  updateText,
 } from './style';
 
 export const RuntimeSettings: React.FC<RouteComponentProps<{ projectId: string }>> = (props) => {
@@ -215,10 +216,9 @@ export const RuntimeSettings: React.FC<RouteComponentProps<{ projectId: string }
           onRenderLabel={onRenderLabel}
         />
       </div>
-      <br />
       {needsUpdate && (
         <div>
-          <p>
+          <p css={updateText}>
             {formatMessage(
               'A newer version of the provisioning scripts has been found, and this project can be updated to the latest.'
             )}

--- a/Composer/packages/client/src/pages/botProject/runtime-settings/style.ts
+++ b/Composer/packages/client/src/pages/botProject/runtime-settings/style.ts
@@ -8,7 +8,6 @@ export const runtimeSettingsStyle = css`
   display: flex;
   flex-direction: column;
   box-sizing: border-box;
-  height: 200px;
 `;
 
 export const runtimeControls = css`
@@ -70,4 +69,9 @@ export const iconStyle = (disabled) => {
 
 export const textOr = css`
   font-size: ${FontSizes.smallPlus};
+`;
+
+export const updateText = css`
+  font-size: ${FontSizes.smallPlus};
+  color: ${NeutralColors.gray130};
 `;


### PR DESCRIPTION
## Description
![image](https://user-images.githubusercontent.com/24380525/101870626-f974bd80-3bbc-11eb-8366-3ec22972c1f1.png)


## Task Item
Closes #5302 

## Screenshots
![settingUX](https://user-images.githubusercontent.com/24380525/101870677-0f827e00-3bbd-11eb-87f8-1d4de72a3432.png)
