### PR TITLE
fix: publish is successful however a failure is being reported in the notifications pane

### DIFF
--- a/Composer/packages/client/src/pages/publish/Publish.tsx
+++ b/Composer/packages/client/src/pages/publish/Publish.tsx
@@ -175,7 +175,9 @@ const Publish: React.FC<RouteComponentProps<{ projectId: string; targetName?: st
       // Show result notifications
       const displayedNotifications = showNotificationsRef.current;
       if (displayedNotifications[botProjectId]) {
-        const resultNotification = createNotification(getPublishedNotificationCardProps(updatedBot));
+        const resultNotification = createNotification(
+          getPublishedNotificationCardProps({ ...updatedBot, status: responseData.status })
+        );
         addNotification(resultNotification);
         setTimeout(() => {
           deleteNotification(resultNotification.id);


### PR DESCRIPTION
## Description

### Bug
 publish  is successful however a failure is being reported in the notifications pane
![image](https://user-images.githubusercontent.com/5860999/109787270-04ce0700-7c49-11eb-93e2-d48576dfa3db.png)

### Reason
The updatedBot status which is used to choose the notification type is not the newest.

### Solution
Merge the newest status for updatedBot

## Task Item

closes #5899 

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
![image](https://user-images.githubusercontent.com/5860999/109787239-faac0880-7c48-11eb-9053-7df598a3c48e.png)
