### PR TITLE
fix: read plugin config for action names in breadcrumb array

### DIFF
--- a/Composer/packages/client/package.json
+++ b/Composer/packages/client/package.json
@@ -61,7 +61,7 @@
     "re-resizable": "^6.9.0",
     "react": "16.13.1",
     "react-app-polyfill": "^0.2.1",
-    "react-dev-utils": "^7.0.3",
+    "react-dev-utils": "^11.0.4",
     "react-dom": "16.13.1",
     "react-frame-component": "^4.0.2",
     "react-markdown": "^5.0.3",

--- a/Composer/packages/client/src/pages/design/VisualPanelHeader.tsx
+++ b/Composer/packages/client/src/pages/design/VisualPanelHeader.tsx
@@ -64,7 +64,7 @@ const getActionName = (action, pluginConfig?: PluginConfig) => {
     detectedActionName = nameFromAction;
   } else {
     const kind: string = action?.$kind as string;
-    const actionNameFromSchema = pluginConfig?.uiSchema?.[kind]?.form?.label as string | (() => string) | undefined;
+    const actionNameFromSchema = pluginConfig?.uiSchema?.[kind]?.form?.label;
     if (typeof actionNameFromSchema === 'string') {
       detectedActionName = actionNameFromSchema;
     } else if (typeof actionNameFromSchema === 'function') {
@@ -145,7 +145,7 @@ const useBreadcrumbs = (projectId: string, pluginConfig?: PluginConfig) => {
             b.label = getFriendlyName(get(currentDialog.content, `triggers[${name}]`));
             break;
           case BreadcrumbKeyPrefix.Action:
-            b.label = getActionName(get(currentDialog.content, name));
+            b.label = getActionName(get(currentDialog.content, name), pluginConfig);
             break;
         }
         return b;


### PR DESCRIPTION
## Description

The breadcrumb array needs to get action names, and we have a function that pulls them from the UI schema as needed. However, this function wasn't getting the schema passed into it in some cases.

## Task Item

closes #6374 

## Screenshots

![image](https://user-images.githubusercontent.com/61990921/110861761-71618b00-8273-11eb-9ecf-c61aff599b3c.png)

