### PR TITLE
fix: LG all up code editor height and templates

### DIFF
--- a/Composer/packages/client/src/pages/language-generation/code-editor.tsx
+++ b/Composer/packages/client/src/pages/language-generation/code-editor.tsx
@@ -169,6 +169,7 @@ const CodeEditor: React.FC<CodeEditorProps> = (props) => {
           path: lspServerPath,
         }}
         lgOption={lgOption}
+        lgTemplates={file?.allTemplates}
         mode="codeEditor"
         value={content}
         onChange={onChange}
@@ -184,6 +185,7 @@ const CodeEditor: React.FC<CodeEditorProps> = (props) => {
         lgOption={{
           fileId: dialogId,
         }}
+        lgTemplates={file?.allTemplates}
         mode="codeEditor"
         options={{
           readOnly: true,

--- a/Composer/packages/lib/code-editor/src/lg/LgCodeEditor.tsx
+++ b/Composer/packages/lib/code-editor/src/lg/LgCodeEditor.tsx
@@ -157,7 +157,7 @@ export const LgCodeEditor = (props: LgCodeEditorProps) => {
   }, [onNavigateToLgPage]);
 
   return (
-    <Stack>
+    <Stack verticalFill>
       <LgEditorToolbar
         lgTemplates={lgTemplates}
         properties={properties}


### PR DESCRIPTION
## Description

Fixes the height of LG editor under LG all up page.
Adds available templates to the template button in the toolbar in LG page.

## Task Item

#minor
