### PR TITLE
feature: put link to documentation in modal

### DIFF
--- a/Composer/package.json
+++ b/Composer/package.json
@@ -49,6 +49,7 @@
     "build:client": "yarn workspace @bfc/client build",
     "build:extensions": "cd ../extensions && yarn && yarn build:all",
     "start": "cross-env NODE_ENV=production PORT=3000 yarn start:server",
+    "start:debug": "cross-env NODE_ENV=production PORT=3000 DEBUG=* yarn start:server",
     "startall": "yarn start",
     "start:dev": "concurrently  \"npm:start:client\" \"npm:start:server:dev\"",
     "start:dev:electron": "concurrently  \"npm:start:client\" \"npm:start:electron\"",

--- a/Composer/packages/client/__tests__/pages/botProjectsSettings/AdapterSettings.test.tsx
+++ b/Composer/packages/client/__tests__/pages/botProjectsSettings/AdapterSettings.test.tsx
@@ -72,6 +72,17 @@ describe('ExternalAdapterSettings', () => {
     setSettingsMock.mockClear();
   });
 
+  it('renders a link to the package manager', () => {
+    const { getByText } = renderWithRecoilAndCustomDispatchers(
+      <ExternalAdapterSettings projectId={PROJECT_ID} />,
+      initRecoilState
+    );
+
+    const link = getByText('Package Settings');
+
+    expect(link.attributes.getNamedItem('href')?.value).toEqual('plugin/package-manager/package-manager');
+  });
+
   it('brings up the modal', () => {
     const { getByTestId, getByText, queryByTestId } = renderWithRecoilAndCustomDispatchers(
       <ExternalAdapterSettings projectId={PROJECT_ID} />,

--- a/Composer/packages/client/src/pages/botProject/adapters/ExternalAdapterModal.tsx
+++ b/Composer/packages/client/src/pages/botProject/adapters/ExternalAdapterModal.tsx
@@ -4,7 +4,9 @@
 import React, { useState, useMemo } from 'react';
 import formatMessage from 'format-message';
 import { DialogFooter } from 'office-ui-fabric-react/lib/Dialog';
+import { Text } from 'office-ui-fabric-react/lib/Text';
 import { PrimaryButton, DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { Link } from 'office-ui-fabric-react/lib/Link';
 import { DialogWrapper, DialogTypes } from '@bfc/ui-shared';
 import { ObjectField } from '@bfc/adaptive-form';
 import { useRecoilValue } from 'recoil';
@@ -28,10 +30,11 @@ type Props = {
   adapterKey: string;
   packageName: string;
   isOpen: boolean;
+  isFirstTime: boolean; // true if the user clicked Configure to get here, false if it's from the Edit menu
   onClose: () => void;
   projectId: string;
   schema: JSONSchema7;
-  uiSchema: JSONSchema7;
+  uiSchema: JSONSchema7 & { helpLink?: string };
   value?: { [key: string]: ConfigValue };
 };
 
@@ -41,7 +44,7 @@ export function hasRequired(testObject: { [key: string]: ConfigValue }, fields?:
 }
 
 const AdapterModal = (props: Props) => {
-  const { isOpen, onClose, schema, uiSchema, projectId, adapterKey, packageName } = props;
+  const { isOpen, onClose, schema, uiSchema, projectId, adapterKey, packageName, isFirstTime } = props;
 
   const [value, setValue] = useState(props.value);
   const { setSettings } = useRecoilValue(dispatcherState);
@@ -77,6 +80,12 @@ const AdapterModal = (props: Props) => {
               if (update != null) setValue({ ...update, $kind: adapterKey });
             }}
           />
+          <Text>
+            {formatMessage.rich('To learn more about the { title }, <a>visit its documentation page</a>.', {
+              title: schema.title,
+              a: ({ children }) => <Link href={uiSchema.helpLink}>{children}</Link>,
+            })}
+          </Text>
           <DialogFooter>
             <DefaultButton onClick={onClose}>{formatMessage('Back')}</DefaultButton>
             <PrimaryButton
@@ -100,7 +109,7 @@ const AdapterModal = (props: Props) => {
                 onClose();
               }}
             >
-              {formatMessage('Create')}
+              {isFirstTime ? formatMessage('Create') : formatMessage('Confirm')}
             </PrimaryButton>
           </DialogFooter>
         </div>

--- a/Composer/packages/client/src/pages/botProject/adapters/ExternalAdapterModal.tsx
+++ b/Composer/packages/client/src/pages/botProject/adapters/ExternalAdapterModal.tsx
@@ -80,7 +80,7 @@ const AdapterModal = (props: Props) => {
               if (update != null) setValue({ ...update, $kind: adapterKey });
             }}
           />
-          <Text>
+          <Text key="helptext">
             {formatMessage.rich('To learn more about the { title }, <a>visit its documentation page</a>.', {
               title: schema.title,
               a: ({ children }) => <Link href={uiSchema.helpLink}>{children}</Link>,

--- a/Composer/packages/client/src/pages/botProject/adapters/ExternalAdapterSettings.tsx
+++ b/Composer/packages/client/src/pages/botProject/adapters/ExternalAdapterSettings.tsx
@@ -15,6 +15,7 @@ import { TooltipHost, DirectionalHint } from 'office-ui-fabric-react/lib/Tooltip
 import { SharedColors } from '@uifabric/fluent-theme';
 import { JSONSchema7 } from '@botframework-composer/types';
 
+import { useRouterCache } from '../../../utils/hooks';
 import { schemasState, settingsState, dispatcherState } from '../../../recoilModel';
 import { subtitle, tableRow, tableRowItem, tableColumnHeader } from '../styles';
 
@@ -32,6 +33,8 @@ const ExternalAdapterSettings = (props: Props) => {
   const schemas = useRecoilValue<BotSchemas>(schemasState(projectId));
   const currentSettings = useRecoilValue<DialogSetting>(settingsState(projectId));
   const { setSettings } = useRecoilValue(dispatcherState);
+  const packageManagerLink = useRouterCache('plugin/package-manager/package-manager');
+
   const adapters: AdapterRecord[] = currentSettings.runtimeSettings?.adapters ?? [];
 
   const { definitions: schemaDefinitions } = schemas?.sdk?.content ?? {};
@@ -58,7 +61,7 @@ const ExternalAdapterSettings = (props: Props) => {
       <div key={'subtitle'} css={subtitle}>
         {formatMessage.rich('Install more adapters in <a>Package Settings</a>.', {
           a: ({ children }) => (
-            <Link key="link" href="plugin/package-manager/package-manager">
+            <Link key="link" href={packageManagerLink}>
               {children}
             </Link>
           ),

--- a/Composer/packages/client/src/pages/botProject/adapters/ExternalAdapterSettings.tsx
+++ b/Composer/packages/client/src/pages/botProject/adapters/ExternalAdapterSettings.tsx
@@ -37,13 +37,15 @@ const ExternalAdapterSettings = (props: Props) => {
   const { definitions: schemaDefinitions } = schemas?.sdk?.content ?? {};
   const uiSchemas = schemas?.ui?.content ?? {};
 
-  const [currentModalProps, setModalProps] = useState<{ key: string; packageName: string } | undefined>();
+  const [currentModalProps, setModalProps] = useState<
+    { key: string; packageName: string; firstTime: boolean } | undefined
+  >();
 
-  const openModal = (key?: string, packageName?: string) => {
-    if (key == null || packageName == null) {
+  const openModal = (key?: string, firstTime?: boolean, packageName?: string) => {
+    if (key == null || packageName == null || firstTime == null) {
       setModalProps(undefined);
     } else {
-      setModalProps({ key, packageName });
+      setModalProps({ key, packageName, firstTime });
     }
   };
 
@@ -51,7 +53,7 @@ const ExternalAdapterSettings = (props: Props) => {
 
   const columnWidths = ['300px', '150px', '150px'];
 
-  const externalServices = (schemas: (JSONSchema7 & { key: string; packageName?: string })[]) => (
+  const externalServices = (schemas: (JSONSchema7 & { key: string; packageName?: string; firstTime?: boolean })[]) => (
     <div>
       <div key={'subtitle'} css={subtitle}>
         {formatMessage.rich('Install more adapters in <a>Package Settings</a>.', {
@@ -84,7 +86,7 @@ const ExternalAdapterSettings = (props: Props) => {
               {keyConfigured ? (
                 <Icon iconName="CheckMark" styles={{ root: { color: SharedColors.green10, fontSize: '18px' } }} />
               ) : (
-                <Link key={key} onClick={() => openModal(key, packageName)}>
+                <Link key={key} onClick={() => openModal(key, true, packageName)}>
                   {formatMessage('Configure')}
                 </Link>
               )}
@@ -125,7 +127,7 @@ const ExternalAdapterSettings = (props: Props) => {
                       key: 'edit',
                       text: formatMessage('Edit'),
                       iconProps: { iconName: 'Edit' },
-                      onClick: () => openModal(key, packageName),
+                      onClick: () => openModal(key, false, packageName),
                     },
                   ],
                 }}
@@ -159,6 +161,7 @@ const ExternalAdapterSettings = (props: Props) => {
         <AdapterModal
           isOpen
           adapterKey={currentKey}
+          isFirstTime={currentModalProps?.firstTime ?? false}
           packageName={currentPackageName}
           projectId={projectId}
           schema={schemaDefinitions[currentKey]}


### PR DESCRIPTION
## Description

This pulls the name of the adapter from the schema and the link to its docs from its uiSchema, combining the two to make a link that will lead users to whatever the adapter sets its help link to.

## Task Item

closes #5907 

## Screenshots

![MicrosoftTeams-image](https://user-images.githubusercontent.com/61990921/109237337-34cb6500-7786-11eb-8459-feeb84f4c4f0.png)

(values blocked out just so we're not exposing them; the real box of course has the actual values)