### PR TITLE
fix: luis deploy e2e test case failed due to unnecessary clicking on the start bots panel.

### DIFF
--- a/Composer/cypress/integration/LuisDeploy.spec.ts
+++ b/Composer/cypress/integration/LuisDeploy.spec.ts
@@ -26,7 +26,6 @@ context('Luis Deploy', () => {
       response: 'fixture:luPublish/failure',
     });
     cy.findByTitle(/^Start bot/).click();
-    cy.findByTitle('Open start bots panel').click();
     cy.findByText('See Details').click();
 
     cy.route({


### PR DESCRIPTION
## Description
Current: after clicking start bots button, the "start bots panel" will open automatically if it is failed to start bots. 
In our e2e test case, there is one more clicking on the panel which will actually close it, so the See Details text cannot be seen.

Fix: delete the clicking on the "start bots panel" operation.

## Task Item
#minor
## Screenshots

