### PR TITLE
refactor: add generics to ClientStorage

### DIFF
--- a/Composer/packages/client/src/utils/auth.ts
+++ b/Composer/packages/client/src/utils/auth.ts
@@ -45,7 +45,7 @@ export function getUserTokenFromCache(): string | null {
 
   // next check to see if we have a token in session storage
   if (!token) {
-    const sessionToken = storage.get<string>(USER_TOKEN_STORAGE_KEY);
+    const sessionToken: string = storage.get(USER_TOKEN_STORAGE_KEY);
 
     if (sessionToken?.length > 0) {
       token = sessionToken;

--- a/Composer/packages/client/src/utils/luFileStatusStorage.ts
+++ b/Composer/packages/client/src/utils/luFileStatusStorage.ts
@@ -6,14 +6,16 @@ import storage, { ClientStorage } from './storage';
 
 const KEY = 'LuFileStatus';
 
-interface ILuFileStatus {
+type LuFileStatus = {
   [fileId: string]: boolean;
-}
+};
+
+type LuFileRecord = { [projectId: string]: LuFileStatus };
 
 // add luis publish status to local storage
 class LuFileStatusStorage {
-  private storage: ClientStorage;
-  private _all: { [projectId: string]: ILuFileStatus };
+  private storage: ClientStorage<LuFileRecord>;
+  private _all: LuFileRecord;
 
   constructor() {
     this.storage = storage;

--- a/Composer/packages/client/src/utils/projectCache.ts
+++ b/Composer/packages/client/src/utils/projectCache.ts
@@ -5,7 +5,7 @@ import { ClientStorage } from './storage';
 const KEY = 'ProjectIdCache';
 
 class ProjectIdCache {
-  private storage: ClientStorage;
+  private storage: ClientStorage<string>;
   private currentProjectId;
 
   constructor() {

--- a/Composer/packages/client/src/utils/qnaFileStatusStorage.ts
+++ b/Composer/packages/client/src/utils/qnaFileStatusStorage.ts
@@ -6,14 +6,16 @@ import storage, { ClientStorage } from './storage';
 
 const KEY = 'QnaFileStatus';
 
-interface IQnaFileStatus {
+type QnaFileStatus = {
   [fileId: string]: boolean;
-}
+};
+
+type QnaFileRecord = { [projectId: string]: QnaFileStatus };
 
 // add qna publish status to local storage
 class QnaFileStatusStorage {
-  private storage: ClientStorage;
-  private _all: { [projectId: string]: IQnaFileStatus };
+  private storage: ClientStorage<QnaFileRecord>;
+  private _all: QnaFileRecord;
 
   constructor() {
     this.storage = storage;

--- a/Composer/packages/client/src/utils/routerCache.ts
+++ b/Composer/packages/client/src/utils/routerCache.ts
@@ -5,7 +5,7 @@ import { ClientStorage } from './storage';
 const KEY = 'RouterCache';
 
 class RouterCache {
-  private storage: ClientStorage;
+  private storage: ClientStorage<string | {}>;
   private _all;
 
   constructor() {

--- a/Composer/packages/client/src/utils/storage.ts
+++ b/Composer/packages/client/src/utils/storage.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export class ClientStorage {
+export class ClientStorage<T> {
   private storage: Storage;
   private _prefix = 'composer';
 
@@ -12,7 +12,7 @@ export class ClientStorage {
     }
   }
 
-  public set<T = any>(key: string, val: T): T | void {
+  public set(key: string, val: T): T | void {
     if (val === undefined) {
       return this.remove(this.prefix(key));
     }
@@ -20,7 +20,9 @@ export class ClientStorage {
     return val;
   }
 
-  public get<T = any>(key: string, def?: T): T {
+  public get(key: string): T | undefined;
+  public get(key: string, def: T): T;
+  public get(key: string, def?: T): T | undefined {
     const val = this.deserialize(this.storage.getItem(this.prefix(key)));
     return val === undefined ? def : val;
   }
@@ -37,7 +39,7 @@ export class ClientStorage {
     this.storage.clear();
   }
 
-  public getAll(): { [key: string]: any } {
+  public getAll(): { [key: string]: TextDecoderOptions } {
     const ret = {};
     this.forEach((key, val) => {
       ret[key] = val;
@@ -45,20 +47,21 @@ export class ClientStorage {
     return ret;
   }
 
-  private forEach(callback: (key: string, val: any) => void) {
+  private forEach(callback: (key: string, val: T) => void) {
     for (let i = 0; i < this.storage.length; i++) {
       const key = this.storage.key(i);
-      if (key) {
-        callback(key.replace(`${this._prefix}:`, ''), this.get(key));
+      if (key != null) {
+        const val = this.get(key);
+        if (val != null) callback(key.replace(`${this._prefix}:`, ''), val);
       }
     }
   }
 
-  private serialize(val: any): string {
+  private serialize(val: T): string {
     return JSON.stringify(val);
   }
 
-  private deserialize(val: any): any {
+  private deserialize(val: any): T | undefined {
     if (typeof val !== 'string') {
       return undefined;
     }
@@ -66,7 +69,7 @@ export class ClientStorage {
     try {
       return JSON.parse(val);
     } catch (error) {
-      return val || undefined;
+      return undefined;
     }
   }
 
@@ -75,6 +78,6 @@ export class ClientStorage {
   }
 }
 
-const storage = new ClientStorage();
+const storage = new ClientStorage<any>();
 
 export default storage;


### PR DESCRIPTION
## Description

This adds a generic to our ClientStorage class so we have more type-safety about what we put into and get out of there (which lets us use fewer "any" type annotations).

## Task Item

#minor