### PR TITLE
fix: Update bf-orchestrator to 4.12.0-beta.20210322.314475a

### DIFF
--- a/Composer/packages/server/package.json
+++ b/Composer/packages/server/package.json
@@ -82,7 +82,7 @@
     "@microsoft/bf-dispatcher": "^4.11.0-beta.20201016.393c6b2",
     "@microsoft/bf-generate-library": "^4.10.0-daily.20210225.217555",
     "@microsoft/bf-lu": "4.12.0-rc0",
-    "@microsoft/bf-orchestrator": "4.12.0-beta.20210316.cdd0819",
+    "@microsoft/bf-orchestrator": "4.12.0-beta.20210322.314475a",
     "applicationinsights": "^1.8.7",
     "archiver": "^5.0.2",
     "axios": "^0.21.1",

--- a/Composer/yarn.lock
+++ b/Composer/yarn.lock
@@ -3947,12 +3947,12 @@
     tslib "^2.0.3"
     xml2js "^0.4.19"
 
-"@microsoft/bf-dispatcher@4.12.0-beta.20210316.cdd0819":
-  version "4.12.0-beta.20210316.cdd0819"
-  resolved "https://registry.yarnpkg.com/@microsoft/bf-dispatcher/-/bf-dispatcher-4.12.0-beta.20210316.cdd0819.tgz#454a612d4e17edc964675259be84ccc1c51425b4"
-  integrity sha512-TzkkoUTIITiBjwB8+UIjle9PCRJH8jolczOTEQszCDB3t7twfs54tLXzTmNVBS/bP9EAgZ+TY4xzd8IhoK/XdQ==
+"@microsoft/bf-dispatcher@4.12.0-beta.20210322.314475a":
+  version "4.12.0-beta.20210322.314475a"
+  resolved "https://registry.yarnpkg.com/@microsoft/bf-dispatcher/-/bf-dispatcher-4.12.0-beta.20210322.314475a.tgz#48c2971b45cecc01461440636cac8fb74a5aac55"
+  integrity sha512-f4LrW7fRLmB+fZXB4OR6bHbKWMAY3E7tgELhSq5fziWCX2QGsOfD7iKekFtFT1NUXFl+J02a0nQm5O8li5/Geg==
   dependencies:
-    "@microsoft/bf-lu" next
+    "@microsoft/bf-lu" "4.12.0-rc0"
     "@oclif/command" "~1.5.19"
     "@oclif/config" "~1.13.3"
     argparse "~1.0.10"
@@ -4057,19 +4057,19 @@
     semver "^5.5.1"
     tslib "^2.0.3"
 
-"@microsoft/bf-orchestrator@4.12.0-beta.20210316.cdd0819":
-  version "4.12.0-beta.20210316.cdd0819"
-  resolved "https://registry.yarnpkg.com/@microsoft/bf-orchestrator/-/bf-orchestrator-4.12.0-beta.20210316.cdd0819.tgz#1869942269909759eb81e8ce9a538019392c2def"
-  integrity sha512-1jIYXtw+x6mm7cM0iCunf/hM7d+xrI5D3UnVMUrILK8t2oByuLyj7NUyt7oSrSmlAwhEAtYGJ/5xpdqdIxKw0Q==
+"@microsoft/bf-orchestrator@4.12.0-beta.20210322.314475a":
+  version "4.12.0-beta.20210322.314475a"
+  resolved "https://registry.yarnpkg.com/@microsoft/bf-orchestrator/-/bf-orchestrator-4.12.0-beta.20210322.314475a.tgz#4bc37966ac1aa144f8daae78873dc92030e2251d"
+  integrity sha512-DLXjmPkdJzwTvbx6vHAEz4qGDe/O/60cax/Payo9cfXRRphsbdiKTD6W2gmnrP6Q9IMitJ0yv9s527iFEI3GrQ==
   dependencies:
-    "@microsoft/bf-dispatcher" "4.12.0-beta.20210316.cdd0819"
-    "@microsoft/bf-lu" next
+    "@microsoft/bf-dispatcher" "4.12.0-beta.20210322.314475a"
+    "@microsoft/bf-lu" "4.12.0-rc0"
     "@types/fs-extra" "~8.1.0"
     "@types/node-fetch" "~2.5.5"
     fast-text-encoding "^1.0.3"
     fs-extra "~9.0.0"
     node-fetch "~2.6.0"
-    orchestrator-core beta
+    orchestrator-core "4.12.0-beta.1"
     read-text-file "~1.1.0"
     tslib "^1.10.0"
     unzip-stream "^0.3.1"
@@ -17309,10 +17309,10 @@ optionator@^0.9.1:
     type-check "^0.4.0"
     word-wrap "^1.2.3"
 
-orchestrator-core@beta:
-  version "4.13.0-dev.20210314.2955922h"
-  resolved "https://registry.yarnpkg.com/orchestrator-core/-/orchestrator-core-4.13.0-dev.20210314.2955922h.tgz#e0ee7852f8654bc72ad7eb10114617a5287cbd7c"
-  integrity sha512-pNyUPjjXc0GuRFYZXvlcicCdipsJCmaCNFmHB3ogYEZo48JW+nCC6Nul1FEZAFeZIDTKZcyBrYg0pY2pCKR+4Q==
+orchestrator-core@4.12.0-beta.1:
+  version "4.12.0-beta.1"
+  resolved "https://registry.yarnpkg.com/orchestrator-core/-/orchestrator-core-4.12.0-beta.1.tgz#bc7a88f48b9c185588a7d179a5da3f2e42cfe23a"
+  integrity sha512-4Q+Ui/6rsiBJU1fwQAvxthMNWDY/qKvhrNYLnQNQ7llN/XI8Rk3yzUxfJ04V2WAa3Dm3GEXgix6/inWaiHjKdg==
   dependencies:
     bindings "1.2.1"
     node-addon-api "^3.0.0"


### PR DESCRIPTION
## Description
Fixes permissions on `libicudata.68.dylib` and `libicuuc.68.dylib` in `orchestrator-core` for Mac.  This should allow the Composer updater to delete the old version of Composer without complaining about write-errors

## Task Item
#minor

