### PR TITLE
fix: make column widths consistent

### DIFF
--- a/Composer/packages/client/src/pages/botProject/adapters/ABSChannels.tsx
+++ b/Composer/packages/client/src/pages/botProject/adapters/ABSChannels.tsx
@@ -37,6 +37,7 @@ import {
   errorContainer,
   errorIcon,
   errorTextStyle,
+  columnSizes,
 } from '../styles';
 
 import ABSChannelSpeechModal from './ABSChannelSpeechModal';
@@ -462,8 +463,6 @@ export const ABSChannels: React.FC<RuntimeSettingsProps> = (props) => {
     }
   }, [token, currentResource]);
 
-  const columnWidths = ['300px', '150px', '150px'];
-
   const absTableToggle = (key: string) => (
     <Stack horizontal tokens={{ childrenGap: 10 }}>
       <Stack.Item>
@@ -485,13 +484,13 @@ export const ABSChannels: React.FC<RuntimeSettingsProps> = (props) => {
 
   const absTableRow = (channel: string, name: string, link: string) => (
     <div key={channel} css={tableRow}>
-      <div css={tableRowItem(columnWidths[0])}>{name}</div>
-      <div css={tableRowItem(columnWidths[1])}>
+      <div css={tableRowItem(columnSizes[0])}>{name}</div>
+      <div css={tableRowItem(columnSizes[1])}>
         <Link href={link} target="_docs">
           {formatMessage('Learn more')}
         </Link>
       </div>
-      <div css={tableRowItem(columnWidths[2])}>{absTableToggle(channel)}</div>
+      <div css={tableRowItem(columnSizes[2])}>{absTableToggle(channel)}</div>
     </div>
   );
 
@@ -558,9 +557,9 @@ export const ABSChannels: React.FC<RuntimeSettingsProps> = (props) => {
         {currentResource && channelStatus && (
           <Fragment>
             <div css={tableRow}>
-              <div css={tableColumnHeader(columnWidths[0])}>{formatMessage('Name')}</div>
-              <div css={tableColumnHeader(columnWidths[1])}>{formatMessage('Documentation')}</div>
-              <div css={tableColumnHeader(columnWidths[2])}>{formatMessage('Enabled')}</div>
+              <div css={tableColumnHeader(columnSizes[0])}>{formatMessage('Name')}</div>
+              <div css={tableColumnHeader(columnSizes[1])}>{formatMessage('Documentation')}</div>
+              <div css={tableColumnHeader(columnSizes[2])}>{formatMessage('Enabled')}</div>
             </div>
             {absTableRow(CHANNELS.TEAMS, formatMessage('MS Teams'), teamsHelpLink)}
             {absTableRow(CHANNELS.WEBCHAT, formatMessage('Webchat'), webchatHelpLink)}

--- a/Composer/packages/client/src/pages/botProject/styles.ts
+++ b/Composer/packages/client/src/pages/botProject/styles.ts
@@ -106,4 +106,4 @@ export const unknownIconStyle = (required: boolean) => {
   };
 };
 
-export const columnSizes = ['200px', '350px', '50px'];
+export const columnSizes = ['300px', '150px', '150px'];

--- a/Composer/packages/server/src/locales/en-US.json
+++ b/Composer/packages/server/src/locales/en-US.json
@@ -3266,6 +3266,9 @@
   "to_learn_more_about_the_qna_file_format_read_the_d_1ce18259": {
     "message": "> To learn more about the QnA file format, read the documentation at\n> { QNA_HELP }"
   },
+  "to_learn_more_about_the_title_a_visit_its_document_c302e9b1": {
+    "message": "To learn more about the { title }, <a>visit its documentation page</a>."
+  },
   "to_make_your_bot_available_for_others_as_a_skill_w_f2c19b9c": {
     "message": "To make your bot available for others as a skill, we need to generate a manifest."
   },


### PR DESCRIPTION
## Description

The column widths on the settings page didn't line up with each other; this fixes that.

## Task Item

#minor

## Screenshots

![image](https://user-images.githubusercontent.com/61990921/109541626-dc8fae00-7a78-11eb-8dc0-061eb4a23a22.png)

