### PR TITLE
fix: Restrict template feed to those published by Microsoft

### DIFF
--- a/Composer/packages/client/src/constants.ts
+++ b/Composer/packages/client/src/constants.ts
@@ -391,7 +391,7 @@ export const triggerNotSupportedWarning = () =>
 
 export const feedDictionary: { [key in FeedName]: string } = {
   firstPartyCsharp:
-    'https://registry.npmjs.org/-/v1/search?text=conversationalcore&size=100&from=0&quality=0.65&popularity=0.98&maintenance=0.5',
+    'https://registry.npmjs.org/-/v1/search?text=conversationalcore+scope:microsoft&size=100&from=0&quality=0.65&popularity=0.98&maintenance=0.5',
   firstPartyNode: '',
 };
 


### PR DESCRIPTION
This adds the `scope: microsoft` parameter to the feed that is used as the source of templates in the new creation flow.