### PR TITLE
fix: hide debug panel on settings pages

### DIFF
--- a/Composer/packages/client/src/components/Page.tsx
+++ b/Composer/packages/client/src/components/Page.tsx
@@ -215,7 +215,7 @@ const Page: React.FC<IPageProps> = (props) => {
               role="region"
             >
               <div css={contentStyle}>{children}</div>
-              {title !== 'Diagnostics' && <DebugPanel />}
+              {shouldShowEditorError && <DebugPanel />}
             </div>
           </Split>
         </div>

--- a/Composer/packages/client/src/components/Page.tsx
+++ b/Composer/packages/client/src/components/Page.tsx
@@ -78,13 +78,13 @@ export const main = css`
   label: PageMain;
 `;
 
-export const content = (shouldShowEditorError: boolean) => css`
+export const content = css`
   flex: 4;
   display: flex;
   flex-direction: column;
   position: relative;
   overflow: auto;
-  height: ${shouldShowEditorError ? 'calc(100% - 40px)' : '100%'};
+  height: 100%;
   label: PageContent;
   box-sizing: border-box;
 `;
@@ -92,7 +92,6 @@ export const content = (shouldShowEditorError: boolean) => css`
 const contentStyle = css`
   padding: 20px;
   flex-grow: 1;
-  height: 0;
   position: relative;
 `;
 
@@ -208,12 +207,7 @@ const Page: React.FC<IPageProps> = (props) => {
             ) : (
               <NavTree navLinks={navLinks as INavTreeItem[]} regionName={navRegionName} />
             )}
-            <div
-              aria-label={mainRegionName}
-              css={content(shouldShowEditorError)}
-              data-testid="PageContent"
-              role="region"
-            >
+            <div aria-label={mainRegionName} css={content} data-testid="PageContent" role="region">
               <div css={contentStyle}>{children}</div>
               {shouldShowEditorError && <DebugPanel />}
             </div>

--- a/Composer/packages/client/src/pages/botProject/DeleteBotButton.tsx
+++ b/Composer/packages/client/src/pages/botProject/DeleteBotButton.tsx
@@ -7,7 +7,7 @@ import { jsx, css } from '@emotion/core';
 import { useRecoilValue } from 'recoil';
 import formatMessage from 'format-message';
 import { FontIcon } from 'office-ui-fabric-react/lib/Icon';
-import { Button } from 'office-ui-fabric-react/lib/Button';
+import { PrimaryButton } from 'office-ui-fabric-react/lib/Button';
 import { Text } from 'office-ui-fabric-react/lib/Text';
 import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
 import { NeutralColors, SharedColors } from '@uifabric/fluent-theme';
@@ -17,10 +17,6 @@ import { navigateTo } from '../../utils/navigation';
 import { dispatcherState } from '../../recoilModel';
 
 // -------------------- Styles -------------------- //
-
-const marginBottom = css`
-  margin-bottom: 140px;
-`;
 
 const deleteBotText = css`
   font-weight: ${FontWeights.semibold};
@@ -118,11 +114,11 @@ export const DeleteBotButton: React.FC<DeleteBotButtonProps> = (props) => {
   };
 
   return (
-    <div css={marginBottom}>
-      <div css={deleteBotText}> {formatMessage('Delete this bot')}</div>
-      <Button styles={deleteBotButton} onClick={openDeleteBotModal}>
+    <React.Fragment>
+      <div css={deleteBotText}>{formatMessage('Delete this bot')}</div>
+      <PrimaryButton styles={deleteBotButton} onClick={openDeleteBotModal}>
         {formatMessage('Delete')}
-      </Button>
-    </div>
+      </PrimaryButton>
+    </React.Fragment>
   );
 };

--- a/Composer/packages/client/src/pages/knowledge-base/QnAPage.tsx
+++ b/Composer/packages/client/src/pages/knowledge-base/QnAPage.tsx
@@ -74,6 +74,7 @@ const QnAPage: React.FC<RouteComponentProps<{
 
   return (
     <Page
+      shouldShowEditorError
       useNewTree
       data-testid="QnAPage"
       dialogId={dialogId}

--- a/Composer/packages/client/src/pages/language-generation/LGPage.tsx
+++ b/Composer/packages/client/src/pages/language-generation/LGPage.tsx
@@ -60,6 +60,7 @@ const LGPage: React.FC<RouteComponentProps<{
 
   return (
     <Page
+      shouldShowEditorError
       showCommonLinks
       useNewTree
       data-testid="LGPage"

--- a/Composer/packages/client/src/pages/language-understanding/LUPage.tsx
+++ b/Composer/packages/client/src/pages/language-understanding/LUPage.tsx
@@ -57,6 +57,7 @@ const LUPage: React.FC<RouteComponentProps<{
 
   return (
     <Page
+      shouldShowEditorError
       useNewTree
       data-testid="LUPage"
       dialogId={dialogId}


### PR DESCRIPTION
## Description

This rearranges and simplifies some things so the debug panel doesn't show up halfway down (or at all on) the settings pages.

## Task Item

fixes #5902

## Screenshots

![image](https://user-images.githubusercontent.com/61990921/108912252-3c033f00-75dd-11eb-8c43-ac38d0afabe1.png)

