### PR TITLE
fix: qna template to create right empty bot generator

### DIFF
--- a/Composer/packages/lib/shared/src/constant.ts
+++ b/Composer/packages/lib/shared/src/constant.ts
@@ -3,6 +3,8 @@
 
 export const QnABotTemplateId = 'QnASample';
 
+export const emptyBotNpmTemplateName = '@microsoft/generator-microsoft-bot-empty';
+
 export const SensitiveProperties = [
   'MicrosoftAppPassword',
   'luis.endpointKey',

--- a/Composer/packages/server/src/controllers/asset.ts
+++ b/Composer/packages/server/src/controllers/asset.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { Request, Response } from 'express';
-import { BotTemplate, QnABotTemplateId } from '@bfc/shared';
+import { BotTemplate, emptyBotNpmTemplateName, QnABotTemplateId } from '@bfc/shared';
 import formatMessage from 'format-message';
 
 import AssetService from '../services/asset';
@@ -31,15 +31,20 @@ export async function getProjTemplatesV2(req: any, res: any) {
     // Grab templates from FeedURls
     if (feedUrls) {
       const feedTemplates = await AssetService.manager.getCustomFeedTemplates(feedUrls);
+      const emptyBot = feedTemplates.filter((template) => {
+        return template.id === emptyBotNpmTemplateName;
+      });
+      const qnaTemplateVersion =
+        emptyBot.length > 0 && emptyBot[0].package?.packageVersion ? emptyBot[0].package.packageVersion : '*';
       templates = templates.concat(feedTemplates);
       templates.push({
         id: QnABotTemplateId,
         name: 'QNA',
         description: formatMessage('Empty bot template that routes to qna configuration'),
         package: {
-          packageName: 'generator-empty-bot',
+          packageName: emptyBotNpmTemplateName,
           packageSource: 'npm',
-          packageVersion: '1.0.0',
+          packageVersion: qnaTemplateVersion,
         },
       });
     }

--- a/Composer/packages/server/src/models/asset/assetManager.ts
+++ b/Composer/packages/server/src/models/asset/assetManager.ts
@@ -7,7 +7,7 @@ import path from 'path';
 import find from 'lodash/find';
 import { UserIdentity, FileExtensions, FeedType } from '@bfc/extension';
 import { mkdirSync, readFile } from 'fs-extra';
-import { BotTemplate, QnABotTemplateId } from '@bfc/shared';
+import { BotTemplate, emptyBotNpmTemplateName, QnABotTemplateId } from '@bfc/shared';
 
 import { ExtensionContext } from '../extension/extensionContext';
 import log from '../../logger';
@@ -108,7 +108,7 @@ export class AssetManager {
       log('About to create folder', dstDir);
       mkdirSync(dstDir, { recursive: true });
 
-      const npmPackageName = templateId === QnABotTemplateId ? 'generator-empty-bot' : templateId;
+      const npmPackageName = templateId === QnABotTemplateId ? emptyBotNpmTemplateName : templateId;
 
       await runYeomanTemplatePipeline(npmPackageName, templateVersion, dstDir, projectName, jobId);
 


### PR DESCRIPTION
## Description

QNA template instantiates empty bot template under the hood and when we changed the empty bot generator name to the @microosft/ name we did not update the naming in Composer. This PR updates that logic and moves that template named to a shared constant
fixes #6383 