### PR TITLE
fix: GitHub auth plugin's name

### DIFF
--- a/extensions/githubAuth/package.json
+++ b/extensions/githubAuth/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "authtest",
+  "name": "githubauth",
   "version": "1.0.0",
   "description": "",
   "main": "lib/index.js",


### PR DESCRIPTION
#minor