### PR TITLE
chore: Avoid re-render on project tree

### DIFF
--- a/Composer/packages/client/src/components/Page.tsx
+++ b/Composer/packages/client/src/components/Page.tsx
@@ -151,7 +151,7 @@ const Page: React.FC<IPageProps> = (props) => {
           >
             {useNewTree ? (
               <ProjectTree
-                defaultSelected={{
+                selectedLink={{
                   projectId,
                   skillId,
                   dialogId,

--- a/Composer/packages/client/src/components/ProjectTree/ProjectTree.tsx
+++ b/Composer/packages/client/src/components/ProjectTree/ProjectTree.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 /** @jsx jsx */
-import React, { useCallback, useState, useEffect, useRef } from 'react';
+import React, { useCallback, useState, useRef } from 'react';
 import { jsx, css } from '@emotion/core';
 import { SearchBox } from 'office-ui-fabric-react/lib/SearchBox';
 import { FocusZone, FocusZoneDirection } from 'office-ui-fabric-react/lib/FocusZone';
@@ -150,7 +150,7 @@ type Props = {
   onDialogCreateTrigger?: (projectId: string, dialogId: string) => void;
   onDialogDeleteTrigger?: (projectId: string, dialogId: string, index: number) => void;
   onErrorClick?: (projectId: string, skillId: string, diagnostic: Diagnostic) => void;
-  defaultSelected?: Partial<TreeLink>;
+  selectedLink?: Partial<TreeLink>;
   options?: ProjectTreeOptions;
 };
 
@@ -170,7 +170,7 @@ export const ProjectTree: React.FC<Props> = ({
   onBotRemoveSkill = () => {},
   onDialogCreateTrigger = () => {},
   onErrorClick = () => {},
-  defaultSelected,
+  selectedLink,
   options = {
     showDelete: true,
     showDialogs: true,
@@ -200,7 +200,6 @@ export const ProjectTree: React.FC<Props> = ({
   const [filter, setFilter] = useState('');
   const [isMenuOpen, setMenuOpen] = useState<boolean>(false);
   const formDialogComposerFeatureEnabled = useFeatureFlag('FORM_DIALOG');
-  const [selectedLink, setSelectedLink] = useState<Partial<TreeLink> | undefined>(defaultSelected);
 
   const notificationMap: { [projectId: string]: { [dialogId: string]: Diagnostic[] } } = {};
   const lgImportsByProjectByDialog: Record<string, Record<string, LanguageFileImport[]>> = {};
@@ -214,10 +213,6 @@ export const ProjectTree: React.FC<Props> = ({
   }, 200);
 
   const addMainDialogRef = useCallback((mainDialog) => onboardingAddCoachMarkRef({ mainDialog }), []);
-
-  useEffect(() => {
-    setSelectedLink(defaultSelected);
-  }, [defaultSelected?.projectId, defaultSelected?.skillId, defaultSelected?.dialogId, defaultSelected?.trigger]);
 
   const rootProjectId = useRecoilValue(rootBotProjectIdSelector);
   const selectorOptions = {
@@ -253,7 +248,6 @@ export const ProjectTree: React.FC<Props> = ({
     // Skip state change when link not changed.
     if (isEqual(link, selectedLink)) return;
 
-    setSelectedLink(link);
     onSelect?.(link);
   };
 

--- a/Composer/packages/client/src/pages/design/DesignPage.tsx
+++ b/Composer/packages/client/src/pages/design/DesignPage.tsx
@@ -583,7 +583,7 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
           onMeasuredSizesChanged={onMeasuredSizesChanged}
         >
           <ProjectTree
-            defaultSelected={{
+            selectedLink={{
               projectId,
               skillId: skillId ?? undefined,
               dialogId,


### PR DESCRIPTION
## Description
When select items on project tree, avoid re-rendering by reducing local state and useEffect.
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
#minor 
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots
Before:

<img width="527" alt="image" src="https://user-images.githubusercontent.com/49866537/105017268-8cd3c500-5a7e-11eb-99da-7ee9a15f4ee2.png">

After: 

<img width="524" alt="Screen Shot 2021-01-19 at 5 50 37 PM" src="https://user-images.githubusercontent.com/49866537/105017570-e5a35d80-5a7e-11eb-9acf-2532f19d0eae.png">


<!---
Please include screenshots or gifs if your PR include UX changes.
--->
