### PR TITLE
fix: LG worker cache expires occasionally

### DIFF
--- a/Composer/packages/client/src/recoilModel/parsers/workers/lgParser.worker.ts
+++ b/Composer/packages/client/src/recoilModel/parsers/workers/lgParser.worker.ts
@@ -151,7 +151,8 @@ const filterParseResult = (lgFile: LgFile) => {
 const getTargetFile = (projectId: string, lgFile: LgFile) => {
   const cachedFile = cache.get(projectId, lgFile.id);
 
-  return !cachedFile || cachedFile.content !== lgFile.content ? lgFile : cachedFile;
+  // Instead of compare content, just use cachedFile as single truth of fact, because all updates are supposed to be happen in worker, and worker will always update cache.
+  return cachedFile ?? lgFile;
 };
 
 export const handleMessage = (msg: LgMessageEvent) => {

--- a/Composer/packages/lib/indexers/src/utils/lgUtil.ts
+++ b/Composer/packages/lib/indexers/src/utils/lgUtil.ts
@@ -44,6 +44,7 @@ function templateToLgTemplate(templates: Template[]): LgTemplate[] {
   });
 }
 
+// get parsed resource from lgFile, if not exist do reparse
 function getLgResource(lgFile: LgFile, importResolver?: ImportResolverDelegate) {
   const { content, parseResult } = lgFile;
 


### PR DESCRIPTION
## Description

# The issue
Inside LG worker, we maintained a cache which holds the parsed lg index, to avoid a full parse every time. We also designed a cache expiring mechanism that once we found the current state of lg file is not equaling the cached lg file, we consider lg file is changed outside, and thus the cache is invalid, we will do a full parse and resyncing with the master state. 
But we found that this caching is expiring more often than we think, and causing more full parsing than the expected incremental parsing.

Cache is expiring too fast and too often is because our store is updating slower than the caching itself. When user is typing fast, the store must be updated after the parsed result is obtained, because today, our raw lg content is tightened up with the parsed lg result and be updated together (This is actually the same case with dialog and lu).

For example, typing from '' to '12345' like:

![image](https://user-images.githubusercontent.com/49866537/103724152-a8ff4d00-500e-11eb-9167-a60178003be5.png)

If get-from-store and get-from-cache content not match, will do a full re-parse.

# The Solution
Instead of compare content, just use cache as single truth of fact, because all updates are supposed to be happen in worker, and worker will always update cache.


## Task Item
 
refs #5396 

