### PR TITLE
fix: Pass updated MSAppID and MsPass on restart

### DIFF
--- a/Composer/packages/client/src/components/WebChat/WebChatPanel.tsx
+++ b/Composer/packages/client/src/components/WebChat/WebChatPanel.tsx
@@ -132,7 +132,8 @@ export const WebChatPanel: React.FC<WebChatPanelProps> = ({
       const chatData = await conversationService.restartConversation(
         chats[oldConversationId],
         requireNewUserId,
-        activeLocale
+        activeLocale,
+        secrets
       );
       setConversationData(chatData);
       sendInitialActivities(chatData);

--- a/Composer/packages/client/src/components/WebChat/utils/conversationService.ts
+++ b/Composer/packages/client/src/components/WebChat/utils/conversationService.ts
@@ -92,7 +92,8 @@ export class ConversationService {
     oldConversationId: string,
     newConversationId: string,
     userId: string,
-    activeLocale: string
+    activeLocale: string,
+    secrets: BotSecrets
   ) {
     const url = `${this.directlineHostUrl}/conversations/${oldConversationId}/updateConversation`;
     return axios.put(
@@ -101,6 +102,8 @@ export class ConversationService {
         conversationId: newConversationId,
         userId,
         locale: activeLocale,
+        msaAppId: secrets.msAppId,
+        msaPassword: secrets.msPassword,
       },
       {
         headers: {
@@ -195,7 +198,12 @@ export class ConversationService {
     };
   }
 
-  public async restartConversation(oldChatData: ChatData, requireNewUserID: boolean, activeLocale: string) {
+  public async restartConversation(
+    oldChatData: ChatData,
+    requireNewUserID: boolean,
+    activeLocale: string,
+    secrets: BotSecrets
+  ) {
     if (oldChatData.directline) {
       oldChatData.directline.end();
     }
@@ -207,7 +215,13 @@ export class ConversationService {
       user = this.getUser();
     }
 
-    const resp = await this.conversationUpdate(oldChatData.conversationId, conversationId, user.id, activeLocale);
+    const resp = await this.conversationUpdate(
+      oldChatData.conversationId,
+      conversationId,
+      user.id,
+      activeLocale,
+      secrets
+    );
     const { endpointId } = resp.data;
     const directline = await this.fetchDirectLineObject(conversationId, {
       mode: oldChatData.webChatMode,

--- a/Composer/packages/server/src/directline/middleware/__tests__/conversationHandler.test.ts
+++ b/Composer/packages/server/src/directline/middleware/__tests__/conversationHandler.test.ts
@@ -241,6 +241,7 @@ describe('updateConversation handler', () => {
       body: {
         conversationId: 'conversation-new',
         userId: 'user-new',
+        locale: 'en-us',
       },
     };
 

--- a/Composer/packages/server/src/directline/middleware/__tests__/conversationHandler.test.ts
+++ b/Composer/packages/server/src/directline/middleware/__tests__/conversationHandler.test.ts
@@ -241,7 +241,6 @@ describe('updateConversation handler', () => {
       body: {
         conversationId: 'conversation-new',
         userId: 'user-new',
-        locale: 'en-us',
       },
     };
 

--- a/Composer/packages/server/src/directline/middleware/conversationHandler.ts
+++ b/Composer/packages/server/src/directline/middleware/conversationHandler.ts
@@ -91,7 +91,6 @@ export const createUpdateConversationHandler = (state: DLServerState) => {
       currentConversation.updateConversationId(conversationId);
       currentConversation.updateSecrets(msaAppId, msaPassword);
       currentConversation.updateUser(userId);
-      console.log('LOC', locale);
       currentConversation.updateLocale(locale);
 
       const user: User | undefined = currentConversation.members.find((member) => member.name === 'User');

--- a/Composer/packages/server/src/directline/middleware/conversationHandler.ts
+++ b/Composer/packages/server/src/directline/middleware/conversationHandler.ts
@@ -79,7 +79,7 @@ export const createUpdateConversationHandler = (state: DLServerState) => {
   return (req: express.Request, res: express.Response): void => {
     const oldConversationId = req.params.conversationId;
     try {
-      const { conversationId, userId, locale } = req.body;
+      const { conversationId, userId, locale, msaPassword, msaAppId } = req.body;
       const currentConversation = state.conversations.conversationById(oldConversationId);
       if (!oldConversationId || !currentConversation) {
         res.status(StatusCodes.NOT_FOUND).send(formatMessage('Conversation ID cannot be updated.'));
@@ -87,11 +87,12 @@ export const createUpdateConversationHandler = (state: DLServerState) => {
       // update the conversation object and reset as much as we can to resemble a new conversation
       state.conversations.deleteConversation(oldConversationId);
 
-      currentConversation.conversationId = conversationId;
-      currentConversation.user.id = userId;
-      if (locale && currentConversation.locale !== locale) {
-        currentConversation.locale = locale;
-      }
+      // Update conversation object with new data supplied from Composer
+      currentConversation.updateConversationId(conversationId);
+      currentConversation.updateSecrets(msaAppId, msaPassword);
+      currentConversation.updateUser(userId);
+      console.log('LOC', locale);
+      currentConversation.updateLocale(locale);
 
       const user: User | undefined = currentConversation.members.find((member) => member.name === 'User');
       if (!user) {
@@ -106,6 +107,7 @@ export const createUpdateConversationHandler = (state: DLServerState) => {
 
       currentConversation.clearConversation();
       currentConversation.nextWatermark = 0;
+
       state.dispatchers.updateConversation(conversationId, currentConversation);
 
       res.status(StatusCodes.CREATED).json({

--- a/Composer/packages/server/src/directline/store/entities/botEndpoint.ts
+++ b/Composer/packages/server/src/directline/store/entities/botEndpoint.ts
@@ -72,7 +72,7 @@ export class BotEndpoint {
   }
 
   public async fetchWithAuth(url: string, reqOptions: { body: any; headers: any }, forceRefresh = false): Promise<any> {
-    if (this.msaAppId) {
+    if (this.msaAppId || this.msaPassword) {
       reqOptions.headers = {
         ...reqOptions.headers,
         Authorization: `Bearer ${await this.getAccessToken(forceRefresh)}`,

--- a/Composer/packages/server/src/directline/store/entities/conversation.ts
+++ b/Composer/packages/server/src/directline/store/entities/conversation.ts
@@ -190,4 +190,21 @@ export class Conversation {
     }
     return activities;
   }
+
+  public updateConversationId(conversationId: string) {
+    this.conversationId = conversationId;
+  }
+
+  public updateSecrets(msaAppId: string, msaPassword: string) {
+    this.botEndpoint.msaAppId = msaAppId;
+    this.botEndpoint.msaPassword = msaPassword;
+  }
+
+  public updateLocale(activeLocal: string) {
+    this.locale = activeLocal;
+  }
+
+  public updateUser(userId: string) {
+    this.user.id = userId;
+  }
 }

--- a/Composer/packages/server/src/directline/store/entities/conversation.ts
+++ b/Composer/packages/server/src/directline/store/entities/conversation.ts
@@ -201,7 +201,9 @@ export class Conversation {
   }
 
   public updateLocale(activeLocal: string) {
-    this.locale = activeLocal;
+    if (this.locale !== activeLocal) {
+      this.locale = activeLocal;
+    }
   }
 
   public updateUser(userId: string) {

--- a/Composer/packages/server/src/directline/store/entities/conversation.ts
+++ b/Composer/packages/server/src/directline/store/entities/conversation.ts
@@ -201,9 +201,7 @@ export class Conversation {
   }
 
   public updateLocale(activeLocal: string) {
-    if (this.locale !== activeLocal) {
-      this.locale = activeLocal;
-    }
+    this.locale = activeLocal;
   }
 
   public updateUser(userId: string) {


### PR DESCRIPTION
## Description
This PR fixes a bug in which secrets are not passed to update conversation handler that happens during restart conversation.

Fixes #minor