### PR TITLE
fix: Fixed SelectField dropdown arrow

### DIFF
--- a/Composer/packages/adaptive-form/src/utils/resolveFieldWidget.ts
+++ b/Composer/packages/adaptive-form/src/utils/resolveFieldWidget.ts
@@ -66,7 +66,9 @@ export function resolveFieldWidget(params: {
       if (value.startsWith('=')) {
         return { field: isOneOf ? DefaultFields.IntellisenseExpressionField : IntellisenseExpressionFieldWithIcon };
       } else {
-        if (showIntellisense && isOneOf) {
+        if (schema.enum?.includes(value)) {
+          return { field: isOneOf ? DefaultFields.SelectField : SelectFieldWithIcon };
+        } else if (showIntellisense && isOneOf) {
           return { field: DefaultFields.IntellisenseTextField };
         } else if (showIntellisense && !isOneOf) {
           return { field: IntellisenseTextFieldWithIcon };


### PR DESCRIPTION
## Description
When the user selected an enum option, the field resolved to a StringField instead of a SelectField.

## Task Item
Closes #6168

