### PR TITLE
fix: load bot will do full index twice (step 1: improve the load bot perf)

### DIFF
--- a/Composer/packages/client/src/recoilModel/dispatchers/project.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/project.ts
@@ -478,7 +478,7 @@ export const projectDispatcher = () => {
             // Bot creation successful
             clearInterval(timer);
             callbackHelpers.set(botOpeningMessage, response.data.latestMessage);
-            const { botFiles, projectData } = loadProjectData(response.data.result);
+            const { botFiles, projectData } = await loadProjectData(response.data.result);
             const projectId = response.data.result.id;
             if (settingStorage.get(projectId)) {
               settingStorage.remove(projectId);

--- a/Composer/packages/client/src/recoilModel/parsers/lgWorker.ts
+++ b/Composer/packages/client/src/recoilModel/parsers/lgWorker.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-import { LgFile, LgTemplate } from '@bfc/shared';
+import { LgFile, LgTemplate, TextFile } from '@bfc/shared';
 
 import Worker from './workers/lgParser.worker.ts';
 import { BaseWorker } from './baseWorker';
@@ -15,12 +15,13 @@ import {
   LgCopyTemplatePayload,
   LgNewCachePayload,
   LgCleanCachePayload,
+  LgParseAllPayload,
 } from './types';
 
 // Wrapper class
 class LgWorker extends BaseWorker<LgActionType> {
-  addProject(projectId: string, lgFiles: LgFile[]) {
-    return this.sendMsg<LgNewCachePayload>(LgActionType.NewCache, { projectId, lgFiles });
+  addProject(projectId: string) {
+    return this.sendMsg<LgNewCachePayload>(LgActionType.NewCache, { projectId });
   }
 
   removeProject(projectId: string) {
@@ -29,6 +30,10 @@ class LgWorker extends BaseWorker<LgActionType> {
 
   parse(projectId: string, id: string, content: string, lgFiles: LgFile[]) {
     return this.sendMsg<LgParsePayload>(LgActionType.Parse, { id, content, lgFiles, projectId });
+  }
+
+  parseAll(projectId: string, lgResources: TextFile[]) {
+    return this.sendMsg<LgParseAllPayload>(LgActionType.ParseAll, { lgResources, projectId });
   }
 
   addTemplate(projectId: string, lgFile: LgFile, template: LgTemplate, lgFiles: LgFile[]) {

--- a/Composer/packages/client/src/recoilModel/parsers/luWorker.ts
+++ b/Composer/packages/client/src/recoilModel/parsers/luWorker.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-import { LuIntentSection, LuFile } from '@bfc/shared';
+import { LuIntentSection, LuFile, TextFile } from '@bfc/shared';
 
 import Worker from './workers/luParser.worker.ts';
 import { BaseWorker } from './baseWorker';
@@ -12,12 +12,18 @@ import {
   LuRemoveIntentsPayload,
   LuRemoveIntentPayload,
   LuUpdateIntentPayload,
+  LuParseAllPayload,
 } from './types';
 // Wrapper class
 class LuWorker extends BaseWorker<LuActionType> {
   parse(id: string, content: string, luFeatures) {
     const payload = { id, content, luFeatures };
     return this.sendMsg<LuParsePayload>(LuActionType.Parse, payload);
+  }
+
+  parseAll(luResources: TextFile[], luFeatures) {
+    const payload = { luResources, luFeatures };
+    return this.sendMsg<LuParseAllPayload>(LuActionType.ParseAll, payload);
   }
 
   addIntent(luFile: LuFile, intent: LuIntentSection, luFeatures) {

--- a/Composer/packages/client/src/recoilModel/parsers/qnaWorker.ts
+++ b/Composer/packages/client/src/recoilModel/parsers/qnaWorker.ts
@@ -1,30 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { TextFile } from '@bfc/shared';
+
 import Worker from './workers/qnaParser.worker.ts';
 import { BaseWorker } from './baseWorker';
-import { QnAPayload, QnAActionType } from './types';
+import { QnAActionType, QnAParseAllPayload, QnAParsePayload } from './types';
 
 // Wrapper class
 class QnAWorker extends BaseWorker<QnAActionType> {
   parse(id: string, content: string) {
     const payload = { id, content };
-    return this.sendMsg<QnAPayload>(QnAActionType.Parse, payload);
+    return this.sendMsg<QnAParsePayload>(QnAActionType.Parse, payload);
   }
 
-  addSection(content: string, newContent: string) {
-    const payload = { content, newContent };
-    return this.sendMsg<QnAPayload>(QnAActionType.AddSection, payload);
-  }
-
-  updateSection(indexId: number, content: string, newContent: string) {
-    const payload = { indexId, content, newContent };
-    return this.sendMsg<QnAPayload>(QnAActionType.UpdateSection, payload);
-  }
-
-  removeSection(indexId: number, content: string) {
-    const payload = { content, indexId };
-    return this.sendMsg<QnAPayload>(QnAActionType.RemoveSection, payload);
+  parseAll(qnaResources: TextFile[]) {
+    const payload = { qnaResources };
+    return this.sendMsg<QnAParseAllPayload>(QnAActionType.ParseAll, payload);
   }
 }
 

--- a/Composer/packages/client/src/recoilModel/parsers/types.ts
+++ b/Composer/packages/client/src/recoilModel/parsers/types.ts
@@ -1,12 +1,26 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-import { LuIntentSection, LgFile, LuFile, QnASection, FileInfo, LgTemplate, ILUFeaturesConfig } from '@bfc/shared';
+import {
+  LuIntentSection,
+  LgFile,
+  LuFile,
+  QnASection,
+  FileInfo,
+  LgTemplate,
+  ILUFeaturesConfig,
+  TextFile,
+} from '@bfc/shared';
 
 import { FileAsset } from '../persistence/types';
 
 export type LuParsePayload = {
   id: string;
   content: string;
+  luFeatures: ILUFeaturesConfig;
+};
+
+export type LuParseAllPayload = {
+  luResources: TextFile[];
   luFeatures: ILUFeaturesConfig;
 };
 
@@ -86,12 +100,16 @@ export interface LgRemoveAllTemplatesPayload {
 
 export interface LgNewCachePayload {
   projectId: string;
-  lgFiles: LgFile[];
 }
 
 export interface LgCleanCachePayload {
   projectId: string;
 }
+
+export type LgParseAllPayload = {
+  projectId: string;
+  lgResources: TextFile[];
+};
 
 export interface LgCopyTemplatePayload {
   projectId: string;
@@ -109,10 +127,13 @@ export type IndexPayload = {
   luFeatures: { key: string; value: boolean };
 };
 
-export type QnAPayload = {
+export type QnAParsePayload = {
   content: string;
-  id?: string;
-  section?: QnASection;
+  id: string;
+};
+
+export type QnAParseAllPayload = {
+  qnaResources: TextFile[];
 };
 
 export enum LuActionType {
@@ -122,6 +143,7 @@ export enum LuActionType {
   RemoveIntent = 'remove-intent',
   AddIntents = 'add-intents',
   RemoveIntents = 'remove-intents',
+  ParseAll = 'parse-all',
 }
 
 export enum LgActionType {
@@ -134,6 +156,7 @@ export enum LgActionType {
   RemoveTemplate = 'remove-template',
   RemoveAllTemplates = 'remove-all-templates',
   CopyTemplate = 'copy-template',
+  ParseAll = 'parse-all',
 }
 
 export enum IndexerActionType {
@@ -142,9 +165,7 @@ export enum IndexerActionType {
 
 export enum QnAActionType {
   Parse = 'parse',
-  AddSection = 'add-section',
-  UpdateSection = 'update-section',
-  RemoveSection = 'remove-section',
+  ParseAll = 'parse-all',
 }
 
 export type FilesDifferencePayload = {

--- a/Composer/packages/client/src/recoilModel/parsers/workers/luParser.worker.ts
+++ b/Composer/packages/client/src/recoilModel/parsers/workers/luParser.worker.ts
@@ -11,6 +11,7 @@ import {
   LuUpdateIntentPayload,
   LuAddIntentsPayload,
   LuAddIntentPayload,
+  LuParseAllPayload,
 } from '../types';
 const ctx: Worker = self as any;
 
@@ -50,7 +51,20 @@ interface RemoveIntentsMessage {
   payload: LuRemoveIntentsPayload;
 }
 
-type LuMessageEvent = ParseMessage | AddMessage | AddsMessage | UpdateMessage | RemoveMessage | RemoveIntentsMessage;
+type ParseAllMessage = {
+  id: string;
+  type: LuActionType.ParseAll;
+  payload: LuParseAllPayload;
+};
+
+type LuMessageEvent =
+  | ParseMessage
+  | AddMessage
+  | AddsMessage
+  | UpdateMessage
+  | RemoveMessage
+  | RemoveIntentsMessage
+  | ParseAllMessage;
 
 export const handleMessage = (msg: LuMessageEvent) => {
   let result: any = null;
@@ -58,6 +72,12 @@ export const handleMessage = (msg: LuMessageEvent) => {
     case LuActionType.Parse: {
       const { id, content, luFeatures } = msg.payload;
       result = luUtil.parse(id, content, luFeatures);
+      break;
+    }
+
+    case LuActionType.ParseAll: {
+      const { luResources, luFeatures } = msg.payload;
+      result = luResources.map(({ id, content }) => luUtil.parse(id, content, luFeatures));
       break;
     }
 

--- a/Composer/packages/client/src/recoilModel/parsers/workers/qnaParser.worker.ts
+++ b/Composer/packages/client/src/recoilModel/parsers/workers/qnaParser.worker.ts
@@ -2,34 +2,48 @@
 // Licensed under the MIT License.
 import * as qnaUtil from '@bfc/indexers/lib/utils/qnaUtil';
 
-import { QnAActionType } from './../types';
+import { QnAActionType, QnAParseAllPayload, QnAParsePayload } from './../types';
 const ctx: Worker = self as any;
 
-ctx.onmessage = function (msg) {
-  const { id: msgId, type, payload } = msg.data;
-  const { content, id, file, indexId } = payload;
+type ParseMessage = {
+  id: string;
+  type: QnAActionType.Parse;
+  payload: QnAParsePayload;
+};
+
+type ParseAllMessage = {
+  id: string;
+  type: QnAActionType.ParseAll;
+  payload: QnAParseAllPayload;
+};
+
+type QnaMessageEvent = ParseMessage | ParseAllMessage;
+
+export const handleMessage = (msg: QnaMessageEvent) => {
   let result: any = null;
-  try {
-    switch (type) {
-      case QnAActionType.Parse: {
-        result = qnaUtil.parse(id, content);
-        break;
-      }
-      case QnAActionType.AddSection: {
-        result = qnaUtil.addSection(file.content, content);
-        break;
-      }
-      case QnAActionType.UpdateSection: {
-        result = qnaUtil.updateSection(indexId, file.content, content);
-        break;
-      }
-      case QnAActionType.RemoveSection: {
-        result = qnaUtil.removeSection(indexId, file.content);
-        break;
-      }
+  switch (msg.type) {
+    case QnAActionType.Parse: {
+      const { id, content } = msg.payload;
+      result = qnaUtil.parse(id, content);
+      break;
     }
-    ctx.postMessage({ id: msgId, payload: result });
+
+    case QnAActionType.ParseAll: {
+      const { qnaResources } = msg.payload;
+      result = qnaResources.map(({ id, content }) => qnaUtil.parse(id, content));
+      console.log(result);
+      break;
+    }
+  }
+  return result;
+};
+
+ctx.onmessage = function (event) {
+  const msg = event.data as QnaMessageEvent;
+  try {
+    const payload = handleMessage(msg);
+    ctx.postMessage({ id: msg.id, payload });
   } catch (error) {
-    ctx.postMessage({ id: msgId, error: error.message });
+    ctx.postMessage({ id: msg.id, error: error.message });
   }
 };

--- a/Composer/packages/lib/indexers/src/index.ts
+++ b/Composer/packages/lib/indexers/src/index.ts
@@ -1,21 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-import { DialogSetting, FileInfo, lgImportResolverGenerator } from '@bfc/shared';
+import { FileInfo } from '@bfc/shared';
 
 import { recognizerIndexer } from './recognizerIndexer';
 import { dialogIndexer } from './dialogIndexer';
 import { dialogSchemaIndexer } from './dialogSchemaIndexer';
 import { jsonSchemaFileIndexer } from './jsonSchemaFileIndexer';
-import { lgIndexer } from './lgIndexer';
-import { luIndexer } from './luIndexer';
-import { qnaIndexer } from './qnaIndexer';
 import { skillManifestIndexer } from './skillManifestIndexer';
 import { botProjectSpaceIndexer } from './botProjectSpaceIndexer';
 import { FileExtensions } from './utils/fileExtensions';
 import { getExtension, getBaseName } from './utils/help';
 import { formDialogSchemaIndexer } from './formDialogSchemaIndexer';
 import { crossTrainConfigIndexer } from './crossTrainConfigIndexer';
-import { BotIndexer } from './botIndexer';
 
 class Indexer {
   private classifyFile(files: FileInfo[]) {
@@ -69,28 +65,24 @@ class Indexer {
     );
   };
 
-  private getLgImportResolver = (files: FileInfo[], locale: string) => {
-    const lgFiles = files.map(({ name, content }) => {
-      return {
-        id: getBaseName(name, '.lg'),
-        content,
-      };
-    });
-
-    return lgImportResolverGenerator(lgFiles, '.lg', locale);
+  private getResources = (files: FileInfo[], extension: string) => {
+    return files.map(({ name, content }) => ({
+      id: getBaseName(name, extension),
+      content,
+    }));
   };
 
-  public index(files: FileInfo[], botName: string, locale: string, settings: DialogSetting) {
+  public index(files: FileInfo[], botName: string) {
     const result = this.classifyFile(files);
-    const luFeatures = settings.luFeatures;
+    //const luFeatures = settings.luFeatures;
     const { dialogs, recognizers } = this.separateDialogsAndRecognizers(result[FileExtensions.Dialog]);
     const { skillManifestFiles, crossTrainConfigs } = this.separateConfigAndManifests(result[FileExtensions.Manifest]);
     const assets = {
       dialogs: dialogIndexer.index(dialogs, botName),
       dialogSchemas: dialogSchemaIndexer.index(result[FileExtensions.DialogSchema]),
-      lgFiles: lgIndexer.index(result[FileExtensions.lg], this.getLgImportResolver(result[FileExtensions.lg], locale)),
-      luFiles: luIndexer.index(result[FileExtensions.Lu], luFeatures),
-      qnaFiles: qnaIndexer.index(result[FileExtensions.QnA]),
+      lgResources: this.getResources(result[FileExtensions.lg], '.lg'),
+      luResources: this.getResources(result[FileExtensions.Lu], '.lu'),
+      qnaResources: this.getResources(result[FileExtensions.QnA], '.qna'),
       skillManifests: skillManifestIndexer.index(skillManifestFiles),
       botProjectSpaceFiles: botProjectSpaceIndexer.index(result[FileExtensions.BotProjectSpace]),
       jsonSchemaFiles: jsonSchemaFileIndexer.index(result[FileExtensions.Json]),
@@ -98,9 +90,7 @@ class Indexer {
       recognizers: recognizerIndexer.index(recognizers),
       crossTrainConfig: crossTrainConfigIndexer.index(crossTrainConfigs),
     };
-    const botProjectFile = assets.botProjectSpaceFiles[0];
-    const diagnostics = BotIndexer.validate({ ...assets, setting: settings, botProjectFile });
-    return { ...assets, diagnostics };
+    return { ...assets };
   }
 }
 


### PR DESCRIPTION
## Description
When we open a new bot(calendar skill), composer will do twice full index today. Every full index will take about 9s, and the loading time is about 22s today.
![image](https://user-images.githubusercontent.com/39758135/108491755-4a044780-72df-11eb-9a9c-4b6d3c919fb4.png)

**In this PR**
reduce one full index, the loading time is about 14s
![image](https://user-images.githubusercontent.com/39758135/108493422-42de3900-72e1-11eb-8eea-c9618d2722e6.png)


**Next step**
Put the full index to the background. 
If we need to show UI during the indexing stage, only parse the resource(lg, lu, qna) for current dialog  
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
refs #5708
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
