### PR TITLE
ci: re-trigger pr validation on push

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -2,7 +2,7 @@ name: Pull Request Validation
 
 on:
   pull_request:
-    types: [opened, edited]
+    types: [opened, edited, synchronize]
 
 jobs:
   conventional-pr:


### PR DESCRIPTION
## Description

#5505 added `opened` and `edited` to the pr validation triggers, however the check was being cleared when new commits were pushed and never re-running. The `synchronize` event should re-trigger in that case as well.

## Task Item

#minor
