### PR TITLE
chore: fix formatting code pre-commit on windows

### DIFF
--- a/Composer/package.json
+++ b/Composer/package.json
@@ -86,7 +86,11 @@
     }
   },
   "lint-staged": {
-    "../**/*.{ts,tsx,js,jsx}": [
+    "**/*.{ts,tsx,js,jsx}": [
+      "prettier --write",
+      "git add"
+    ],
+    "../extensions/**/*": [
       "prettier --write",
       "git add"
     ]


### PR DESCRIPTION
## Description

We noticed the pre-commit hook was not being run anymore on windows since #6090. It's unclear why that was happening.

Adding a specific glob for extension files works properly.

## Task Item

closes #6316 
