### PR TITLE
fix: provision process shown in publish list

### DIFF
--- a/Composer/packages/client/src/recoilModel/dispatchers/publisher.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/publisher.ts
@@ -21,12 +21,12 @@ import { openInEmulator } from '../../utils/navigation';
 import { botEndpointsState } from '../atoms';
 import { rootBotProjectIdSelector, dialogsSelectorFamily } from '../selectors';
 import * as luUtil from '../../utils/luUtil';
+import { ClientStorage } from '../../utils/storage';
 
 import { BotStatus, Text } from './../../constants';
 import httpClient from './../../utils/httpUtil';
 import { logMessage, setError } from './shared';
 import { setRootBotSettingState } from './setting';
-import { ClientStorage } from '../../utils/storage';
 
 const PUBLISH_SUCCESS = 200;
 const PUBLISH_PENDING = 202;

--- a/Composer/packages/client/src/recoilModel/dispatchers/publisher.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/publisher.ts
@@ -106,7 +106,7 @@ export const publisherDispatcher = () => {
     // remove job id in publish storage if published
     if (status === PUBLISH_SUCCESS || status === PUBLISH_FAILED) {
       const publishJobIds = publishStorage.get('jobIds') || {};
-      publishJobIds[`${projectId}-${target.name}`] = '';
+      delete publishJobIds[`${projectId}-${target.name}`];
       publishStorage.set('jobIds', publishJobIds);
     }
     // the action below only applies to when a bot is being started using the "start bot" button

--- a/Composer/packages/client/src/recoilModel/dispatchers/publisher.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/publisher.ts
@@ -101,7 +101,7 @@ export const publisherDispatcher = () => {
   ) => {
     if (data == null) return;
     const { set, snapshot } = callbackHelpers;
-    const { endpointURL, status, id } = data;
+    const { endpointURL, status } = data;
 
     // remove job id in publish storage if published
     if (status === PUBLISH_SUCCESS || status === PUBLISH_FAILED) {

--- a/Composer/packages/client/src/recoilModel/dispatchers/publisher.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/publisher.ts
@@ -105,7 +105,7 @@ export const publisherDispatcher = () => {
 
     // remove job id in publish storage if published
     if (status === PUBLISH_SUCCESS || status === PUBLISH_FAILED) {
-      const publishJobIds = publishStorage.get('jobIds');
+      const publishJobIds = publishStorage.get('jobIds') || {};
       publishJobIds[`${projectId}-${target.name}`] = '';
       publishStorage.set('jobIds', publishJobIds);
     }
@@ -199,9 +199,12 @@ export const publisherDispatcher = () => {
           },
           sensitiveSettings,
         });
+
+        // add job id to storage
         const publishJobIds = publishStorage.get('jobIds') || {};
         publishJobIds[`${projectId}-${target.name}`] = response.data.id;
         publishStorage.set('jobIds', publishJobIds);
+
         await publishSuccess(callbackHelpers, projectId, response.data, target);
       } catch (err) {
         // special case to handle dotnet issues
@@ -242,10 +245,9 @@ export const publisherDispatcher = () => {
         const currentJobId =
           jobId ??
           (publishStorage.get('jobIds') ? publishStorage.get('jobIds')[`${projectId}-${target.name}`] : undefined);
-        if (!currentJobId) {
-          return;
-        }
-        const response = await httpClient.get(`/publish/${projectId}/status/${target.name}/${currentJobId}`);
+        const response = await httpClient.get(
+          `/publish/${projectId}/status/${target.name}/${currentJobId ? '/' + currentJobId : ''}`
+        );
         updatePublishStatus(callbackHelpers, projectId, target, response.data);
       } catch (err) {
         updatePublishStatus(callbackHelpers, projectId, target, err.response?.data);

--- a/Composer/packages/client/src/recoilModel/dispatchers/publisher.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/publisher.ts
@@ -26,6 +26,7 @@ import { BotStatus, Text } from './../../constants';
 import httpClient from './../../utils/httpUtil';
 import { logMessage, setError } from './shared';
 import { setRootBotSettingState } from './setting';
+import { ClientStorage } from '../../utils/storage';
 
 const PUBLISH_SUCCESS = 200;
 const PUBLISH_PENDING = 202;
@@ -46,6 +47,8 @@ const missingDotnetVersionError = {
 const checkIfDotnetVersionMissing = (err: any) => {
   return /(Command failed: dotnet user-secrets)|(install[\w\r\s\S\t\n]*\.NET Core SDK)/.test(err.message as string);
 };
+
+export const publishStorage = new ClientStorage(window.sessionStorage, 'publish');
 
 export const publisherDispatcher = () => {
   const publishFailure = async ({ set }: CallbackInterface, title: string, error, target, projectId: string) => {
@@ -98,7 +101,14 @@ export const publisherDispatcher = () => {
   ) => {
     if (data == null) return;
     const { set, snapshot } = callbackHelpers;
-    const { endpointURL, status } = data;
+    const { endpointURL, status, id } = data;
+
+    // remove job id in publish storage if published
+    if (status === PUBLISH_SUCCESS || status === PUBLISH_FAILED) {
+      const publishJobIds = publishStorage.get('jobIds');
+      publishJobIds[`${projectId}-${target.name}`] = '';
+      publishStorage.set('jobIds', publishJobIds);
+    }
     // the action below only applies to when a bot is being started using the "start bot" button
     // a check should be added to this that ensures this ONLY applies to the "default" profile.
     if (target.name === defaultPublishConfig.name) {
@@ -189,6 +199,9 @@ export const publisherDispatcher = () => {
           },
           sensitiveSettings,
         });
+        const publishJobIds = publishStorage.get('jobIds') || {};
+        publishJobIds[`${projectId}-${target.name}`] = response.data.id;
+        publishStorage.set('jobIds', publishJobIds);
         await publishSuccess(callbackHelpers, projectId, response.data, target);
       } catch (err) {
         // special case to handle dotnet issues
@@ -226,7 +239,13 @@ export const publisherDispatcher = () => {
   const getPublishStatus = useRecoilCallback(
     (callbackHelpers: CallbackInterface) => async (projectId: string, target: any, jobId?: string) => {
       try {
-        const response = await httpClient.get(`/publish/${projectId}/status/${target.name}${jobId ? '/' + jobId : ''}`);
+        const currentJobId =
+          jobId ??
+          (publishStorage.get('jobIds') ? publishStorage.get('jobIds')[`${projectId}-${target.name}`] : undefined);
+        if (!currentJobId) {
+          return;
+        }
+        const response = await httpClient.get(`/publish/${projectId}/status/${target.name}/${currentJobId}`);
         updatePublishStatus(callbackHelpers, projectId, target, response.data);
       } catch (err) {
         updatePublishStatus(callbackHelpers, projectId, target, err.response?.data);

--- a/Composer/packages/client/src/utils/publishStatusPollingUpdater.ts
+++ b/Composer/packages/client/src/utils/publishStatusPollingUpdater.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { publishStorage } from '../recoilModel/dispatchers/publisher';
+
 import httpClient from './httpUtil';
 
 enum PollingStateEnum {

--- a/Composer/packages/client/src/utils/publishStatusPollingUpdater.ts
+++ b/Composer/packages/client/src/utils/publishStatusPollingUpdater.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { publishStorage } from '../recoilModel/dispatchers/publisher';
 import httpClient from './httpUtil';
 
 enum PollingStateEnum {
@@ -39,8 +40,14 @@ export class PublishStatusPollingUpdater {
 
   private async fetchPublishStatusData(botProjectId: string, publishTargetName: string, onData: OnDataHandler) {
     // TODO: DONT set HTTP Status code with 500 404 directly!
+    const currentJobId = publishStorage.get('jobIds')
+      ? publishStorage.get('jobIds')[`${botProjectId}-${publishTargetName}`]
+      : undefined;
+    if (!currentJobId) {
+      return;
+    }
     const response = await httpClient
-      .get(`/publish/${this.botProjectId}/status/${this.publishTargetName}`)
+      .get(`/publish/${this.botProjectId}/status/${this.publishTargetName}/${currentJobId}`)
       .catch((reason) => reason.response);
 
     onData({


### PR DESCRIPTION
## Description

### Bug
 provision process shown in publish list
![MicrosoftTeams-image (4)](https://user-images.githubusercontent.com/5860999/109457334-a4e32f00-7a95-11eb-84cb-e6f605c3f8b0.png)

### Reason
The process poor is shared by provision & publish. So the provision process will be shown in publish page when get publish status without jobId

### Solution
Store jobId in client and add job id in get publish status api

## Task Item

#minors

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
