### PR TITLE
fix: luis/qna key shows missing while root bot has one

### DIFF
--- a/Composer/packages/client/src/recoilModel/selectors/diagnosticsPageSelector.ts
+++ b/Composer/packages/client/src/recoilModel/selectors/diagnosticsPageSelector.ts
@@ -129,12 +129,13 @@ export const settingDiagnosticsSelectorFamily = selectorFamily({
     if (botAssets === null) return [];
 
     const rootProjectId = get(rootBotProjectIdSelector) ?? projectId;
+    const rootSetting = get(settingsState(rootProjectId));
     const diagnosticList: DiagnosticInfo[] = [];
 
     //1. Missing LUIS key
     //2. Missing QnA Maker subscription key.
     //appsettings.json
-    const settingDiagnostic = BotIndexer.checkSetting(botAssets);
+    const settingDiagnostic = BotIndexer.checkSetting(botAssets, rootSetting);
     settingDiagnostic.forEach((item) => {
       diagnosticList.push(new SettingDiagnostic(rootProjectId, projectId, item.source, item.source, item));
     });

--- a/Composer/packages/client/src/recoilModel/selectors/project.ts
+++ b/Composer/packages/client/src/recoilModel/selectors/project.ts
@@ -212,6 +212,8 @@ export const perProjectDiagnosticsSelectorFamily = selectorFamily({
   key: 'perProjectDiagnosticsSelectorFamily',
   get: (projectId: string) => ({ get }) => {
     const { isRemote, isRootBot } = get(projectMetaDataState(projectId));
+    const rootBotId = get(rootBotProjectIdSelector) || projectId;
+    const rootSetting = get(settingsState(rootBotId));
     const dialogs = get(dialogsSelectorFamily(projectId));
     const formDialogSchemas = get(formDialogSchemasSelectorFamily(projectId));
     const luFiles = get(luFilesState(projectId));
@@ -237,7 +239,7 @@ export const perProjectDiagnosticsSelectorFamily = selectorFamily({
       recognizers: [],
       crossTrainConfig: {},
     };
-    return BotIndexer.validate({ ...botAssets, isRemote, isRootBot });
+    return BotIndexer.validate({ ...botAssets, isRemote, isRootBot }, rootSetting);
   },
 });
 


### PR DESCRIPTION
## Description
When root bot has a luis/qna key, the skill bot still shows needing a luis/qna key. The error shows in design page Project Tree.
fix: need to check whether the root bot has a key before generating this key missing error.
## Task Item
#minor
## Screenshots
![bug](https://user-images.githubusercontent.com/24380525/104893792-d5bc4880-59ae-11eb-9f7b-da0f2b65ce2a.gif)

