### PR TITLE
fix: lg create error with multi-language

### DIFF
--- a/Composer/packages/client/src/recoilModel/dispatchers/lg.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/lg.ts
@@ -56,12 +56,12 @@ const updateLgFiles = (
 
   // adds
   if (adds?.length) {
-    set(lgFileIdsState(projectId), (ids) => ids.concat(adds.map((file) => file.id)));
     adds.forEach((lgFile) => {
       set(lgFileState({ projectId, lgFileId: lgFile.id }), (preFile) =>
         needUpdate ? (needUpdate(preFile, lgFile) ? lgFile : preFile) : lgFile
       );
     });
+    set(lgFileIdsState(projectId), (ids) => ids.concat(adds.map((file) => file.id)));
   }
 };
 


### PR DESCRIPTION
## Description
**Root cause**
when we create a new lg file, today's flow is:
1. add id to lgFileIds state 
2. FilePersistence find the ids changes and create new file for lg
3. add single lg file state by id
in the step 2, FilePersistence will use the ids to find the new file and get the default value (empty) from the state. In fact, we need the real value from step 3.

**fix**
update the state change order. set file state first, then set the ids state. FilePersistence will do nothing when the id doesn't been add to the ids state.

 
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
closes #6409
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
