### PR TITLE
fix: consume some env variables from bash instead of JS

### DIFF
--- a/Composer/packages/electron-server/scripts/sign-mac.js
+++ b/Composer/packages/electron-server/scripts/sign-mac.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const path = require('path');
 // eslint-disable-next-line security/detect-child-process
 const { execSync } = require('child_process');
+
 const glob = require('globby');
 
 const { log } = require('./common');
@@ -86,13 +87,12 @@ try {
   execSync(`security unlock-keychain -p pwd ${keychainPath}`, { stdio: 'inherit' });
 
   log.info(`echo ********* | base64 -D > ${certPath}`);
-  execSync(`echo ${process.env.DEV_CERT} | base64 -D > ${certPath}`, { stdio: 'inherit' });
+  execSync(`echo "$DEV_CERT" | base64 -D > ${certPath}`, { stdio: 'inherit' });
 
   log.info(`security import ${certPath} -k ${keychainPath} -P "*********" -T /usr/bin/codesign`);
-  execSync(
-    `security import ${certPath} -k ${keychainPath} -P "${process.env.DEV_CERT_PASSWORD}" -T /usr/bin/codesign`,
-    { stdio: 'inherit' }
-  );
+  execSync(`security import ${certPath} -k ${keychainPath} -P "$DEV_CERT_PASSWORD" -T /usr/bin/codesign`, {
+    stdio: 'inherit',
+  });
 
   log.info(`security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k pwd ${keychainPath}`);
   execSync(`security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k pwd ${keychainPath}`, {

--- a/Composer/packages/electron-server/scripts/sign-mac.js
+++ b/Composer/packages/electron-server/scripts/sign-mac.js
@@ -114,13 +114,13 @@ try {
 
     for (const lib of dylibs) {
       log.info(`codesign -s ******* --timestamp=none --force "${path.join(fwPath, lib)}"`);
-      execSync(`codesign -s ${process.env.DEV_CERT_ID} --timestamp=none --force "${path.join(fwPath, lib)}"`, {
+      execSync(`codesign -s $DEV_CERT_ID --timestamp=none --force "${path.join(fwPath, lib)}"`, {
         stdio: 'inherit',
       });
     }
 
     log.info(`codesign -s ******* --timestamp=none --force "${fwPath}"`);
-    execSync(`codesign -s ${process.env.DEV_CERT_ID} --timestamp=none --force "${fwPath}"`, {
+    execSync(`codesign -s $DEV_CERT_ID --timestamp=none --force "${fwPath}"`, {
       stdio: 'inherit',
     });
   }
@@ -136,7 +136,7 @@ try {
       `codesign -s ******* --timestamp=none --force --options runtime --entitlements "${bundle.entitlements}" "${bundle.path}"`
     );
     execSync(
-      `codesign -s ${process.env.DEV_CERT_ID} --timestamp=none --force --options runtime --entitlements "${bundle.entitlements}" "${bundle.path}"`,
+      `codesign -s $DEV_CERT_ID --timestamp=none --force --options runtime --entitlements "${bundle.entitlements}" "${bundle.path}"`,
       { stdio: 'inherit' }
     );
   }


### PR DESCRIPTION
## Description

Do not interpolate env variables when executing bash scripts. This had unintended consequences when values contained un-escaped characters. It is also safer to do so by not leaking secrets in the bash history.

## Task Item

#minor
