### PR TITLE
fix: clean the hostedBots/botid folder when deleting a bot

### DIFF
--- a/Composer/packages/server/src/server.ts
+++ b/Composer/packages/server/src/server.ts
@@ -34,6 +34,7 @@ import DLServerContext from './directline/store/dlServerState';
 import { mountConversationsRoutes } from './directline/mountConversationRoutes';
 import { mountDirectLineRoutes } from './directline/mountDirectlineRoutes';
 import { mountAttachmentRoutes } from './directline/mountAttachmentRoutes';
+import { cleanHostedBots } from './utility/cleanHostedBots';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const session = require('express-session');
@@ -42,6 +43,7 @@ export async function start(electronContext?: ElectronContext): Promise<number |
   if (electronContext) {
     setElectronContext(electronContext);
   }
+  cleanHostedBots();
   const clientDirectory = path.resolve(require.resolve('@bfc/client'), '..');
   const app: Express = express();
   app.set('view engine', 'ejs');

--- a/Composer/packages/server/src/settings/env.ts
+++ b/Composer/packages/server/src/settings/env.ts
@@ -55,3 +55,5 @@ export const extensionDataDir = process.env.COMPOSER_EXTENSION_DATA_DIR || resol
 export const extensionsBuiltinDir = process.env.COMPOSER_BUILTIN_EXTENSIONS_DIR || resolveFromRoot('../extensions');
 export const extensionsRemoteDir =
   process.env.COMPOSER_REMOTE_EXTENSIONS_DIR || resolveFromRoot('.composer/extensions');
+export const localPublishPath =
+  process.env.LOCAL_PUBLISH_PATH || resolveFromRoot('../extensions/localPublish/hostedBots');

--- a/Composer/packages/server/src/utility/cleanHostedBots.ts
+++ b/Composer/packages/server/src/utility/cleanHostedBots.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+import { join } from 'path';
+
+import { pathExists, readJson, readdir, remove } from 'fs-extra';
+
+import { appDataPath, localPublishPath } from './../settings/env';
+
+// this function is used to clean the deleted bots in the extensions's cache
+export const cleanHostedBots = async () => {
+  try {
+    if (!(await pathExists(appDataPath))) return;
+    const envData = await readJson(appDataPath);
+
+    if (!envData.projectLocationMap) return;
+    const projects = envData.projectLocationMap;
+
+    let localHostedBots: string[] = [];
+    if (await pathExists(localPublishPath)) {
+      localHostedBots = await readdir(localPublishPath);
+    }
+
+    localHostedBots.forEach((id) => {
+      if (!projects[id]) {
+        remove(join(localPublishPath, id));
+      }
+    });
+  } catch (error) {
+    //TODO: if we can't remove these hostedBots, do we need to show the error
+  }
+};

--- a/extensions/localPublish/src/index.ts
+++ b/extensions/localPublish/src/index.ts
@@ -195,7 +195,7 @@ class LocalPublisher implements PublishPlugin<PublishConfig> {
   };
 
   removeRuntimeData = async (botId: string) => {
-    const targetDir = path.resolve(__dirname, `../hostedBots/${botId}`);
+    const targetDir = path.resolve(this.getBotsDir(), `./${botId}`);
     if (!(await this.dirExist(targetDir))) {
       return { msg: `runtime path ${targetDir} does not exist` };
     }


### PR DESCRIPTION
## Description
**issue**
We support the clean the local runtime date already, but the folder path is not correct when use the electron.

**fix**
1. use the correct the folder path to clean the electron runtime data.
2. add the check function to clean the local runtime folder when starting composer.
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
closes #5331
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots
![deletebot](https://user-images.githubusercontent.com/39758135/113289903-702bf700-9323-11eb-87d5-43cf7f26b444.gif)

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
