### PR TITLE
fix: Make sure advanced settings editor is to 100% height

### DIFF
--- a/Composer/packages/client/src/pages/botProject/BotProjectSettings.tsx
+++ b/Composer/packages/client/src/pages/botProject/BotProjectSettings.tsx
@@ -39,6 +39,7 @@ const container = css`
   display: flex;
   flex-direction: column;
   max-width: 1000px;
+  height: 100%;
 `;
 
 const botNameStyle = css`


### PR DESCRIPTION
## Description
Reverts the height issue in our advanced settings editor.

https://github.com/microsoft/BotFramework-Composer/pull/5928/files#diff-971523261f66177d194b51799eeb7a8a710720c76d00e757eb801016a4a3dd8cL41


<img width="1381" alt="Screen Shot 2021-02-26 at 12 46 23 PM" src="https://user-images.githubusercontent.com/13004779/109353039-abbd3800-7830-11eb-9b3c-77335b111aee.png">


## Task Item
#minor