### PR TITLE
fix: give adapter section a unique scrollToId

### DIFF
--- a/Composer/packages/client/src/pages/botProject/adapters/AdapterSection.tsx
+++ b/Composer/packages/client/src/pages/botProject/adapters/AdapterSection.tsx
@@ -32,7 +32,7 @@ const renderSectionHeader = (name: string, tooltip?: string) => (
 const AdapterSection = ({ projectId, scrollToSectionId }: Props) => {
   const containerRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
-    if (containerRef.current && scrollToSectionId === '#runtimeSettings') {
+    if (containerRef.current && scrollToSectionId === '#connections') {
       containerRef.current.scrollIntoView({ behavior: 'smooth' });
     }
   }, [scrollToSectionId]);


### PR DESCRIPTION
## Description

Fixed the Adapter section of the settings to have a unique scrollToId, confirmed that the get started button scrolls to this section.

## Task Item

fixes #6116 
