### PR TITLE
fix: botProject UT depends on external service

### DIFF
--- a/Composer/packages/server/src/models/bot/__tests__/botProject.test.ts
+++ b/Composer/packages/server/src/models/bot/__tests__/botProject.test.ts
@@ -257,9 +257,10 @@ describe('lu operations', () => {
 describe('qna operations', () => {
   it('should get qna endpoint key', async () => {
     await proj.init();
-    const subscriptionKey = '21640b8e2110449abfdfccf2f6bbee02';
+    proj.builder.qnaBuilder.getEndpointKeys = jest.fn(() => ({ primaryEndpointKey: 'new key' }));
+    const subscriptionKey = 'test';
     const endpointKey = await proj.updateQnaEndpointKey(subscriptionKey);
-    expect(endpointKey).toBe('d423d198-b0cc-46b3-a48c-e32d7a7e5b8a');
+    expect(endpointKey).toBe('new key');
   });
 });
 describe('buildFiles', () => {
@@ -272,11 +273,11 @@ describe('buildFiles', () => {
     }
   });
 
-  xit('should build lu & qna file successfully', async () => {
+  it('should build lu & qna file successfully', async () => {
     proj.init();
     const luisConfig = {
       authoringEndpoint: '',
-      authoringKey: '412f0bfc19824ceca7a6076d05478850',
+      authoringKey: 'test',
       authoringRegion: 'westus',
       defaultLanguage: 'en-us',
       endpoint: '',
@@ -287,7 +288,7 @@ describe('buildFiles', () => {
     const qnaConfig = {
       endpointKey: '',
       qnaRegion: 'westus',
-      subscriptionKey: '21640b8e2110449abfdfccf2f6bbee02',
+      subscriptionKey: 'test',
     };
     const luResource: Resource[] = [
       { id: 'a.en-us', isEmpty: false },
@@ -299,16 +300,13 @@ describe('buildFiles', () => {
       { id: 'b.en-us', isEmpty: false },
       { id: 'bot1.en-us', isEmpty: false },
     ];
+    proj.builder.luBuilder.build = jest.fn((items) => items.map((item) => item.id));
+    proj.builder.luBuilder.writeDialogAssets = jest.fn();
+    proj.builder.qnaBuilder.build = jest.fn((items) => items.map((item) => item.id));
+    proj.builder.qnaBuilder.writeDialogAssets = jest.fn();
     await proj.buildFiles({ luisConfig, qnaConfig, luResource, qnaResource });
-
-    try {
-      if (fs.existsSync(path)) {
-        const files = fs.readdirSync(path);
-        expect(files).toContain('a.lu.qna.dialog');
-      }
-    } catch (err) {
-      // ignore
-    }
+    expect(proj.builder.luBuilder.build).toHaveReturnedWith(['a', 'b', 'bot1']);
+    expect(proj.builder.qnaBuilder.build).toHaveReturnedWith(['a', 'b', 'bot1']);
   });
 });
 

--- a/Composer/packages/server/src/models/bot/builder.ts
+++ b/Composer/packages/server/src/models/bot/builder.ts
@@ -61,10 +61,10 @@ export class Builder {
   private _locale: string;
   private containOrchestrator = false;
 
-  private luBuilder = new luBuild.Builder((message) => {
+  public luBuilder = new luBuild.Builder((message) => {
     log(message);
   });
-  private qnaBuilder = new qnaBuild.Builder((message) => {
+  public qnaBuilder = new qnaBuild.Builder((message) => {
     log(message);
   });
 


### PR DESCRIPTION
## Description
The outside service may be not stable, when we call it in unit tests, it may cause time out or access deny error.

**In this PR**
mock the luBuild and qnaBuild functions to avoid call outside service

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
closes #5646
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
