### PR TITLE
fix: Docker Compose build context

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   composer:
-    build: Composer
+    build: .
     ports:
       - "3000:3000"
       - "3979-5000:3979-5000"


### PR DESCRIPTION
## Description

The build context in the `docker-compose.yml` file is currently incorrect. This PR is fixing that.

## Task Item

Closes #5381 

