### PR TITLE
fix: improve type-safety of server code

### DIFF
--- a/Composer/packages/server/package.json
+++ b/Composer/packages/server/package.json
@@ -17,6 +17,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "typecheck": "tsc --noEmit",
+    "typecheck:watch": "tsc --noEmit --noImplicitAny --watch",
     "lint": "eslint --quiet ./src",
     "lint:fix": "yarn lint --fix"
   },

--- a/Composer/packages/server/src/controllers/__tests__/auth.test.ts
+++ b/Composer/packages/server/src/controllers/__tests__/auth.test.ts
@@ -27,7 +27,7 @@ describe('auth controller', () => {
   };
 
   beforeEach(() => {
-    mockRes.status.mockClear();
+    mockRes.status?.mockClear();
     chainedRes.json.mockClear();
     chainedRes.send.mockClear();
   });

--- a/Composer/packages/server/src/controllers/asset.ts
+++ b/Composer/packages/server/src/controllers/asset.ts
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { Request, Response } from 'express';
+
 import AssetService from '../services/asset';
 
-async function getProjTemplates(req: any, res: any) {
+async function getProjTemplates(req: Request, res: Response) {
   try {
     const templates = await AssetService.manager.getProjectTemplates();
     res.status(200).json(templates);

--- a/Composer/packages/server/src/externalContentProvider/externalContentProvider.ts
+++ b/Composer/packages/server/src/externalContentProvider/externalContentProvider.ts
@@ -25,12 +25,12 @@ export abstract class ExternalContentProvider<T extends IContentProviderMetadata
   /**
    * Downloads bot content and returns a path to the downloaded content.
    */
-  abstract async downloadBotContent(): Promise<BotContentInfo>;
+  abstract downloadBotContent(): Promise<BotContentInfo>;
 
   /**
    * Cleans up any leftover downloaded bot content and performs any other needed cleanup.
    */
-  abstract async cleanUp(): Promise<void>;
+  abstract cleanUp(): Promise<void>;
 
   /**
    * Returns a custom identifier defined by the service that will allow Composer
@@ -47,10 +47,10 @@ export abstract class ExternalContentProvider<T extends IContentProviderMetadata
    * is being imported. Composer can now prompt the user and ask if they want to save the
    * updated content to the existing project.
    */
-  abstract async getAlias?(): Promise<string>;
+  abstract getAlias?(): Promise<string>;
 
   /**
    * (Optional) Performs any necessary authentication for the service and returns an access token.
    */
-  abstract async authenticate?(): Promise<string>;
+  abstract authenticate?(): Promise<string>;
 }

--- a/Composer/packages/server/src/models/bot/botProject.ts
+++ b/Composer/packages/server/src/models/bot/botProject.ts
@@ -544,7 +544,7 @@ export class BotProject implements IBotProject {
     if (this.settings == null) return; // we shouldn't be able to get here without settings
     const qnaEndpointKey = await this.builder.getQnaEndpointKey(subscriptionKey, {
       ...this.settings.luis,
-      qnaRegion: this.settings?.qna.qnaRegion ?? this.settings?.luis.authoringRegion ?? 'westus',
+      qnaRegion: this.settings.qna.qnaRegion ?? this.settings.luis.authoringRegion ?? 'westus',
       subscriptionKey,
     });
     return qnaEndpointKey;

--- a/Composer/packages/server/src/models/bot/botProject.ts
+++ b/Composer/packages/server/src/models/bot/botProject.ts
@@ -351,7 +351,7 @@ export class BotProject implements IBotProject {
         });
         writer.on('close', () => {
           if (!error) {
-            resolve();
+            resolve(null);
           }
         });
       });
@@ -460,7 +460,7 @@ export class BotProject implements IBotProject {
   };
 
   public createFiles = async (files) => {
-    const createdFiles: any = [];
+    const createdFiles: FileInfo[] = [];
     for (const { name, content } of files) {
       const file = await this.createFile(name, content);
       createdFiles.push(file);
@@ -541,9 +541,10 @@ export class BotProject implements IBotProject {
 
   // update qna endpointKey in settings
   public updateQnaEndpointKey = async (subscriptionKey: string) => {
+    if (this.settings == null) return; // we shouldn't be able to get here without settings
     const qnaEndpointKey = await this.builder.getQnaEndpointKey(subscriptionKey, {
-      ...this.settings?.luis,
-      qnaRegion: this.settings?.qna.qnaRegion || this.settings?.luis.authoringRegion,
+      ...this.settings.luis,
+      qnaRegion: this.settings?.qna.qnaRegion ?? this.settings?.luis.authoringRegion ?? 'westus',
       subscriptionKey,
     });
     return qnaEndpointKey;
@@ -691,7 +692,7 @@ export class BotProject implements IBotProject {
     // instead of calling stat again which could be expensive
     const stats = await this.fileStorage.stat(absolutePath);
 
-    const file = {
+    const file: FileInfo = {
       name: Path.basename(relativePath),
       content: content,
       path: absolutePath,

--- a/Composer/packages/server/src/models/bot/botProject.ts
+++ b/Composer/packages/server/src/models/bot/botProject.ts
@@ -890,7 +890,7 @@ export class BotProject implements IBotProject {
   private _createBotProjectFileForOldBots = async (files: Map<string, FileInfo>) => {
     const fileList = new Map<string, FileInfo>();
     try {
-      const defaultBotProjectFile: any = await AssetService.manager.botProjectFileTemplate;
+      const defaultBotProjectFile = await AssetService.manager.botProjectFileTemplate;
 
       for (const [, file] of files) {
         if (file.name.endsWith(FileExtensions.BotProject)) {

--- a/Composer/packages/server/src/models/bot/builder.ts
+++ b/Composer/packages/server/src/models/bot/builder.ts
@@ -113,7 +113,7 @@ export class Builder {
     }
   };
 
-  public getQnaEndpointKey = async (subscriptionKey: string, config: IConfig | Record<string, any>) => {
+  public getQnaEndpointKey = async (subscriptionKey: string, config: IConfig) => {
     try {
       const subscriptionKeyEndpoint = `https://${config?.qnaRegion}.api.cognitive.microsoft.com/qnamaker/v4.0`;
       const endpointKey = await this.qnaBuilder.getEndpointKeys(subscriptionKey, subscriptionKeyEndpoint);
@@ -174,7 +174,7 @@ export class Builder {
     const returnData = await this.orchestratorBuilder(luFiles, modelPath);
 
     // write snapshot data into /generated folder
-    const snapshots: any = {};
+    const snapshots: { [key: string]: string } = {};
     for (const dialog of returnData.outputs) {
       const bluFilePath = Path.resolve(this.generatedFolderPath, dialog.id.replace('.lu', '.blu'));
       snapshots[dialog.id.replace('.lu', '').replace(/[-.]/g, '_')] = bluFilePath;
@@ -183,13 +183,13 @@ export class Builder {
     }
 
     // write settings into /generated/orchestrator.settings.json
-    const orchestratorSettings: any = {
+    const orchestratorSettings = {
       orchestrator: {
         ModelPath: modelPath,
+        snapshots,
       },
     };
 
-    orchestratorSettings.orchestrator.snapshots = snapshots;
     const orchestratorSettingsPath = Path.resolve(this.generatedFolderPath, 'orchestrator.settings.json');
     await writeFile(orchestratorSettingsPath, JSON.stringify(orchestratorSettings));
   };
@@ -269,7 +269,7 @@ export class Builder {
     if (!paths.length) return {};
 
     const qnaConfigFile = await this.storage.readFile(Path.join(this.generatedFolderPath, paths[0]));
-    const qna: any = {};
+    const qna = {};
 
     const qnaConfig = await JSON.parse(qnaConfigFile);
     const endpointKey = await this.qnaBuilder.getEndpointKeys(config.subscriptionKey, subscriptionKeyEndpoint);

--- a/Composer/packages/server/src/models/bot/interface.ts
+++ b/Composer/packages/server/src/models/bot/interface.ts
@@ -37,7 +37,6 @@ export interface IOperationLUFile {
   relativePath?: string;
   content?: string;
   intents: [];
-  [key: string]: any;
 }
 
 export interface ILuisStatusOperation {
@@ -61,13 +60,6 @@ export interface IOrchestratorNLRList {
 export interface IOrchestratorProgress {
   (status: string): void;
 }
-
-export interface IOrchestratorRecognizer extends BaseSchema {
-  modelPath: string;
-  snapshotPath: string;
-  entityRecognizers: any[];
-}
-
 export interface IOrchestratorBuildOutput {
   outputs: [{ id: string; snapshot: Uint8Array; recognizer: Record<string, BaseSchema> }];
   settings: {

--- a/Composer/packages/server/src/models/settings/defaultSettingManager.ts
+++ b/Composer/packages/server/src/models/settings/defaultSettingManager.ts
@@ -7,6 +7,7 @@ import has from 'lodash/has';
 import get from 'lodash/get';
 import set from 'lodash/set';
 import unset from 'lodash/unset';
+import omit from 'lodash/omit';
 
 import { Path } from '../../utility/path';
 import log from '../../logger';
@@ -128,16 +129,7 @@ export class DefaultSettingManager extends FileSettingManager {
     return result;
   }
 
-  private filterOutSensitiveValue = (obj: any) => {
-    if (obj && typeof obj === 'object') {
-      SensitiveProperties.map((key) => {
-        set(obj, key, '');
-      });
-      return obj;
-    }
-  };
-
-  public set = async (settings: any): Promise<void> => {
+  public set = async (settings: DialogSetting): Promise<void> => {
     const path = this.getPath();
     const dir = Path.dirname(path);
     if (!(await this.storage.exists(dir))) {
@@ -145,7 +137,7 @@ export class DefaultSettingManager extends FileSettingManager {
       await this.storage.mkDir(dir, { recursive: true });
     }
     // remove sensitive values before saving to disk
-    const settingsWithoutSensitive = this.filterOutSensitiveValue(settings);
+    const settingsWithoutSensitive = omit(settings, SensitiveProperties);
 
     await this.storage.writeFile(path, JSON.stringify(settingsWithoutSensitive, null, 2));
   };

--- a/Composer/packages/server/src/models/settings/fileSettingManager.ts
+++ b/Composer/packages/server/src/models/settings/fileSettingManager.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { UserIdentity } from '@bfc/extension';
+import mapValues from 'lodash/mapValues';
 
 import { Path } from '../../utility/path';
 import { IFileStorage } from '../storage/interface';
@@ -26,6 +27,7 @@ export class FileSettingManager implements ISettingManager {
     this.storage = StorageService.getStorageClient('default', user);
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public async get(obfuscate = false): Promise<any> {
     const path = this.getPath();
     const settings = await this._getFromStorage(path);
@@ -45,10 +47,11 @@ export class FileSettingManager implements ISettingManager {
     }
   };
 
-  protected createDefaultSettings = (): any => {
+  protected createDefaultSettings = () => {
     return {};
   };
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public set = async (settings: any): Promise<void> => {
     const path = this.getPath();
 
@@ -62,20 +65,15 @@ export class FileSettingManager implements ISettingManager {
 
   public getFileName = () => fileName;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private obfuscateValues = (obj: any): any => {
     if (obj) {
       const type = typeof obj;
       if (type === 'object') {
         if (Array.isArray(obj)) {
-          const result: any[] = [];
-          obj.forEach((x) => result.push(this.obfuscateValues(x)));
-          return result;
+          return obj.map(this.obfuscateValues);
         } else {
-          const result: any = {};
-          for (const p in obj) {
-            result[p] = this.obfuscateValues(obj[p]);
-          }
-          return result;
+          return mapValues(obj, this.obfuscateValues);
         }
       }
     }

--- a/Composer/packages/server/src/services/project.ts
+++ b/Composer/packages/server/src/services/project.ts
@@ -124,8 +124,11 @@ export class BotProjectService {
     throw new Error('getCurrentBotProject is DEPRECATED');
   }
 
-  public static getProjectsDateModifiedDict = async (projects: LocationRef[], user?: UserIdentity): Promise<any> => {
-    const dateModifiedDict: any = [];
+  public static getProjectsDateModifiedDict = async (
+    projects: LocationRef[],
+    user?: UserIdentity
+  ): Promise<{ dateModified: string; path: string }[]> => {
+    const dateModifiedDict: { dateModified: string; path: string }[] = [];
     const promises = projects.map(async (project) => {
       let dateModified = '';
       try {
@@ -145,16 +148,16 @@ export class BotProjectService {
       BotProjectService.recentBotProjects,
       user
     );
-    const recentBots = BotProjectService.recentBotProjects.reduce((result: any[], item) => {
-      const name = Path.basename(item.path);
-      //remove .botproj. Someone may open project before new folder structure.
-      if (!name.includes('.botproj')) {
-        result.push({ name, ...item });
-      }
-      return result;
-    }, []);
+    const allRecentBots = BotProjectService.recentBotProjects;
 
-    return recentBots.map((item: any) => {
+    const recentBots = allRecentBots
+      .filter((bot) => !Path.basename(bot.path).includes('.botproj'))
+      .map((bot) => ({
+        ...bot,
+        name: Path.basename(bot.path),
+      }));
+
+    return recentBots.map((item) => {
       return merge(item, find(dateModifiedDict, { path: item.path }));
     });
   };

--- a/Composer/packages/server/src/settings/env.ts
+++ b/Composer/packages/server/src/settings/env.ts
@@ -16,7 +16,7 @@ if (folder && folder.endsWith(':')) {
 }
 
 let names: string[] = [];
-const getDiskNames = (text) => {
+const getDiskNames = (text: string) => {
   names = text
     .split('\r\r\n')
     .filter((token) => token.indexOf(':') > -1)

--- a/Composer/packages/server/src/store/migrations.ts
+++ b/Composer/packages/server/src/store/migrations.ts
@@ -11,7 +11,7 @@ import settings from '../settings';
 
 import initData from './data.template';
 
-interface Migration {
+interface Migration<D> {
   /**
    * Migration label. Will be printed to the console in debug.
    * @example 'Update Designer to Composer'
@@ -21,15 +21,15 @@ interface Migration {
    * Use to check if a condition exists that requires migration.
    * @example data => data.name === 'Designer';
    */
-  condition: (data: any) => boolean;
+  condition: (data: D) => boolean;
   /**
    * Data transform to run if condition is met.
    * @example data => ({ ...data, name: 'Composer' });
    */
-  run: (data: any) => any;
+  run: (data: D) => void;
 }
 
-const migrations: Migration[] = [
+const migrations: Migration<any>[] = [
   {
     name: 'Add defaultPath',
     condition: (data) => get(data, 'storageConnections.0.defaultPath') !== settings.botsFolder,
@@ -42,13 +42,13 @@ const migrations: Migration[] = [
   },
   {
     name: 'Re-init when version update',
-    condition: (data) => !data.version || data.version != initData.version,
-    run: (data) => initData,
+    condition: (data) => !data?.version || data?.version != initData.version,
+    run: () => initData,
   },
 ];
 
 export function runMigrations(initialData: any): any {
-  const migrationsToRun: Migration[] = migrations.filter((m) => m.condition(initialData));
+  const migrationsToRun: Migration<any>[] = migrations.filter((m) => m.condition(initialData));
   if (migrationsToRun.length > 0) {
     log('migration: running migrations...');
 

--- a/Composer/packages/server/src/store/migrations.ts
+++ b/Composer/packages/server/src/store/migrations.ts
@@ -43,11 +43,12 @@ const migrations: Migration<any>[] = [
   {
     name: 'Re-init when version update',
     condition: (data) => !data?.version || data?.version != initData.version,
-    run: () => initData,
+    run: () => initData, // no argument needed here
   },
 ];
 
 export function runMigrations(initialData) {
+  // note: this 'any' type is because these elements are from data read from a JSON file
   const migrationsToRun: Migration<any>[] = migrations.filter((m) => m.condition(initialData));
   if (migrationsToRun.length > 0) {
     log('migration: running migrations...');

--- a/Composer/packages/server/src/store/migrations.ts
+++ b/Composer/packages/server/src/store/migrations.ts
@@ -47,7 +47,7 @@ const migrations: Migration<any>[] = [
   },
 ];
 
-export function runMigrations(initialData: any): any {
+export function runMigrations(initialData) {
   const migrationsToRun: Migration<any>[] = migrations.filter((m) => m.condition(initialData));
   if (migrationsToRun.length > 0) {
     log('migration: running migrations...');

--- a/Composer/packages/server/src/utility/attachLSP.ts
+++ b/Composer/packages/server/src/utility/attachLSP.ts
@@ -8,7 +8,7 @@ import * as net from 'net';
 import * as ws from 'ws';
 import * as rpc from 'vscode-ws-jsonrpc';
 
-export function createSocketHandler(webSocket: any): rpc.IWebSocket {
+export function createSocketHandler(webSocket): rpc.IWebSocket {
   const socket: rpc.IWebSocket = {
     send: (content) => webSocket.send(content),
     onMessage: (cb) => webSocket.on('message', cb),

--- a/Composer/packages/server/src/utility/isSubdirectory.ts
+++ b/Composer/packages/server/src/utility/isSubdirectory.ts
@@ -8,7 +8,7 @@ import path from 'path';
  * @param parent parent directory
  * @param dir directory to test
  */
-export function isSubdirectory(parent, dir) {
+export function isSubdirectory(parent: string, dir: string) {
   const relative = path.relative(parent, dir);
   return Boolean(relative && !relative.startsWith('..') && !path.isAbsolute(relative));
 }

--- a/Composer/packages/tools/language-servers/language-understanding/__tests__/helpers/server.ts
+++ b/Composer/packages/tools/language-servers/language-understanding/__tests__/helpers/server.ts
@@ -23,7 +23,7 @@ const luImportResolver = (_source, id) => {
   };
 };
 
-function createSocketHandler(webSocket: any): rpc.IWebSocket {
+function createSocketHandler(webSocket): rpc.IWebSocket {
   const socket: rpc.IWebSocket = {
     send: (content) =>
       webSocket.send(content, (error) => {

--- a/Composer/packages/types/src/indexers.ts
+++ b/Composer/packages/types/src/indexers.ts
@@ -114,7 +114,7 @@ export type LuFile = {
   intents: LuIntentSection[];
   empty: boolean;
   resource: LuParseResource;
-  [key: string]: any;
+  published: boolean;
 };
 
 export type LuParseResource = {
@@ -140,7 +140,6 @@ export type QnAFile = {
   options: { id: string; name: string; value: string }[];
   empty: boolean;
   resource: LuParseResource;
-  [key: string]: any;
 };
 
 export type LgTemplate = {
@@ -187,8 +186,6 @@ export type Manifest = {
   version: string;
   description: string;
   endpoints: ManifestEndpoint[];
-  // Other props of manifest are not used in Composer.
-  [prop: string]: any;
 };
 
 export type ManifestEndpoint = {
@@ -196,8 +193,6 @@ export type ManifestEndpoint = {
   endpointUrl: string;
   msAppId: string;
   description: string;
-  // Other skill endpoint fields in the schema that Composer is not using presently
-  [prop: string]: any;
 };
 
 export type Skill = {
@@ -284,7 +279,6 @@ export type RecognizerFile = {
   id: string;
   content: {
     $kind: SDKKinds;
-    [key: string]: any;
   };
 };
 

--- a/Composer/packages/types/src/indexers.ts
+++ b/Composer/packages/types/src/indexers.ts
@@ -114,7 +114,7 @@ export type LuFile = {
   intents: LuIntentSection[];
   empty: boolean;
   resource: LuParseResource;
-  published: boolean;
+  published?: boolean;
 };
 
 export type LuParseResource = {


### PR DESCRIPTION
## Description

This is a fix that cleans up a lot of the server code, adding type annotations where appropriate and smoothing out a few bumps. A lot of these "any" types are there for a good reason (they're either for test mocks or for data we're importing from a file), but there are some places that could be improved.

## Task Item

#minor
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
