### PR TITLE
feat: support multibot templates during in new creation flow

### DIFF
--- a/Composer/packages/client/src/pages/design/SideBar.tsx
+++ b/Composer/packages/client/src/pages/design/SideBar.tsx
@@ -103,28 +103,32 @@ const SideBar: React.FC<SideBarProps> = React.memo(({ projectId }) => {
   const setBrokenSkillInfo = useSetRecoilState(brokenSkillInfoState);
   const setAddSkillDialogModalVisibility = useSetRecoilState(showAddSkillDialogModalState);
 
-  function handleSelect(link: TreeLink) {
-    if (link.botError) {
-      setBrokenSkillInfo(link);
+  function handleSelect(destination: TreeLink) {
+    if (destination.botError) {
+      setBrokenSkillInfo(destination);
     }
-    const { skillId, dialogId, trigger } = link;
+    const {
+      skillId: targetSkillId,
+      dialogId: targetDialogId,
+      trigger: targetTrigger,
+      projectId: targetProjectId,
+    } = destination;
 
     updateZoomRate({ currentRate: 1 });
 
-    if (trigger != null) {
-      selectTo(skillId ?? null, dialogId ?? null, `triggers[${trigger}]`);
-    } else if (dialogId != null) {
-      navTo(skillId ?? projectId, dialogId);
+    if (targetTrigger != null) {
+      selectTo(targetSkillId ?? null, targetDialogId ?? null, `triggers[${targetTrigger}]`);
+    } else if (targetDialogId != null) {
+      navTo(targetSkillId ?? targetProjectId, targetDialogId);
     } else {
       // with no dialog or ID, we must be looking at a bot link
-      navTo(skillId ?? projectId, null);
+      navTo(targetSkillId ?? targetProjectId, null);
     }
   }
 
-  const onCreateDialogComplete = (projectId: string) => (dialogId: string) => {
-    const target = projectId;
-    if (dialogId) {
-      navTo(target, dialogId);
+  const onCreateDialogComplete = (targetProjectId: string) => (targetDialogId: string) => {
+    if (targetDialogId) {
+      navTo(targetProjectId, targetDialogId);
     }
   };
 
@@ -262,30 +266,28 @@ const SideBar: React.FC<SideBarProps> = React.memo(({ projectId }) => {
   const selectedTrigger = currentDialog?.triggers.find((t) => t.id === selected);
 
   return (
-    <React.Fragment>
-      <ProjectTree
-        headerMenu={projectTreeHeaderMenuItems}
-        selectedLink={{
-          projectId: rootProjectId,
-          skillId: rootProjectId === projectId ? undefined : projectId,
-          dialogId,
-          trigger: parseTriggerId(selectedTrigger?.id),
-        }}
-        onBotCreateDialog={handleCreateDialog}
-        onBotDeleteDialog={handleDeleteDialog}
-        onBotEditManifest={handleDisplayManifestModal}
-        onBotExportZip={exportToZip}
-        onBotRemoveSkill={handleRemoveSkill}
-        onBotStart={startSingleBot}
-        onBotStop={stopSingleBot}
-        onDialogCreateTrigger={(projectId, dialogId) => {
-          setTriggerModalInfo({ projectId, dialogId });
-        }}
-        onDialogDeleteTrigger={handleDeleteTrigger}
-        onErrorClick={handleErrorClick}
-        onSelect={handleSelect}
-      />
-    </React.Fragment>
+    <ProjectTree
+      headerMenu={projectTreeHeaderMenuItems}
+      selectedLink={{
+        projectId: rootProjectId,
+        skillId: rootProjectId === projectId ? undefined : projectId,
+        dialogId,
+        trigger: parseTriggerId(selectedTrigger?.id),
+      }}
+      onBotCreateDialog={handleCreateDialog}
+      onBotDeleteDialog={handleDeleteDialog}
+      onBotEditManifest={handleDisplayManifestModal}
+      onBotExportZip={exportToZip}
+      onBotRemoveSkill={handleRemoveSkill}
+      onBotStart={startSingleBot}
+      onBotStop={stopSingleBot}
+      onDialogCreateTrigger={(projectId, dialogId) => {
+        setTriggerModalInfo({ projectId, dialogId });
+      }}
+      onDialogDeleteTrigger={handleDeleteTrigger}
+      onErrorClick={handleErrorClick}
+      onSelect={handleSelect}
+    />
   );
 });
 

--- a/Composer/packages/client/src/recoilModel/dispatchers/project.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/project.ts
@@ -2,7 +2,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { BotProjectFile } from '@bfc/shared';
 import formatMessage from 'format-message';
 import findIndex from 'lodash/findIndex';
 import { RootBotManagedProperties } from '@bfc/shared';
@@ -22,7 +21,6 @@ import {
   botNameIdentifierState,
   botOpeningMessage,
   botOpeningState,
-  botProjectFileState,
   botProjectIdsState,
   botProjectSpaceLoadedState,
   botStatusState,
@@ -53,6 +51,7 @@ import {
   navigateToSkillBot,
   openLocalSkill,
   openRemoteSkill,
+  openRootBotAndSkills,
   openRootBotAndSkillsByPath,
   openRootBotAndSkillsByProjectId,
   removeRecentProject,
@@ -484,11 +483,8 @@ export const projectDispatcher = () => {
             if (settingStorage.get(projectId)) {
               settingStorage.remove(projectId);
             }
-            const currentBotProjectFileIndexed: BotProjectFile = botFiles.botProjectSpaceFiles[0];
-            callbackHelpers.set(botProjectFileState(projectId), currentBotProjectFileIndexed);
 
-            const mainDialog = await initBotState(callbackHelpers, projectData, botFiles);
-            callbackHelpers.set(botProjectIdsState, [projectId]);
+            const { mainDialog } = await openRootBotAndSkills(callbackHelpers, { botFiles, projectData });
 
             // Post project creation
             callbackHelpers.set(projectMetaDataState(projectId), {

--- a/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
@@ -599,7 +599,7 @@ const handleSkillLoadingFailure = (callbackHelpers, { ex, skillNameIdentifier })
   return projectId;
 };
 
-const openRootBotAndSkills = async (callbackHelpers: CallbackInterface, data, storageId = 'default') => {
+export const openRootBotAndSkills = async (callbackHelpers: CallbackInterface, data, storageId = 'default') => {
   const { projectData, botFiles } = data;
   const { set, snapshot } = callbackHelpers;
   const dispatcher = await snapshot.getPromise(dispatcherState);

--- a/Composer/packages/server/src/locales/en-US.json
+++ b/Composer/packages/server/src/locales/en-US.json
@@ -1232,6 +1232,9 @@
   "extracting_qna_pairs_from_url_b0331bba": {
     "message": "Extracting QNA pairs from { url }"
   },
+  "fail_to_save_bot_578fa8aa": {
+    "message": "Fail to save bot"
+  },
   "failed_to_start_1edb0dbe": {
     "message": "Failed to start"
   },
@@ -1270,6 +1273,15 @@
   },
   "folder_foldername_already_exists_4a2260e9": {
     "message": "folder { folderName } already exists"
+  },
+  "font_family_baa0c6a3": {
+    "message": "Font family"
+  },
+  "font_size_bf4db203": {
+    "message": "Font size"
+  },
+  "font_weight_188bb2b9": {
+    "message": "Font weight"
   },
   "for_each_def04c48": {
     "message": "For Each"
@@ -1652,6 +1664,9 @@
   "local_skill_6ce0d311": {
     "message": "Local Skill."
   },
+  "locale_locale_is_not_supported_by_luis_a3a72047": {
+    "message": "locale \"{ locale }\" is not supported by LUIS"
+  },
   "locate_the_bot_file_and_repair_the_link_202045b1": {
     "message": "Locate the bot file and repair the link"
   },
@@ -1717,6 +1732,9 @@
   },
   "luis_authoring_region_b142f97b": {
     "message": "Luis Authoring Region"
+  },
+  "luis_build_warning_320e4ee2": {
+    "message": "Luis build warning"
   },
   "luis_endpoint_key_c685e219": {
     "message": "LUIS endpoint key"
@@ -2831,6 +2849,9 @@
   "the_root_bot_is_not_a_bot_project_d1495cf6": {
     "message": "The root bot is not a bot project"
   },
+  "the_skill_you_tried_to_remove_from_the_project_is__2c0bd965": {
+    "message": "The skill you tried to remove from the project is currently used in the below bot(s). Removing this skill won’t delete the files, but it will cause your Bot to malfunction without additional action."
+  },
   "the_target_where_you_publish_your_bot_3132ef47": {
     "message": "The target where you publish your bot"
   },
@@ -3164,6 +3185,9 @@
   "warning_53c98b03": {
     "message": "Warning!"
   },
+  "warning_aacb8c24": {
+    "message": "Warning"
+  },
   "warning_the_action_you_are_about_to_take_cannot_be_1071a3c3": {
     "message": "Warning: the action you are about to take cannot be undone. Going further will delete this bot and any related files in the bot project folder."
   },
@@ -3253,6 +3277,9 @@
   },
   "you_are_about_to_pull_project_files_from_the_selec_15786351": {
     "message": "You are about to pull project files from the selected publish profiles. The current project will be overwritten by the pulled files, and will be saved as a backup automatically. You will be able to retrieve the backup anytime in the future."
+  },
+  "you_are_about_to_remove_the_skill_from_this_projec_2ba31a6d": {
+    "message": "You are about to remove the skill from this project. Removing this skill won’t delete the files."
   },
   "you_can_create_a_new_bot_from_scratch_with_compose_1486288c": {
     "message": "You can create a new bot from scratch with Composer, or start with a template."

--- a/Composer/packages/server/src/models/asset/__tests__/assetManager.test.ts
+++ b/Composer/packages/server/src/models/asset/__tests__/assetManager.test.ts
@@ -10,6 +10,8 @@ import { Path } from '../../../utility/path';
 import { AssetManager } from '../assetManager';
 import StorageService from '../../../services/storage';
 
+const mockchdir = jest.spyOn(process, 'chdir').mockImplementation(() => {});
+
 jest.mock('azure-storage', () => {
   return {};
 });
@@ -162,6 +164,7 @@ describe('assetManager', () => {
         path: '/path/to/npmbot/sampleConversationalCore',
         storageId: 'default',
       });
+      expect(mockchdir).toBeCalledWith('/path/to/npmbot');
     });
   });
 });

--- a/Composer/packages/server/src/models/asset/assetManager.ts
+++ b/Composer/packages/server/src/models/asset/assetManager.ts
@@ -113,6 +113,7 @@ export class AssetManager {
         throw new Error('already have this folder, please give another name');
       }
 
+      log('About to create folder', dstDir);
       mkdirSync(dstDir, { recursive: true });
 
       // find selected template
@@ -159,9 +160,10 @@ export class AssetManager {
     dstDir: string,
     projectName: string
   ): Promise<boolean> {
-    this.yeomanEnv.cwd = dstDir;
-
     log('About to instantiate a template!', dstDir, generatorName, projectName);
+    this.yeomanEnv.cwd = dstDir;
+    process.chdir(dstDir);
+
     await this.yeomanEnv.run([generatorName, projectName], {}, () => {
       log('Template successfully instantiated', dstDir, generatorName, projectName);
     });

--- a/Composer/packages/server/src/models/bot/botProject.ts
+++ b/Composer/packages/server/src/models/bot/botProject.ts
@@ -709,6 +709,7 @@ export class BotProject implements IBotProject {
   // update file in this project this function will guarantee the memory cache
   // (this.files, all indexes) also gets updated
   private _updateFile = async (relativePath: string, content: string) => {
+    log('Update file', relativePath, content);
     const file = this.files.get(Path.basename(relativePath));
     if (!file) {
       throw new Error(`no such file at ${relativePath}`);

--- a/Composer/packages/server/src/services/project.ts
+++ b/Composer/packages/server/src/services/project.ts
@@ -456,7 +456,7 @@ export class BotProjectService {
       // The outcome of our creation might be > 1 bot! We need to determine how many bots we find in this folder.
       // is this a single bot?
       if (await StorageService.checkIsBotFolder(newProjRef.storageId, newProjRef.path, user)) {
-        botsToProcess.push({ ...newProjRef, name: name });
+        botsToProcess.push({ ...newProjRef, name });
       } else {
         // or multiple bots?
         const files = await StorageService.getBlob(newProjRef.storageId, newProjRef.path, user);

--- a/Composer/packages/server/src/services/project.ts
+++ b/Composer/packages/server/src/services/project.ts
@@ -431,7 +431,6 @@ export class BotProjectService {
       // TODO: Replace with default template once one is determined
       throw Error('empty templateID passed');
     }
-
     // location to store the bot project
     const locationRef = getLocationRef(location, storageId, name);
     try {
@@ -452,36 +451,71 @@ export class BotProjectService {
 
       BackgroundProcessManager.updateProcess(jobId, 202, formatMessage('Bot files created'));
 
-      const id = await BotProjectService.openProject(newProjRef, user);
+      const botsToProcess: { storageId: string; path: string; name: string }[] = [];
 
-      // in the case of PVA, we need to update the eTag and alias used by the import mechanism
-      createFromPva && BotProjectService.setProjectLocationData(id, { alias, eTag });
+      // The outcome of our creation might be > 1 bot! We need to determine how many bots we find in this folder.
+      // is this a single bot?
+      if (await StorageService.checkIsBotFolder(newProjRef.storageId, newProjRef.path, user)) {
+        botsToProcess.push({ ...newProjRef, name: name });
+      } else {
+        // or multiple bots?
+        const files = await StorageService.getBlob(newProjRef.storageId, newProjRef.path, user);
+        const childbots = files.children.filter((f) => f.type === 'bot');
 
-      const currentProject = await BotProjectService.getProjectById(id, user);
+        childbots.forEach((b) => {
+          botsToProcess.push({
+            storageId: newProjRef.storageId,
+            path: b.path,
+            name: b.name,
+          });
+        });
+      }
 
-      // inject shared content into every new project.  this comes from assets/shared
-      !createFromPva &&
-        (await AssetService.manager.copyBoilerplate(currentProject.dataDir, currentProject.fileStorage));
+      for (const botRef of botsToProcess) {
+        log('Open project', botRef);
+        const id = await BotProjectService.openProject(botRef, user);
 
-      if (currentProject !== undefined) {
-        !createFromPva && (await ejectAndMerge(currentProject, jobId));
-        BackgroundProcessManager.updateProcess(jobId, 202, formatMessage('Initializing bot project'));
-        await currentProject.updateBotInfo(name, description, preserveRoot);
+        // in the case of PVA, we need to update the eTag and alias used by the import mechanism
+        createFromPva && BotProjectService.setProjectLocationData(id, { alias, eTag });
 
-        if (schemaUrl && !createFromPva) {
-          await currentProject.saveSchemaToProject(schemaUrl, locationRef.path);
+        log('Get Project by Id', id);
+        const currentProject = await BotProjectService.getProjectById(id, user);
+
+        // inject shared content into every new project.  this comes from assets/shared
+        !createFromPva &&
+          (await AssetService.manager.copyBoilerplate(currentProject.dataDir, currentProject.fileStorage));
+
+        if (currentProject !== undefined) {
+          !createFromPva && (await ejectAndMerge(currentProject, jobId));
+          BackgroundProcessManager.updateProcess(jobId, 202, formatMessage('Initializing bot project'));
+
+          log('Updatebot info', id, preserveRoot);
+          await currentProject.updateBotInfo(botRef.name, description, true);
+
+          if (schemaUrl && !createFromPva) {
+            await currentProject.saveSchemaToProject(schemaUrl, botRef.path);
+          }
+
+          log('Init project', id);
+          await currentProject.init();
         }
+      }
 
-        await currentProject.init();
-
+      const rootBot = botsToProcess.find((b) => b.name === name);
+      if (rootBot) {
+        const id = await BotProjectService.openProject({ storageId: rootBot?.storageId, path: rootBot.path }, user);
+        const currentProject = await BotProjectService.getProjectById(id, user);
         const project = currentProject.getProject();
         log('Project created successfully.');
         BackgroundProcessManager.updateProcess(jobId, 200, 'Created Successfully', {
           id,
           ...project,
         });
+
+        TelemetryService.trackEvent('CreateNewBotProjectCompleted', { template: templateId, status: 200 });
+      } else {
+        throw new Error('Could not find root bot');
       }
-      TelemetryService.trackEvent('CreateNewBotProjectCompleted', { template: templateId, status: 200 });
     } catch (err) {
       BackgroundProcessManager.updateProcess(jobId, 500, err instanceof Error ? err.message : err, err);
       TelemetryService.trackEvent('CreateNewBotProjectCompleted', { template: templateId, status: 500 });

--- a/Composer/packages/server/src/utility/project.ts
+++ b/Composer/packages/server/src/utility/project.ts
@@ -77,7 +77,7 @@ export async function ejectAndMerge(currentProject: BotProject, jobId: string) {
     // run the merge command to merge all package dependencies from the template to the bot project
     BackgroundProcessManager.updateProcess(jobId, 202, formatMessage('Merging Packages'));
     const realMerge = new SchemaMerger(
-      [manifestFile],
+      [manifestFile, '!**/imported/**', '!**/generated/**'],
       Path.join(currentProject.dataDir, 'schemas/sdk'),
       Path.join(currentProject.dataDir, 'dialogs/imported'),
       false,


### PR DESCRIPTION
## Description

This change allows any number of bots to be created by a template, enabling multi-skill scenarios. 

Previously our code assumed there would be one bot project resulting from the file -> new action. 

This change detects whether the result of the create is a single project or multiple projects. It then processes any projects found, resulting in N-number of fully instantiated projects available to open in Composer.

It then returns the root bot to the client so that it can open it and all child bots.

#minor

## Screenshots

https://www.loom.com/share/e6c545242a9e4f409eb54d28cb7cc2f2