### PR TITLE
fix: 431 error when publish

### DIFF
--- a/Composer/packages/server/package.json
+++ b/Composer/packages/server/package.json
@@ -12,7 +12,7 @@
     "build": "tsc -p tsconfig.build.json && node scripts/build.js",
     "clean": "rimraf build",
     "prep:dist:electron": "yarn build --outDir ../electron-server/dist && node scripts/copyAssets.js",
-    "start": "node build/init.js",
+    "start": "node --max-http-header-size=16000 build/init.js",
     "start:dev": "nodemon",
     "test": "jest",
     "test:watch": "jest --watch",
@@ -23,7 +23,7 @@
   },
   "author": "",
   "nodemonConfig": {
-    "exec": "cross-env TS_NODE_FILES=true node --inspect=9228 -r ts-node/register src/init.ts",
+    "exec": "cross-env TS_NODE_FILES=true node --max-http-header-size=16000 --inspect=9228 -r ts-node/register src/init.ts",
     "watch": [
       "src",
       "../extension/lib"


### PR DESCRIPTION
## Description
fix 431 header too large error when publishing by setting max http header size in server.

## Task Item

close #5467 

## Screenshots
Use user's token to test, won't return 431.
![image](https://user-images.githubusercontent.com/21174180/104565278-020e5700-5687-11eb-93be-b473f625eff1.png)


