### PR TITLE
fix: qna section display errs

### DIFF
--- a/Composer/packages/client/src/pages/knowledge-base/table-view.tsx
+++ b/Composer/packages/client/src/pages/knowledge-base/table-view.tsx
@@ -231,7 +231,7 @@ const TableView: React.FC<TableViewProps> = (props) => {
         projectId: actualProjectId,
       });
     } else {
-      setQnASections(qnaSections.filter((section) => section.Answer === '' && section.Questions.length === 0));
+      setQnASections(qnaSections.filter((section) => !(section.Answer === '' && section.Questions.length === 0)));
     }
     // update expand status
     if (expandedIndex) {

--- a/Composer/packages/client/src/pages/knowledge-base/table-view.tsx
+++ b/Composer/packages/client/src/pages/knowledge-base/table-view.tsx
@@ -224,11 +224,15 @@ const TableView: React.FC<TableViewProps> = (props) => {
     actions.setMessage('item deleted');
     const sectionIndex = qnaSections.findIndex((item) => item.fileId === fileId);
     setCreateQnAPairSettings({ groupKey: '', sectionIndex: -1 });
-    removeQnAPairs({
-      id: fileId,
-      sectionId,
-      projectId: actualProjectId,
-    });
+    if (sectionId) {
+      removeQnAPairs({
+        id: fileId,
+        sectionId,
+        projectId: actualProjectId,
+      });
+    } else {
+      setQnASections(qnaSections.filter((section) => section.Answer === '' && section.Questions.length === 0));
+    }
     // update expand status
     if (expandedIndex) {
       if (sectionIndex < expandedIndex) {
@@ -252,11 +256,11 @@ const TableView: React.FC<TableViewProps> = (props) => {
     const groupStartIndex = qnaSections.findIndex((item) => item.fileId === fileId);
     // create on empty KB.
     let insertPosition = groupStartIndex;
-    if (groupStartIndex === -1) {
-      insertPosition = 0;
-    }
     const newGroups = getGroups(fileId);
     setGroups(newGroups);
+    if (groupStartIndex === -1) {
+      insertPosition = newGroups?.find((group) => group.key === fileId)?.startIndex || 0;
+    }
     const newItem = createQnASectionItem(fileId);
     const newQnaSections = [...qnaSections];
     newQnaSections.splice(insertPosition, 0, newItem);


### PR DESCRIPTION
## Description

### Bug 1
- Display: Create new kb from scratch after created from url, the url Kb last qna pair will show in the new kb qna pair when adding new pair.
![qna-bugfix](https://user-images.githubusercontent.com/5860999/113382159-694cc500-93b3-11eb-9978-9f7e8f1540cf.gif)
- Reason: the new qna pair index is not match the selected qna group
- Solution: set the qna pair index as the selected qna group's startIndex

### Bug 2
- Display: Create new qna pair failed after delete empty qna pair. 
![qna-bugfix1](https://user-images.githubusercontent.com/5860999/113382165-6ce04c00-93b3-11eb-8db4-a4acee1c15b0.gif)
- Reason: the empty qna pair is not deleted but set `isCreateQnaSection` as false when clicking delete button, so  the `updateQnaSection` is invoked when re-create the qna pair, but the sectionId is none. The action will trigger the error modal.
- Solution: delete the empty qna pair.

### Expected
![qna-bugfix-fix](https://user-images.githubusercontent.com/5860999/113383355-57205600-93b6-11eb-8d23-4c1c4d8dca30.gif)



## Task Item

closes #6657

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
