### PR TITLE
fix: Diagnostics location navigation issue

### DIFF
--- a/Composer/packages/client/src/recoilModel/dispatchers/navigation.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/navigation.ts
@@ -142,7 +142,7 @@ export const navigationDispatcher = () => {
       }
       if (checkUrl(currentUri, projectId, skillId, designPageLocation)) return;
 
-      set(designPageLocationState(projectId), {
+      set(designPageLocationState(skillId || projectId), {
         dialogId,
         selected: getSelected(focusPath) || selected,
         focused: focusPath ?? '',


### PR DESCRIPTION
## Description
**Root cause**
when we click the action in the VisualEditor, client will call focusTo to update the designPageLocationState. But the focusTo always update the root bot state. So if we click the skill bot action then navigate to the root bot, the dialog name is from the skill bot and the currentDialog will be undefined.

**Fix**
use the correct projectID to update the designPageLocationState

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
closes #5978
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
