### PR TITLE
fix: add cache for orchestrator build to reduce the re-build time

### DIFF
--- a/Composer/packages/server/src/models/bot/__tests__/orchestratorBuilder.test.ts
+++ b/Composer/packages/server/src/models/bot/__tests__/orchestratorBuilder.test.ts
@@ -48,16 +48,16 @@ describe('Orchestrator Tests', () => {
   });
 
   it('throws if input empty', () => {
-    expect(orchestratorBuilder([], nlrPath)).rejects.toThrow();
+    expect(orchestratorBuilder('test', [], nlrPath)).rejects.toThrow();
   });
 
   it('throws if NLR path invalid', () => {
     const data: FileInfo[] = [{ name: 'hello', content: 'test', lastModified: '', path: '', relativePath: '' }];
-    expect(orchestratorBuilder(data, 'invalidPath')).rejects.toThrow();
+    expect(orchestratorBuilder('test', data, 'invalidPath')).rejects.toThrow();
   });
 
   it('produces expected snapshot and recognizer shape', async () => {
-    const buildOutput = await orchestratorBuilder(mockLUInput, nlrPath);
+    const buildOutput = await orchestratorBuilder('test', mockLUInput, nlrPath);
 
     expect(buildOutput.outputs.map((o) => o.id)).toContain('additem.en-us.lu');
 
@@ -66,7 +66,7 @@ describe('Orchestrator Tests', () => {
   });
 
   it('produces expected recognizer shape', async () => {
-    const buildOutput = await orchestratorBuilder(mockLUInput, nlrPath);
+    const buildOutput = await orchestratorBuilder('test', mockLUInput, nlrPath);
 
     expect(buildOutput.outputs.map((o) => o.id)).toContain('additem.en-us.lu');
 

--- a/Composer/packages/server/src/models/bot/process/orchestratorBuilder.ts
+++ b/Composer/packages/server/src/models/bot/process/orchestratorBuilder.ts
@@ -10,33 +10,26 @@ import uniqueId from 'lodash/uniqueId';
 import { ResponseMsg } from './types';
 
 class OrchestratorBuilder {
-  private worker: ChildProcess;
+  private static _worker: ChildProcess;
   private resolves = {};
   private rejects = {};
 
   constructor() {
-    const workerScriptPath = path.join(__dirname, 'orchestratorWorker.ts');
-    if (fs.existsSync(workerScriptPath)) {
-      // set exec arguments to empty, avoid fork nodemon `--inspect` error
-      this.worker = fork(workerScriptPath, [], { execArgv: ['-r', 'ts-node/register'] });
-    } else {
-      // set exec arguments to empty, avoid fork nodemon `--inspect` error
-      this.worker = fork(path.join(__dirname, 'orchestratorWorker.js'), [], { execArgv: [] });
-    }
-    this.worker.on('message', this.handleMsg.bind(this));
+    OrchestratorBuilder.worker.on('message', this.handleMsg.bind(this));
   }
 
   public async build(
+    projectId: string,
     files: FileInfo[],
     modelPath: string,
     generatedFolderPath: string
-  ): Promise<{ [key: string]: string }> {
+  ): Promise<Record<string, string>> {
     const msgId = uniqueId();
-    const msg = { id: msgId, payload: { files, type: 'build', modelPath, generatedFolderPath } };
+    const msg = { id: msgId, payload: { projectId, files, type: 'build', modelPath, generatedFolderPath } };
     return new Promise((resolve, reject) => {
       this.resolves[msgId] = resolve;
       this.rejects[msgId] = reject;
-      this.worker.send(msg);
+      OrchestratorBuilder.worker.send(msg);
     });
   }
 
@@ -56,9 +49,22 @@ class OrchestratorBuilder {
     delete this.rejects[id];
   }
 
-  public exit() {
-    this.worker.kill();
+  static get worker() {
+    if (this._worker && !this._worker.killed) {
+      return this._worker;
+    }
+
+    const workerScriptPath = path.join(__dirname, 'orchestratorWorker.ts');
+    if (fs.existsSync(workerScriptPath)) {
+      // set exec arguments to empty, avoid fork nodemon `--inspect` error
+      this._worker = fork(workerScriptPath, [], { execArgv: ['-r', 'ts-node/register'] });
+    } else {
+      // set exec arguments to empty, avoid fork nodemon `--inspect` error
+      this._worker = fork(path.join(__dirname, 'orchestratorWorker.js'), [], { execArgv: [] });
+    }
+    return this._worker;
   }
 }
 
-export { OrchestratorBuilder };
+const orchestratorBuilder = new OrchestratorBuilder();
+export default orchestratorBuilder;

--- a/Composer/packages/server/src/models/bot/process/types.ts
+++ b/Composer/packages/server/src/models/bot/process/types.ts
@@ -4,6 +4,7 @@ import { FileInfo } from '@bfc/shared';
 
 export type BuildPayload = {
   type: 'build';
+  projectId: string;
   files: FileInfo[];
   modelPath: string;
   generatedFolderPath: string;


### PR DESCRIPTION
## Description
**issue**
composer will do orchestrator build every time. some big bot may take 15min. It is a long time to wait even the lu files don't update.

**fix**
Add the cache of LabelResolvers for orchestrator build. the build worker will re-use the resolvers and reduce the re-training time.
In my local test, the first time will use 15min and the second only use 800ms.
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
#minor
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
