### PR TITLE
fix: Only publish the dialog referred qna file

### DIFF
--- a/Composer/packages/client/src/recoilModel/dispatchers/builder.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/builder.ts
@@ -12,6 +12,7 @@ import luFileStatusStorage from '../../utils/luFileStatusStorage';
 import qnaFileStatusStorage from '../../utils/qnaFileStatusStorage';
 import { luFilesState, qnaFilesState, botStatusState, botRuntimeErrorState } from '../atoms';
 import { dialogsSelectorFamily } from '../selectors';
+import { getReferredQnaFiles } from '../../utils/qnaUtil';
 
 const checkEmptyQuestionOrAnswerInQnAFile = (sections) => {
   return sections.some((s) => !s.Answer || s.Questions.some((q) => !q.content));
@@ -28,7 +29,8 @@ export const builderDispatcher = () => {
       const luFiles = await snapshot.getPromise(luFilesState(projectId));
       const qnaFiles = await snapshot.getPromise(qnaFilesState(projectId));
       const referredLuFiles = luUtil.checkLuisBuild(luFiles, dialogs);
-      const errorMsg = qnaFiles.reduce(
+      const referredQnaFiles = getReferredQnaFiles(qnaFiles, dialogs);
+      const errorMsg = referredQnaFiles.reduce(
         (result, file) => {
           if (
             file.qnaSections &&
@@ -52,7 +54,7 @@ export const builderDispatcher = () => {
           qnaConfig,
           projectId,
           luFiles: referredLuFiles.map((file) => ({ id: file.id, isEmpty: file.empty })),
-          qnaFiles: qnaFiles.map((file) => ({ id: file.id, isEmpty: file.empty })),
+          qnaFiles: referredQnaFiles.map((file) => ({ id: file.id, isEmpty: file.empty })),
         });
         luFileStatusStorage.publishAll(projectId);
         qnaFileStatusStorage.publishAll(projectId);

--- a/Composer/packages/client/src/utils/qnaUtil.ts
+++ b/Composer/packages/client/src/utils/qnaUtil.ts
@@ -17,10 +17,11 @@ export const getFileLocale = (fileName: string) => {
   //file name = 'a.en-us.qna'
   return getExtension(getBaseName(fileName));
 };
-export const getReferredQnaFiles = (qnaFiles: QnAFile[], dialogs: DialogInfo[]) => {
+export const getReferredQnaFiles = (qnaFiles: QnAFile[], dialogs: DialogInfo[], checkContent = true) => {
   return qnaFiles.filter((file) => {
     const idWithOutLocale = getBaseName(file.id);
-    return dialogs.some((dialog) => dialog.qnaFile === idWithOutLocale && !!file.content);
+    const contentNotEmpty = (checkContent && !!file.content) || !checkContent;
+    return dialogs.some((dialog) => dialog.qnaFile === idWithOutLocale && contentNotEmpty);
   });
 };
 // substring text file by lines


### PR DESCRIPTION
## Description
Only publish the referred qna file when do files build in the PR.

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
closes #4884
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
