### PR TITLE
fix: refine the error message when the bot is deleted

### DIFF
--- a/Composer/packages/client/src/recoilModel/dispatchers/project.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/project.ts
@@ -264,6 +264,9 @@ export const projectDispatcher = () => {
       });
       projectIdCache.set(projectId);
     } catch (ex) {
+      if (projectId === projectIdCache.get()) {
+        projectIdCache.clear();
+      }
       set(botProjectIdsState, []);
       handleProjectFailure(callbackHelpers, ex);
       navigateTo('/home');

--- a/Composer/packages/server/src/services/project.ts
+++ b/Composer/packages/server/src/services/project.ts
@@ -254,7 +254,7 @@ export class BotProjectService {
       if (!(await StorageService.checkBlob('default', path, user))) {
         BotProjectService.deleteRecentProject(path);
         BotProjectService.removeProjectIdFromCache(projectId);
-        throw new Error(`${path} doesn't seems to be exists any longer`);
+        throw new Error(`${path} doesn't seem to be exist any longer`);
       }
       const project = new BotProject({ storageId: 'default', path: path }, user, eTag);
       await project.init();
@@ -304,7 +304,7 @@ export class BotProjectService {
         if (!(await StorageService.checkBlob('default', path, user))) {
           BotProjectService.deleteRecentProject(path);
           BotProjectService.removeProjectIdFromCache(matchingProjectId);
-          throw new Error(`${path} doesn't seems to be exists any longer`);
+          throw new Error(`${path} doesn't seem to be exist any longer`);
         }
         const project = new BotProject({ storageId: 'default', path: path }, user, eTag);
         await project.init();

--- a/Composer/packages/server/src/services/project.ts
+++ b/Composer/packages/server/src/services/project.ts
@@ -254,7 +254,7 @@ export class BotProjectService {
       if (!(await StorageService.checkBlob('default', path, user))) {
         BotProjectService.deleteRecentProject(path);
         BotProjectService.removeProjectIdFromCache(projectId);
-        throw new Error(`file ${path} does not exist`);
+        throw new Error(`${path} doesn't seems to be exists anymore`);
       }
       const project = new BotProject({ storageId: 'default', path: path }, user, eTag);
       await project.init();
@@ -304,7 +304,7 @@ export class BotProjectService {
         if (!(await StorageService.checkBlob('default', path, user))) {
           BotProjectService.deleteRecentProject(path);
           BotProjectService.removeProjectIdFromCache(matchingProjectId);
-          throw new Error(`file ${path} does not exist`);
+          throw new Error(`${path} doesn't seems to be exists anymore`);
         }
         const project = new BotProject({ storageId: 'default', path: path }, user, eTag);
         await project.init();

--- a/Composer/packages/server/src/services/project.ts
+++ b/Composer/packages/server/src/services/project.ts
@@ -254,7 +254,7 @@ export class BotProjectService {
       if (!(await StorageService.checkBlob('default', path, user))) {
         BotProjectService.deleteRecentProject(path);
         BotProjectService.removeProjectIdFromCache(projectId);
-        throw new Error(`${path} doesn't seems to be exists anymore`);
+        throw new Error(`${path} doesn't seems to be exists any longer`);
       }
       const project = new BotProject({ storageId: 'default', path: path }, user, eTag);
       await project.init();
@@ -304,7 +304,7 @@ export class BotProjectService {
         if (!(await StorageService.checkBlob('default', path, user))) {
           BotProjectService.deleteRecentProject(path);
           BotProjectService.removeProjectIdFromCache(matchingProjectId);
-          throw new Error(`${path} doesn't seems to be exists anymore`);
+          throw new Error(`${path} doesn't seems to be exists any longer`);
         }
         const project = new BotProject({ storageId: 'default', path: path }, user, eTag);
         await project.init();


### PR DESCRIPTION
## Description
refine the message to "path" doesn't seems to be exists anymore.

![Kapture 2021-02-03 at 01 34 44](https://user-images.githubusercontent.com/39758135/106639650-255e5f00-65c0-11eb-8ff2-a2f267b0adb0.gif)

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
closes #3671
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
