### PR TITLE
fix: switching in project tree is lagging

### DIFF
--- a/Composer/packages/client/src/App.tsx
+++ b/Composer/packages/client/src/App.tsx
@@ -15,6 +15,11 @@ import { useInitializeLogger } from './telemetry/useInitializeLogger';
 
 initializeIcons(undefined, { disableWarnings: true });
 
+const Logger = () => {
+  useInitializeLogger();
+  return null;
+};
+
 export const App: React.FC = () => {
   const { appLocale } = useRecoilValue(userSettingsState);
   const { fetchExtensions, fetchFeatureFlags } = useRecoilValue(dispatcherState);
@@ -28,10 +33,9 @@ export const App: React.FC = () => {
     fetchFeatureFlags();
   }, []);
 
-  useInitializeLogger();
-
   return (
     <Fragment key={appLocale}>
+      <Logger />
       <Announcement />
       <Header />
       <MainContainer />

--- a/Composer/packages/client/src/pages/design/VisualEditorHeader.tsx
+++ b/Composer/packages/client/src/pages/design/VisualEditorHeader.tsx
@@ -1,0 +1,178 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/** @jsx jsx */
+import { jsx } from '@emotion/core';
+import React, { useMemo } from 'react';
+import formatMessage from 'format-message';
+import { Breadcrumb, IBreadcrumbItem } from 'office-ui-fabric-react/lib/Breadcrumb';
+import { ActionButton } from 'office-ui-fabric-react/lib/Button';
+import { useRecoilValue } from 'recoil';
+import { PluginConfig } from '@bfc/extension-client';
+import { DialogInfo } from '@bfc/shared';
+import get from 'lodash/get';
+
+import { TreeLink } from '../../components/ProjectTree/ProjectTree';
+import {
+  designPageLocationState,
+  dialogsSelectorFamily,
+  dispatcherState,
+  visualEditorSelectionState,
+} from '../../recoilModel';
+import { getDialogData, getFriendlyName } from '../../utils/dialogUtil';
+import { decodeDesignerPathToArrayPath } from '../../utils/convertUtils/designerPathEncoder';
+import { getFocusPath } from '../../utils/navigation';
+
+import { breadcrumbClass } from './styles';
+
+type BreadcrumbItem = {
+  key: string;
+  label: string;
+  link?: Partial<TreeLink>;
+  onClick?: () => void;
+};
+
+type VisualEditorHeaderProps = {
+  projectId: string;
+  visible: boolean;
+  showCode: boolean;
+  onShowCodeClick: () => void;
+  pluginConfig?: PluginConfig;
+};
+
+const parseTriggerId = (triggerId: string | undefined): number | undefined => {
+  if (triggerId == null) return undefined;
+  const indexString = triggerId.match(/\d+/)?.[0];
+  if (indexString == null) return undefined;
+  return parseInt(indexString);
+};
+
+const getActionName = (action, pluginConfig?: PluginConfig) => {
+  const nameFromAction = action?.$designer?.name as string | undefined;
+  let detectedActionName: string;
+
+  if (typeof nameFromAction === 'string') {
+    detectedActionName = nameFromAction;
+  } else {
+    const kind: string = action?.$kind as string;
+    const actionNameFromSchema = pluginConfig?.uiSchema?.[kind]?.form?.label as string | (() => string) | undefined;
+    if (typeof actionNameFromSchema === 'string') {
+      detectedActionName = actionNameFromSchema;
+    } else if (typeof actionNameFromSchema === 'function') {
+      detectedActionName = actionNameFromSchema();
+    } else {
+      detectedActionName = formatMessage('Unknown');
+    }
+  }
+  return detectedActionName;
+};
+
+const useBreadcrumbs = (projectId: string, pluginConfig?: PluginConfig) => {
+  const designPageLocation = useRecoilValue(designPageLocationState(projectId));
+  const dialogs = useRecoilValue(dialogsSelectorFamily(projectId));
+  const { navTo } = useRecoilValue(dispatcherState);
+  const visualEditorSelection = useRecoilValue(visualEditorSelectionState);
+
+  const { dialogId, selected: encodedSelect, focused: encodedFocused } = designPageLocation;
+  const dialogMap = dialogs.reduce((acc, { content, id }) => ({ ...acc, [id]: content }), {});
+  const dialogData = getDialogData(dialogMap, dialogId);
+  const selected = decodeDesignerPathToArrayPath(dialogData, encodedSelect ?? '');
+  const focused = decodeDesignerPathToArrayPath(dialogData, encodedFocused ?? '');
+
+  // TODO: get these from a second return value from decodeDesignerPathToArrayPath
+  const triggerIndex = parseTriggerId(selected);
+  //make sure focusPath always valid
+  const focusPath = getFocusPath(selected, focused);
+  const trigger = triggerIndex != null && dialogData.triggers[triggerIndex];
+
+  let breadcrumbArray: Array<BreadcrumbItem> = [];
+
+  breadcrumbArray.push({
+    key: 'dialog-' + dialogId,
+    label: dialogMap[dialogId]?.$designer?.name ?? dialogMap[dialogId]?.$designer?.$designer?.name,
+    link: {
+      projectId: projectId,
+      dialogId: dialogId,
+    },
+    onClick: () => navTo(projectId, dialogId),
+  });
+
+  if (triggerIndex != null && trigger != null) {
+    breadcrumbArray.push({
+      key: 'trigger-' + triggerIndex,
+      label: trigger.$designer?.name || getFriendlyName(trigger),
+      link: {
+        projectId: projectId,
+        dialogId: dialogId,
+        trigger: triggerIndex,
+      },
+      onClick: () => navTo(projectId, dialogId, `${triggerIndex}`),
+    });
+  }
+
+  // getDialogData returns whatever's at the end of the path, which could be a trigger or an action
+  const possibleAction = getDialogData(dialogMap, dialogId, focusPath);
+
+  if (encodedFocused) {
+    // we've linked to an action, so put that in too
+    breadcrumbArray.push({
+      key: 'action-' + focusPath,
+      label: getActionName(possibleAction, pluginConfig),
+    });
+  }
+
+  const currentDialog = (dialogs.find(({ id }) => id === dialogId) ?? dialogs[0]) as DialogInfo;
+
+  const selectedActions = useMemo(() => {
+    const actionSelected = Array.isArray(visualEditorSelection) && visualEditorSelection.length > 0;
+    if (!actionSelected) return [];
+
+    const selectedActions = visualEditorSelection.map((id) => get(currentDialog?.content, id));
+
+    return selectedActions;
+  }, [visualEditorSelection, currentDialog?.content]);
+
+  if (selectedActions.length === 1 && selectedActions[0] != null) {
+    const action = selectedActions[0] as any;
+    const actionName = getActionName(action, pluginConfig);
+
+    breadcrumbArray = [...breadcrumbArray.slice(0, 2), { key: 'action-' + actionName, label: actionName }];
+  }
+
+  return breadcrumbArray;
+};
+
+const VisualEditorHeader: React.FC<VisualEditorHeaderProps> = (props) => {
+  const { visible, showCode, projectId, onShowCodeClick, pluginConfig } = props;
+  const breadcrumbs = useBreadcrumbs(projectId, pluginConfig);
+
+  const createBreadcrumbItem: (breadcrumb: BreadcrumbItem) => IBreadcrumbItem = (breadcrumb: BreadcrumbItem) => {
+    return {
+      key: breadcrumb.key,
+      text: breadcrumb.label,
+      onClick: () => breadcrumb.onClick?.(),
+    };
+  };
+
+  const items = breadcrumbs.map(createBreadcrumbItem);
+
+  return visible ? (
+    <div style={{ display: 'flex', justifyContent: 'space-between', height: '65px' }}>
+      <Breadcrumb
+        ariaLabel={formatMessage('Navigation Path')}
+        data-testid="Breadcrumb"
+        items={items}
+        maxDisplayedItems={3}
+        styles={breadcrumbClass}
+        onReduceData={() => undefined}
+      />
+      <div style={{ padding: '10px' }}>
+        <ActionButton onClick={onShowCodeClick}>
+          {showCode ? formatMessage('Hide code') : formatMessage('Show code')}
+        </ActionButton>
+      </div>
+    </div>
+  ) : null;
+};
+
+export default VisualEditorHeader;

--- a/Composer/packages/client/src/recoilModel/dispatchers/__tests__/navigation.test.tsx
+++ b/Composer/packages/client/src/recoilModel/dispatchers/__tests__/navigation.test.tsx
@@ -112,6 +112,8 @@ describe('navigation dispatcher', () => {
       await act(async () => {
         await dispatcher.setDesignPageLocation(projectId, {
           dialogId: 'dialogId',
+          selected: '',
+          focused: '',
           promptTab: undefined,
         });
       });
@@ -130,6 +132,7 @@ describe('navigation dispatcher', () => {
         await dispatcher.setDesignPageLocation(projectId, {
           dialogId: 'dialogId',
           selected: 'select',
+          focused: '',
           promptTab: undefined,
         });
       });

--- a/Composer/packages/client/src/recoilModel/dispatchers/navigation.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/navigation.ts
@@ -5,47 +5,55 @@
 //TODO: refactor the router to use one-way data flow
 import { useRecoilCallback, CallbackInterface } from 'recoil';
 import { PromptTab } from '@bfc/shared';
+import isEqual from 'lodash/isEqual';
 
 import { currentProjectIdState } from '../atoms';
 import { encodeArrayPathToDesignerPath } from '../../utils/convertUtils/designerPathEncoder';
 import { dialogsSelectorFamily, rootBotProjectIdSelector } from '../selectors';
+import { DesignPageLocation } from '../types';
 
 import { getSelected } from './../../utils/dialogUtil';
 import { designPageLocationState, focusPathState } from './../atoms/botState';
 import { checkUrl, convertPathToUrl, getUrlSearch, navigateTo } from './../../utils/navigation';
 
+const setCurrentProjectId = async ({ set, snapshot }: CallbackInterface, projectId: string) => {
+  const currentProjectId = await snapshot.getPromise(currentProjectIdState);
+  if (currentProjectId !== projectId) {
+    set(currentProjectIdState, projectId);
+  }
+};
+
 export const navigationDispatcher = () => {
   const setDesignPageLocation = useRecoilCallback(
-    ({ set }: CallbackInterface) => (projectId: string, { dialogId = '', selected = '', focused = '', promptTab }) => {
-      let focusPath = dialogId + '#';
-      if (focused) {
-        focusPath = dialogId + '#.' + focused;
-      } else if (selected) {
-        focusPath = dialogId + '#.' + selected;
-      }
-      set(currentProjectIdState, projectId);
+    (callbackInterface: CallbackInterface) => async (projectId: string, location: DesignPageLocation) => {
+      const { set, snapshot } = callbackInterface;
+
+      await setCurrentProjectId(callbackInterface, projectId);
+
+      const preLocation = await snapshot.getPromise(designPageLocationState(projectId));
+
+      if (isEqual(preLocation, location)) return;
+
+      const { dialogId = '', selected = '', focused = '' } = location;
+      const focusPath = `${dialogId}#${focused ? `.${focused}` : selected ? `.${selected}` : ''}`;
       set(focusPathState(projectId), focusPath);
-      set(designPageLocationState(projectId), {
-        dialogId,
-        selected,
-        focused,
-        promptTab: Object.values(PromptTab).find((value) => promptTab === value),
-      });
+      set(designPageLocationState(projectId), location);
     }
   );
 
   const navTo = useRecoilCallback(
-    ({ snapshot, set }: CallbackInterface) => async (
+    (callbackInterface: CallbackInterface) => async (
       skillId: string | null,
       dialogId: string | null,
       trigger?: string
     ) => {
+      const { set, snapshot } = callbackInterface;
       const rootBotProjectId = await snapshot.getPromise(rootBotProjectIdSelector);
       if (rootBotProjectId == null) return;
 
       const projectId = skillId ?? rootBotProjectId;
 
-      set(currentProjectIdState, projectId);
+      await setCurrentProjectId(callbackInterface, projectId);
 
       const currentUri =
         trigger == null
@@ -56,24 +64,28 @@ export const navigationDispatcher = () => {
         dialogId: dialogId ?? '',
         selected: trigger ?? '',
         focused: '',
+        promptTab: undefined,
       });
       navigateTo(currentUri);
     }
   );
 
   const selectTo = useRecoilCallback(
-    ({ snapshot, set }: CallbackInterface) => async (
+    (callbackInterface: CallbackInterface) => async (
       skillId: string | null,
       destinationDialogId: string | null,
       selectPath: string
     ) => {
       if (!selectPath) return;
+
+      const { set, snapshot } = callbackInterface;
       const rootBotProjectId = await snapshot.getPromise(rootBotProjectIdSelector);
       if (rootBotProjectId == null) return;
 
       const projectId = skillId ?? rootBotProjectId;
 
-      set(currentProjectIdState, projectId);
+      await setCurrentProjectId(callbackInterface, projectId);
+
       const designPageLocation = await snapshot.getPromise(designPageLocationState(projectId));
 
       // target dialogId, projectId maybe empty string  ""
@@ -89,19 +101,22 @@ export const navigationDispatcher = () => {
         dialogId,
         selected: selectPath,
         focused: '',
+        promptTab: undefined,
       });
       navigateTo(currentUri);
     }
   );
 
   const focusTo = useRecoilCallback(
-    ({ snapshot, set }: CallbackInterface) => async (
+    (callbackInterface: CallbackInterface) => async (
       projectId: string,
       skillId: string | null,
       focusPath: string,
       fragment: string
     ) => {
-      set(currentProjectIdState, skillId ?? projectId);
+      const { set, snapshot } = callbackInterface;
+      await setCurrentProjectId(callbackInterface, skillId ?? projectId);
+
       const designPageLocation = await snapshot.getPromise(designPageLocationState(skillId ?? projectId));
       const { dialogId, selected } = designPageLocation;
 


### PR DESCRIPTION
## Description
Switching in project tree is causing too much re-rendering (including some full re-rendering), up to 8 times in a simple switch. This fix some simple refactoring that saves us at least 4 full rendering times, leaves us to 3-4 partial rendering. Will continue investigate the other unnecessary rendering.   

The goal eventually is to have only one rendering in one switch. 

### Root cause
1. We always set local state in useEffect when location change.
2. We are setting < breadcrumb /> when switching the item, but the state only used by breadcrumb component and put it in the < DesignPage />  will make the page full re-render.
3. The < App /> will listen to the url to initialize the logger, the location change will make the whole app re-render

### Fix
1. add value check, if no change, do nothing
2. move the < Breadscrum/> to a single component, and let it's own to manage the state
3. The same as 2

### next step
1. split the < DesignPage />
2. investigate the reach/router's state management, There is still a full re-render caused by Router

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
#minor
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots
before

![image](https://user-images.githubusercontent.com/39758135/104568191-bbbaf700-568a-11eb-916b-796b0b1b733d.png)

after

![image](https://user-images.githubusercontent.com/39758135/104568168-b198f880-568a-11eb-88d0-f28ef599d078.png)

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
