### PR TITLE
chore: Concurrency safe state manipulation for lg/lu/qna/multilang

### DIFF
--- a/Composer/packages/client/src/recoilModel/atoms/botState.ts
+++ b/Composer/packages/client/src/recoilModel/atoms/botState.ts
@@ -17,7 +17,6 @@ import {
   QnAFile,
   SkillManifestFile,
   RecognizerFile,
-  Skill,
 } from '@bfc/shared';
 import { atomFamily } from 'recoil';
 
@@ -346,13 +345,6 @@ export const botNameIdentifierState = atomFamily<string, string>({
 export const currentSkillManifestIndexState = atomFamily<number, string>({
   key: getFullyQualifiedKey('currentSkillManifestIndex'),
   default: 0,
-});
-
-export const skillsState = atomFamily<Skill[], string>({
-  key: getFullyQualifiedKey('skills'),
-  default: (id) => {
-    return [];
-  },
 });
 
 export const canUndoState = atomFamily<boolean, string>({

--- a/Composer/packages/client/src/recoilModel/dispatchers/lg.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/lg.ts
@@ -224,7 +224,7 @@ export const lgDispatcher = () => {
         const updatedFile = (await LgWorker.parse(projectId, id, content, lgFiles)) as LgFile;
         const updatedFiles = await getRelatedLgFileChanges(projectId, lgFiles, updatedFile);
 
-        // compaire to drop expired change on current id lg file.
+        // compare to drop expired change on current id lg file.
         /**
          * Why other methods do not need double check content?
          * Because this method already did set content before call lgFilesAtomUpdater.
@@ -234,7 +234,7 @@ export const lgDispatcher = () => {
           lgFilesAtomUpdater({ updates: updatedFiles }, (prevLgFiles) => {
             const targetInState = prevLgFiles.find((file) => file.id === updatedFile.id);
             const targetInCurrentChange = updatedFiles.find((file) => file.id === updatedFile.id);
-            // compaire to drop expired content already setted above.
+            // compare to drop expired content already setted above.
             if (targetInState?.content !== targetInCurrentChange?.content) {
               return (lgFile) => lgFile.id !== updatedFile.id;
             } else {
@@ -269,7 +269,7 @@ export const lgDispatcher = () => {
       const { set, snapshot } = callbackHelpers;
       const lgFiles = await snapshot.getPromise(lgFilesState(projectId));
       const lgFile = lgFiles.find((file) => file.id === id);
-      if (!lgFile) return;
+      if (!lgFile) return lgFiles;
       const sameIdOtherLocaleFiles = lgFiles.filter((file) => getBaseName(file.id) === getBaseName(id));
 
       // create need sync to multi locale file.
@@ -331,7 +331,7 @@ export const lgDispatcher = () => {
     }) => {
       const lgFiles = await snapshot.getPromise(lgFilesState(projectId));
       const lgFile = lgFiles.find((file) => file.id === id);
-      if (!lgFile) return;
+      if (!lgFile) return lgFiles;
       const updatedFile = (await LgWorker.addTemplate(projectId, lgFile, template, lgFiles)) as LgFile;
       const updatedFiles = await getRelatedLgFileChanges(projectId, lgFiles, updatedFile);
       set(lgFilesState(projectId), lgFilesAtomUpdater({ updates: updatedFiles }));
@@ -352,7 +352,7 @@ export const lgDispatcher = () => {
         const { set, snapshot } = callbackHelpers;
         const lgFiles = await snapshot.getPromise(lgFilesState(projectId));
         const lgFile = lgFiles.find((file) => file.id === id);
-        if (!lgFile) return;
+        if (!lgFile) return lgFiles;
         const updatedFile = (await LgWorker.addTemplates(projectId, lgFile, templates, lgFiles)) as LgFile;
         const updatedFiles = await getRelatedLgFileChanges(projectId, lgFiles, updatedFile);
         set(lgFilesState(projectId), lgFilesAtomUpdater({ updates: updatedFiles }));
@@ -375,7 +375,7 @@ export const lgDispatcher = () => {
       const { set, snapshot } = callbackHelpers;
       const lgFiles = await snapshot.getPromise(lgFilesState(projectId));
       const lgFile = lgFiles.find((file) => file.id === id);
-      if (!lgFile) return;
+      if (!lgFile) return lgFiles;
       try {
         const updatedFile = (await LgWorker.removeTemplate(projectId, lgFile, templateName, lgFiles)) as LgFile;
 
@@ -401,7 +401,7 @@ export const lgDispatcher = () => {
         const { set, snapshot } = callbackHelpers;
         const lgFiles = await snapshot.getPromise(lgFilesState(projectId));
         const lgFile = lgFiles.find((file) => file.id === id);
-        if (!lgFile) return;
+        if (!lgFile) return lgFiles;
 
         const updatedFile = (await LgWorker.removeTemplates(projectId, lgFile, templateNames, lgFiles)) as LgFile;
 
@@ -429,7 +429,7 @@ export const lgDispatcher = () => {
         const { set, snapshot } = callbackHelpers;
         const lgFiles = await snapshot.getPromise(lgFilesState(projectId));
         const lgFile = lgFiles.find((file) => file.id === id);
-        if (!lgFile) return;
+        if (!lgFile) return lgFiles;
         const updatedFile = (await LgWorker.copyTemplate(
           projectId,
           lgFile,
@@ -458,7 +458,7 @@ export const lgDispatcher = () => {
         set(
           lgFilesState(projectId),
           lgFilesAtomUpdater({ updates: reparsedLgFiles }, (prevLgFiles) => {
-            // compaire to drop expired content already setted above.
+            // compare to drop expired content already setted above.
             return (target) => {
               const targetInState = prevLgFiles.find((file) => file.id === target.id);
               const targetInCurrentChange = reparsedLgFiles.find((file) => file.id === target.id);

--- a/Composer/packages/client/src/recoilModel/dispatchers/lu.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/lu.ts
@@ -22,29 +22,44 @@ const initialBody = '- ';
 /**
  * Recoil state from snapshot can be expired, use updater can make fine-gained operations.
  *
- * @param changes lu files need to be updated, usually one locale lu file's structure change need sync to other locale.
- * @param contentCheckTargetId If content is expired, drop update on this file.
+ * @param changes files need to update/add/delete
+ * @param filter drop some expired changes.
  *
  */
-const luFilesAtomUpdater = (changes: LuFile[], contentCheckTargetId?: string) => {
-  return (prevLuFiles: LuFile[]): LuFile[] => {
-    if (contentCheckTargetId) {
-      const currentFile = prevLuFiles.find((file) => file.id === contentCheckTargetId);
-      const targetFile = changes.find((file) => file.id === contentCheckTargetId);
-      // compaire to drop expired change on current lu file.
-      if (currentFile?.content !== targetFile?.content) {
-        changes = changes.filter((file) => file.id !== contentCheckTargetId);
-      }
-    }
 
-    return prevLuFiles.map((file) => {
-      const changedFile = changes.find(({ id }) => id === file.id);
+const luFilesAtomUpdater = (
+  changes: {
+    adds?: LuFile[];
+    deletes?: LuFile[];
+    updates?: LuFile[];
+  },
+  filter?: (oldList: LuFile[]) => (changeItem: LuFile) => boolean
+) => {
+  return (oldList: LuFile[]) => {
+    const updates = changes.updates ? (filter ? changes.updates.filter(filter(oldList)) : changes.updates) : [];
+    const adds = changes.adds ? (filter ? changes.adds.filter(filter(oldList)) : changes.adds) : [];
+    const deletes = changes.deletes
+      ? filter
+        ? changes.deletes.filter(filter(oldList)).map(({ id }) => id)
+        : changes.deletes.map(({ id }) => id)
+      : [];
+
+    // updates
+    let newList = oldList.map((file) => {
+      const changedFile = updates.find(({ id }) => id === file.id);
       return changedFile ?? file;
     });
+
+    // deletes
+    newList = newList.filter((file) => !deletes.includes(file.id));
+
+    // adds
+    newList = adds.concat(newList);
+
+    return newList;
   };
 };
-
-const updateLuFileState = async (
+const getRelatedLuFileChanges = async (
   luFiles: LuFile[],
   updatedLuFile: LuFile,
   projectId: string,
@@ -126,7 +141,7 @@ export const createLuFileState = async (
     });
   });
 
-  set(luFilesState(projectId), (prevLuFiles) => [...prevLuFiles, ...changes]);
+  set(luFilesState(projectId), luFilesAtomUpdater({ adds: changes }));
 };
 
 export const removeLuFileState = async (
@@ -149,10 +164,7 @@ export const removeLuFileState = async (
       luFileStatusStorage.removeFileStatus(projectId, targetLuFile.id);
     }
   });
-
-  set(luFilesState(projectId), (prevLuFiles) => {
-    return prevLuFiles.filter((file) => file.id !== targetLuFile.id);
-  });
+  set(luFilesState(projectId), luFilesAtomUpdater({ deletes: [targetLuFile] }));
 };
 
 export const luDispatcher = () => {
@@ -185,13 +197,25 @@ export const luDispatcher = () => {
 
       try {
         const updatedFile = (await luWorker.parse(id, content, luFeatures)) as LuFile;
-        const updatedFiles = await updateLuFileState(luFiles, updatedFile, projectId, luFeatures);
+        const updatedFiles = await getRelatedLuFileChanges(luFiles, updatedFile, projectId, luFeatures);
         // compaire to drop expired change on current id file.
         /**
          * Why other methods do not need double check content?
          * Because this method already did set content before call luFilesAtomUpdater.
          */
-        set(luFilesState(projectId), luFilesAtomUpdater(updatedFiles, id));
+        set(
+          luFilesState(projectId),
+          luFilesAtomUpdater({ updates: updatedFiles }, (prevLuFiles) => {
+            const targetInState = prevLuFiles.find((file) => file.id === updatedFile.id);
+            const targetInCurrentChange = updatedFiles.find((file) => file.id === updatedFile.id);
+            // compaire to drop expired content already setted above.
+            if (targetInState?.content !== targetInCurrentChange?.content) {
+              return (luFile) => luFile.id !== updatedFile.id;
+            } else {
+              return () => true;
+            }
+          })
+        );
       } catch (error) {
         setError(callbackHelpers, error);
       }
@@ -239,13 +263,8 @@ export const luDispatcher = () => {
             )) as LuFile;
             changes.push(updatedFile);
           }
+          set(luFilesState(projectId), luFilesAtomUpdater({ updates: changes }));
 
-          set(luFilesState(projectId), (prevLuFiles) => {
-            return prevLuFiles.map((file) => {
-              const changedFile = changes.find(({ id }) => id === file.id);
-              return changedFile ? changedFile : file;
-            });
-          });
           // body change, only update current locale file
         } else {
           const updatedFile = (await luWorker.updateIntent(
@@ -254,11 +273,7 @@ export const luDispatcher = () => {
             { Body: intent.Body },
             luFeatures
           )) as LuFile;
-          set(luFilesState(projectId), (prevLuFiles) => {
-            return prevLuFiles.map((file) => {
-              return file.id === id ? updatedFile : file;
-            });
-          });
+          set(luFilesState(projectId), luFilesAtomUpdater({ updates: [updatedFile] }));
         }
       } catch (error) {
         setError(callbackHelpers, error);
@@ -284,8 +299,8 @@ export const luDispatcher = () => {
       if (!file) return luFiles;
       try {
         const updatedFile = (await luWorker.addIntent(file, intent, luFeatures)) as LuFile;
-        const updatedFiles = await updateLuFileState(luFiles, updatedFile, projectId, luFeatures);
-        set(luFilesState(projectId), luFilesAtomUpdater(updatedFiles));
+        const updatedFiles = await getRelatedLuFileChanges(luFiles, updatedFile, projectId, luFeatures);
+        set(luFilesState(projectId), luFilesAtomUpdater({ updates: updatedFiles }));
       } catch (error) {
         setError(callbackHelpers, error);
       }
@@ -310,8 +325,8 @@ export const luDispatcher = () => {
       if (!file) return luFiles;
       try {
         const updatedFile = (await luWorker.removeIntent(file, intentName, luFeatures)) as LuFile;
-        const updatedFiles = await updateLuFileState(luFiles, updatedFile, projectId, luFeatures);
-        set(luFilesState(projectId), luFilesAtomUpdater(updatedFiles));
+        const updatedFiles = await getRelatedLuFileChanges(luFiles, updatedFile, projectId, luFeatures);
+        set(luFilesState(projectId), luFilesAtomUpdater({ updates: updatedFiles }));
       } catch (error) {
         setError(callbackHelpers, error);
       }

--- a/Composer/packages/client/src/recoilModel/dispatchers/lu.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/lu.ts
@@ -198,7 +198,7 @@ export const luDispatcher = () => {
       try {
         const updatedFile = (await luWorker.parse(id, content, luFeatures)) as LuFile;
         const updatedFiles = await getRelatedLuFileChanges(luFiles, updatedFile, projectId, luFeatures);
-        // compaire to drop expired change on current id file.
+        // compare to drop expired change on current id file.
         /**
          * Why other methods do not need double check content?
          * Because this method already did set content before call luFilesAtomUpdater.
@@ -208,7 +208,7 @@ export const luDispatcher = () => {
           luFilesAtomUpdater({ updates: updatedFiles }, (prevLuFiles) => {
             const targetInState = prevLuFiles.find((file) => file.id === updatedFile.id);
             const targetInCurrentChange = updatedFiles.find((file) => file.id === updatedFile.id);
-            // compaire to drop expired content already setted above.
+            // compare to drop expired content already setted above.
             if (targetInState?.content !== targetInCurrentChange?.content) {
               return (luFile) => luFile.id !== updatedFile.id;
             } else {

--- a/Composer/packages/client/src/recoilModel/dispatchers/qna.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/qna.ts
@@ -28,6 +28,47 @@ import { rootBotProjectIdSelector } from '../selectors';
 
 import { addNotificationInternal, deleteNotificationInternal, createNotification } from './notification';
 
+/**
+ * Recoil state from snapshot can be expired, use updater can make fine-gained operations.
+ *
+ * @param changes files need to update/add/delete
+ * @param filter drop some expired changes.
+ *
+ */
+
+const qnaFilesAtomUpdater = (
+  changes: {
+    adds?: QnAFile[];
+    deletes?: QnAFile[];
+    updates?: QnAFile[];
+  },
+  filter?: (oldList: QnAFile[]) => (changeItem: QnAFile) => boolean
+) => {
+  return (oldList: QnAFile[]) => {
+    const updates = changes.updates ? (filter ? changes.updates.filter(filter(oldList)) : changes.updates) : [];
+    const adds = changes.adds ? (filter ? changes.adds.filter(filter(oldList)) : changes.adds) : [];
+    const deletes = changes.deletes
+      ? filter
+        ? changes.deletes.filter(filter(oldList)).map(({ id }) => id)
+        : changes.deletes.map(({ id }) => id)
+      : [];
+
+    // updates
+    let newList = oldList.map((file) => {
+      const changedFile = updates.find(({ id }) => id === file.id);
+      return changedFile ?? file;
+    });
+
+    // deletes
+    newList = newList.filter((file) => !deletes.includes(file.id));
+
+    // adds
+    newList = adds.concat(newList);
+
+    return newList;
+  };
+};
+
 export const updateQnAFileState = async (
   callbackHelpers: CallbackInterface,
   { id, content, projectId }: { id: string; content: string; projectId: string }
@@ -37,14 +78,7 @@ export const updateQnAFileState = async (
   id = id.endsWith('.source') ? id : `${getBaseName(id)}.en-us`;
   const updatedQnAFile = (await qnaWorker.parse(id, content)) as QnAFile;
 
-  set(qnaFilesState(projectId), (prevQnAFiles) => {
-    return prevQnAFiles.map((file) => {
-      if (file.id === id) {
-        return updatedQnAFile;
-      }
-      return file;
-    });
-  });
+  set(qnaFilesState(projectId), qnaFilesAtomUpdater({ updates: [updatedQnAFile] }));
 };
 
 export const createQnAFileState = async (
@@ -73,8 +107,7 @@ export const createQnAFileState = async (
       id: fileId,
     });
   });
-
-  set(qnaFilesState(projectId), (prevQnAFiles) => [...changes, ...prevQnAFiles]);
+  set(qnaFilesState(projectId), qnaFilesAtomUpdater({ adds: changes }));
 };
 
 /**
@@ -104,10 +137,7 @@ export const removeQnAFileState = async (
       qnaFileStatusStorage.removeFileStatus(projectId, targetQnAFile.id);
     }
   });
-
-  set(qnaFilesState(projectId), (prevQnAFiles) => {
-    return prevQnAFiles.filter((file) => file.id !== targetQnAFile.id);
-  });
+  set(qnaFilesState(projectId), qnaFilesAtomUpdater({ deletes: [targetQnAFile] }));
 };
 
 export const createKBFileState = async (
@@ -124,7 +154,7 @@ export const createKBFileState = async (
 
   const createdQnAFile = (await qnaWorker.parse(createdSourceQnAId, content)) as QnAFile;
 
-  let newQnAFiles = [...qnaFiles];
+  let updatedQnAFiles: QnAFile[] = [];
 
   // if created on a dialog, need update this dialog's all locale qna ref
   if (id.includes('.source') === false) {
@@ -133,18 +163,17 @@ export const createKBFileState = async (
       throw new Error(`update qna file ${updatedQnAId}.qna not exist`);
     }
 
-    newQnAFiles = qnaFiles.map((file) => {
-      if (!file.id.endsWith('.source') && getBaseName(file.id) === getBaseName(updatedQnAId)) {
+    updatedQnAFiles = qnaFiles
+      .filter((file) => !file.id.endsWith('.source') && getBaseName(file.id) === getBaseName(updatedQnAId))
+      .map((file) => {
         return qnaUtil.addImport(file, `${createdSourceQnAId}.qna`);
-      }
-      return file;
-    });
+      });
 
     qnaFileStatusStorage.updateFileStatus(projectId, updatedQnAId);
   }
 
   qnaFileStatusStorage.updateFileStatus(projectId, createdSourceQnAId);
-  set(qnaFilesState(projectId), (prevQnAFiles) => [createdQnAFile, ...prevQnAFiles]);
+  set(qnaFilesState(projectId), qnaFilesAtomUpdater({ updates: updatedQnAFiles, adds: [createdQnAFile] }));
 };
 
 export const removeKBFileState = async (
@@ -168,10 +197,7 @@ export const removeKBFileState = async (
       qnaFileStatusStorage.removeFileStatus(projectId, targetQnAFile.id);
     }
   });
-
-  set(qnaFilesState(projectId), (prevQnAFiles) => {
-    return prevQnAFiles.filter((file) => file.id !== targetQnAFile.id);
-  });
+  set(qnaFilesState(projectId), qnaFilesAtomUpdater({ deletes: [targetQnAFile] }));
 };
 
 export const renameKBFileState = async (
@@ -458,11 +484,7 @@ ${response.data}
 
       // const updatedFile = await updateQnAFileState(callbackHelpers, { id, content });
       const updatedFile = qnaUtil.updateQnAQuestion(qnaFile, sectionId, questionId, content);
-      set(qnaFilesState(projectId), (qnaFiles) => {
-        return qnaFiles.map((file) => {
-          return file.id === id ? updatedFile : file;
-        });
-      });
+      set(qnaFilesState(projectId), qnaFilesAtomUpdater({ updates: [updatedFile] }));
     }
   );
 
@@ -483,11 +505,7 @@ ${response.data}
       if (!qnaFile) return qnaFiles;
 
       const updatedFile = qnaUtil.updateQnAAnswer(qnaFile, sectionId, content);
-      set(qnaFilesState(projectId), (qnaFiles) => {
-        return qnaFiles.map((file) => {
-          return file.id === id ? updatedFile : file;
-        });
-      });
+      set(qnaFilesState(projectId), qnaFilesAtomUpdater({ updates: [updatedFile] }));
     }
   );
 
@@ -508,11 +526,7 @@ ${response.data}
       if (!qnaFile) return qnaFiles;
 
       const updatedFile = qnaUtil.createQnAQuestion(qnaFile, sectionId, content);
-      set(qnaFilesState(projectId), (qnaFiles) => {
-        return qnaFiles.map((file) => {
-          return file.id === id ? updatedFile : file;
-        });
-      });
+      set(qnaFilesState(projectId), qnaFilesAtomUpdater({ updates: [updatedFile] }));
     }
   );
 
@@ -533,11 +547,7 @@ ${response.data}
       if (!qnaFile) return qnaFiles;
 
       const updatedFile = qnaUtil.removeQnAQuestion(qnaFile, sectionId, questionId);
-      set(qnaFilesState(projectId), (qnaFiles) => {
-        return qnaFiles.map((file) => {
-          return file.id === id ? updatedFile : file;
-        });
-      });
+      set(qnaFilesState(projectId), qnaFilesAtomUpdater({ updates: [updatedFile] }));
     }
   );
 
@@ -557,11 +567,7 @@ ${response.data}
 
       // insert into head, need investigate
       const updatedFile = qnaUtil.insertSection(qnaFile, 0, content);
-      set(qnaFilesState(projectId), (qnaFiles) => {
-        return qnaFiles.map((file) => {
-          return file.id === id ? updatedFile : file;
-        });
-      });
+      set(qnaFilesState(projectId), qnaFilesAtomUpdater({ updates: [updatedFile] }));
     }
   );
 
@@ -580,11 +586,7 @@ ${response.data}
       if (!qnaFile) return qnaFiles;
 
       const updatedFile = qnaUtil.removeSection(qnaFile, sectionId);
-      set(qnaFilesState(projectId), (qnaFiles) => {
-        return qnaFiles.map((file) => {
-          return file.id === id ? updatedFile : file;
-        });
-      });
+      set(qnaFilesState(projectId), qnaFilesAtomUpdater({ updates: [updatedFile] }));
     }
   );
 
@@ -603,11 +605,7 @@ ${response.data}
       if (!qnaFile) return qnaFiles;
 
       const updatedFile = qnaUtil.addImport(qnaFile, `${sourceId}.qna`);
-      set(qnaFilesState(projectId), (qnaFiles) => {
-        return qnaFiles.map((file) => {
-          return file.id === id ? updatedFile : file;
-        });
-      });
+      set(qnaFilesState(projectId), qnaFilesAtomUpdater({ updates: [updatedFile] }));
     }
   );
   const removeQnAImport = useRecoilCallback(
@@ -625,11 +623,7 @@ ${response.data}
       if (!qnaFile) return qnaFiles;
 
       const updatedFile = qnaUtil.removeImport(qnaFile, `${sourceId}.qna`);
-      set(qnaFilesState(projectId), (qnaFiles) => {
-        return qnaFiles.map((file) => {
-          return file.id === id ? updatedFile : file;
-        });
-      });
+      set(qnaFilesState(projectId), qnaFilesAtomUpdater({ updates: [updatedFile] }));
     }
   );
   const updateQnAImport = useRecoilCallback(
@@ -650,11 +644,7 @@ ${response.data}
 
       let updatedFile = qnaUtil.removeImport(qnaFile, `${sourceId}.qna`);
       updatedFile = qnaUtil.addImport(updatedFile, `${newSourceId}.qna`);
-      set(qnaFilesState(projectId), (qnaFiles) => {
-        return qnaFiles.map((file) => {
-          return file.id === id ? updatedFile : file;
-        });
-      });
+      set(qnaFilesState(projectId), qnaFilesAtomUpdater({ updates: [updatedFile] }));
     }
   );
   const removeQnAKB = useRecoilCallback(


### PR DESCRIPTION
## Description
As describe in #5339. In current dispatchers methods, some of them, state manipulations are not concurrency safe.
If a concurrency call incoming also mutate same state variable, last time long time parsing will overwrite the concurrency mutation.

This PR reviewed those code again, change to use updater callback function make fine-gained operations.

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
close #5339
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
