### PR TITLE
fix: move graphToken into body, fix http call header too large

### DIFF
--- a/Composer/packages/client/package.json
+++ b/Composer/packages/client/package.json
@@ -8,7 +8,7 @@
     "node": ">=12"
   },
   "scripts": {
-    "start": "node --max_old_space_size=4096 scripts/start.js",
+    "start": "node --max_old_space_size=4096 --max-http-header-size=16000 scripts/start.js",
     "build": "node --max_old_space_size=4096 scripts/build.js",
     "clean": "rimraf build",
     "test": "jest",

--- a/Composer/packages/client/src/recoilModel/dispatchers/provision.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/provision.ts
@@ -42,9 +42,13 @@ export const provisionDispatcher = () => {
       graphToken = ''
     ) => {
       try {
-        const result = await httpClient.post(`/provision/${projectId}/${type}`, config, {
-          headers: { Authorization: `Bearer ${armToken}`, graphtoken: graphToken },
-        });
+        const result = await httpClient.post(
+          `/provision/${projectId}/${type}`,
+          { ...config, graphToken: graphToken },
+          {
+            headers: { Authorization: `Bearer ${armToken}` },
+          }
+        );
         // set notification
         const notification = createNotification(getProvisionPendingNotification(result.data.message));
         addNotificationInternal(callbackHelpers, notification);

--- a/Composer/packages/server/src/controllers/provision.ts
+++ b/Composer/packages/server/src/controllers/provision.ts
@@ -34,7 +34,7 @@ export const ProvisionController = {
   },
   provision: async (req: Request, res) => {
     const accessToken = req.headers.authorization?.substring('Bearer '.length);
-    const graphToken = req.headers.graphtoken;
+    // const graphToken = req.headers.graphtoken;
     const user = await ExtensionContext.getUserFromRequest(req);
     const type = req.params.type; // type is webapp or functions
     const projectId = req.params.projectId;
@@ -48,7 +48,7 @@ export const ProvisionController = {
           // call the method
           const result = await pluginMethod.call(
             null,
-            { ...req.body, accessToken, graphToken },
+            { ...req.body, accessToken },
             currentProject,
             user,
             authService.getAccessToken.bind(authService)

--- a/Composer/packages/server/src/locales/en-US.json
+++ b/Composer/packages/server/src/locales/en-US.json
@@ -47,6 +47,9 @@
   "a_valid_url_should_start_with_http_or_https_327b1a30": {
     "message": "A valid URL should start with http:// or https://"
   },
+  "a_valid_url_should_start_with_http_or_https_d24b3591": {
+    "message": "A valid url should start with http:// or https://"
+  },
   "about_70c18bba": {
     "message": "About"
   },
@@ -140,6 +143,9 @@
   "add_a_welcome_message_9e1480b2": {
     "message": "Add a welcome message"
   },
+  "add_additional_url_bdfac25d": {
+    "message": "Add additional URL"
+  },
   "add_alternative_phrasing_17e0304c": {
     "message": "+ Add alternative phrasing"
   },
@@ -224,6 +230,9 @@
   "app_id_password_424f613a": {
     "message": "App Id / Password"
   },
+  "append_choices_35c45a2d": {
+    "message": "Append choices"
+  },
   "application_language_f100f3e0": {
     "message": "Application language"
   },
@@ -259,6 +268,9 @@
   },
   "are_you_sure_you_want_to_uninstall_these_extension_cf6265e8": {
     "message": "Are you sure you want to uninstall these extensions?"
+  },
+  "arm_template_bc8441bb": {
+    "message": "ARM Template"
   },
   "array_643947ee": {
     "message": "Array"
@@ -302,8 +314,29 @@
   "automatically_generate_dialogs_that_collect_inform_e7cf619e": {
     "message": "Automatically generate dialogs that collect information from a user to manage conversations."
   },
+  "available_skills_95c114ac": {
+    "message": "Available Skills"
+  },
+  "azure_app_service_plan_a285fb06": {
+    "message": "Azure App Service Plan"
+  },
+  "azure_application_insights_c80028e4": {
+    "message": "Azure Application Insights"
+  },
+  "azure_blob_storage_b5503630": {
+    "message": "Azure Blob Storage"
+  },
+  "azure_bot_service_3afc983": {
+    "message": "Azure Bot Service"
+  },
+  "azure_cosmos_db_a82b5d09": {
+    "message": "Azure Cosmos DB"
+  },
   "back_2900f52a": {
     "message": "Back"
+  },
+  "basic_assistant_d23bde15": {
+    "message": "Basic Assistant"
   },
   "been_used_5daccdb2": {
     "message": "Been used"
@@ -359,6 +392,12 @@
   "bot_asks_5e9f0202": {
     "message": "Bot Asks"
   },
+  "bot_configured_for_speech_66fc8e57": {
+    "message": "Bot Configured for Speech"
+  },
+  "bot_configured_for_text_a67eca78": {
+    "message": "Bot Configured for Text"
+  },
   "bot_content_was_successfully_imported_5a07ae64": {
     "message": "Bot content was successfully imported."
   },
@@ -392,6 +431,9 @@
   "bot_management_and_configurations_b7dadd69": {
     "message": "Bot management and configurations"
   },
+  "bot_name_bbd0779d": {
+    "message": "Bot Name"
+  },
   "bot_name_is_botname_a28c2d05": {
     "message": "Bot name is { botName }"
   },
@@ -415,6 +457,9 @@
   },
   "bot_settings_ce2783e4": {
     "message": "Bot Settings"
+  },
+  "bot_web_app_ca8b1468": {
+    "message": "Bot Web App"
   },
   "branch_if_else_391e5681": {
     "message": "Branch: If/else"
@@ -478,6 +523,12 @@
   },
   "choose_one_2c4277df": {
     "message": "Choose One"
+  },
+  "choose_one_7feacdb6": {
+    "message": "Choose one:"
+  },
+  "choose_your_assistant_7ee96d89": {
+    "message": "Choose Your Assistant"
   },
   "chris_whitten_11df1f35": {
     "message": "Chris Whitten"
@@ -548,8 +599,20 @@
   "conditionalselector_ed2031f0": {
     "message": "ConditionalSelector"
   },
+  "configuration_summary_f9b92424": {
+    "message": "Configuration Summary"
+  },
   "configure_composer_to_start_your_bot_using_runtime_fe37dadf": {
     "message": "Configure Composer to start your bot using runtime code you can customize and control."
+  },
+  "configured_with_enterprise_scenarios_calendar_who__e9e7e75a": {
+    "message": "Configured with enterprise scenarios, calendar, who bot, professional chit-chat."
+  },
+  "configured_with_hospitality_scenarios_bing_search__f71c09c0": {
+    "message": "Configured with hospitality scenarios, Bing search and caring chit-chat."
+  },
+  "configured_with_simple_conversational_capability_l_d42f128c": {
+    "message": "Configured with simple conversational capability like greeting, chit-chat & more."
   },
   "configures_default_language_model_to_use_if_there__f09f1acd": {
     "message": "Configures default language model to use if there is no culture code in the file name (Default: en-us)"
@@ -575,6 +638,9 @@
   "connect_a_remote_skill_10cf0724": {
     "message": "Connect a remote skill"
   },
+  "connect_to_a_new_skill_34d582ab": {
+    "message": "Connect to a new skill"
+  },
   "connect_to_a_skill_53c9dff0": {
     "message": "Connect to a skill"
   },
@@ -586,6 +652,9 @@
   },
   "connecting_to_b_targetname_b_to_import_bot_content_65d8db95": {
     "message": "Connecting to <b>{ targetName }</b> to import bot content..."
+  },
+  "content_1440204b": {
+    "message": "Content"
   },
   "continue_ac067716": {
     "message": "Continue"
@@ -620,6 +689,9 @@
   "could_not_connect_to_storage_50411de0": {
     "message": "Could not connect to storage."
   },
+  "could_not_init_plugin_1f1c29cd": {
+    "message": "Could not init plugin"
+  },
   "couldn_t_complete_the_update_a337a359": {
     "message": "Couldn''t complete the update:"
   },
@@ -640,6 +712,9 @@
   },
   "create_a_name_for_the_project_which_will_be_used_t_57e9b690": {
     "message": "Create a name for the project which will be used to name the application: (projectname-environment-LUfilename)"
+  },
+  "create_a_new_bot_or_choose_from_virtual_assistant__7c1e6674": {
+    "message": "Create a new bot or choose from Virtual assistant templates."
   },
   "create_a_new_dialog_21d84b82": {
     "message": "Create a new dialog"
@@ -674,6 +749,9 @@
   "create_form_dialog_bb98a4f2": {
     "message": "Create form dialog"
   },
+  "create_from_6db143f6": {
+    "message": "Create from"
+  },
   "create_from_knowledge_base_qna_maker_7422486": {
     "message": "Create from knowledge base (QnA Maker)"
   },
@@ -688,6 +766,9 @@
   },
   "create_kb_e78571ba": {
     "message": "Create KB"
+  },
+  "create_knowledge_base_db6d66c4": {
+    "message": "Create knowledge base"
   },
   "create_knowledge_base_from_scratch_afe4d2a2": {
     "message": "Create knowledge base from scratch"
@@ -733,6 +814,9 @@
   },
   "custom_runtime_426aa34f": {
     "message": "Custom runtime"
+  },
+  "customize_your_assistant_e4038b74": {
+    "message": "Customize your assistant"
   },
   "cut_c8c92681": {
     "message": "Cut"
@@ -1091,6 +1175,9 @@
   "enter_skill_host_endpoint_url_e22eeab5": {
     "message": "Enter Skill host endpoint url"
   },
+  "enterprise_assistant_434df551": {
+    "message": "Enterprise Assistant"
+  },
   "entities_ef09392c": {
     "message": "Entities"
   },
@@ -1192,6 +1279,9 @@
   },
   "failed_to_start_1edb0dbe": {
     "message": "Failed to start"
+  },
+  "fallback_text_e5ff1cb7": {
+    "message": "Fallback Text"
   },
   "false_2f39ee6d": {
     "message": "false"
@@ -1304,6 +1394,9 @@
   "getting_template_910a4116": {
     "message": "Getting template"
   },
+  "give_your_bot_personality_multi_language_capabilit_f00c2c93": {
+    "message": "Give your bot personality, multi-language capabilities and more; you can edit this later in Bot Settings."
+  },
   "go_to_qna_all_up_view_page_d475333d": {
     "message": "Go to QnA all-up view page."
   },
@@ -1312,6 +1405,9 @@
   },
   "greeting_f906f962": {
     "message": "Greeting"
+  },
+  "greeting_message_ce77bbb2": {
+    "message": "Greeting Message"
   },
   "handle_a_condition_f32eb8d": {
     "message": "Handle a Condition"
@@ -1328,14 +1424,32 @@
   "here_s_what_we_know_4e9c1731": {
     "message": "Here’s what we know…"
   },
+  "hi_there_here_are_some_things_that_i_can_do_32909722": {
+    "message": "Hi there! Here are some things that I can do!"
+  },
   "hide_code_5dcffa94": {
     "message": "Hide code"
   },
   "home_351838cd": {
     "message": "Home"
   },
+  "hospitality_assistant_c330e403": {
+    "message": "Hospitality Assistant"
+  },
+  "hostname_fa8632e6": {
+    "message": "HostName"
+  },
+  "hosts_your_bot_application_9dd01ffc": {
+    "message": "Hosts your Bot application."
+  },
+  "hosts_your_qna_maker_knowledgebases_64713aee": {
+    "message": "Hosts your QnA Maker knowledgebases"
+  },
   "http_request_79847109": {
     "message": "HTTP Request"
+  },
+  "i_am_sorry_i_didn_t_understand_that_f86e307a": {
+    "message": "I am sorry, I didn''t understand that"
   },
   "i_want_to_delete_this_bot_f81a4735": {
     "message": "I want to delete this bot"
@@ -1514,6 +1628,9 @@
   "learn_more_about_manifests_6e7c364b": {
     "message": "Learn more about manifests"
   },
+  "learn_more_about_qna_maker_skus_998c567": {
+    "message": "Learn more about QnA Maker SKUs."
+  },
   "learn_more_about_skill_manifests_7708ce2c": {
     "message": "Learn more about skill manifests"
   },
@@ -1594,6 +1711,9 @@
   },
   "location_is_location_8c17b5de": {
     "message": "location is { location }"
+  },
+  "locations_346f0a33": {
+    "message": "Locations"
   },
   "log_to_console_4fc23e34": {
     "message": "Log to console"
@@ -1793,6 +1913,9 @@
   "must_have_a_name_d5c5c464": {
     "message": "Must have a name"
   },
+  "my_publish_profile_2ed56828": {
+    "message": "My Publish Profile"
+  },
   "my_staging_environment_2b92d0aa": {
     "message": "My Staging Environment"
   },
@@ -1819,6 +1942,9 @@
   },
   "name_of_the_property_f3cae657": {
     "message": "Name of the property"
+  },
+  "name_of_your_new_resource_group_1b7a34e4": {
+    "message": "Name of your new resource group"
   },
   "navigation_control_94f2649e": {
     "message": "navigation control"
@@ -1895,6 +2021,18 @@
   "not_yet_published_669e37b3": {
     "message": "Not yet published"
   },
+  "notes_c42e0fd5": {
+    "message": "Notes"
+  },
+  "notification_list_ee2abb6c": {
+    "message": "Notification list"
+  },
+  "notification_message_msg_7d55d08e": {
+    "message": "Notification Message { msg }"
+  },
+  "notification_type_263c145d": {
+    "message": "Notification type"
+  },
   "notifications_cbfa7704": {
     "message": "Notifications"
   },
@@ -1964,6 +2102,9 @@
   "open_notification_panel_5796edb3": {
     "message": "Open notification panel"
   },
+  "open_skills_page_for_configuration_details_a2a484ea": {
+    "message": "Open Skills page for configuration details"
+  },
   "open_start_bots_panel_f7f87200": {
     "message": "Open start bots panel"
   },
@@ -2021,6 +2162,15 @@
   "paste_token_here_eccec7e4": {
     "message": "Paste token here"
   },
+  "personality_1381bf78": {
+    "message": "{ personality }"
+  },
+  "personality_cf47985f": {
+    "message": "Personality"
+  },
+  "personality_choice_3dfd8268": {
+    "message": "Personality Choice"
+  },
   "please_add_at_least_minitems_endpoint_5439fd74": {
     "message": "Please add at least { minItems } endpoint"
   },
@@ -2059,6 +2209,9 @@
   },
   "please_select_an_activity_type_92f4a8a1": {
     "message": "Please select an activity type"
+  },
+  "populate_your_knowledge_base_bb2d3605": {
+    "message": "Populate your Knowledge Base"
   },
   "powervirtualagents_logo_11858924": {
     "message": "PowerVirtualAgents Logo"
@@ -2168,6 +2321,9 @@
   "provisioning_1330aede": {
     "message": "Provisioning ..."
   },
+  "provisioning_summary_2be9422f": {
+    "message": "Provisioning Summary"
+  },
   "pseudo_1a319287": {
     "message": "Pseudo"
   },
@@ -2176,6 +2332,9 @@
   },
   "publish_configuration_d759a4e3": {
     "message": "Publish Configuration"
+  },
+  "publish_destination_type_5f8c200a": {
+    "message": "Publish Destination Type"
   },
   "publish_models_9a36752a": {
     "message": "Publish models"
@@ -2222,11 +2381,20 @@
   "qna_intent_recognized_49c3d797": {
     "message": "QnA Intent recognized"
   },
+  "qna_maker_azure_search_service_88a403db": {
+    "message": "QnA Maker Azure Search Service"
+  },
+  "qna_maker_c313ed6e": {
+    "message": "QnA Maker"
+  },
   "qna_maker_subscription_key_e009c9d9": {
     "message": "QnA Maker Subscription key"
   },
   "qna_maker_subscription_key_is_required_to_start_yo_1892741": {
     "message": "QnA Maker Subscription key is required to start your bot locally, and publish"
+  },
+  "qna_maker_web_app_3da183bd": {
+    "message": "QnA Maker Web App"
   },
   "qna_navigation_pane_b79ebcbf": {
     "message": "Qna Navigation Pane"
@@ -2282,6 +2450,9 @@
   "regex_intent_is_already_defined_df095c1f": {
     "message": "RegEx { intent } is already defined"
   },
+  "regular_expression_855557bf": {
+    "message": "Regular Expression"
+  },
   "regular_expression_recognizer_44664557": {
     "message": "Regular expression recognizer"
   },
@@ -2336,11 +2507,20 @@
   "requiredtext_priority_priority_4293288f": {
     "message": "{ requiredText } | Priority: { priority }"
   },
+  "resource_374a9df": {
+    "message": "Resource"
+  },
+  "resource_group_59eac426": {
+    "message": "Resource group"
+  },
   "response_is_response_3cd62f8f": {
     "message": "Response is { response }"
   },
   "responses_12d6df1d": {
     "message": "Responses"
+  },
+  "restart_bot_34e36428": {
+    "message": "Restart Bot"
   },
   "review_and_generate_63dec712": {
     "message": "Review and generate"
@@ -2414,6 +2594,9 @@
   "search_for_extensions_on_npm_c5ca65d9": {
     "message": "Search for extensions on npm"
   },
+  "search_index_for_your_qna_maker_knowledgebases_22700ca7": {
+    "message": "Search index for your QnA Maker knowledgebases."
+  },
   "see_details_da74090e": {
     "message": "See Details"
   },
@@ -2434,6 +2617,9 @@
   },
   "select_an_event_type_3d7108f1": {
     "message": "Select an event type"
+  },
+  "select_an_option_9f5dfb55": {
+    "message": "Select an option"
   },
   "select_an_schema_to_edit_or_create_a_new_one_59c7326a": {
     "message": "Select an schema to edit or create a new one"
@@ -2462,8 +2648,20 @@
   "select_which_tasks_this_skill_can_perform_172b0eae": {
     "message": "Select which tasks this skill can perform"
   },
+  "select_your_location_1d5c501": {
+    "message": "Select your location"
+  },
   "select_your_publish_target_de531f7f": {
     "message": "Select your publish target"
+  },
+  "select_your_resource_group_bf36b186": {
+    "message": "Select your resource group"
+  },
+  "select_your_subscription_17b5260": {
+    "message": "Select your subscription"
+  },
+  "selected_assistant_type_83d58f54": {
+    "message": "Selected Assistant Type"
   },
   "selection_field_86d1dc94": {
     "message": "selection field"
@@ -2519,6 +2717,9 @@
   "show_all_diagnostics_c11f4e09": {
     "message": "Show All Diagnostics"
   },
+  "show_all_notifications_55bf7858": {
+    "message": "Show All Notifications"
+  },
   "show_code_f3e9d1cc": {
     "message": "Show code"
   },
@@ -2549,6 +2750,9 @@
   "skill_host_endpoint_4118a173": {
     "message": "Skill host endpoint"
   },
+  "skill_host_endpoint_b1088d0": {
+    "message": "Skill Host Endpoint"
+  },
   "skill_host_endpoint_url_e68b65f6": {
     "message": "Skill host endpoint url"
   },
@@ -2557,6 +2761,12 @@
   },
   "skillname_manifest_ef3d9fed": {
     "message": "{ skillName } Manifest"
+  },
+  "skills_49cccd6a": {
+    "message": "Skills"
+  },
+  "skip_this_step_to_add_questions_and_answers_manual_ed1b9f80": {
+    "message": "Skip this step to add questions and answers manually after creation. The number of sources and file size you can add depends on the QnA service SKU you choose. "
   },
   "something_happened_while_attempting_to_pull_e_952c7afe": {
     "message": "Something happened while attempting to pull: { e }"
@@ -2590,6 +2800,9 @@
   },
   "specify_a_name_description_and_location_for_your_n_667f1438": {
     "message": "Specify a name, description, and location for your new bot project."
+  },
+  "speech_16063aed": {
+    "message": "Speech"
   },
   "start_and_stop_local_bot_runtimes_individually_901c8d7d": {
     "message": "Start and stop local bot runtimes individually."
@@ -2645,6 +2858,18 @@
   "submit_a3cc6859": {
     "message": "Submit"
   },
+  "subscription_15330b8a": {
+    "message": "Subscription"
+  },
+  "subscription_keys_for_language_understanding_cogni_105e039f": {
+    "message": "Subscription keys for Language Understanding Cognitive Service."
+  },
+  "subscription_keys_for_qna_maker_cognitive_service__91da99a4": {
+    "message": "Subscription keys for QnA Maker Cognitive Service which facilitates the bot personality you selected."
+  },
+  "summary_24ad7681": {
+    "message": "Summary"
+  },
   "synonyms_optional_afe5cdb1": {
     "message": "Synonyms (Optional)"
   },
@@ -2669,20 +2894,38 @@
   "the_api_messages_endpoint_for_the_skill_f318dc63": {
     "message": "The /api/messages endpoint for the skill."
   },
+  "the_azure_bot_service_resource_stores_configuratio_b7b4e73d": {
+    "message": "The Azure Bot Service resource stores configuration information that allows your Virtual Assistant to be accessed on the supported Channels and provide OAuth authentication."
+  },
+  "the_callback_url_for_the_skill_host_e20e1012": {
+    "message": "The callback url for the skill host."
+  },
   "the_dialog_you_have_tried_to_delete_is_currently_u_a37c7a02": {
     "message": "The dialog you have tried to delete is currently used in the below dialog(s). Removing this dialog will cause your Bot to malfunction without additional action."
   },
   "the_file_name_can_not_be_empty_cbdbe9c8": {
     "message": "The file name can not be empty"
   },
+  "the_following_customizations_will_be_applied_to_yo_7d3384cf": {
+    "message": "The following customizations will be applied to your bot"
+  },
   "the_following_lufile_s_are_invalid_c61ea748": {
     "message": "The Following LuFile(s) are invalid: \n"
+  },
+  "the_following_will_be_provisioned_to_enable_your_b_6c52fdac": {
+    "message": "The following will be provisioned to enable your bot"
   },
   "the_main_dialog_is_named_after_your_bot_it_is_the__3d9864f": {
     "message": "The main dialog is named after your bot. It is the root and entry point of a bot."
   },
   "the_manifest_can_be_edited_and_refined_manually_if_9269e3f2": {
     "message": "The manifest can be edited and refined manually if and where needed."
+  },
+  "the_microsoft_app_id_that_will_be_calling_the_skil_955424de": {
+    "message": "The Microsoft App Id that will be calling the skill."
+  },
+  "the_microsoft_app_password_that_will_be_calling_th_acf9e1ea": {
+    "message": "The Microsoft App Password that will be calling the skill."
   },
   "the_page_you_are_looking_for_can_t_be_found_a3b75795": {
     "message": "The page you are looking for can''t be found."
@@ -2732,11 +2975,17 @@
   "this_dialog_has_no_trigger_yet_d1f1d173": {
     "message": "This dialog has no trigger yet."
   },
+  "this_is_a_botname_notification_c8a391c7": {
+    "message": "This is a { botName } notification"
+  },
   "this_is_a_required_field_acb9837e": {
     "message": "This is a required field."
   },
   "this_is_a_severity_diagnostic_58312674": {
     "message": "This is a { severity } diagnostic"
+  },
+  "this_is_a_severity_notification_9beabb58": {
+    "message": "This is a { severity } notification"
   },
   "this_is_the_bot_language_you_are_currently_authori_4a26541": {
     "message": "This is the bot language you are currently authoring. Change the active language in the dropdown below."
@@ -2761,6 +3010,9 @@
   },
   "this_trigger_type_is_not_supported_by_the_regex_re_dc3eefa2": {
     "message": "This trigger type is not supported by the RegEx recognizer. To ensure this trigger is fired, change the recognizer type."
+  },
+  "this_url_is_duplicated_a0768f44": {
+    "message": "This url is duplicated"
   },
   "this_version_of_the_content_is_out_of_date_and_you_5e878f29": {
     "message": "This version of the content is out of date, and your last change was rejected. The content will be automatically refreshed."
@@ -2885,6 +3137,9 @@
   "typing_activity_6b634ae": {
     "message": "Typing activity"
   },
+  "unable_to_determine_recognizer_type_from_data_valu_2960f526": {
+    "message": "Unable to determine recognizer type from data: { value }"
+  },
   "undo_a7be8fef": {
     "message": "Undo"
   },
@@ -2945,6 +3200,9 @@
   "updating_scripts_e17a5722": {
     "message": "Updating scripts... "
   },
+  "url_22a5f3b8": {
+    "message": "URL"
+  },
   "url_8c4ff7d2": {
     "message": "Url"
   },
@@ -2971,6 +3229,18 @@
   },
   "used_in_126529e5": {
     "message": "Used In"
+  },
+  "used_to_capture_conversation_and_application_telem_cae2c2a4": {
+    "message": "Used to capture conversation and application telemetry."
+  },
+  "used_to_host_your_bot_web_app_and_qna_maker_web_ap_514dc11b": {
+    "message": "Used to host your Bot Web App and QnA Maker Web App."
+  },
+  "used_to_store_conversation_state_11f348bd": {
+    "message": "Used to store conversation state."
+  },
+  "used_to_store_conversation_transcripts_d80440ab": {
+    "message": "Used to store conversation transcripts."
   },
   "user_input_673e4a89": {
     "message": "User input"
@@ -3001,6 +3271,9 @@
   },
   "video_tutorials_79eb26ca": {
     "message": "Video tutorials:"
+  },
+  "view_ba339f93": {
+    "message": "View"
   },
   "view_dialog_f5151228": {
     "message": "View dialog"
@@ -3067,6 +3340,9 @@
   },
   "what_is_the_type_of_this_trigger_d2701744": {
     "message": "What is the type of this trigger?"
+  },
+  "what_will_your_virtual_assistant_say_if_it_does_no_972dd9ab": {
+    "message": "What will your Virtual Assistant say if it does not understand the user?"
   },
   "what_your_bot_says_to_the_user_this_is_a_template__a8d2266d": {
     "message": "What your bot says to the user. This is a template used to create the outgoing message. It can include language generation rules, properties from memory, and other features.\n\nFor example, to define variations that will be chosen at random, write:\n- hello\n- hi"


### PR DESCRIPTION
## Description
Someone's arm token was too large, and we pass both arm token and graph token in provision call header, so that the http call will throw `431 header fields are too large` error.

Reason: The HTTP protocol parser that Node uses appears to be hard-coded with a maximum header size.

Solution: 
1. set --max-http-header-size in client package.json.      **But it have no effect.**
2. move graph token from header into body.                   **I take this one in this fix.**
3. change a http parse, like used `http-parser-js` instead.

## Task Item

close #5335 

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
