### PR TITLE
fix: runtime throw exception when there is no cosmosdb config

### DIFF
--- a/extensions/azurePublish/src/luisAndQnA.ts
+++ b/extensions/azurePublish/src/luisAndQnA.ts
@@ -112,7 +112,7 @@ export async function publishLuisToPrediction(
         break;
       } catch (err) {
         if (retryCount < 1) {
-          this.logger({
+          logger({
             status: BotProjectDeployLoggerType.DEPLOY_ERROR,
             message: JSON.stringify(err, Object.getOwnPropertyNames(err)),
           });

--- a/runtime/dotnet/NuGet.Config
+++ b/runtime/dotnet/NuGet.Config
@@ -2,6 +2,5 @@
 <configuration>
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="BotBuilder.myget.org" value="https://botbuilder.myget.org/F/botbuilder-v4-dotnet-daily/api/v3/index.json" protocolVersion="3" />
   </packageSources>
 </configuration>

--- a/runtime/dotnet/NuGet.Config
+++ b/runtime/dotnet/NuGet.Config
@@ -2,5 +2,6 @@
 <configuration>
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="BotBuilder.myget.org" value="https://botbuilder.myget.org/F/botbuilder-v4-dotnet-daily/api/v3/index.json" protocolVersion="3" />
   </packageSources>
 </configuration>

--- a/runtime/dotnet/azurewebapp/Startup.cs
+++ b/runtime/dotnet/azurewebapp/Startup.cs
@@ -74,7 +74,7 @@ namespace Microsoft.BotFramework.Composer.WebAppTemplates
 
         public IStorage ConfigureStorage(BotSettings settings)
         {
-            if (string.IsNullOrEmpty(settings?.CosmosDb.ContainerId))
+            if (string.IsNullOrEmpty(settings?.CosmosDb?.ContainerId))
             {
                 if (!string.IsNullOrEmpty(this.Configuration["cosmosdb:collectionId"]))
                 {


### PR DESCRIPTION
## Description
This PR include 3 fixes:
1. This is a fix to backward compatible issue with 1.0 created bot, which don't have cosmosdb config but our latest runtime code assume there is always one cosmosdb section and throw exception if there isn't. Fixing by loosing the constraints here.
2. remove the myget package source in Nuget.config
3. use logger instead of this.logger to fix the exception when publishing multiple lu files which triggers the retry logic. 

#minor

## Task Item

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
