### PR TITLE
fix: Fixing projectId state save for new creation flow

### DIFF
--- a/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
@@ -704,8 +704,6 @@ export const postRootBotCreation = async (
   source,
   projectIdCache
 ) => {
-  callbackHelpers.set(botProjectIdsState, (current) => [...current, projectId]);
-
   if (settingStorage.get(projectId)) {
     settingStorage.remove(projectId);
   }
@@ -719,6 +717,9 @@ export const postRootBotCreation = async (
     callbackHelpers.set(createQnAOnState, { projectId, dialogId: mainDialog });
     callbackHelpers.set(showCreateQnAFromUrlDialogState(projectId), true);
   }
+
+  callbackHelpers.set(botProjectIdsState, [projectId]);
+
   if (profile) {
     // ABS Create Flow, update publishProfile after create project
     const dispatcher = await callbackHelpers.snapshot.getPromise(dispatcherState);


### PR DESCRIPTION
## Description

Previously projectId state change in the new create flow happened before opening root bot and skills which resulted in undo state for the projectID to not be configured accordingly and ultimately caused the history object to not instantiate for the created botProj (resulted in error modal with message: history.clear is not a function).

This small change saves projectID after running openRootBotAndSkills which ensures the history obj for the created bot proj is configured correctly and does not result in the aforementioned error

## Task Item

#minor
