### PR TITLE
feat: Support unread notification marker on Webchat inspector

### DIFF
--- a/Composer/packages/client/src/pages/design/DebugPanel/TabExtensions/DiagnosticsTab/DiagnosticsTabHeader.tsx
+++ b/Composer/packages/client/src/pages/design/DebugPanel/TabExtensions/DiagnosticsTab/DiagnosticsTabHeader.tsx
@@ -28,7 +28,6 @@ export const DiagnosticsHeader = () => {
       >
         {formatMessage('Problems')}
       </div>
-      <DebugPanelErrorIndicator hasError={hasError} hasWarning={hasWarning} />
     </div>
   );
 };

--- a/Composer/packages/client/src/pages/design/DebugPanel/TabExtensions/DiagnosticsTab/DiagnosticsTabHeader.tsx
+++ b/Composer/packages/client/src/pages/design/DebugPanel/TabExtensions/DiagnosticsTab/DiagnosticsTabHeader.tsx
@@ -5,8 +5,6 @@
 import { jsx, css } from '@emotion/core';
 import formatMessage from 'format-message';
 
-import { DebugPanelErrorIndicator } from '../DebugPanelErrorIndicator';
-
 import { useDiagnosticsStatistics } from './useDiagnostics';
 
 export const DiagnosticsHeader = () => {

--- a/Composer/packages/client/src/pages/design/DebugPanel/TabExtensions/WebchatLog/WebchatLogItemHeader.tsx
+++ b/Composer/packages/client/src/pages/design/DebugPanel/TabExtensions/WebchatLog/WebchatLogItemHeader.tsx
@@ -10,25 +10,26 @@ import isEqual from 'lodash/isEqual';
 
 import { rootBotProjectIdSelector, webChatLogsState } from '../../../../../recoilModel';
 import { DebugPanelErrorIndicator } from '../DebugPanelErrorIndicator';
+import { DebugPanelTabHeaderProps } from '../types';
 
-export const WebChatLogItemHeader = (props: { isActive: boolean }) => {
-  const { isActive } = props;
+export const WebChatLogItemHeader: React.FC<DebugPanelTabHeaderProps> = ({ isActive }) => {
   const rootBotId = useRecoilValue(rootBotProjectIdSelector);
   const logItems = useRecoilValue(webChatLogsState(rootBotId ?? ''));
-  const [unreadMessageIndicatorVisible, showUnreadMessageIndicator] = useState(false);
-  const [currentLogItems, setCurrentLocalItems] = useState<string[]>([]);
+
+  const [hasUnreadLog, setHasUnreadLog] = useState(false);
+  const [lastReadLogIds, setLastReadLogIds] = useState<string[]>([]);
 
   useEffect(() => {
     if (isActive || !logItems.length) {
-      showUnreadMessageIndicator(false);
+      setHasUnreadLog(false);
       return;
     }
 
-    const newItems = logItems.map((item) => item.timestamp);
-    if (!isEqual(newItems, currentLogItems)) {
-      setCurrentLocalItems(newItems);
+    const newLogIds = logItems.map((item) => item.timestamp);
+    if (!isEqual(newLogIds, lastReadLogIds)) {
+      setLastReadLogIds(newLogIds);
       if (!isActive) {
-        showUnreadMessageIndicator(true);
+        setHasUnreadLog(true);
       }
     }
   }, [logItems, isActive]);
@@ -49,7 +50,7 @@ export const WebChatLogItemHeader = (props: { isActive: boolean }) => {
       >
         {formatMessage('Webchat Inspector')}
       </div>
-      <DebugPanelErrorIndicator hasError={unreadMessageIndicatorVisible} />
+      <DebugPanelErrorIndicator hasError={hasUnreadLog} />
     </div>
   );
 };

--- a/Composer/packages/client/src/pages/design/DebugPanel/TabExtensions/WebchatLog/WebchatLogItemHeader.tsx
+++ b/Composer/packages/client/src/pages/design/DebugPanel/TabExtensions/WebchatLog/WebchatLogItemHeader.tsx
@@ -19,11 +19,11 @@ export const WebChatLogItemHeader = (props: { isActive: boolean }) => {
   const [currentLogItems, setCurrentLocalItems] = useState<string[]>([]);
 
   useEffect(() => {
-    console.log('CurrentItems', currentLogItems);
-    console.log('isactive', isActive);
-    if (isActive) {
+    if (isActive || !logItems.length) {
       showUnreadMessageIndicator(false);
+      return;
     }
+
     const newItems = logItems.map((item) => item.timestamp);
     if (!isEqual(newItems, currentLogItems)) {
       setCurrentLocalItems(newItems);
@@ -31,10 +31,6 @@ export const WebChatLogItemHeader = (props: { isActive: boolean }) => {
         showUnreadMessageIndicator(true);
       }
     }
-
-    return () => {
-      console.log('Destroyed');
-    };
   }, [logItems, isActive]);
 
   return (

--- a/Composer/packages/client/src/pages/design/DebugPanel/TabExtensions/WebchatLog/WebchatLogItemHeader.tsx
+++ b/Composer/packages/client/src/pages/design/DebugPanel/TabExtensions/WebchatLog/WebchatLogItemHeader.tsx
@@ -4,14 +4,38 @@
 /** @jsx jsx */
 import { jsx, css } from '@emotion/core';
 import formatMessage from 'format-message';
+import { useEffect, useState } from 'react';
 import { useRecoilValue } from 'recoil';
+import isEqual from 'lodash/isEqual';
 
 import { rootBotProjectIdSelector, webChatLogsState } from '../../../../../recoilModel';
 import { DebugPanelErrorIndicator } from '../DebugPanelErrorIndicator';
 
-export const WebchatLogItemHeader = () => {
+export const WebChatLogItemHeader = (props: { isActive: boolean }) => {
+  const { isActive } = props;
   const rootBotId = useRecoilValue(rootBotProjectIdSelector);
   const logItems = useRecoilValue(webChatLogsState(rootBotId ?? ''));
+  const [unreadMessageIndicatorVisible, showUnreadMessageIndicator] = useState(false);
+  const [currentLogItems, setCurrentLocalItems] = useState<string[]>([]);
+
+  useEffect(() => {
+    console.log('CurrentItems', currentLogItems);
+    console.log('isactive', isActive);
+    if (isActive) {
+      showUnreadMessageIndicator(false);
+    }
+    const newItems = logItems.map((item) => item.timestamp);
+    if (!isEqual(newItems, currentLogItems)) {
+      setCurrentLocalItems(newItems);
+      if (!isActive) {
+        showUnreadMessageIndicator(true);
+      }
+    }
+
+    return () => {
+      console.log('Destroyed');
+    };
+  }, [logItems, isActive]);
 
   return (
     <div
@@ -29,7 +53,7 @@ export const WebchatLogItemHeader = () => {
       >
         {formatMessage('Webchat Inspector')}
       </div>
-      <DebugPanelErrorIndicator hasError={logItems.length > 0} />
+      <DebugPanelErrorIndicator hasError={unreadMessageIndicatorVisible} />
     </div>
   );
 };

--- a/Composer/packages/client/src/pages/design/DebugPanel/TabExtensions/WebchatLog/index.ts
+++ b/Composer/packages/client/src/pages/design/DebugPanel/TabExtensions/WebchatLog/index.ts
@@ -6,11 +6,11 @@ import formatMessage from 'format-message';
 import { TabExtensionConfig, WebChatInspectorTabKey } from '../types';
 
 import { WebchatLogContent } from './WebchatLogContent';
-import { WebchatLogItemHeader } from './WebchatLogItemHeader';
+import { WebChatLogItemHeader } from './WebchatLogItemHeader';
 
 export const WebchatLogTabConfig: TabExtensionConfig = {
   key: WebChatInspectorTabKey,
   description: formatMessage('Webchat log.'),
-  HeaderWidget: WebchatLogItemHeader,
+  HeaderWidget: WebChatLogItemHeader,
   ContentWidget: WebchatLogContent,
 };

--- a/Composer/packages/client/src/pages/design/DebugPanel/TabExtensions/types.ts
+++ b/Composer/packages/client/src/pages/design/DebugPanel/TabExtensions/types.ts
@@ -8,6 +8,15 @@ export const WebChatInspectorTabKey = 'WebChatInspector';
 
 export type DebugDrawerKeys = typeof DiagnosticsTabKey | typeof WebChatInspectorTabKey;
 
+export type DebugPanelTabHeaderProps = {
+  isActive: boolean;
+};
+
+export type DebugPanelProps = {
+  expanded: boolean;
+  onToggleExpansion: (expanded: boolean) => void;
+};
+
 export interface TabExtensionConfig {
   /** Unique name of this extension. */
   key: DebugDrawerKeys;
@@ -16,7 +25,7 @@ export interface TabExtensionConfig {
   description?: string;
 
   /** Tab header component. If it's typed with string, shows a plain text as the tab header. */
-  HeaderWidget: FC | string;
+  HeaderWidget: FC<DebugPanelTabHeaderProps>;
 
   /** Tab content component used when debug panel is expanded. */
   ContentWidget: FC;

--- a/Composer/packages/client/src/pages/design/DebugPanel/TabExtensions/types.ts
+++ b/Composer/packages/client/src/pages/design/DebugPanel/TabExtensions/types.ts
@@ -25,7 +25,7 @@ export interface TabExtensionConfig {
   description?: string;
 
   /** Tab header component. If it's typed with string, shows a plain text as the tab header. */
-  HeaderWidget: FC<DebugPanelTabHeaderProps>;
+  HeaderWidget: FC<DebugPanelTabHeaderProps> | string;
 
   /** Tab content component used when debug panel is expanded. */
   ContentWidget: FC;

--- a/Composer/packages/client/src/pages/design/DebugPanel/styles.ts
+++ b/Composer/packages/client/src/pages/design/DebugPanel/styles.ts
@@ -7,7 +7,7 @@ export const DebugPaneHeaderHeight = 36;
 
 export const DebugPaneFooterHeight = 24;
 
-export const debugPaneContainerExpandedStyle = css`
+export const debugPaneContainerStyle = css`
   display: flex;
   flex-direction: column;
 `;
@@ -22,7 +22,7 @@ export const debugPaneContentStyle = css`
   overflow-x: auto;
 `;
 
-export const statusBarStyle = css`
+export const debugPaneFooterStyle = css`
   height: ${DebugPaneFooterHeight}px;
   border-top: 1px solid #dfdfdf;
 `;

--- a/Composer/packages/client/src/recoilModel/atoms/appState.ts
+++ b/Composer/packages/client/src/recoilModel/atoms/appState.ts
@@ -315,9 +315,9 @@ export const debugPanelExpansionState = atom<boolean>({
   default: false,
 });
 
-export const debugPanelActiveTabState = atom<DebugDrawerKeys>({
+export const debugPanelActiveTabState = atom<DebugDrawerKeys | undefined>({
   key: getFullyQualifiedKey('degbugPanelActiveTab'),
-  default: 'Diagnostics',
+  default: undefined,
 });
 
 export const selectedTemplateReadMeState = atom<string>({


### PR DESCRIPTION
## Description
This PR adds a red indicator to the webchat inspector if its not the current tab and new errors have happened. It also removes the unread indicator from the Problems tab.

![debugpanel-unread](https://user-images.githubusercontent.com/13004779/109230516-dbf5cf80-7779-11eb-8e55-1ab81d6fdd5b.gif)


## Task Item
refs #5918 
