### PR TITLE
fix: Updated condition to check for correct publish API

### DIFF
--- a/Composer/packages/server/src/controllers/publisher.ts
+++ b/Composer/packages/server/src/controllers/publisher.ts
@@ -185,7 +185,7 @@ export const PublishController = {
     // get the publish plugin key
     const extensionName = profile ? profile.type : '';
 
-    if (profile && extensionImplementsMethod(extensionName, 'history')) {
+    if (profile && extensionImplementsMethod(extensionName, 'getHistory')) {
       // get the externally defined method
       const pluginMethod = ExtensionContext.extensions.publish[extensionName].methods.getHistory;
       if (typeof pluginMethod === 'function') {


### PR DESCRIPTION
## Description

PR #4924 updated the publish history API to `getHistory()` but did not update the conditional check above it to also check for the updated method name. This was causing the history call to fail for PVA publish profiles, and was not allowing users to select their PVA publishing profile from the dropdown.


## Task Item

Fixes #5398

