### PR TITLE
fix: Update to latest generator to fix #5975

### DIFF
--- a/Composer/packages/server/package.json
+++ b/Composer/packages/server/package.json
@@ -78,7 +78,7 @@
     "@botframework-composer/types": "*",
     "@microsoft/bf-dialog": "4.11.0-dev.20201025.69cf2b9",
     "@microsoft/bf-dispatcher": "^4.11.0-beta.20201016.393c6b2",
-    "@microsoft/bf-generate-library": "^4.10.0-daily.20210222.216348",
+    "@microsoft/bf-generate-library": "^4.10.0-daily.20210225.217555",
     "@microsoft/bf-lu": "4.12.0-rc0",
     "@microsoft/bf-orchestrator": "4.12.0-beta.20210218.668cdac",
     "applicationinsights": "^1.8.7",

--- a/Composer/yarn.lock
+++ b/Composer/yarn.lock
@@ -3937,10 +3937,10 @@
     ts-md5 "^1.2.6"
     tslib "^1.10.0"
 
-"@microsoft/bf-generate-library@^4.10.0-daily.20210222.216348":
-  version "4.10.0-daily.20210222.216348"
-  resolved "https://botbuilder.myget.org/F/botframework-cli/npm/@microsoft/bf-generate-library/-/@microsoft/bf-generate-library-4.10.0-daily.20210222.216348.tgz#22d78d17c592955853fc81c84932118f34d09c92"
-  integrity sha1-IteNF8WSlVhT/IHISTIRjzTQnJI=
+"@microsoft/bf-generate-library@^4.10.0-daily.20210225.217555":
+  version "4.10.0-daily.20210225.217555"
+  resolved "https://botbuilder.myget.org/F/botframework-cli/npm/@microsoft/bf-generate-library/-/@microsoft/bf-generate-library-4.10.0-daily.20210225.217555.tgz#aaddb2021bc04997a508fc40e38acca02156e7e2"
+  integrity sha1-qt2yAhvASZelCPxA44rMoCFW5+I=
   dependencies:
     "@microsoft/bf-lu" rc
     adaptive-expressions "4.11.1"


### PR DESCRIPTION
## Description
Fixes #5975

Underlying issue was caused by cached templates not being returned because of a missing break.  They are missed only on production composer because of the order of directories passed in. Fix is to update to the latest version of bf-generate-library to pick up the fix.

