### PR TITLE
fix: LG diagnostics mismatch by update reference in cache 

### DIFF
--- a/Composer/packages/client/src/recoilModel/parsers/workers/lgParser.worker.ts
+++ b/Composer/packages/client/src/recoilModel/parsers/workers/lgParser.worker.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { lgUtil } from '@bfc/indexers';
 import { lgImportResolverGenerator, LgFile } from '@bfc/shared';
+import { getBaseName } from '../../../utils/fileUtil';
 
 import {
   LgActionType,
@@ -105,6 +106,19 @@ export class LgCache {
     if (!lgResources) return;
 
     lgResources.set(value.id, value);
+
+    // update reference resource
+    if (getBaseName(value.id) === 'common') {
+      const updatedCommonLg = value.parseResult;
+      lgResources.forEach((lgResource) => {
+        if (lgResource.parseResult) {
+          lgResource.parseResult.references = lgResource.parseResult.references.map((ref) => {
+            return getBaseName(ref.id) === 'common' ? updatedCommonLg : ref;
+          });
+        }
+      });
+    }
+
     this.projects.set(projectId, lgResources);
   }
 

--- a/Composer/packages/client/src/recoilModel/parsers/workers/lgParser.worker.ts
+++ b/Composer/packages/client/src/recoilModel/parsers/workers/lgParser.worker.ts
@@ -108,16 +108,14 @@ export class LgCache {
     lgResources.set(value.id, value);
 
     // update reference resource
-    if (getBaseName(value.id) === 'common') {
-      const updatedCommonLg = value.parseResult;
-      lgResources.forEach((lgResource) => {
-        if (lgResource.parseResult) {
-          lgResource.parseResult.references = lgResource.parseResult.references.map((ref) => {
-            return getBaseName(ref.id) === 'common' ? updatedCommonLg : ref;
-          });
-        }
-      });
-    }
+    const updatedResource = value.parseResult;
+    lgResources.forEach((lgResource) => {
+      if (lgResource.parseResult) {
+        lgResource.parseResult.references = lgResource.parseResult.references.map((ref) => {
+          return ref.id === value.id ? updatedResource : ref;
+        });
+      }
+    });
 
     this.projects.set(projectId, lgResources);
   }

--- a/Composer/packages/client/src/recoilModel/parsers/workers/lgParser.worker.ts
+++ b/Composer/packages/client/src/recoilModel/parsers/workers/lgParser.worker.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 import { lgUtil } from '@bfc/indexers';
 import { lgImportResolverGenerator, LgFile } from '@bfc/shared';
-import { getBaseName } from '../../../utils/fileUtil';
 
 import {
   LgActionType,

--- a/Composer/packages/lib/shared/src/resolverFactory.ts
+++ b/Composer/packages/lib/shared/src/resolverFactory.ts
@@ -88,6 +88,6 @@ export function lgImportResolverGenerator(
       resources.find(({ id }) => id === `${targetId}.${locale}`) || resources.find(({ id }) => id === targetId);
 
     if (!targetFile) throw new Error(formatMessage(`File not found`));
-    return new LGResource(resourceId, resourceId, targetFile.content);
+    return new LGResource(targetFile.id, targetFile.id, targetFile.content);
   };
 }


### PR DESCRIPTION
## Description

For performance consideration, LG file parseResults are cached in client. the next time do CRUD, will directly use previous parseResult do increment parse. 
1. initially we have two file (`common.lg`, `a.lg`) and it's parsed resource ( `CommonParseResource:T0`, `AParseResource:T0` )
2. when modify common.lg file, will update common.lg to `CommonParseResource:T1`.
3. when modify a.lg (referred common.lg), a.lg will use  `AParseResource:T0 ` update itself. but in `AParseResource `, it referred
common.lg is expired `CommonParseResource:T0`.  which cause mismatch error.


### Solution
At step2, not only update itself, but also update all rest lg files 's  resource reference.
 
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
#minor 
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
