### PR TITLE
fix: delete bot bug

### DIFF
--- a/Composer/packages/client/src/pages/botProject/runtime-settings/RuntimeSettings.tsx
+++ b/Composer/packages/client/src/pages/botProject/runtime-settings/RuntimeSettings.tsx
@@ -72,6 +72,9 @@ export const RuntimeSettings: React.FC<RouteComponentProps<{ projectId: string }
   useEffect(() => {
     // check the status of the boilerplate material and see if it requires an update
     if (projectId) getBoilerplateVersion(projectId);
+  }, [projectId]);
+
+  useEffect(() => {
     setRuntimePath(settings.runtime?.path ?? '');
     setRuntimeCommand(settings.runtime?.command ?? '');
     setUsingCustomRuntime(settings.runtime?.customRuntime ?? false);

--- a/Composer/packages/client/src/recoilModel/dispatchers/project.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/project.ts
@@ -413,6 +413,7 @@ export const projectDispatcher = () => {
     try {
       const { reset } = callbackHelpers;
       await httpClient.delete(`/projects/${projectId}`);
+      reset(filePersistenceState(projectId));
       luFileStatusStorage.removeAllStatuses(projectId);
       qnaFileStatusStorage.removeAllStatuses(projectId);
       settingStorage.remove(projectId);


### PR DESCRIPTION
## Description
The bug should already exist for months, but does not show up until recent change on file persistence layer.
Reason: 1. after deleting bots, the file persistence layer does another comparison and resends requests to delete files that are already deleted. 
2. During deleting bots,it does another call to getBoilerplateVersion because of settings changed which is unnecessary.

Fix: 1. clear filePersistence state after deleting bots files.
2. split useEffect in RuntimeSetting to avoid interfere each other.
## Task Item
Closes #6042 
## Screenshots
error request: 
![微信图片_20210301171107](https://user-images.githubusercontent.com/24380525/109475836-2300ff00-7ab1-11eb-90bc-d813752d444d.png)

after fix:
![de](https://user-images.githubusercontent.com/24380525/109475715-fea52280-7ab0-11eb-896d-62b6b1e0c3af.gif)
