### PR TITLE
chore: Hide triggers 'OnQnAMatch' and 'OnChooseIntent' in PVA env

### DIFF
--- a/Composer/packages/extension-client/src/hooks/useTriggerConfig.ts
+++ b/Composer/packages/extension-client/src/hooks/useTriggerConfig.ts
@@ -2,12 +2,17 @@
 // Licensed under the MIT License.
 
 import { useContext, useMemo } from 'react';
+import get from 'lodash/get';
+import { SDKKinds } from '@botframework-composer/types';
 
 import { EditorExtensionContext } from '../EditorExtensionContext';
 import { TriggerUISchema } from '../types';
 
 export function useTriggerConfig() {
-  const { plugins } = useContext(EditorExtensionContext);
+  const { plugins, shellData } = useContext(EditorExtensionContext);
+  const { schemas } = shellData;
+
+  const isPvaEnv = Boolean(get(schemas, 'sdk.content.definitions["Microsoft.VirtualAgents.Recognizer"]'));
 
   const triggerConfig: TriggerUISchema = useMemo(() => {
     const implementedTriggerSchema: TriggerUISchema = {};
@@ -16,6 +21,12 @@ export function useTriggerConfig() {
         implementedTriggerSchema[$kind] = options.trigger;
       }
     });
+
+    // Hide 'OnChooseIntent' and 'OnQnAMatch' from PVA bots.
+    if (isPvaEnv) {
+      delete implementedTriggerSchema[SDKKinds.OnChooseIntent];
+      delete implementedTriggerSchema[SDKKinds.OnQnAMatch];
+    }
     return implementedTriggerSchema;
   }, [plugins.uiSchema]);
 


### PR DESCRIPTION
## Description

#minor

In #4079, the TriggerCreationModal becomes completely schema-driven, a small piece of PVA-only code was removed.

It will cause an issue, in PVA env, two triggers be visible to users but not available in PVA env:
- `Microsoft.OnQnAMatch` aka 'QnA Intent recognized'
- `Microsoft.OnChooseIntent` aka 'Duplicated intents recognized'

This PR forces these two triggers to be hidden when the env is detected as the PVA env.

**Notes**:
I was considering that updating the `app.uischema` on PVA side, however, it only affects newly created skills but won't work for existing skills.

On the other hand, an update on PVA's app.uischema is still required, will follow up with @tonyanziano.

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
![image](https://user-images.githubusercontent.com/8528761/105958114-27528a80-60b5-11eb-9615-57c6a70d157d.png)
