### PR TITLE
fix: heap out of memory error when run yarn build

### DIFF
--- a/Composer/package.json
+++ b/Composer/package.json
@@ -15,8 +15,7 @@
     "set-value": "^3.0.2",
     "terser-webpack-plugin": "^2.3.7",
     "axios": "^0.21.1",
-    "y18n": "^5.0.5",
-    "immer": "^8.0.1"
+    "y18n": "^5.0.5"
   },
   "engines": {
     "node": ">=12"


### PR DESCRIPTION
## Description
fix the immer version in resolutions will cause heap out of memory during yarn build.

remove the resolution first, but this may cause the security analysis fail 
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
#minor
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
