### PR TITLE
fix: Updated publish extensions to use updated APIs

### DIFF
--- a/Composer/packages/client/src/plugins/api.ts
+++ b/Composer/packages/client/src/plugins/api.ts
@@ -22,8 +22,6 @@ interface AuthAPI {
 }
 
 interface PublishAPI {
-  setConfigIsValid?: (valid: boolean) => void;
-  setPublishConfig?: (config: PublishConfig) => void;
   useConfigBeingEdited?: (() => PublishConfig[]) | (() => void);
   startProvision?: (config: any) => void;
   currentProjectId?: () => string;
@@ -51,8 +49,6 @@ class API implements IAPI {
       },
     };
     this.publish = {
-      setConfigIsValid: undefined,
-      setPublishConfig: undefined,
       useConfigBeingEdited: undefined,
       startProvision: undefined,
       currentProjectId: undefined,

--- a/Composer/packages/extension-client/src/publish/index.ts
+++ b/Composer/packages/extension-client/src/publish/index.ts
@@ -5,14 +5,6 @@ import { ComposerGlobalName } from '../common/constants';
 
 import { PublishConfig } from './types';
 
-export function setPublishConfig(config: PublishConfig) {
-  window[ComposerGlobalName].setPublishConfig(config);
-}
-
-export function setConfigIsValid(valid: boolean) {
-  window[ComposerGlobalName].setConfigIsValid(valid);
-}
-
 export function useConfigBeingEdited(): PublishConfig[] | undefined[] {
   return window[ComposerGlobalName].useConfigBeingEdited();
 }

--- a/extensions/pvaPublish/src/ui/pvaDialog.tsx
+++ b/extensions/pvaPublish/src/ui/pvaDialog.tsx
@@ -89,7 +89,6 @@ export const PVADialog: FC = () => {
         setFetchingEnvironments(false);
         setEnvs(envs);
         if (envs && envs.length) {
-          console.log(envs[0]);
           setEnv(envs[0]);
         }
       };

--- a/extensions/pvaPublish/src/ui/pvaDialog.tsx
+++ b/extensions/pvaPublish/src/ui/pvaDialog.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useState, FC } from 'react';
 import * as React from 'react';
