### PR TITLE
fix: Merge settings error

### DIFF
--- a/Composer/packages/client/src/recoilModel/dispatchers/project.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/project.ts
@@ -48,6 +48,7 @@ import {
   handleProjectFailure,
   initBotState,
   loadProjectData,
+  mergePropertiesManagedByRootBot,
   navigateToBot,
   navigateToSkillBot,
   openLocalSkill,
@@ -190,6 +191,13 @@ export const projectDispatcher = () => {
           isRootBot: false,
         });
         set(botProjectIdsState, (current) => [...current, projectId]);
+        set(settingsState(projectId), (current) => {
+          return {
+            ...mergePropertiesManagedByRootBot(projectId, rootBotProjectId, current),
+            ...current,
+          };
+        });
+
         await dispatcher.addLocalSkillToBotProjectFile(projectId);
         navigateToSkillBot(rootBotProjectId, projectId, mainDialog);
         return projectId;

--- a/Composer/packages/client/src/recoilModel/dispatchers/project.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/project.ts
@@ -48,7 +48,6 @@ import {
   handleProjectFailure,
   initBotState,
   loadProjectData,
-  mergePropertiesManagedByRootBot,
   navigateToBot,
   navigateToSkillBot,
   openLocalSkill,
@@ -191,13 +190,6 @@ export const projectDispatcher = () => {
           isRootBot: false,
         });
         set(botProjectIdsState, (current) => [...current, projectId]);
-        set(settingsState(projectId), (current) => {
-          return {
-            ...mergePropertiesManagedByRootBot(projectId, rootBotProjectId, current),
-            ...current,
-          };
-        });
-
         await dispatcher.addLocalSkillToBotProjectFile(projectId);
         navigateToSkillBot(rootBotProjectId, projectId, mainDialog);
         return projectId;

--- a/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
@@ -165,7 +165,9 @@ export const mergePropertiesManagedByRootBot = (projectId: string, rootBotProjec
       }
       if (projectId !== rootBotProjectId) {
         const skillValue = objectGet(localSetting, property, {})[projectId];
-        objectSet(mergedSettings, property, skillValue ?? '');
+        if (skillValue) {
+          objectSet(mergedSettings, property, skillValue);
+        }
       }
     }
   }


### PR DESCRIPTION
## Description
This PR fixes an issue where the root bot's keys are not propogated into the skills and we notice an error that the key is missing in the skill even though the key is available in the root bot.

Fixes #minor