### PR TITLE
fix: should allow to click outside focuszone

### DIFF
--- a/Composer/packages/client/src/components/Header.tsx
+++ b/Composer/packages/client/src/components/Header.tsx
@@ -239,7 +239,7 @@ export const Header = () => {
               'This is the bot language you are currently authoring. Change the active language in the dropdown below.'
             )}
           </div>
-          <FocusTrapZone>
+          <FocusTrapZone isClickableOutsideFocusTrap>
             <Dropdown
               options={languageListOptions}
               placeholder="Select an option"


### PR DESCRIPTION
## Description
should allow to click outside focuszone

## Task Item
Closes #5597 
## Screenshots
![tab](https://user-images.githubusercontent.com/24380525/106080312-c75df180-6151-11eb-97d3-2c4b8279e739.gif)
