### PR TITLE
fix: read default values from schema when building modal

### DIFF
--- a/Composer/packages/client/src/pages/botProject/adapters/ExternalAdapterModal.tsx
+++ b/Composer/packages/client/src/pages/botProject/adapters/ExternalAdapterModal.tsx
@@ -14,6 +14,7 @@ import { DialogSetting } from '@bfc/shared';
 import { JSONSchema7 } from '@botframework-composer/types';
 import { EditorExtension, PluginConfig } from '@bfc/extension-client';
 import mapValues from 'lodash/mapValues';
+import { JSONSchema4Type } from 'json-schema';
 
 import { settingsState, dispatcherState } from '../../../recoilModel';
 import { useShell } from '../../../shell';
@@ -25,8 +26,6 @@ export type AdapterRecord = {
   enabled: boolean;
 };
 
-type ConfigValue = string | number | boolean;
-
 type Props = {
   adapterKey: string;
   packageName: string;
@@ -36,10 +35,10 @@ type Props = {
   projectId: string;
   schema: JSONSchema7;
   uiSchema: JSONSchema7 & { helpLink?: string };
-  value?: { [key: string]: ConfigValue };
+  value?: { [key: string]: JSONSchema4Type };
 };
 
-export function hasRequired(testObject: { [key: string]: ConfigValue }, fields?: string[]) {
+export function hasRequired(testObject: { [key: string]: JSONSchema4Type | undefined }, fields?: string[]) {
   if (fields == null || fields.length === 0) return true;
   return fields.every((field: string) => field in testObject);
 }

--- a/Composer/packages/client/src/pages/botProject/adapters/ExternalAdapterModal.tsx
+++ b/Composer/packages/client/src/pages/botProject/adapters/ExternalAdapterModal.tsx
@@ -13,6 +13,7 @@ import { useRecoilValue } from 'recoil';
 import { DialogSetting } from '@bfc/shared';
 import { JSONSchema7 } from '@botframework-composer/types';
 import { EditorExtension, PluginConfig } from '@bfc/extension-client';
+import mapValues from 'lodash/mapValues';
 
 import { settingsState, dispatcherState } from '../../../recoilModel';
 import { useShell } from '../../../shell';
@@ -43,10 +44,16 @@ export function hasRequired(testObject: { [key: string]: ConfigValue }, fields?:
   return fields.every((field: string) => field in testObject);
 }
 
+function makeDefault(schema: JSONSchema7) {
+  const { properties } = schema;
+
+  return mapValues(properties, 'default');
+}
+
 const AdapterModal = (props: Props) => {
   const { isOpen, onClose, schema, uiSchema, projectId, adapterKey, packageName, isFirstTime } = props;
 
-  const [value, setValue] = useState(props.value);
+  const [value, setValue] = useState(props.value == null ? makeDefault(schema) : props.value);
   const { setSettings } = useRecoilValue(dispatcherState);
   const currentSettings = useRecoilValue<DialogSetting>(settingsState(projectId));
 

--- a/Composer/packages/client/src/pages/botProject/adapters/ExternalAdapterModal.tsx
+++ b/Composer/packages/client/src/pages/botProject/adapters/ExternalAdapterModal.tsx
@@ -14,7 +14,7 @@ import { DialogSetting } from '@bfc/shared';
 import { JSONSchema7 } from '@botframework-composer/types';
 import { EditorExtension, PluginConfig } from '@bfc/extension-client';
 import mapValues from 'lodash/mapValues';
-import { JSONSchema4Type } from 'json-schema';
+import { JSONSchema7Type } from 'json-schema';
 
 import { settingsState, dispatcherState } from '../../../recoilModel';
 import { useShell } from '../../../shell';
@@ -35,10 +35,10 @@ type Props = {
   projectId: string;
   schema: JSONSchema7;
   uiSchema: JSONSchema7 & { helpLink?: string };
-  value?: { [key: string]: JSONSchema4Type };
+  value?: { [key: string]: JSONSchema7Type | undefined };
 };
 
-export function hasRequired(testObject: { [key: string]: JSONSchema4Type | undefined }, fields?: string[]) {
+export function hasRequired(testObject: { [key: string]: JSONSchema7Type | undefined }, fields?: string[]) {
   if (fields == null || fields.length === 0) return true;
   return fields.every((field: string) => field in testObject);
 }
@@ -52,7 +52,7 @@ function makeDefault(schema: JSONSchema7) {
 const AdapterModal = (props: Props) => {
   const { isOpen, onClose, schema, uiSchema, projectId, adapterKey, packageName, isFirstTime } = props;
 
-  const [value, setValue] = useState(props.value == null ? makeDefault(schema) : props.value);
+  const [value, setValue] = useState(props.value ?? makeDefault(schema));
   const { setSettings } = useRecoilValue(dispatcherState);
   const currentSettings = useRecoilValue<DialogSetting>(settingsState(projectId));
 


### PR DESCRIPTION
## Description

The adapter settings modal wasn't reading the values for defaults from the schema; it was just initializing the values as empty if there was no existing value object to load.

## Task Item

closes #5906

## Screenshots

![image](https://user-images.githubusercontent.com/61990921/109558378-2fc02b80-7a8e-11eb-941e-3a1e2572ab0f.png)
