### PR TITLE
fix: Orchestrator don't show notification if model already exists

### DIFF
--- a/Composer/packages/server/src/controllers/orchestrator.ts
+++ b/Composer/packages/server/src/controllers/orchestrator.ts
@@ -60,6 +60,11 @@ async function downloadDefaultModel(req: Request, res: Response) {
   const modelName = lang.language === 'en' ? modelList.defaults?.en_intent : modelList.defaults?.multilingual_intent;
   const modelPath = await getModelPath(modelName);
 
+  if (await pathExists(modelPath)) {
+    state = DownloadState.ALREADYDOWNLOADED;
+    return res.send(201);
+  }
+
   const onProgress = (msg: string) => {
     setTimeout(() => {
       state = DownloadState.DOWNLOADING;
@@ -73,11 +78,7 @@ async function downloadDefaultModel(req: Request, res: Response) {
   state = DownloadState.DOWNLOADING;
 
   setTimeout(async () => {
-    if (!(await pathExists(modelPath))) {
-      await Orchestrator.baseModelGetAsync(modelPath, modelName, onProgress, onFinish);
-    } else {
-      state = DownloadState.ALREADYDOWNLOADED;
-    }
+    await Orchestrator.baseModelGetAsync(modelPath, modelName, onProgress, onFinish);
   }, 0);
 
   return res.send(200, '/orchestrator/status');


### PR DESCRIPTION
## Description
The download model notification pops whenever we use Orchestrator, even when not necessary.  This is a minor fix to not show the notification unless the model download is actually started.

## Task Item
#minor

