### PR TITLE
chore: Shared check for using adaptive runtime

### DIFF
--- a/Composer/packages/lib/shared/src/skillsUtils/index.ts
+++ b/Composer/packages/lib/shared/src/skillsUtils/index.ts
@@ -100,3 +100,6 @@ export const isLocalhostUrl = (matchUrl: string) => {
 export const isSkillHostUpdateRequired = (skillHostEndpoint?: string) => {
   return !skillHostEndpoint || isLocalhostUrl(skillHostEndpoint);
 };
+
+export const isUsingAdaptiveRuntime = (runtime?: DialogSetting['runtime']): boolean =>
+  runtime?.key === 'csharp-azurewebapp-v2' || !!runtime?.key?.startsWith('adaptive-runtime-');

--- a/Composer/packages/server/src/models/bot/botProject.ts
+++ b/Composer/packages/server/src/models/bot/botProject.ts
@@ -7,6 +7,7 @@ import fs from 'fs';
 import has from 'lodash/has';
 import axios from 'axios';
 import { autofixReferInDialog } from '@bfc/indexers';
+import { isUsingAdaptiveRuntime } from '@bfc/shared';
 import {
   getNewDesigner,
   FileInfo,
@@ -47,9 +48,6 @@ const oauthInput = () => ({
 });
 
 const defaultLanguage = 'en-us'; // default value for settings.defaultLanguage
-
-const isUsingAdaptiveRuntime = (runtime?: DialogSetting['runtime']): boolean =>
-  runtime?.key === 'csharp-azurewebapp-v2' || runtime?.key === 'adaptive-runtime-dotnet-webapp';
 export class BotProject implements IBotProject {
   public ref: LocationRef;
   // TODO: address need to instantiate id - perhaps do so in constructor based on Store.get(projectLocationMap)

--- a/extensions/azurePublish/src/node/index.ts
+++ b/extensions/azurePublish/src/node/index.ts
@@ -14,6 +14,7 @@ import {
   PublishResponse,
   PublishResult,
 } from '@botframework-composer/types';
+import { isUsingAdaptiveRuntime } from '@bfc/shared';
 
 import { authConfig, ResourcesItem } from '../types';
 
@@ -190,7 +191,7 @@ export default async (composer: IExtensionRegistration): Promise<void> => {
         // include both pre-release and release identifiers here
         // TODO: eventually we can clean this up when the "old" runtime is deprecated
         // (old runtime support is the else block below)
-        if (runtime.key === 'csharp-azurewebapp-v2' || runtime.key === 'adaptive-runtime-dotnet-webapp') {
+        if (isUsingAdaptiveRuntime(runtime)) {
           const buildFolder = this.getProjectFolder(resourcekey, this.mode);
 
           // clean up from any previous deploys

--- a/extensions/azurePublish/src/node/luisAndQnA.ts
+++ b/extensions/azurePublish/src/node/luisAndQnA.ts
@@ -5,13 +5,11 @@ import * as path from 'path';
 
 import * as fs from 'fs-extra';
 import * as rp from 'request-promise';
+import { isUsingAdaptiveRuntime } from '@bfc/shared';
 import { ILuisConfig, FileInfo, IBotProject, RuntimeTemplate, DialogSetting } from '@botframework-composer/types';
 
 import { AzurePublishErrors } from './utils/errorHandler';
 import { BotProjectDeployLoggerType } from './types';
-
-const isUsingAdaptiveRuntime = (runtime?: DialogSetting['runtime']): boolean =>
-  runtime?.key === 'csharp-azurewebapp-v2' || runtime?.key === 'adaptive-runtime-dotnet-webapp';
 
 const botPath = (projPath: string, runtime?: DialogSetting['runtime']) =>
   isUsingAdaptiveRuntime(runtime) ? projPath : path.join(projPath, 'ComposerDialogs');


### PR DESCRIPTION
## Description

The isUsingAdaptiveRuntime code is repeated in several places across the code.  
It has too narrow a check for adaptive runtime types.
This moves the check to @bfc/shared and widens the check on the runtime setting.

## Task Item

#minor

## Screenshots

N/A
