### PR TITLE
fix: Added gray Composer icon to 'no triggers' dialog state

### DIFF
--- a/Composer/packages/client/src/pages/design/VisualEditor.tsx
+++ b/Composer/packages/client/src/pages/design/VisualEditor.tsx
@@ -33,6 +33,7 @@ function onRenderBlankVisual(isTriggerEmpty, onClickAddTrigger, isRemoteSkill) {
           </React.Fragment>
         ) : isTriggerEmpty ? (
           <React.Fragment>
+            <img alt={formatMessage('bot framework composer icon gray')} src={grayComposerIcon} />
             {formatMessage(`This dialog has no trigger yet.`)}
             <ActionButton
               css={triggerButton}


### PR DESCRIPTION
## Description

Adds a gray Composer icon to the flow editor when a selected dialog has no triggers

## Task Item

Fixes #6377 

## Screenshots

**BEFORE:**

![trigger-landing-before](https://user-images.githubusercontent.com/3452012/111198390-bb50b680-857c-11eb-9480-96e68da59680.PNG)


**AFTER:**

![trigger-landing-after](https://user-images.githubusercontent.com/3452012/111198420-c3a8f180-857c-11eb-9255-1acc2cf0fb8b.PNG)

