### PR TITLE
fix: small bug fixes in the ui for package manager

### DIFF
--- a/extensions/packageManager/src/components/FeedModal.tsx
+++ b/extensions/packageManager/src/components/FeedModal.tsx
@@ -38,7 +38,6 @@ const DisplayField: React.FC<DisplayFieldProps> = (props) => {
 
 export interface WorkingModalProps {
   hidden: boolean;
-  title: string;
   feeds: PackageSourceFeed[];
   closeDialog: any;
   onUpdateFeed: any;

--- a/extensions/packageManager/src/components/FeedModal.tsx
+++ b/extensions/packageManager/src/components/FeedModal.tsx
@@ -18,12 +18,11 @@ import {
 } from 'office-ui-fabric-react';
 import { useState, useEffect, Fragment } from 'react';
 import { useApplicationApi } from '@bfc/extension-client';
-
 import { DialogWrapper, DialogTypes } from '@bfc/ui-shared';
 import formatMessage from 'format-message';
 import { v4 as uuid } from 'uuid';
 
-import { PackageSourceFeed } from './Library';
+import { PackageSourceFeed } from '../pages/Library';
 
 interface DisplayFieldProps {
   text: string;
@@ -83,14 +82,14 @@ export const FeedModal: React.FC<WorkingModalProps> = (props) => {
       isResizable: false,
       onRender: (item: PackageSourceFeed) => {
         if (!selectedItem || item.key !== selectedItem.key || !editRow)
-          return <DisplayField text={item.text} readonly={item.readonly} />;
+          return <DisplayField readonly={item.readonly} text={item.text} />;
         return (
           <TextField
-            placeholder={formatMessage('Feed Name')}
-            value={selectedItem?.text}
             disabled={!selectedItem || selectedItem.readonly}
-            onChange={updateSelected('text')}
+            placeholder={formatMessage('Feed Name')}
             styles={{ field: { fontSize: 12 } }}
+            value={selectedItem?.text}
+            onChange={updateSelected('text')}
           />
         );
       },
@@ -106,11 +105,11 @@ export const FeedModal: React.FC<WorkingModalProps> = (props) => {
         if (!selectedItem || item.key !== selectedItem.key || !editRow) return <DisplayField text={item.url} />;
         return (
           <TextField
-            placeholder={formatMessage('URL')}
-            value={selectedItem ? selectedItem.url : ''}
             disabled={!selectedItem || selectedItem.readonly}
-            onChange={updateSelected('url')}
+            placeholder={formatMessage('URL')}
             styles={{ field: { fontSize: 12 } }}
+            value={selectedItem ? selectedItem.url : ''}
+            onChange={updateSelected('url')}
           />
         );
       },
@@ -125,14 +124,14 @@ export const FeedModal: React.FC<WorkingModalProps> = (props) => {
           return (
             <Fragment>
               <IconButton
+                disabled={!selectedItem || selectedItem.readonly}
                 iconProps={{ iconName: 'Edit' }}
                 onClick={() => setEditRow(true)}
-                disabled={!selectedItem || selectedItem.readonly}
               />
               <IconButton
+                disabled={!selectedItem || selectedItem.readonly}
                 iconProps={{ iconName: 'Delete' }}
                 onClick={removeSelected}
-                disabled={!selectedItem || selectedItem.readonly}
               />
             </Fragment>
           );
@@ -140,12 +139,12 @@ export const FeedModal: React.FC<WorkingModalProps> = (props) => {
         if (selectedItem && item.key === selectedItem.key && editRow)
           return (
             <IconButton
+              disabled={!selectedItem || !selectedItem.text || !selectedItem.url || selectedItem.readonly}
               iconProps={{ iconName: 'Checkmark' }}
               onClick={() => {
                 setEditRow(false);
                 props.onUpdateFeed(selectedItem.key, selectedItem);
               }}
-              disabled={!selectedItem || !selectedItem.text || !selectedItem.url || selectedItem.readonly}
             />
           );
       },
@@ -183,8 +182,6 @@ export const FeedModal: React.FC<WorkingModalProps> = (props) => {
     setSelection(selection);
 
     setEditRow(true);
-
-
   };
 
   const removeSelected = async () => {
@@ -199,35 +196,50 @@ export const FeedModal: React.FC<WorkingModalProps> = (props) => {
     }
   };
 
+  const closeDialog = () => {
+    if (editRow) {
+      confirm(
+        formatMessage('Discard changes?'),
+        formatMessage('You have unsaved changes. Are you sure you want to close this window?')
+      ).then((confirmed) => {
+        if (confirmed) {
+          props.closeDialog();
+        }
+      });
+    } else {
+      props.closeDialog();
+    }
+  };
+
   return (
     <DialogWrapper
-      isOpen={!props.hidden}
       dialogType={DialogTypes.Customer}
+      isOpen={!props.hidden}
       minWidth={900}
-      title={uitext.title}
       subText={uitext.subTitle}
+      title={uitext.title}
       onDismiss={props.closeDialog}
     >
-      <div style={{ minHeight: '300px', maxHeight: '400px', overflow: 'auto' }} data-is-scrollable="true">
+      <div data-is-scrollable="true" style={{ minHeight: '300px', maxHeight: '400px', overflow: 'auto' }}>
         <DetailsList
-          items={items}
-          columns={columns}
-          setKey="set"
-          selectionMode={SelectionMode.single}
-          layoutMode={DetailsListLayoutMode.justified}
-          checkboxVisibility={CheckboxVisibility.hidden}
-          selection={selection}
-          selectionPreservedOnEmptyClick={true}
-          ariaLabelForSelectionColumn={formatMessage('Toggle selection')}
+          selectionPreservedOnEmptyClick
           ariaLabelForSelectAllCheckbox={formatMessage('Toggle selection for all items')}
+          ariaLabelForSelectionColumn={formatMessage('Toggle selection')}
+          checkboxVisibility={CheckboxVisibility.hidden}
           checkButtonAriaLabel={formatMessage('Row checkbox')}
+          columns={columns}
+          items={items}
+          layoutMode={DetailsListLayoutMode.justified}
+          selection={selection}
+          selectionMode={SelectionMode.single}
+          setKey="set"
         />
       </div>
       <ActionButton iconProps={{ iconName: 'Add' }} onClick={addItem}>
         {formatMessage('Add a new feed')}
       </ActionButton>
       <DialogFooter>
-        <PrimaryButton onClick={props.closeDialog}>{formatMessage('Done')}</PrimaryButton>
+        <PrimaryButton onClick={closeDialog}>{formatMessage('Done')}</PrimaryButton>
       </DialogFooter>
     </DialogWrapper>
   );

--- a/extensions/packageManager/src/components/WorkingModal.tsx
+++ b/extensions/packageManager/src/components/WorkingModal.tsx
@@ -17,7 +17,6 @@ export const WorkingModal: React.FC<WorkingModalProps> = (props) => {
     <Dialog
       dialogContentProps={{
         type: DialogType.normal,
-        title: props.title,
       }}
       hidden={props.hidden}
       modalProps={{
@@ -25,7 +24,7 @@ export const WorkingModal: React.FC<WorkingModalProps> = (props) => {
       }}
     >
       <div css={modalControlGroup}>
-        <LoadingSpinner />
+        <LoadingSpinner message={props.title} />
       </div>
     </Dialog>
   );

--- a/extensions/packageManager/src/pages/Library.tsx
+++ b/extensions/packageManager/src/pages/Library.tsx
@@ -64,7 +64,7 @@ const Library: React.FC = () => {
   const [selectedItemVersions, setSelectedItemVersions] = useState<string[]>([]);
   const [selectedVersion, setSelectedVersion] = useState<string>('');
   const [currentProjectId, setCurrentProjectId] = useState<string>(projectId);
-  const [working, setWorking] = useState(false);
+  const [working, setWorking] = useState<string>('');
   const [addDialogHidden, setAddDialogHidden] = useState(true);
   const [isModalVisible, setModalVisible] = useState<boolean>(false);
   const [readmeContent, setReadmeContent] = useState<string>('');
@@ -88,6 +88,7 @@ const Library: React.FC = () => {
     installed: formatMessage('installed'),
     importDialogTitle: formatMessage('Install a Package'),
     installProgress: formatMessage('Installing package...'),
+    uninstallProgress: formatMessage('Removing package...'),
     recentlyUsedCategory: formatMessage('Recently Used'),
     installedCategory: formatMessage('Installed'),
     updateConfirmationPrompt: formatMessage(
@@ -358,9 +359,9 @@ const Library: React.FC = () => {
 
     if (okToProceed) {
       closeDialog();
-      setWorking(true);
+      setWorking(strings.installProgress);
       await importComponent(packageName, version, isUpdating || false, source);
-      setWorking(false);
+      setWorking('');
     }
   };
 
@@ -376,7 +377,7 @@ const Library: React.FC = () => {
           await installComponentAPI(currentProjectId, packageName, version, true, source);
         }
       } else {
-        setWorking(false);
+        setWorking('');
 
         updateInstalledComponents(results.data.components);
 
@@ -466,7 +467,7 @@ const Library: React.FC = () => {
       const okToProceed = await confirm(title, msg);
       if (okToProceed) {
         closeDialog();
-        setWorking(true);
+        setWorking(strings.uninstallProgress);
         try {
           const results = await uninstallComponentAPI(currentProjectId, selectedItem.name);
 
@@ -485,7 +486,7 @@ const Library: React.FC = () => {
             summary: strings.importError,
           });
         }
-        setWorking(false);
+        setWorking('');
       }
     }
   };
@@ -535,12 +536,11 @@ const Library: React.FC = () => {
       >
         <ImportDialog closeDialog={closeDialog} doImport={importFromWeb} />
       </Dialog>
-      <WorkingModal hidden={!working} title={strings.installProgress} />
+      <WorkingModal hidden={working === ''} title={working} />
       <FeedModal
         closeDialog={() => setModalVisible(false)}
         feeds={feeds}
         hidden={!isModalVisible}
-        title={strings.installProgress}
         onUpdateFeed={updateFeed}
       />
       <Toolbar toolbarItems={toolbarItems} />

--- a/extensions/packageManager/src/pages/Library.tsx
+++ b/extensions/packageManager/src/pages/Library.tsx
@@ -176,6 +176,10 @@ const Library: React.FC = () => {
   }, []);
 
   useEffect(() => {
+    getInstalledLibraries();
+  }, [currentProjectId]);
+
+  useEffect(() => {
     if (!feed && feeds.length) {
       if (runtimeLanguage === 'js') {
         setFeed('npm');
@@ -195,7 +199,6 @@ const Library: React.FC = () => {
     const settings = projectCollection.find((b) => b.projectId === currentProjectId).setting;
     if (settings?.runtime && settings.runtime.customRuntime === true && settings.runtime.path) {
       setEjectedRuntime(true);
-      getInstalledLibraries();
       // detect programming language.
       // should one day be a dynamic property of the runtime or at least stored in the settings?
       if (settings.runtime.key === 'node-azurewebapp') {
@@ -373,6 +376,8 @@ const Library: React.FC = () => {
           await installComponentAPI(currentProjectId, packageName, version, true, source);
         }
       } else {
+        setWorking(false);
+
         updateInstalledComponents(results.data.components);
 
         // reload modified content


### PR DESCRIPTION
## Description

1) improve performance and reduce calls to the "get installed" api, which was causing the UI to flicker and be slow.  
2) ask user to double confirm close of edit feeds modal if they are mid-edit
3) update the text and handling of the installing/uninstalling progress indicator


## Task Item

fixes #5933 
fixes #5934 
fixes #5943 

## Screenshots

![u7O59GTAEj](https://user-images.githubusercontent.com/729873/109227975-cc30b800-7786-11eb-81f3-384a1acc8274.gif)
