### PR TITLE
fix: design page navigating to settings Page url error

### DIFF
--- a/Composer/packages/client/src/components/ProjectTree/ProjectHeader.tsx
+++ b/Composer/packages/client/src/components/ProjectTree/ProjectHeader.tsx
@@ -82,7 +82,7 @@ export const ProjectHeader = (props: ProjectHeaderProps) => {
 
   const link: TreeLink = {
     displayName,
-    projectId,
+    projectId: rootProjectId,
     skillId: rootProjectId === projectId ? undefined : projectId,
     isRoot: true,
     botError,


### PR DESCRIPTION
## Description
A url bug was introduced in recent Pr. When a skill bot is missing a luis/qna key, we can click on the error and navigate to settings page in Design page project tree. But the navigation url is incorrect. It passed current project id which should be root bot project Id.

## Task Item
#minor

## Screenshots
![bug1](https://user-images.githubusercontent.com/24380525/104895696-2765d280-59b1-11eb-9c1a-a9882ee1f8fd.gif)

