### PR TITLE
fix: return more verbose error during new creation for display in the client

### DIFF
--- a/Composer/packages/server/src/controllers/status.ts
+++ b/Composer/packages/server/src/controllers/status.ts
@@ -9,7 +9,11 @@ const getStatus = async (req, res) => {
     if (jobId) {
       const result = BackgroundProcessManager.getProcessStatus(jobId);
       if (result) {
-        res.status(result.httpStatusCode).json(result);
+        res.status(result.httpStatusCode).json({
+          ...result,
+          statusCode: result.httpStatusCode,
+          message: result.latestMessage,
+        });
       } else {
         res.status(404).json({
           statusCode: '404',


### PR DESCRIPTION
## Description

This PR exposes the error message from inside background build processes to the client for display.


## Task Item
fixes #5783 
