### PR TITLE
fix: css err when clicking node in visual editor

### DIFF
--- a/Composer/packages/adaptive-flow/src/adaptive-flow-editor/renderers/NodeWrapper.tsx
+++ b/Composer/packages/adaptive-flow/src/adaptive-flow-editor/renderers/NodeWrapper.tsx
@@ -81,6 +81,9 @@ export const ActionNodeWrapper: FC<NodeWrapperProps> = ({ id, tab, data, onEvent
         &:hover {
           ${!nodeFocused && nodeBorderHoveredStyle}
         }
+        &:focus {
+          outline: 0;
+        }
       `}
       data-testid="ActionNodeWrapper"
       id={nodeId}


### PR DESCRIPTION
## Description

Fix css err when clicking node in visual editor.

- Before
css err when clicking node in visual editor
![image](https://user-images.githubusercontent.com/5860999/107143506-695eb480-6970-11eb-9d16-40f629fb0b16.png)

- After
![image](https://user-images.githubusercontent.com/5860999/107143516-7aa7c100-6970-11eb-8c57-0deaa078f6b5.png)

### Solution
Add 
```
 &:focus {
          outline: 0;
        }
```
for clicked div to remove outline


## Task Item
close #5712 

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
