### PR TITLE
fix: repair unquoted braces in l10n files

### DIFF
--- a/Composer/packages/server/src/locales/de.json
+++ b/Composer/packages/server/src/locales/de.json
@@ -204,10 +204,10 @@
     "message": "+ QnA-Paar hinzufügen"
   },
   "add_some_example_phrases_to_trigger_this_intent_pl_568eaf51": {
-    "message": "> Fügen Sie einige Beispielausdrücke hinzu, mit denen diese Absicht ausgelöst wird:\n> – Informiere mich über das Wetter\n> – Wie ist das Wetter in {'city=Seattle'}\n\n> Entitätsdefinitionen:\n> @ ml city"
+    "message": "> Fügen Sie einige Beispielausdrücke hinzu, mit denen diese Absicht ausgelöst wird:\n> – Informiere mich über das Wetter\n> – Wie ist das Wetter in '{'city=Seattle'}'\n\n> Entitätsdefinitionen:\n> @ ml city"
   },
   "add_some_expected_user_responses_please_remind_me__31dc5c07": {
-    "message": "> Fügen Sie einige erwartete Benutzerantworten hinzu:\n> – Erinnere mich an \"{'itemTitle=Milch kaufen'}\"\n> – Erinnerung an \"{'itemTitle'}\"\n> –\"{'itemTitle'}\" meiner Aufgabenliste hinzufügen\n>\n> Entitätsdefinitionen:\n> @ ml itemTitle\n"
+    "message": "> Fügen Sie einige erwartete Benutzerantworten hinzu:\n> – Erinnere mich an '{'itemTitle=Milch kaufen'}'\n> – Erinnerung an '{'itemTitle'}'\n> –'{'itemTitle'}' meiner Aufgabenliste hinzufügen\n>\n> Entitätsdefinitionen:\n> @ ml itemTitle\n"
   },
   "add_suggested_action_baf855ca": {
     "message": "Add suggested action"

--- a/Composer/packages/server/src/locales/es.json
+++ b/Composer/packages/server/src/locales/es.json
@@ -204,10 +204,10 @@
     "message": "+ Agregar par PyR"
   },
   "add_some_example_phrases_to_trigger_this_intent_pl_568eaf51": {
-    "message": "> agregue algunas frases de ejemplo para desencadenar esta intención:\n> - dime el tiempo\n-¿cómo es el tiempo en \"{'city=Seattle'}\"?\n\nDefiniciones de entidad:\n> @ ml city"
+    "message": "> agregue algunas frases de ejemplo para desencadenar esta intención:\n> - dime el tiempo\n-¿cómo es el tiempo en '{'city=Seattle'}'?\n\nDefiniciones de entidad:\n> @ ml city"
   },
   "add_some_expected_user_responses_please_remind_me__31dc5c07": {
-    "message": "> agregue algunas respuestas de usuario esperadas:\n> - Recuérdame que \"{\"itemTitle=compre leche\"}\"\n> - Recuérdame que \"{\" itemTitle \"}\"\n> - agregue \"{\"itemTitle\"}\" a mi lista de tareas pendientes\n>\n> definiciones de entidad:\n> @ ml itemTitle\n"
+    "message": "> agregue algunas respuestas de usuario esperadas:\n> - Recuérdame que '{'itemTitle=compre leche'}'\n> - Recuérdame que '{' itemTitle '}'\n> - agregue '{'itemTitle'}' a mi lista de tareas pendientes\n>\n> definiciones de entidad:\n> @ ml itemTitle\n"
   },
   "add_suggested_action_baf855ca": {
     "message": "Add suggested action"

--- a/Composer/packages/server/src/locales/fr.json
+++ b/Composer/packages/server/src/locales/fr.json
@@ -33,7 +33,7 @@
     "message": "Un profil de ce nom existe déjà."
   },
   "a_property_is_a_piece_of_information_that_your_bot_eccd34bf": {
-    "message": "Une propriété est une information collectée par votre bot. Le nom de propriété est le nom utilisé dans Composer, ce n'est pas nécessairement le même texte que celui qui apparaît dans les messages de votre bot."
+    "message": "Une propriété est une information collectée par votre bot. Le nom de propriété est le nom utilisé dans Composer, ce n’est pas nécessairement le même texte que celui qui apparaît dans les messages de votre bot."
   },
   "a_publishing_profile_provides_the_secure_connectiv_e203980e": {
     "message": "A publishing profile provides the secure connectivity required to publish your bot. "
@@ -204,10 +204,10 @@
     "message": "+ Ajouter une paire QnA"
   },
   "add_some_example_phrases_to_trigger_this_intent_pl_568eaf51": {
-    "message": "> ajouter des exemples d'expressions pour déclencher cette intention :\n> - peux-tu me donner la météo\n> - comment est la météo à « '{'city=Paris'}' »\n\n> définitions d'entité :\n> @ ml city"
+    "message": "> ajouter des exemples d’expressions pour déclencher cette intention :\n> - peux-tu me donner la météo\n> - comment est la météo à « '{'city=Paris'}' »\n\n> définitions d’entité :\n> @ ml city"
   },
   "add_some_expected_user_responses_please_remind_me__31dc5c07": {
-    "message": "> ajouter des réponses utilisateur attendues :\n> - peux-tu me rappeler de « '{'itemTitle=acheter du lait'}' »\n> - rappelle-moi de « '{'itemTitle'}' »\n> - ajouter « '{'itemTitle'}' » à ma liste de choses à faire\n>\n> définitions d'entité :\n> @ ml itemTitle\n"
+    "message": "> ajouter des réponses utilisateur attendues :\n> - peux-tu me rappeler de « '{'itemTitle=acheter du lait'}' »\n> - rappelle-moi de « '{'itemTitle'}' »\n> - ajouter « '{'itemTitle'}' » à ma liste de choses à faire\n>\n> définitions d’entité :\n> @ ml itemTitle\n"
   },
   "add_suggested_action_baf855ca": {
     "message": "Add suggested action"
@@ -723,7 +723,7 @@
     "message": "Impossible de se connecter au stockage."
   },
   "couldn_t_complete_the_update_a337a359": {
-    "message": "Impossible d'effectuer la mise à jour :"
+    "message": "Impossible d’effectuer la mise à jour :"
   },
   "create_132b3be1": {
     "message": "Créer"
@@ -2703,7 +2703,7 @@
     "message": "Schéma"
   },
   "schemaid_doesn_t_exists_select_an_schema_to_edit_o_9cccc954": {
-    "message": "{ schemaId } n'existe pas, sélectionner un schéma à modifier ou en créer un"
+    "message": "{ schemaId } n’existe pas, sélectionner un schéma à modifier ou en créer un"
   },
   "schemas_74566170": {
     "message": "Schémas"
@@ -3105,7 +3105,7 @@
     "message": "Une erreur s’est produite durant la création de votre base de connaissances"
   },
   "these_examples_bring_together_all_of_the_best_prac_ca1b89c7": {
-    "message": "Ces exemples rassemblent toutes les bonnes pratiques et les composants de prise en charge que nous avons identifiés dans le cadre de la création d'expériences de conversation."
+    "message": "Ces exemples rassemblent toutes les bonnes pratiques et les composants de prise en charge que nous avons identifiés dans le cadre de la création d’expériences de conversation."
   },
   "these_tasks_will_be_used_to_generate_the_manifest__2791be0e": {
     "message": "Ces tâches sont utilisées pour générer le manifeste et décrire les fonctionnalités de cette compétence aux personnes susceptibles de l’utiliser."
@@ -3153,7 +3153,7 @@
     "message": "Cette opération supprime le dialogue et son contenu. Voulez-vous continuer ?"
   },
   "this_will_open_your_emulator_application_if_you_do_ba277151": {
-    "message": "Cette opération ouvre votre application d'émulateur. Si vous n'avez pas encore installé Bot Framework Emulator, vous pouvez le télécharger <a>ici</a>."
+    "message": "Cette opération ouvre votre application d’émulateur. Si vous n’avez pas encore installé Bot Framework Emulator, vous pouvez le télécharger <a>ici</a>."
   },
   "throw_exception_9d0d1db": {
     "message": "Lever une exception"
@@ -3177,7 +3177,7 @@
     "message": "{ title }. { msg }"
   },
   "to_customize_the_welcome_message_select_the_i_send_9b4bf4f": {
-    "message": "Pour personnaliser le message d'accueil, sélectionnez l'action <i>Envoyer une réponse</i> dans l'éditeur visuel. Ensuite, dans l'éditeur de formulaire à droite, vous pouvez modifier le message d'accueil du bot dans le champ <b>Génération de langage</b>."
+    "message": "Pour personnaliser le message d’accueil, sélectionnez l’action <i>Envoyer une réponse</i> dans l’éditeur visuel. Ensuite, dans l’éditeur de formulaire à droite, vous pouvez modifier le message d’accueil du bot dans le champ <b>Génération de langage</b>."
   },
   "to_learn_more_a_visit_this_document_a_ce188d8": {
     "message": "To learn more, <a>visit this document</a>."
@@ -3207,7 +3207,7 @@
     "message": "Pour comprendre ce que dit l’utilisateur, votre dialogue a besoin d’un « module de reconnaissance » qui comprend des exemples de mots et de phrases utilisables par les utilisateurs."
   },
   "to_understand_what_the_user_says_your_dialog_needs_957034cc": {
-    "message": "Pour comprendre ce que l'utilisateur dit, votre dialogue a besoin d'un « IRecognizer » qui contient des exemples de mots et de phrases que les utilisateurs peuvent utiliser."
+    "message": "Pour comprendre ce que l’utilisateur dit, votre dialogue a besoin d’un « IRecognizer » qui contient des exemples de mots et de phrases que les utilisateurs peuvent utiliser."
   },
   "to_which_language_will_you_be_translating_your_bot_77219d69": {
     "message": "Dans quelle langue voulez-vous traduire votre bot ?"

--- a/Composer/packages/server/src/locales/fr.json
+++ b/Composer/packages/server/src/locales/fr.json
@@ -204,10 +204,10 @@
     "message": "+ Ajouter une paire QnA"
   },
   "add_some_example_phrases_to_trigger_this_intent_pl_568eaf51": {
-    "message": "> ajouter des exemples d'expressions pour déclencher cette intention :\n> - peux-tu me donner la météo\n> - comment est la météo à « {'city=Paris'} »\n\n> définitions d'entité :\n> @ ml city"
+    "message": "> ajouter des exemples d'expressions pour déclencher cette intention :\n> - peux-tu me donner la météo\n> - comment est la météo à « '{'city=Paris'}' »\n\n> définitions d'entité :\n> @ ml city"
   },
   "add_some_expected_user_responses_please_remind_me__31dc5c07": {
-    "message": "> ajouter des réponses utilisateur attendues :\n> - peux-tu me rappeler de « {'itemTitle=acheter du lait'} »\n> - rappelle-moi de « {'itemTitle'} »\n> - ajouter « {'itemTitle'} » à ma liste de choses à faire\n>\n> définitions d'entité :\n> @ ml itemTitle\n"
+    "message": "> ajouter des réponses utilisateur attendues :\n> - peux-tu me rappeler de « '{'itemTitle=acheter du lait'}' »\n> - rappelle-moi de « '{'itemTitle'}' »\n> - ajouter « '{'itemTitle'}' » à ma liste de choses à faire\n>\n> définitions d'entité :\n> @ ml itemTitle\n"
   },
   "add_suggested_action_baf855ca": {
     "message": "Add suggested action"

--- a/Composer/packages/server/src/locales/it.json
+++ b/Composer/packages/server/src/locales/it.json
@@ -33,7 +33,7 @@
     "message": "Esiste già un profilo con il nome specificato."
   },
   "a_property_is_a_piece_of_information_that_your_bot_eccd34bf": {
-    "message": "Una proprietà è un'informazione che verrà raccolta dal bot. Il nome della proprietà è il nome usato in Composer; non è necessariamente lo stesso testo che verrà visualizzato nei messaggi del bot."
+    "message": "Una proprietà è un’informazione che verrà raccolta dal bot. Il nome della proprietà è il nome usato in Composer; non è necessariamente lo stesso testo che verrà visualizzato nei messaggi del bot."
   },
   "a_publishing_profile_provides_the_secure_connectiv_e203980e": {
     "message": "A publishing profile provides the secure connectivity required to publish your bot. "
@@ -204,10 +204,10 @@
     "message": "+ Aggiungi coppia di domanda e risposta"
   },
   "add_some_example_phrases_to_trigger_this_intent_pl_568eaf51": {
-    "message": "> aggiungere alcune frasi di esempio per attivare questa finalità:\n> - che tempo fa\n> - com'è il tempo a '{'city=Seattle'}'\n\n>definizioni di entità:\n> @ ml city"
+    "message": "> aggiungere alcune frasi di esempio per attivare questa finalità:\n> - che tempo fa\n> - com’è il tempo a '{'city=Seattle'}'\n\n>definizioni di entità:\n> @ ml city"
   },
   "add_some_expected_user_responses_please_remind_me__31dc5c07": {
-    "message": "> aggiungere alcune risposte previste dell'utente:\n> - Ricordami di '{'itemTitle=buy milk'}'\n> - ricordami '{'itemTitle'}'\n> - aggiungere '{'itemTitle'}' all'elenco di cose da fare\n>\n> definizioni di entità:\n> @ ml itemTitle\n"
+    "message": "> aggiungere alcune risposte previste dell’utente:\n> - Ricordami di '{'itemTitle=buy milk'}'\n> - ricordami '{'itemTitle'}'\n> - aggiungere '{'itemTitle'}' all’elenco di cose da fare\n>\n> definizioni di entità:\n> @ ml itemTitle\n"
   },
   "add_suggested_action_baf855ca": {
     "message": "Add suggested action"
@@ -723,7 +723,7 @@
     "message": "Non è stato possibile connettersi alla risorsa di archiviazione."
   },
   "couldn_t_complete_the_update_a337a359": {
-    "message": "Non è stato possibile completare l'aggiornamento:"
+    "message": "Non è stato possibile completare l’aggiornamento:"
   },
   "create_132b3be1": {
     "message": "Crea"
@@ -1251,7 +1251,7 @@
     "message": "Error occurred (Error event)"
   },
   "error_please_add_unknown_functions_to_setting_s_cu_14b4abf8": {
-    "message": "{ error } Aggiungere funzioni sconosciute al campo customFunctions dell'impostazione."
+    "message": "{ error } Aggiungere funzioni sconosciute al campo customFunctions dell’impostazione."
   },
   "error_processing_schema_2c707cf3": {
     "message": "Errore durante l’elaborazione dello schema"
@@ -3153,7 +3153,7 @@
     "message": "Questa operazione eliminerà il dialogo e il relativo contenuto. Continuare?"
   },
   "this_will_open_your_emulator_application_if_you_do_ba277151": {
-    "message": "Questa operazione aprirà l'applicazione Emulator. Se Bot Framework Emulator non è stato ancora installato, è possibile scaricarlo <a>qui</a>."
+    "message": "Questa operazione aprirà l’applicazione Emulator. Se Bot Framework Emulator non è stato ancora installato, è possibile scaricarlo <a>qui</a>."
   },
   "throw_exception_9d0d1db": {
     "message": "Genera eccezione"
@@ -3177,7 +3177,7 @@
     "message": "{ title }. { msg }"
   },
   "to_customize_the_welcome_message_select_the_i_send_9b4bf4f": {
-    "message": "Per personalizzare il messaggio di benvenuto, selezionare l'azione <i>Invia una risposta</i> nell'editor visivo. Quindi, nell'editor di moduli a destra è possibile modificare il messaggio di benvenuto del bot nel campo <b>Generazione di linguaggio</b>."
+    "message": "Per personalizzare il messaggio di benvenuto, selezionare l’azione <i>Invia una risposta</i> nell’editor visivo. Quindi, nell’editor di moduli a destra è possibile modificare il messaggio di benvenuto del bot nel campo <b>Generazione di linguaggio</b>."
   },
   "to_learn_more_a_visit_this_document_a_ce188d8": {
     "message": "To learn more, <a>visit this document</a>."
@@ -3207,7 +3207,7 @@
     "message": "Per comprendere cosa dice l’utente, il dialogo necessita di un \"Riconoscimento\", che include parole e frasi di esempio che gli utenti possono usare."
   },
   "to_understand_what_the_user_says_your_dialog_needs_957034cc": {
-    "message": "Per comprendere cosa dice l'utente, il dialogo necessita di un \"IRecognizer\", che includa parole e frasi di esempio che gli utenti possono usare."
+    "message": "Per comprendere cosa dice l’utente, il dialogo necessita di un \"IRecognizer\", che includa parole e frasi di esempio che gli utenti possono usare."
   },
   "to_which_language_will_you_be_translating_your_bot_77219d69": {
     "message": "In quale lingua verrà tradotto il bot?"

--- a/Composer/packages/server/src/locales/ko.json
+++ b/Composer/packages/server/src/locales/ko.json
@@ -1785,7 +1785,7 @@
     "message": "List of attachments with their type. Used by channels to render as UI cards or other generic file attachment types."
   },
   "list_of_languages_that_bot_will_be_able_to_underst_e4851dc5": {
-    "message": "봇이 이해(사용자 입력)하고 응답(봇 응답)할 수 있는 언어의 목록입니다. 이 봇을 다른 언어로 사용할 수 있게 하려면 '봇 언어 관리'를 클릭하여 기본 언어의 복사본을 만든 다음, 콘텐츠를 새 언어로 번역합니다."
+    "message": "봇이 이해(사용자 입력)하고 응답(봇 응답)할 수 있는 언어의 목록입니다. 이 봇을 다른 언어로 사용할 수 있게 하려면 ’봇 언어 관리’를 클릭하여 기본 언어의 복사본을 만든 다음, 콘텐츠를 새 언어로 번역합니다."
   },
   "list_view_e33843f0": {
     "message": "목록 보기"

--- a/Composer/packages/server/src/locales/tr.json
+++ b/Composer/packages/server/src/locales/tr.json
@@ -33,7 +33,7 @@
     "message": "Bu ada sahip bir profil zaten var."
   },
   "a_property_is_a_piece_of_information_that_your_bot_eccd34bf": {
-    "message": "Özellik, botunuzun toplayacağı bir bilgi parçasıdır. Özellik adı, Composer'de kullanılan addır. Botunuzun iletilerinde görünecek metinle aynı olması gerekmez."
+    "message": "Özellik, botunuzun toplayacağı bir bilgi parçasıdır. Özellik adı, Composer’de kullanılan addır. Botunuzun iletilerinde görünecek metinle aynı olması gerekmez."
   },
   "a_publishing_profile_provides_the_secure_connectiv_e203980e": {
     "message": "A publishing profile provides the secure connectivity required to publish your bot. "

--- a/Composer/packages/server/src/locales/zh-Hans.json
+++ b/Composer/packages/server/src/locales/zh-Hans.json
@@ -204,10 +204,10 @@
     "message": "+ 添加 QnA 对"
   },
   "add_some_example_phrases_to_trigger_this_intent_pl_568eaf51": {
-    "message": "> 添加一些示例短语来触发此意向:\n> - 请告诉我天气情况\n> -“{'city=Seattle'}”的天气怎么样\n\n> 实体定义:\n> @ ml city"
+    "message": "> 添加一些示例短语来触发此意向:\n> - 请告诉我天气情况\n> -“'{'city=Seattle'}'”的天气怎么样\n\n> 实体定义:\n> @ ml city"
   },
   "add_some_expected_user_responses_please_remind_me__31dc5c07": {
-    "message": "> 添加一些预期的用户响应:\n> - 请提醒我“{'itemTitle=buy milk'}”\n> - 提醒我“{'itemTitle'}”\n> - 将“{'itemTitle'}”添加到我的待办事项列表\n>\n> 实体定义:\n> @ ml itemTitle\n"
+    "message": "> 添加一些预期的用户响应:\n> - 请提醒我“'{'itemTitle=buy milk'}'”\n> - 提醒我“'{'itemTitle'}'”\n> - 将“'{'itemTitle'}'”添加到我的待办事项列表\n>\n> 实体定义:\n> @ ml itemTitle\n"
   },
   "add_suggested_action_baf855ca": {
     "message": "Add suggested action"

--- a/Composer/scripts/l10nCheck.js
+++ b/Composer/scripts/l10nCheck.js
@@ -30,8 +30,12 @@ for (;;) {
         errorCount += 1;
       }
     }
-    if (/[^'{}]'[^'{}]/.exec(msg)) {
+    if (/(\p{L}|\s)'(\p{L})/.exec(msg)) {
       console.log(src, `single quote between letters`);
+      errorCount += 1;
+    }
+    if (/([^']\{')|('\}[^'])/.exec(msg)) {
+      console.log(src, `incorrect brace quoting`);
       errorCount += 1;
     }
   }


### PR DESCRIPTION
## Description

Some of the l10n files ended up with curly braces without the single-quotes around them; this was causing the app to crash in those locales (German, Spanish, French, and Simplified Chinese).

## Task Item

closes #5496 