-import { getAccessToken, setConfigIsValid, setPublishConfig, fetch } from '@bfc/extension-client';
+import { closeDialog, getAccessToken, savePublishConfig, fetch, onBack } from '@bfc/extension-client';
 import {
+  DefaultButton,
   Dropdown,
   IDropdownOption,
   ResponsiveMode,
@@ -14,7 +15,7 @@ import {
 } from 'office-ui-fabric-react';
 import formatMessage from 'format-message';
 
-import { root } from './styles';
+import { buttonBar as buttonBarStyles, root } from './styles';
 import { Bot, BotEnvironment } from './types';
 
 const PVABotIcon = require('./media/pva-bot-icon.svg');
@@ -38,6 +39,7 @@ export const PVADialog: FC = () => {
   const [loggingIn, setLoggingIn] = useState(false);
   const [fetchingEnvironments, setFetchingEnvironments] = useState(false);
   const [fetchingBots, setFetchingBots] = useState(false);
+  const [configIsValid, setConfigIsValid] = useState(false);
 
   const login = useCallback(() => {
     setLoggingIn(true);
@@ -87,6 +89,7 @@ export const PVADialog: FC = () => {
         setFetchingEnvironments(false);
         setEnvs(envs);
         if (envs && envs.length) {
+          console.log(envs[0]);
           setEnv(envs[0]);
         }
       };
@@ -137,7 +140,11 @@ export const PVADialog: FC = () => {
     } else {
       setConfigIsValid(false);
     }
-    setPublishConfig({ botId: (bot || {}).id, envId: env, tenantId, deleteMissingComponents: true });
+  }, [env, bot, tenantId]);
+
+  const onSave = useCallback(() => {
+    savePublishConfig({ botId: (bot || {}).id, envId: env, tenantId, deleteMissingComponents: true });
+    closeDialog();
   }, [env, bot, tenantId]);
 
   const loggedIn = useMemo(() => {
@@ -274,11 +281,36 @@ export const PVADialog: FC = () => {
     }
   }, [loggedIn, loggingIn]);
 
+  const buttonBar = useMemo(() => {
+    if (loggedIn) {
+      return (
+        <div style={buttonBarStyles}>
+          <DefaultButton
+            text="Back"
+            onClick={onBack}
+            styles={{
+              root: { marginLeft: 'auto' },
+            }}
+          />
+          <PrimaryButton
+            text="Save"
+            onClick={onSave}
+            disabled={!configIsValid}
+            styles={{
+              root: { marginLeft: 8 },
+            }}
+          />
+        </div>
+      );
+    }
+  }, [configIsValid, loggedIn]);
+
   return (
     <div style={root}>
       {loginSplash}
       {envPicker}
       {botPicker}
+      {buttonBar}
     </div>
   );
 };

--- a/extensions/pvaPublish/src/ui/styles.ts
+++ b/extensions/pvaPublish/src/ui/styles.ts
@@ -6,7 +6,7 @@ import { CSSProperties } from 'react';
 export const root: CSSProperties = {
   display: 'flex',
   flexFlow: 'column nowrap',
-  height: 'auto',
+  height: '100vh', // fill the iframe
   position: 'relative',
   backgroundColor: 'white',
   padding: '0',
@@ -59,4 +59,13 @@ export const dropdown: CSSProperties = {
 export const label: CSSProperties = {
   display: 'block',
   marginTop: 12,
+};
+
+export const buttonBar: CSSProperties = {
+  borderTop: '1px solid #000',
+  display: 'flex',
+  flexFlow: 'row nowrap',
+  marginTop: 'auto',
+  paddingTop: 16,
+  width: '100%',
 };

--- a/extensions/sample-ui-plugin/src/client/publish/main.tsx
+++ b/extensions/sample-ui-plugin/src/client/publish/main.tsx
@@ -2,15 +2,16 @@
 // Licensed under the MIT License.
 
 import React, { useEffect, useCallback, useState } from 'react';
-import { setConfigIsValid, setPublishConfig, useConfigBeingEdited } from '@bfc/extension-client';
+import { closeDialog, onBack, savePublishConfig, useConfigBeingEdited } from '@bfc/extension-client';
 
-import { column, label, publishRoot, textField } from '../styles';
+import { backButton, buttonBar, column, label, publishRoot, saveButton, textField, title } from '../styles';
 
 export const Main: React.FC<{ title: string }> = (props) => {
   const [configBeingEdited] = useConfigBeingEdited();
   const [val1, setVal1] = useState(configBeingEdited ? configBeingEdited.val1 : '');
   const [val2, setVal2] = useState(configBeingEdited ? configBeingEdited.val2 : '');
   const [val3, setVal3] = useState(configBeingEdited ? configBeingEdited.val3 : '');
+  const [configIsValid, setConfigIsValid] = useState(false);
 
   const updateVal1 = useCallback((ev) => {
     setVal1(ev.target.value);
@@ -25,7 +26,6 @@ export const Main: React.FC<{ title: string }> = (props) => {
   }, []);
 
   useEffect(() => {
-    setPublishConfig({ val1, val2, val3 });
     if (val1 && val2 && val3) {
       setConfigIsValid(true);
     } else {
@@ -33,9 +33,14 @@ export const Main: React.FC<{ title: string }> = (props) => {
     }
   }, [val1, val2, val3]);
 
+  const onSave = useCallback(() => {
+    savePublishConfig({ val1, val2, val3 });
+    closeDialog();
+  }, [val1, val2, val3]);
+
   return (
     <div className={publishRoot}>
-      <h3>{props.title}</h3>
+      <h3 className={title}>{props.title}</h3>
       <div className={column}>
         <label className={label} htmlFor={'val1'}>
           Value 1
@@ -71,6 +76,14 @@ export const Main: React.FC<{ title: string }> = (props) => {
           value={val3}
           onChange={updateVal3}
         ></input>
+      </div>
+      <div className={buttonBar}>
+        <button className={backButton} onClick={onBack}>
+          Back
+        </button>
+        <button className={saveButton} onClick={onSave} disabled={!configIsValid}>
+          Save
+        </button>
       </div>
     </div>
   );

--- a/extensions/sample-ui-plugin/src/client/styles.ts
+++ b/extensions/sample-ui-plugin/src/client/styles.ts
@@ -69,3 +69,21 @@ export const output = css`
   font-size: 14px;
   font-weight: 400;
 `;
+
+export const title = css`
+  margin-top: 0;
+`;
+
+export const buttonBar = css`
+  display: flex;
+  flex-flow: row nowrap;
+  margin-top: 16px;
+`;
+
+export const backButton = css`
+  margin-left: auto;
+`;
+
+export const saveButton = css`
+  margin-left: 8px;
+`;


### PR DESCRIPTION
## Description

Upon merging the provisioning work, there were some changes made to the publishing extension API that were not translated into all the publishing extensions, breaking some of them.

This PR rewrites the `pvaPublish` and `sample-ui-plugin` extensions to use those updated APIs.

Gets rid of the `setPublishConfig()` and `setConfigIsValid()` APIs.

#minor

## Screenshots

**`pvaPublish`**

![pva1](https://user-images.githubusercontent.com/3452012/102284096-761ed900-3ee8-11eb-8955-c0d18b446aaf.PNG)
![pva2](https://user-images.githubusercontent.com/3452012/102284099-76b76f80-3ee8-11eb-978a-dacf3d282685.PNG)
![pva3](https://user-images.githubusercontent.com/3452012/102284101-76b76f80-3ee8-11eb-86b8-014ad8ee14e4.PNG)

**`sample-ui-plugin`**

![sample1](https://user-images.githubusercontent.com/3452012/102284111-7919c980-3ee8-11eb-9759-f23d3932bf8e.PNG)
![sample2](https://user-images.githubusercontent.com/3452012/102284112-79b26000-3ee8-11eb-873c-71373b113f2a.PNG)

