### PR TITLE
fix: Fixed issue where an env object was being stored in state instead of …

### DIFF
--- a/extensions/pvaPublish/src/ui/pvaDialog.tsx
+++ b/extensions/pvaPublish/src/ui/pvaDialog.tsx
@@ -87,7 +87,7 @@ export const PVADialog: FC = () => {
         setFetchingEnvironments(false);
         setEnvs(envs);
         if (envs && envs.length) {
-          setEnv(envs[0]);
+          setEnv(envs[0].id);
         }
       };
       fetchEnvs();


### PR DESCRIPTION
…an env ID string.

## Description

There was a [line in the PVA publish extension code](https://github.com/microsoft/BotFramework-Composer/blob/main/extensions/pvaPublish/src/ui/pvaDialog.tsx#L90) that was storing the entire PVA environment object in state instead of just the environment ID.

This was then causing the following HTTP request to PVA to target the wrong environment endpoint because it was encoding the stringified environment object instead of just the environment ID in the URL:

**Before fix:**

`https://powerva.microsoft.com/api/botmanagement/v1/environments/%5Bobject%20Object%5D/bots`

**After fix:**

`https://powerva.microsoft.com/api/botmanagement/v1/environments/839eace6-59ab-4243-97ec-a5b8fcc104e4/bots`

This was preventing users with only one selectable environment from showing their list of available bots within the extension.

## Task Item

closes #5270

