### PR TITLE
fix: Fix issue in path that caused multibot templates to be misinterpreted as single bots

### DIFF
--- a/Composer/packages/server/src/models/asset/assetManager.ts
+++ b/Composer/packages/server/src/models/asset/assetManager.ts
@@ -135,8 +135,6 @@ export class AssetManager {
         throw new Error(`error hit when installing remote template`);
       }
 
-      ref.path = `${ref.path}/${projectName}`;
-
       return ref;
     } catch (err) {
       if (err?.message.match(/npm/)) {
@@ -164,8 +162,10 @@ export class AssetManager {
       log('Looking up local packages');
       await yeomanEnv.lookupLocalPackages();
       return true;
-    } catch {
-      return false;
+    } catch (err) {
+      log('Error installing template');
+      log(err);
+      throw err;
     }
   }
 


### PR DESCRIPTION
## Description

when using a new template, there may be > 1 bot created.

the code will crawl the folder looking for multiple bots.

this change ensures that the template generator returns the parent folder which includes all created bot projects.

also included, expose errors in creation more directly.

#minor