### PR TITLE
fix: reload project method does not load settings correctly

### DIFF
--- a/Composer/packages/client/src/recoilModel/dispatchers/project.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/project.ts
@@ -30,10 +30,10 @@ import {
   filePersistenceState,
   projectMetaDataState,
   selectedTemplateReadMeState,
-  settingsState,
   showCreateQnAFromUrlDialogState,
 } from '../atoms';
 import { botRuntimeOperationsSelector, rootBotProjectIdSelector } from '../selectors';
+import { mergePropertiesManagedByRootBot } from '../../recoilModel/dispatchers/utils/project';
 
 import { announcementState, boilerplateVersionState, recentProjectsState, templateIdState } from './../atoms';
 import { logMessage, setError } from './../dispatchers/shared';
@@ -464,8 +464,9 @@ export const projectDispatcher = () => {
     callbackHelpers.reset(filePersistenceState(projectId));
     const { projectData, botFiles } = await fetchProjectDataById(projectId);
 
+    const rootBotProjectId = await snapshot.getPromise(rootBotProjectIdSelector);
     // Reload needs to pull the settings from the local storage persisted in the current settingsState of the project
-    botFiles.mergedSettings = await snapshot.getPromise(settingsState(projectId));
+    botFiles.mergedSettings = mergePropertiesManagedByRootBot(projectId, rootBotProjectId, botFiles.mergedSettings);
     await initBotState(callbackHelpers, projectData, botFiles);
   });
 


### PR DESCRIPTION
## Description

When we install a package, the settings only get updated on server side(cache and hard disk). On client side, the settingState (cache state) does not have the property like "plugins". So we should continue to use settings got from server side and merge sensitive property on client side localStorage.
## Task Item
Closes #5935

## Screenshots
data got from server:
![before](https://user-images.githubusercontent.com/24380525/109137423-271cdc00-7794-11eb-8139-c08dda545e31.png)
after merge sensitive property, we have the authoring key
![after](https://user-images.githubusercontent.com/24380525/109137435-297f3600-7794-11eb-95f5-ade11c793707.png)