### PR TITLE
fix: exclude new runtime from ejection list

### DIFF
--- a/Composer/packages/server/src/controllers/eject.ts
+++ b/Composer/packages/server/src/controllers/eject.ts
@@ -7,7 +7,7 @@ import { LocalDiskStorage } from '../models/storage/localDiskStorage';
 
 export const EjectController = {
   getTemplates: async (req, res) => {
-    res.json(ExtensionContext.extensions.runtimeTemplates);
+    res.json(ExtensionContext.extensions.runtimeTemplates.filter((t) => (t.eject ? true : false)));
   },
   eject: async (req, res) => {
     const user = await ExtensionContext.getUserFromRequest(req);
@@ -15,7 +15,7 @@ export const EjectController = {
     const currentProject = await BotProjectService.getProjectById(projectId, user);
 
     const template = ExtensionContext.extensions.runtimeTemplates.find((i) => i.key === req.params.template);
-    if (template) {
+    if (template?.eject) {
       let runtimePath;
       try {
         runtimePath = await template.eject(currentProject, new LocalDiskStorage(), req.body?.isReplace);

--- a/Composer/packages/server/src/locales/en-US.json
+++ b/Composer/packages/server/src/locales/en-US.json
@@ -1058,6 +1058,9 @@
   "downloading_bb6fb34b": {
     "message": "Downloading..."
   },
+  "downloading_language_model_9d40c817": {
+    "message": "Downloading Language Model"
+  },
   "duplicate_31cec192": {
     "message": "Duplicate"
   },

--- a/Composer/packages/server/src/utility/project.ts
+++ b/Composer/packages/server/src/utility/project.ts
@@ -65,9 +65,12 @@ export async function ejectAndMerge(currentProject: BotProject, jobId: string) {
     const runtimePath = currentProject.getRuntimePath();
     if (runtimePath) {
       if (!fs.existsSync(runtimePath)) {
-        await runtime.eject(currentProject, currentProject.fileStorage);
+        if (runtime.eject) {
+          await runtime.eject(currentProject, currentProject.fileStorage);
+        } else {
+          log('Eject skipped for project with invalid runtime setting');
+        }
       }
-
       // install all dependencies and build the app
       BackgroundProcessManager.updateProcess(jobId, 202, formatMessage('Building runtime'));
       await runtime.build(runtimePath, currentProject);

--- a/Composer/packages/types/src/runtime.ts
+++ b/Composer/packages/types/src/runtime.ts
@@ -52,7 +52,7 @@ export type BotTemplate = {
 
 export type RuntimeTemplate = {
   /** method used to eject the runtime into a project. returns resulting path of runtime! */
-  eject: (project: IBotProject, localDisk?: any, isReplace?: boolean) => Promise<string>;
+  eject?: (project: IBotProject, localDisk?: any, isReplace?: boolean) => Promise<string>;
 
   /** build method used for local publish */
   build: (runtimePath: string, project: IBotProject) => Promise<void>;

--- a/extensions/runtimes/src/index.ts
+++ b/extensions/runtimes/src/index.ts
@@ -165,7 +165,7 @@ export default async (composer: any): Promise<void> => {
         await copyDir(schemaSrcPath, localDisk, schemaDstPath, project.fileStorage, pathsToExclude);
         const schemaFolderInRuntime = path.join(destPath, 'azurewebapp/Schemas');
         await removeDirAndFiles(schemaFolderInRuntime);
-        return path.relative(project.dir, destPath);
+        return path.relative(path.join(project.dir, 'settings'), destPath);
       }
       throw new Error(`Runtime already exists at ${destPath}`);
     },
@@ -308,7 +308,7 @@ export default async (composer: any): Promise<void> => {
         const schemaFolderInRuntime = path.join(destPath, 'schemas');
         await removeDirAndFiles(schemaFolderInRuntime);
 
-        return path.relative(project.dir, destPath);
+        return path.relative(path.join(project.dir, 'settings'), destPath);
       }
       throw new Error(`Runtime already exists at ${destPath}`);
     },
@@ -451,33 +451,6 @@ export default async (composer: any): Promise<void> => {
 
       // return the location of the build artifiacts
       return publishFolder;
-    },
-    eject: async (project, localDisk: IFileStorage, isReplace: boolean) => {
-      const sourcePath = dotnetTemplatePath;
-      const destPath = path.join(project.dir, 'runtime');
-      if ((await project.fileStorage.exists(destPath)) && isReplace) {
-        // remove runtime folder
-        await removeDirAndFiles(destPath);
-      }
-      if (!(await project.fileStorage.exists(destPath))) {
-        // used to read bot project template from source (bundled in plugin)
-        await copyDir(sourcePath, localDisk, destPath, project.fileStorage);
-        const schemaDstPath = path.join(project.dir, 'schemas');
-        const schemaSrcPath = path.join(sourcePath, 'azurewebapp/Schemas');
-        const customSchemaExists = fs.existsSync(schemaDstPath);
-        const pathsToExclude: Set<string> = new Set();
-        if (customSchemaExists) {
-          const sdkExcludePath = await localDisk.glob('sdk.schema', schemaSrcPath);
-          if (sdkExcludePath.length > 0) {
-            pathsToExclude.add(path.join(schemaSrcPath, sdkExcludePath[0]));
-          }
-        }
-        await copyDir(schemaSrcPath, localDisk, schemaDstPath, project.fileStorage, pathsToExclude);
-        const schemaFolderInRuntime = path.join(destPath, 'azurewebapp/Schemas');
-        await removeDirAndFiles(schemaFolderInRuntime);
-        return path.relative(project.dir, destPath);
-      }
-      throw new Error(`Runtime already exists at ${destPath}`);
     },
     setSkillManifest: async (
       dstRuntimePath: string,


### PR DESCRIPTION
This PR removes the new runtime from the eject list, removing the duplicated "C#" option.

behind the scenes, this is done by filtering on the existence of the rutnime's eject method, which has been (appropriately) removed from the new v2 runtime.


## Task Item

Fixes #5979 