### PR TITLE
fix: make new creation flow feature flag visible, combine package manager feature

### DIFF
--- a/Composer/packages/client/src/recoilModel/selectors/extensions.ts
+++ b/Composer/packages/client/src/recoilModel/selectors/extensions.ts
@@ -26,7 +26,7 @@ export const pluginPagesSelector = selector({
       if (Array.isArray(pagesConfig) && pagesConfig.length > 0) {
         // TODO: This code is present to enable the package manager to be behind a feature flag.
         // When this is no longer necessary, we should remove this conditional!
-        if (p.id !== 'package-manager' || featureFlags?.PACKAGE_MANAGER?.enabled === true) {
+        if (p.id !== 'package-manager' || featureFlags?.NEW_CREATION_FLOW?.enabled === true) {
           pages.push(...pagesConfig.map((page) => ({ ...page, id: p.id })));
         }
       }

--- a/Composer/packages/lib/shared/src/featureFlagUtils/index.ts
+++ b/Composer/packages/lib/shared/src/featureFlagUtils/index.ts
@@ -7,8 +7,8 @@ import { FeatureFlagMap } from '@botframework-composer/types';
 export const getDefaultFeatureFlags = (): FeatureFlagMap => ({
   NEW_CREATION_FLOW: {
     displayName: formatMessage('New Creation Experience'),
-    description: formatMessage('Component templates populated from npm feeds'),
-    isHidden: true,
+    description: formatMessage('Preview the new adaptive runtime and component system'),
+    isHidden: false,
     enabled: false,
   },
   FORM_DIALOG: {
@@ -26,12 +26,5 @@ export const getDefaultFeatureFlags = (): FeatureFlagMap => ({
     documentationLink: 'https://aka.ms/bf-orchestrator',
     isHidden: false,
     enabled: false,
-  },
-  PACKAGE_MANAGER: {
-    displayName: formatMessage('Package manager'),
-    description: formatMessage('Discover and use components that can be installed into your bot'),
-    isHidden: false,
-    enabled: false,
-    documentationLink: 'https://aka.ms/composer-package-manager-readme',
   },
 });

--- a/Composer/packages/types/src/featureFlags.ts
+++ b/Composer/packages/types/src/featureFlags.ts
@@ -14,6 +14,6 @@ export type FeatureFlag = {
   enabled: boolean;
 };
 
-export type FeatureFlagKey = 'FORM_DIALOG' | 'ORCHESTRATOR' | 'PACKAGE_MANAGER' | 'NEW_CREATION_FLOW';
+export type FeatureFlagKey = 'FORM_DIALOG' | 'ORCHESTRATOR' | 'NEW_CREATION_FLOW';
 
 export type FeatureFlagMap = Record<FeatureFlagKey, FeatureFlag>;


### PR DESCRIPTION
## Description

Make the new creation flow feature flag visible on the application settings page.  This gates access to the new flow, package manager, and the new connection management area of the bot settings.

## Task Item

fixes #5757 