### PR TITLE
fix: use directVersionPublish for LUIS to avoid 404 in bot response

### DIFF
--- a/Composer/packages/lib/indexers/package.json
+++ b/Composer/packages/lib/indexers/package.json
@@ -26,7 +26,7 @@
     "rimraf": "^2.6.3"
   },
   "dependencies": {
-    "@microsoft/bf-lu": "^4.12.0-dev.20210129.82760de0",
+    "@microsoft/bf-lu": "^4.12.0-dev.20210129.82760de",
     "adaptive-expressions": "^4.11.0-dev.20201013.d5458bf",
     "botbuilder-lg": "4.12.0-dev-20201119.9afa93623c3e",
     "lodash": "^4.17.19"

--- a/Composer/packages/lib/indexers/package.json
+++ b/Composer/packages/lib/indexers/package.json
@@ -26,7 +26,7 @@
     "rimraf": "^2.6.3"
   },
   "dependencies": {
-    "@microsoft/bf-lu": "^4.12.0-dev.20201209.a2ab9dd",
+    "@microsoft/bf-lu": "^4.12.0-dev.20210129.82760de0",
     "adaptive-expressions": "^4.11.0-dev.20201013.d5458bf",
     "botbuilder-lg": "4.12.0-dev-20201119.9afa93623c3e",
     "lodash": "^4.17.19"

--- a/Composer/packages/server/package.json
+++ b/Composer/packages/server/package.json
@@ -67,7 +67,7 @@
     "@microsoft/bf-dialog": "4.11.0-dev.20201025.69cf2b9",
     "@microsoft/bf-dispatcher": "^4.11.0-beta.20201016.393c6b2",
     "@microsoft/bf-generate-library": "^4.10.0-daily.20210113.202382",
-    "@microsoft/bf-lu": "^4.12.0-dev.20210129.82760de0",
+    "@microsoft/bf-lu": "^4.12.0-dev.20210129.82760de",
     "@microsoft/bf-orchestrator": "4.11.0-beta.20201208.165a6d6",
     "applicationinsights": "^1.8.7",
     "archiver": "^5.0.2",

--- a/Composer/packages/server/package.json
+++ b/Composer/packages/server/package.json
@@ -67,7 +67,7 @@
     "@microsoft/bf-dialog": "4.11.0-dev.20201025.69cf2b9",
     "@microsoft/bf-dispatcher": "^4.11.0-beta.20201016.393c6b2",
     "@microsoft/bf-generate-library": "^4.10.0-daily.20210113.202382",
-    "@microsoft/bf-lu": "^4.12.0-dev.20201209.a2ab9dd",
+    "@microsoft/bf-lu": "^4.12.0-dev.20210129.82760de0",
     "@microsoft/bf-orchestrator": "4.11.0-beta.20201208.165a6d6",
     "applicationinsights": "^1.8.7",
     "archiver": "^5.0.2",

--- a/Composer/packages/server/src/models/bot/builder.ts
+++ b/Composer/packages/server/src/models/bot/builder.ts
@@ -444,6 +444,7 @@ export class Builder {
       keptVersionCount: 10,
       isStaging: false,
       region: config.region,
+      directVersionPublish: true,
     });
 
     await this.luBuilder.writeDialogAssets(buildResult, {

--- a/Composer/packages/tools/language-servers/language-understanding/package.json
+++ b/Composer/packages/tools/language-servers/language-understanding/package.json
@@ -21,7 +21,7 @@
     "@bfc/indexers": "*",
     "@bfc/shared": "*",
     "@microsoft/bf-cli-command": "^4.11.1",
-    "@microsoft/bf-lu": "^4.12.0-dev.20210129.82760de0",
+    "@microsoft/bf-lu": "^4.12.0-dev.20210129.82760de",
     "express": "^4.15.2",
     "monaco-languageclient": "^0.10.0",
     "normalize-url": "^2.0.1",

--- a/Composer/packages/tools/language-servers/language-understanding/package.json
+++ b/Composer/packages/tools/language-servers/language-understanding/package.json
@@ -21,7 +21,7 @@
     "@bfc/indexers": "*",
     "@bfc/shared": "*",
     "@microsoft/bf-cli-command": "^4.11.1",
-    "@microsoft/bf-lu": "^4.12.0-dev.20201209.a2ab9dd",
+    "@microsoft/bf-lu": "^4.12.0-dev.20210129.82760de0",
     "express": "^4.15.2",
     "monaco-languageclient": "^0.10.0",
     "normalize-url": "^2.0.1",

--- a/Composer/yarn.lock
+++ b/Composer/yarn.lock
@@ -3224,32 +3224,10 @@
     seedrandom "~3.0.5"
     swagger-parser "^8.0.4"
 
-"@microsoft/bf-lu@^4.12.0-dev.20210129.82760de0":
+"@microsoft/bf-lu@^4.12.0-dev.20210129.82760de0", "@microsoft/bf-lu@next":
   version "4.12.0-dev.20210129.82760de"
   resolved "https://registry.yarnpkg.com/@microsoft/bf-lu/-/bf-lu-4.12.0-dev.20210129.82760de.tgz#f3b4c932b1fb6b3e69e6d0cba3356fc3ba61ade8"
   integrity sha512-nlzKjMAvr/bgjqVNXh/v4ns7aP4L5d6UT51keXa7k6+XGtHcQQkwXxwgWvo8CQXjZE5Aju8DTbxbIBY0bXcq6A==
-  dependencies:
-    "@azure/cognitiveservices-luis-authoring" "4.0.0-preview.1"
-    "@azure/ms-rest-azure-js" "2.0.1"
-    "@types/node-fetch" "~2.5.5"
-    antlr4 "~4.8.0"
-    chalk "2.4.1"
-    console-stream "^0.1.1"
-    deep-equal "^1.0.1"
-    delay "^4.3.0"
-    fs-extra "^8.1.0"
-    get-stdin "^6.0.0"
-    globby "^10.0.1"
-    intercept-stdout "^0.1.2"
-    lodash "^4.17.19"
-    node-fetch "~2.6.0"
-    semver "^5.5.1"
-    tslib "^2.0.3"
-
-"@microsoft/bf-lu@next":
-  version "4.12.0-dev.20201209.a2ab9dd"
-  resolved "https://registry.yarnpkg.com/@microsoft/bf-lu/-/bf-lu-4.12.0-dev.20201209.a2ab9dd.tgz#edf04d5f7eab1bad05c759e9e8fde8acb7e3dd5e"
-  integrity sha512-w7gr7w4yOfXpooFNGEcKC+WC6WYxRK5SLQBbZzL2lWPwp+3P+d7Yih/HgnZPpFIg//IK6v/b/JfySYZUe0+fBA==
   dependencies:
     "@azure/cognitiveservices-luis-authoring" "4.0.0-preview.1"
     "@azure/ms-rest-azure-js" "2.0.1"

--- a/Composer/yarn.lock
+++ b/Composer/yarn.lock
@@ -3224,7 +3224,7 @@
     seedrandom "~3.0.5"
     swagger-parser "^8.0.4"
 
-"@microsoft/bf-lu@^4.12.0-dev.20210129.82760de0", "@microsoft/bf-lu@next":
+"@microsoft/bf-lu@^4.12.0-dev.20210129.82760de", "@microsoft/bf-lu@next":
   version "4.12.0-dev.20210129.82760de"
   resolved "https://registry.yarnpkg.com/@microsoft/bf-lu/-/bf-lu-4.12.0-dev.20210129.82760de.tgz#f3b4c932b1fb6b3e69e6d0cba3356fc3ba61ade8"
   integrity sha512-nlzKjMAvr/bgjqVNXh/v4ns7aP4L5d6UT51keXa7k6+XGtHcQQkwXxwgWvo8CQXjZE5Aju8DTbxbIBY0bXcq6A==

--- a/Composer/yarn.lock
+++ b/Composer/yarn.lock
@@ -3224,7 +3224,29 @@
     seedrandom "~3.0.5"
     swagger-parser "^8.0.4"
 
-"@microsoft/bf-lu@^4.12.0-dev.20201209.a2ab9dd", "@microsoft/bf-lu@next":
+"@microsoft/bf-lu@^4.12.0-dev.20210129.82760de0":
+  version "4.12.0-dev.20210129.82760de"
+  resolved "https://registry.yarnpkg.com/@microsoft/bf-lu/-/bf-lu-4.12.0-dev.20210129.82760de.tgz#f3b4c932b1fb6b3e69e6d0cba3356fc3ba61ade8"
+  integrity sha512-nlzKjMAvr/bgjqVNXh/v4ns7aP4L5d6UT51keXa7k6+XGtHcQQkwXxwgWvo8CQXjZE5Aju8DTbxbIBY0bXcq6A==
+  dependencies:
+    "@azure/cognitiveservices-luis-authoring" "4.0.0-preview.1"
+    "@azure/ms-rest-azure-js" "2.0.1"
+    "@types/node-fetch" "~2.5.5"
+    antlr4 "~4.8.0"
+    chalk "2.4.1"
+    console-stream "^0.1.1"
+    deep-equal "^1.0.1"
+    delay "^4.3.0"
+    fs-extra "^8.1.0"
+    get-stdin "^6.0.0"
+    globby "^10.0.1"
+    intercept-stdout "^0.1.2"
+    lodash "^4.17.19"
+    node-fetch "~2.6.0"
+    semver "^5.5.1"
+    tslib "^2.0.3"
+
+"@microsoft/bf-lu@next":
   version "4.12.0-dev.20201209.a2ab9dd"
   resolved "https://registry.yarnpkg.com/@microsoft/bf-lu/-/bf-lu-4.12.0-dev.20201209.a2ab9dd.tgz#edf04d5f7eab1bad05c759e9e8fde8acb7e3dd5e"
   integrity sha512-w7gr7w4yOfXpooFNGEcKC+WC6WYxRK5SLQBbZzL2lWPwp+3P+d7Yih/HgnZPpFIg//IK6v/b/JfySYZUe0+fBA==


### PR DESCRIPTION
## Description

Update bf/lu package. 
Set directVersionPublish to true when call luis publish API. 

## Task Item
fixes #5622

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
