### PR TITLE
fix: electron update error

### DIFF
--- a/Composer/packages/client/src/components/AppUpdater.tsx
+++ b/Composer/packages/client/src/components/AppUpdater.tsx
@@ -132,7 +132,7 @@ export const AppUpdater: React.FC<{}> = () => {
         }
 
         case 'update-in-progress': {
-          setAppUpdateStatus(AppUpdaterStatus.UPDATE_AVAILABLE, undefined);
+          setAppUpdateStatus(AppUpdaterStatus.UPDATE_AVAILABLE, payload.version);
           setAppUpdateShowing(true);
           break;
         }

--- a/Composer/packages/client/src/components/AppUpdater.tsx
+++ b/Composer/packages/client/src/components/AppUpdater.tsx
@@ -131,6 +131,12 @@ export const AppUpdater: React.FC<{}> = () => {
           break;
         }
 
+        case 'update-in-progress': {
+          setAppUpdateStatus(AppUpdaterStatus.UPDATE_AVAILABLE, undefined);
+          setAppUpdateShowing(true);
+          break;
+        }
+
         case 'update-not-available': {
           const explicit = payload;
           if (explicit) {

--- a/Composer/packages/electron-server/src/appUpdater.ts
+++ b/Composer/packages/electron-server/src/appUpdater.ts
@@ -17,6 +17,7 @@ export class AppUpdater extends EventEmitter {
   private downloadingUpdate = false;
   private _downloadedUpdate = false;
   private explicitCheck = false;
+  private updateInfo: UpdateInfo | undefined = undefined;
   private settings: AppUpdaterSettings = { autoDownload: false, useNightly: false };
 
   constructor() {
@@ -50,7 +51,7 @@ export class AppUpdater extends EventEmitter {
   public checkForUpdates(explicit = false) {
     this.explicitCheck = explicit;
     if (this.downloadingUpdate || this.checkingForUpdate) {
-      this.emit('update-in-progress');
+      this.emit('update-in-progress', this.updateInfo);
       return;
     }
 
@@ -96,6 +97,7 @@ export class AppUpdater extends EventEmitter {
   private onUpdateAvailable(updateInfo: UpdateInfo) {
     log('Update available: %O', updateInfo);
     this.checkingForUpdate = false;
+    this.updateInfo = updateInfo;
     if (this.explicitCheck || !this.settings.autoDownload) {
       this.emit('update-available', updateInfo);
     }
@@ -103,6 +105,7 @@ export class AppUpdater extends EventEmitter {
 
   private onUpdateNotAvailable(updateInfo: UpdateInfo) {
     log('Update not available: %O', updateInfo);
+    this.updateInfo = updateInfo;
     if (this.explicitCheck || !this.settings.autoDownload) {
       this.emit('update-not-available', this.explicitCheck);
     }
@@ -120,6 +123,7 @@ export class AppUpdater extends EventEmitter {
   private onUpdateDownloaded(updateInfo: UpdateInfo) {
     log('Update downloaded: %O', updateInfo);
     this._downloadedUpdate = true;
+    this.updateInfo = updateInfo;
     if (this.explicitCheck || !this.settings.autoDownload) {
       this.emit('update-downloaded', updateInfo);
     }

--- a/Composer/packages/electron-server/src/main.ts
+++ b/Composer/packages/electron-server/src/main.ts
@@ -102,6 +102,9 @@ function initializeAppUpdater(settings: AppUpdaterSettings) {
     appUpdater.on('progress', (progress) => {
       mainWindow.webContents.send('app-update', 'progress', progress);
     });
+    appUpdater.on('update-in-progress', () => {
+      mainWindow.webContents.send('app-update', 'update-in-progress');
+    });
     appUpdater.on('update-not-available', (explicitCheck: boolean) => {
       mainWindow.webContents.send('app-update', 'update-not-available', explicitCheck);
     });

--- a/Composer/packages/electron-server/src/main.ts
+++ b/Composer/packages/electron-server/src/main.ts
@@ -102,8 +102,8 @@ function initializeAppUpdater(settings: AppUpdaterSettings) {
     appUpdater.on('progress', (progress) => {
       mainWindow.webContents.send('app-update', 'progress', progress);
     });
-    appUpdater.on('update-in-progress', () => {
-      mainWindow.webContents.send('app-update', 'update-in-progress');
+    appUpdater.on('update-in-progress', (updateInfo: UpdateInfo) => {
+      mainWindow.webContents.send('app-update', 'update-in-progress', updateInfo);
     });
     appUpdater.on('update-not-available', (explicitCheck: boolean) => {
       mainWindow.webContents.send('app-update', 'update-not-available', explicitCheck);


### PR DESCRIPTION
## Description
We have a data race when user click "check for updates" with auto-update set to true, causing the updating fail (#5549).

This PR let manual-update can continue auto-update progress.

1. if auto update is downloading, when click "check for updates" will show the progress.
2. if auto update is downloaded, when click "check for updates" will show quit-and-start modal.


<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
close #5551 
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

1. When auto update is downloading.

![3](https://user-images.githubusercontent.com/49866537/105274182-a8061800-5bd7-11eb-9053-97ec278cd91d.gif)

2. When auto update is downloaded.

![1](https://user-images.githubusercontent.com/49866537/105273954-362dce80-5bd7-11eb-8fa0-198e5935708d.gif)


<!---
Please include screenshots or gifs if your PR include UX changes.
--->
