### PR TITLE
fix: Bot Response page show wrong content for common lg file

### DIFF
--- a/Composer/packages/client/src/pages/language-generation/LGPage.tsx
+++ b/Composer/packages/client/src/pages/language-generation/LGPage.tsx
@@ -47,7 +47,7 @@ const LGPage: React.FC<RouteComponentProps<{
       navigateTo(url);
       TelemetryClient.track('EditModeToggled', { jsonView: !edit });
     },
-    [dialogId, projectId, edit, lgFileId]
+    [dialogId, projectId, edit, lgFileId, baseURL]
   );
 
   const onRenderHeaderContent = () => {

--- a/Composer/packages/client/src/router.tsx
+++ b/Composer/packages/client/src/router.tsx
@@ -70,7 +70,6 @@ const Routes = (props) => {
             <LUPage path="language-understanding/:dialogId/item/:luFileId/*" />
             <LUPage path="language-understanding/:dialogId/*" />
             <LGPage path="language-generation/all/*" />
-            <LGPage path="language-generation/common/*" />
             <LGPage path="language-generation/:dialogId/item/:lgFileId/*" />
             <LGPage path="language-generation/:dialogId/*" />
             <QnAPage path="knowledge-base/all/*" />


### PR DESCRIPTION
## Description
**Root cause**
1. The Router catches the url common/*, and doesn't get the correct dialog id. 
2. the baseUrl doesn't been added to the useEffect dependencies, so the show code button will use stale base url and navigate to the wrong page.

 **fix**
1. remote the common/* router, then the url will be cached by the dialogId/*
2. add base Url to the useEffect dependencies

![common](https://user-images.githubusercontent.com/39758135/109457507-f7bce680-7a95-11eb-9c60-e1effe34acd1.gif)

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
closes #6029
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
