### PR TITLE
[DO NOT MERGE][WIP] Package manager: tactical fix for minimum bar myget support

### DIFF
--- a/extensions/packageManager/src/node/index.ts
+++ b/extensions/packageManager/src/node/index.ts
@@ -48,7 +48,7 @@ export default async (composer: IExtensionRegistration): Promise<void> => {
       // this is actually a myget feed that points to the feed we want...
       const queryEndpoint = feed.resources.find((resource) => resource['@type'] === 'SearchQueryService');
       if (queryEndpoint) {
-        const raw = await axios.get(queryEndpoint['@id']);
+        const raw = await axios.get(`queryEndpoint['@id']?q=tags:bf-component&prerelease=true&semVerLevel:2.0.0`);
         return normalizeFeed(raw.data);
       } else {
         return [];


### PR DESCRIPTION
## Description

Currently adding NuGet feeds 'the usual way', such as passing a service index `https://api.nuget.org/v3/index.json` is not working properly. A more advanced approach to fixing this is exposed in this[ alternate PR](https://github.com/microsoft/BotFramework-Composer/pull/6035), however this fix represents the minimum tactical fix to overcome this issue in r12.

## Task Item

Closes #6033 
