### PR TITLE
fix: add new build:ci and fix l10ncheck bug

### DIFF
--- a/Composer/package.json
+++ b/Composer/package.json
@@ -42,6 +42,7 @@
   "scripts": {
     "build": "node scripts/begin.js && yarn build:prod && yarn l10n",
     "build:prod": "yarn build:dev && yarn build:client && yarn build:server && yarn build:electron",
+    "build:ci": "yarn l10n:check && yarn build:dev",
     "build:dev": "yarn build:libs && yarn build:extensions",
     "build:electron": "yarn workspace @bfc/electron-server build && yarn workspace @bfc/electron-server l10n",
     "build:libs": "wsrun -ltm -x @bfc/electron-server -x @bfc/client -x @bfc/server -p @botframework-composer/* -p @bfc/* -c build",

--- a/Composer/scripts/l10nCheck.js
+++ b/Composer/scripts/l10nCheck.js
@@ -18,6 +18,7 @@ for (;;) {
   const json = JSON.parse(data);
   for (const [key, val] of Object.entries(json)) {
     const msg = val.message;
+
     const src = `${dirent.name} at ${key}:`;
     if (/\{.*plural.*}/.exec(msg)) {
       // if we're in a "plural" rules section...
@@ -30,7 +31,7 @@ for (;;) {
         errorCount += 1;
       }
     }
-    if (/(\p{L}|\s)'(\p{L})/.exec(msg)) {
+    if (/(\p{L}|\s|\w)'(\p{L}|\w)/.exec(msg)) {
       console.log(src, `single quote between letters`);
       errorCount += 1;
     }


### PR DESCRIPTION
## Description

We need our CI to be aware of possible problems in L10n files, so this adds a new yarn command to our package.json which runs the l10n:check script and then build:dev, intended to replace the existing build:dev step in our CI flow. This also fixes a small bug in the script that was causing it not to notice some issues.

## Task Item

#minor
