### PR TITLE
feat: introduce ProvisionHandoff component, to display customized instructions

### DIFF
--- a/Composer/packages/lib/ui-shared/src/components/ProvisionHandoff/ProvisionHandoff.tsx
+++ b/Composer/packages/lib/ui-shared/src/components/ProvisionHandoff/ProvisionHandoff.tsx
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/** @jsx jsx */
+import { jsx } from '@emotion/core';
+import { Dialog, DialogType, DialogFooter } from 'office-ui-fabric-react/lib/Dialog';
+import { PrimaryButton } from 'office-ui-fabric-react/lib/Button';
+import formatMessage from 'format-message';
+
+import { instructionStyles, copyPasteStyles, dialog } from './styles';
+type ProvisionHandoffProps = {
+  title: string;
+  developerInstructions: string;
+  handoffInstructions: string;
+  hidden: boolean;
+  onDismiss: () => void;
+};
+
+export const ProvisionHandoff = (props: ProvisionHandoffProps) => {
+  const closeDialog = () => {
+    props.onDismiss();
+  };
+
+  return (
+    <Dialog
+      dialogContentProps={{
+        type: DialogType.normal,
+        title: props.title,
+      }}
+      hidden={props.hidden}
+      modalProps={{
+        isBlocking: false,
+      }}
+      styles={dialog}
+      onDismiss={closeDialog}
+    >
+      <div css={instructionStyles}>{props.developerInstructions}</div>
+      <div css={copyPasteStyles}>{props.handoffInstructions}</div>
+      <DialogFooter>
+        <PrimaryButton text={formatMessage('Ok')} onClick={closeDialog} />
+      </DialogFooter>
+    </Dialog>
+  );
+};

--- a/Composer/packages/lib/ui-shared/src/components/ProvisionHandoff/styles.ts
+++ b/Composer/packages/lib/ui-shared/src/components/ProvisionHandoff/styles.ts
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { css } from '@emotion/core';
+import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
+import { NeutralColors } from '@uifabric/fluent-theme';
+
+export const instructionStyles = css`
+  margin-bottom: 20px;
+`;
+export const copyPasteStyles = css`
+  background: ${NeutralColors.black};
+  color: ${NeutralColors.white};
+  padding: 15px;
+  max-height: 150px;
+  overflow: scroll;
+  white-space: pre;
+`;
+copyPasteStyles;
+
+export const dialog = {
+  root: {
+    maxWidth: 400,
+  },
+  title: {
+    fontWeight: FontWeights.bold,
+  },
+};

--- a/Composer/packages/lib/ui-shared/src/components/index.ts
+++ b/Composer/packages/lib/ui-shared/src/components/index.ts
@@ -7,3 +7,4 @@ export * from './LoadingSpinner';
 export * from './ConfirmDialog';
 export * from './PropertyAssignment';
 export * from './Toolbar';
+export * from './ProvisionHandoff/ProvisionHandoff';

--- a/Composer/packages/server/src/locales/en-US.json
+++ b/Composer/packages/server/src/locales/en-US.json
@@ -1223,9 +1223,6 @@
   "enable_speech_e4a16f1c": {
     "message": "Enable speech"
   },
-  "enable_the_component_model_including_the_new_creat_f6e5659c": {
-    "message": "Enable the Component Model including the new creation experience, the Adaptive Runtime, and Package Manager."
-  },
   "enabled_ba7cab66": {
     "message": "Enabled"
   },
@@ -1493,6 +1490,9 @@
   "for_properties_of_type_list_or_enum_your_bot_accep_9e7649c6": {
     "message": "For properties of type list (or enum), your bot accepts only the values you define. After your dialog is generated, you can provide synonyms for each value."
   },
+  "for_the_bot_project_i_am_working_on_i_need_to_prov_6759ad1e": {
+    "message": "For the bot project I am working on i need to provision some Azure resources. I will need * * * * and *.  Please read instructions here: GITHUB  And then you can use this command:  *** command***"
+  },
   "form_dialog_error_ba7c37fe": {
     "message": "Form dialog error"
   },
@@ -1525,6 +1525,9 @@
   },
   "generate_44e33e72": {
     "message": "Generate"
+  },
+  "generate_a_provisioning_request_2b76c65b": {
+    "message": "Generate a provisioning request"
   },
   "generate_dialog_b80a85b2": {
     "message": "Generate dialog"
@@ -2198,6 +2201,9 @@
   "new_13daf639": {
     "message": "New"
   },
+  "new_creation_experience_29591aca": {
+    "message": "New Creation Experience"
+  },
   "new_template_49e6f0f2": {
     "message": "New template"
   },
@@ -2455,6 +2461,9 @@
   },
   "preview_features_e279bac5": {
     "message": "Preview features"
+  },
+  "preview_the_new_bot_creation_experience_create_new_e0b7150f": {
+    "message": "Preview the new bot creation experience. Create new bots that use the Adaptive Runtime, and can be enhanced using Package Manager."
   },
   "previous_bd2ac015": {
     "message": "Previous"
@@ -2921,6 +2930,9 @@
   "send_messages_c48b239": {
     "message": "Send Messages"
   },
+  "send_this_to_your_it_admin_64af7706": {
+    "message": "Send this to your IT admin"
+  },
   "sentence_wrap_930c8ced": {
     "message": "Sentence wrap"
   },
@@ -3160,9 +3172,6 @@
   },
   "the_api_messages_endpoint_for_the_skill_f318dc63": {
     "message": "The /api/messages endpoint for the skill."
-  },
-  "the_component_model_febefd93": {
-    "message": "The Component Model"
   },
   "the_dialog_you_have_tried_to_delete_is_currently_u_a37c7a02": {
     "message": "The dialog you have tried to delete is currently used in the below dialog(s). Removing this dialog will cause your Bot to malfunction without additional action."


### PR DESCRIPTION
## Description

Introduces a new component used to display "handoff" instructions in the provisioning process, and during setup of the bot.  This will display customized instructions to the user in a manner easy to copy/paste into a helpdesk request or email.

For example, if a user does not have permission to provision resources in Azure by themselves, this will generate a copy-paste instruction for using the provisionComposer script.


## Task Item

Fixes #5896 

## Screenshots
