### PR TITLE
fix: fix one auth not initialize

### DIFF
--- a/Composer/packages/electron-server/src/auth/oneAuthService.ts
+++ b/Composer/packages/electron-server/src/auth/oneAuthService.ts
@@ -185,6 +185,9 @@ export class OneAuthInstance extends OneAuthBase {
   }
 
   public async getARMTokenForTenant(tenantId: string): Promise<string> {
+    if (!this.initialized) {
+      this.initialize();
+    }
     // sign in arm account.
     if (!this.signedInARMAccount) {
       const signInParams = new this.oneAuth.AuthParameters(DEFAULT_AUTH_SCHEME, ARM_AUTHORITY, ARM_RESOURCE, '', '');


### PR DESCRIPTION
## Description

If we already have tenantId, client will call get arm token api directly, we need to initialized oneauth before the api call.

## Task Item

close #6351 

## Screenshots


