### PR TITLE
fix: reset settings fields when a new projectId loads

### DIFF
--- a/Composer/packages/client/src/pages/botProject/runtime-settings/RuntimeSettings.tsx
+++ b/Composer/packages/client/src/pages/botProject/runtime-settings/RuntimeSettings.tsx
@@ -65,12 +65,16 @@ export const RuntimeSettings: React.FC<RouteComponentProps<{ projectId: string }
   const [ejecting, setEjecting] = useState(false);
   const [needsUpdate, setNeedsUpdate] = useState(false);
   const [templateKey, setTemplateKey] = useState('');
-  const [runtimePath, setRuntimePath] = useState(settings.runtime ? settings.runtime.path : '');
-  const [runtimeCommand, setRuntimeCommand] = useState(settings.runtime ? settings.runtime.command : '');
+  const [runtimePath, setRuntimePath] = useState(settings.runtime?.path ?? '');
+  const [runtimeCommand, setRuntimeCommand] = useState(settings.runtime?.command ?? '');
+  const [usingCustomRuntime, setUsingCustomRuntime] = useState(settings.runtime?.customRuntime ?? false);
 
   useEffect(() => {
     // check the status of the boilerplate material and see if it requires an update
     if (projectId) getBoilerplateVersion(projectId);
+    setRuntimePath(settings.runtime?.path ?? '');
+    setRuntimeCommand(settings.runtime?.command ?? '');
+    setUsingCustomRuntime(settings.runtime?.customRuntime ?? false);
   }, [projectId]);
 
   useEffect(() => {
@@ -86,6 +90,7 @@ export const RuntimeSettings: React.FC<RouteComponentProps<{ projectId: string }
 
   const toggleCustomRuntime = (_, isOn = false) => {
     setCustomRuntime(projectId, isOn);
+    setUsingCustomRuntime(isOn);
     TelemetryClient.track('CustomRuntimeToggleChanged', { enabled: isOn });
   };
 
@@ -128,7 +133,7 @@ export const RuntimeSettings: React.FC<RouteComponentProps<{ projectId: string }
     <div css={runtimeToggle}>
       <Toggle
         inlineLabel
-        checked={settings.runtime?.customRuntime}
+        checked={usingCustomRuntime}
         label={formatMessage('Use custom runtime')}
         onChange={toggleCustomRuntime}
       />


### PR DESCRIPTION
## Description

The project settings page was leaving stale values visible when switching between a root bot or any of its skills in the left-hand-side list. This fixes that by reloading the values from the settings when the visible projectId changes.

## Task Item

closes #5785 

## Screenshots
These are a before and after comparison of clicking the "EchoBot-5" label:

![image](https://user-images.githubusercontent.com/61990921/108140150-59cd2300-7076-11eb-8a13-7c213a66463a.png)
![image](https://user-images.githubusercontent.com/61990921/108140159-5e91d700-7076-11eb-9a5f-9ba0d5508d84.png)


