### PR TITLE
fix: surface dotnet build error on runtime

### DIFF
--- a/Composer/packages/client/src/recoilModel/dispatchers/publisher.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/publisher.ts
@@ -44,9 +44,7 @@ const missingDotnetVersionError = {
 };
 
 const checkIfDotnetVersionMissing = (err: any) => {
-  return /(Command failed: dotnet build)| (Command failed: dotnet user-secrets)|(install[\w\r\s\S\t\n]*\.NET Core SDK)/.test(
-    err.message as string
-  );
+  return /(Command failed: dotnet user-secrets)|(install[\w\r\s\S\t\n]*\.NET Core SDK)/.test(err.message as string);
 };
 
 export const publisherDispatcher = () => {


### PR DESCRIPTION
## Description

Prevent capturing dotnet build error from runtime wrongly as missing .NET on the machine.

#minor