### PR TITLE
fix: load feature flags if default keys have changed

### DIFF
--- a/Composer/packages/client/src/recoilModel/dispatchers/storage.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/storage.ts
@@ -20,7 +20,7 @@ import {
 import { FileTypes } from '../../constants';
 import { getExtension } from '../../utils/fileUtil';
 
-import { logMessage } from './shared';
+import { logMessage, setError } from './shared';
 
 const projectFiles = ['bot', 'botproj'];
 
@@ -197,6 +197,11 @@ export const storageDispatcher = () => {
       set(featureFlagsState, response.data);
     } catch (ex) {
       logMessage(callbackHelpers, `Error fetching feature flag data: ${ex}`);
+
+      if (process.env.NODE_ENV === 'development') {
+        const err = new Error(`Error fetching feature flag data: ${ex.message}`);
+        setError(callbackHelpers, err);
+      }
     }
   });
 

--- a/Composer/packages/server/src/services/featureFlags.ts
+++ b/Composer/packages/server/src/services/featureFlags.ts
@@ -28,9 +28,9 @@ export class FeatureFlagService {
       FeatureFlagService.currentFeatureFlagMap[key] = {
         ...FeatureFlagService.defaultFeatureFlags[key],
         ...FeatureFlagService.currentFeatureFlagMap[key],
-        displayName: FeatureFlagService.defaultFeatureFlags[key].displayName,
-        description: FeatureFlagService.defaultFeatureFlags[key].description,
-        documentationLink: FeatureFlagService.defaultFeatureFlags[key].documentationLink,
+        displayName: FeatureFlagService.defaultFeatureFlags[key]?.displayName,
+        description: FeatureFlagService.defaultFeatureFlags[key]?.description,
+        documentationLink: FeatureFlagService.defaultFeatureFlags[key]?.documentationLink,
       };
     });
 


### PR DESCRIPTION
## Description

Fixes an issue where the server would return a 500 after default flags have been removed or renamed but the data.json had not been updated. Also adds an in app error if this happens in the future (only in dev).

## Task Item

closes #6426 
