### PR TITLE
fix: Fixes description for toLower and toUpper built-in functions

### DIFF
--- a/Composer/packages/tools/built-in-functions/src/builtInFunctionsMap.ts
+++ b/Composer/packages/tools/built-in-functions/src/builtInFunctionsMap.ts
@@ -261,7 +261,7 @@ export const buildInFunctionsMap: Map<string, FunctionEntity> = new Map<string, 
     new FunctionEntity(
       ['text: string', 'locale?: string'],
       ReturnType.String,
-      'Convert a string to all upper case characters.'
+      'Convert a string to all lower case characters.'
     ),
   ],
   [
@@ -269,7 +269,7 @@ export const buildInFunctionsMap: Map<string, FunctionEntity> = new Map<string, 
     new FunctionEntity(
       ['text: string', 'locale?: string'],
       ReturnType.String,
-      'Convert a string to all lower case characters.'
+      'Convert a string to all upper case characters.'
     ),
   ],
   [


### PR DESCRIPTION
<details>
<summary>Details</summary>



</details>

## Description

![image](https://user-images.githubusercontent.com/1424596/110363398-cff3f280-8042-11eb-939a-d573b20d393f.png)

Currently the description for `toLower` and `toUpper` is reversed. I have tested the functionality and this is correct, just the description is incorrect.

#minor

