### PR TITLE
fix: hover on pre-built functions displays incorrect ReturnType content

### DIFF
--- a/Composer/packages/tools/built-in-functions/src/builtInFunctionsMap.ts
+++ b/Composer/packages/tools/built-in-functions/src/builtInFunctionsMap.ts
@@ -72,7 +72,7 @@ export const buildInFunctionsMap: Map<string, FunctionEntity> = new Map<string, 
     'concat',
     new FunctionEntity(
       ['...strings: string[]'],
-      ReturnType.String,
+      ReturnType.String + ReturnType.Array,
       'Combine two or more strings and return the resulting string. E.g. concat(‘hello’, ‘world’, ‘…’)'
     ),
   ],

--- a/Composer/packages/tools/language-servers/language-generation/src/LGServer.ts
+++ b/Composer/packages/tools/language-servers/language-generation/src/LGServer.ts
@@ -218,12 +218,33 @@ export class LGServer {
         contents: [
           `Parameters: ${get(functionEntity, 'Params', []).join(', ')}`,
           `Documentation: ${get(functionEntity, 'Introduction', '')}`,
-          `ReturnType: ${get(functionEntity, 'Returntype', '').valueOf()}`,
+          `ReturnType: ${this.getExplicitReturnType(get(functionEntity, 'Returntype', '').valueOf() as number).join(
+            ' | '
+          )}`,
         ],
       };
       return Promise.resolve(hoveritem);
     }
     return Promise.resolve(null);
+  }
+
+  private getExplicitReturnType(numReturnType: number): string[] {
+    const result: string[] = [];
+    const mapping = [
+      { value: 16, name: 'Array' },
+      { value: 8, name: 'String' },
+      { value: 4, name: 'Object' },
+      { value: 2, name: 'Number' },
+      { value: 1, name: 'Boolean' },
+    ];
+    for (const obj of mapping) {
+      if (numReturnType >= obj.value) {
+        numReturnType -= obj.value;
+        result.push(obj.name);
+      }
+    }
+
+    return result;
   }
 
   private removeParamFormat(params: string): string {


### PR DESCRIPTION
Fixes #5332 
Currently, LG editor displayed incorrect ReturnType when user hover on pre-built functions.
In this PR, the value of ReturnType will be mapped to its explicit content.
![image](https://user-images.githubusercontent.com/17074777/105460501-d878af80-5cc6-11eb-95af-acf36154b58e.png)
