### PR TITLE
fix: undo failed after click create trigger and remove trigger

### DIFF
--- a/Composer/packages/client/src/pages/design/DesignPage.tsx
+++ b/Composer/packages/client/src/pages/design/DesignPage.tsx
@@ -632,23 +632,28 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
     );
 
     if (content) {
-      updateDialog({ id: dialogId, content, projectId: skillId ?? projectId });
+      await updateDialog({ id: dialogId, content, projectId: skillId ?? projectId });
       const match = /\[(\d+)\]/g.exec(selected);
       const current = match && match[1];
-      if (!current) return;
+      if (!current) {
+        commitChanges();
+        return;
+      }
       const currentIdx = parseInt(current);
       if (index === currentIdx) {
         if (currentIdx - 1 >= 0) {
           //if the deleted node is selected and the selected one is not the first one, navTo the previous trigger;
-          selectTo(skillId ?? projectId, dialogId, createSelectedPath(currentIdx - 1));
+          await selectTo(skillId ?? projectId, dialogId, createSelectedPath(currentIdx - 1));
         } else {
           //if the deleted node is selected and the selected one is the first one, navTo the first trigger;
-          navTo(skillId ?? projectId, dialogId);
+          await navTo(skillId ?? projectId, dialogId);
         }
       } else if (index < currentIdx) {
         //if the deleted node is at the front, navTo the current one;
-        selectTo(skillId ?? projectId, dialogId, createSelectedPath(currentIdx - 1));
+        await selectTo(skillId ?? projectId, dialogId, createSelectedPath(currentIdx - 1));
       }
+
+      commitChanges();
     }
   }
   const addNewBtnRef = useCallback((addNew) => {
@@ -658,7 +663,7 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
   const handleCreateQnA = async (data) => {
     const { projectId, dialogId } = creatQnAOnInfo;
     if (!projectId || !dialogId) return;
-    createQnATrigger(projectId, dialogId);
+    await createQnATrigger(projectId, dialogId);
 
     const { name, url, multiTurn } = data;
     if (url) {
@@ -666,6 +671,7 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
     } else {
       await createQnAKBFromScratch({ id: `${dialogId}.${locale}`, name, projectId });
     }
+    commitChanges();
   };
 
   const handleCreateDialog = (projectId: string) => {
@@ -828,8 +834,9 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
             dialogId={triggerModalInfo.dialogId}
             projectId={triggerModalInfo.projectId}
             onDismiss={onTriggerCreationDismiss}
-            onSubmit={(dialogId, formData) => {
-              createTrigger(triggerModalInfo.projectId, dialogId, formData);
+            onSubmit={async (dialogId, formData) => {
+              await createTrigger(triggerModalInfo.projectId, dialogId, formData);
+              commitChanges();
             }}
           />
         )}

--- a/Composer/packages/client/src/pages/design/PropertyEditor.tsx
+++ b/Composer/packages/client/src/pages/design/PropertyEditor.tsx
@@ -74,7 +74,7 @@ const PropertyEditor: React.FC = () => {
     if (schemas?.sdk?.content && localData) {
       return resolveBaseSchema(schemas.sdk.content, localData.$kind);
     }
-  }, [schemas?.sdk?.content, localData.$kind]);
+  }, [schemas?.sdk?.content, localData?.$kind]);
 
   const $uiOptions = useMemo(() => {
     return getUIOptions($schema, formUIOptions);

--- a/Composer/packages/client/src/recoilModel/dispatchers/navigation.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/navigation.ts
@@ -143,7 +143,8 @@ export const navigationDispatcher = () => {
       skillId: string | null,
       dialogId: string,
       selectPath: string,
-      focusPath: string
+      focusPath: string,
+      fragment?: string
     ) => {
       set(currentProjectIdState, projectId);
 
@@ -154,12 +155,23 @@ export const navigationDispatcher = () => {
       const search = getUrlSearch(encodedSelectPath, encodedFocusPath);
       const designPageLocation = await snapshot.getPromise(designPageLocationState(projectId));
       if (search) {
-        const currentUri =
+        let currentUri =
           skillId == null || skillId === projectId
             ? `/bot/${projectId}/dialogs/${dialogId}${search}`
             : `/bot/${projectId}/skill/${skillId}/dialogs/${dialogId}${search}`;
 
+        if (fragment && typeof fragment === 'string') {
+          currentUri += `#${fragment}`;
+        }
+
         if (checkUrl(currentUri, projectId, skillId, designPageLocation)) return;
+
+        set(designPageLocationState(projectId), {
+          dialogId,
+          selected: getSelected(focusPath) || selectPath,
+          focused: focusPath ?? '',
+          promptTab: Object.values(PromptTab).find((value) => fragment === value),
+        });
         navigateTo(currentUri);
       } else {
         navTo(skillId ?? projectId, dialogId);

--- a/Composer/packages/client/src/recoilModel/dispatchers/trigger.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/trigger.ts
@@ -115,7 +115,7 @@ export const triggerDispatcher = () => {
         };
         await updateDialog(dialogPayload);
         if (autoSelected) {
-          selectTo(projectId, newDialog.id, `triggers[${index}]`);
+          await selectTo(projectId, newDialog.id, `triggers[${index}]`);
         }
       } catch (ex) {
         setError(callbackHelpers, ex);

--- a/Composer/packages/client/src/recoilModel/undo/__test__/history.test.tsx
+++ b/Composer/packages/client/src/recoilModel/undo/__test__/history.test.tsx
@@ -21,6 +21,7 @@ import { dialogsSelectorFamily } from '../../selectors';
 import { renderRecoilHook } from '../../../../__tests__/testUtils/react-recoil-hooks-testing-library';
 import UndoHistory from '../undoHistory';
 import { undoStatusSelectorFamily } from '../../selectors/undo';
+import { dispatcherState } from '../../DispatcherWrapper';
 const projectId = '123-asd';
 
 export const UndoRedoWrapper = () => {
@@ -73,6 +74,7 @@ describe('<UndoRoot/>', () => {
         { recoilState: undoHistoryState(projectId), initialValue: new UndoHistory(projectId) },
         { recoilState: canUndoState(projectId), initialValue: false },
         { recoilState: canRedoState(projectId), initialValue: false },
+        { recoilState: dispatcherState, initialValue: { selectAndFocus: () => {} } },
         { recoilState: designPageLocationState(projectId), initialValue: { dialogId: '1', focused: '', selected: '' } },
         {
           recoilState: undoFunctionState(projectId),


### PR DESCRIPTION
## Description
### root cause

we didn't commit the changes of creating trigger event in the context menu to undo history

### fix
1. Add commit change for creating and deleting trigger event.
2. Add await to make sure all data can be pushed to the undo history.
3. Use the navigation function from dispatcher to avoid the leakage of the navigate logic.
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
closes #5324


<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots
![undofailed](https://user-images.githubusercontent.com/39758135/102064294-1665f680-3e32-11eb-892b-7f679c100cf9.gif)
<!---
Please include screenshots or gifs if your PR include UX changes.
--->
