### PR TITLE
fix: docker build failed

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,7 +30,8 @@ jobs:
           push: false
           context: .
           file: Dockerfile
-          tags: botframework-composer
+          tags: build
+          target: build
 
       - name: Health check
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,7 +30,7 @@ jobs:
           push: false
           context: .
           file: Dockerfile
-          tags: build
+          tags: botframework-composer
           target: build
 
       - name: Health check

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,7 +31,7 @@ jobs:
           context: .
           file: Dockerfile
           tags: botframework-composer
-          target: build
+          target: build   # CI will stop at the build stage
 
       - name: Health check
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ ENV NODE_ENV "production"
 ENV COMPOSER_BUILTIN_EXTENSIONS_DIR "/src/extensions"
 RUN yarn build:prod $YARN_ARGS
 
+# CI only
 ENV COMPOSER_REMOTE_EXTENSIONS_DIR "/src/remote-extensions"
 ENV COMPOSER_REMOTE_EXTENSION_DATA_DIR "/src/extension-data"
 ENV COMPOSER_EXTENSION_MANIFEST "/src/extensions.json"

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ COPY --from=build /src/extensions ../extensions
 ENV NODE_ENV "production"
 RUN yarn --production --frozen-lockfile --force $YARN_ARGS && yarn cache clean
 
-FROM base as botframework-composer
+FROM base
 ENV NODE_ENV "production"
 
 WORKDIR /app/Composer

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,11 @@ ENV NODE_ENV "production"
 ENV COMPOSER_BUILTIN_EXTENSIONS_DIR "/src/extensions"
 RUN yarn build:prod $YARN_ARGS
 
+ENV COMPOSER_REMOTE_EXTENSIONS_DIR "/src/remote-extensions"
+ENV COMPOSER_REMOTE_EXTENSION_DATA_DIR "/src/extension-data"
+ENV COMPOSER_EXTENSION_MANIFEST "/src/extensions.json"
+CMD ["yarn","start:server"]
+
 FROM base as composerbasic
 ARG YARN_ARGS
 
@@ -38,7 +43,7 @@ COPY --from=build /src/extensions ../extensions
 ENV NODE_ENV "production"
 RUN yarn --production --frozen-lockfile --force $YARN_ARGS && yarn cache clean
 
-FROM base
+FROM base as botframework-composer
 ENV NODE_ENV "production"
 
 WORKDIR /app/Composer


### PR DESCRIPTION
## Description
**Root cause**
The docker build use multi-stage builds today. There are three stages and will take more than 21G device size before the final image created. Our virtual machine's disk available space is 21G today. 

![image](https://user-images.githubusercontent.com/39758135/112456152-70614b00-8d95-11eb-973a-935721c0bf5a.png)

so when we do copy will throw the error: 'no space left on device'

**Fix**

Only use the first stage  to do the docker build ci
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
#minor
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
