### PR TITLE
feature: Added skill manifest URL to publish page

### DIFF
--- a/Composer/packages/client/src/pages/publish/type.ts
+++ b/Composer/packages/client/src/pages/publish/type.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { DialogSetting, PublishResult, PublishTarget } from '@bfc/shared';
+import { DialogSetting, PublishResult, PublishTarget, SkillManifestFile } from '@bfc/shared';
 
 import { PublishType } from '../../recoilModel/types';
 
@@ -16,6 +16,10 @@ export type BotStatus = {
   status?: number;
   message?: string;
   comment?: string;
+  /**
+   * The skill manifest URL associated with the current publishTarget.
+   */
+  skillManifestUrl?: string;
 };
 
 export type Bot = {
@@ -28,6 +32,7 @@ type BotProperty = {
   setting: DialogSetting;
   publishTargets: PublishTarget[];
   publishTypes: PublishType[];
+  skillManifests: SkillManifestFile[];
 };
 
 export type BotProjectType = {

--- a/Composer/packages/client/src/recoilModel/selectors/project.ts
+++ b/Composer/packages/client/src/recoilModel/selectors/project.ts
@@ -181,6 +181,7 @@ export const botProjectSpaceSelector = selector({
         buildEssentials,
         isPvaSchema,
         publishTypes,
+        skillManifests,
       };
     });
     return result;

--- a/Composer/packages/server/src/locales/en-US.json
+++ b/Composer/packages/server/src/locales/en-US.json
@@ -815,7 +815,7 @@
   "copy_project_location_to_clipboard_eb85c474": {
     "message": "Copy project location to clipboard"
   },
-  "copy_skill_manifest_url_8f9371d0": {
+  "copy_skill_manifest_url_217975ba": {
     "message": "Copy Skill Manifest URL"
   },
   "could_not_connect_to_storage_50411de0": {
@@ -1207,6 +1207,9 @@
   },
   "done_54e3d4b6": {
     "message": "Done"
+  },
+  "download_icon_2e0d10": {
+    "message": "Download Icon"
   },
   "download_now_and_install_when_you_close_composer_e241ed74": {
     "message": "Download now and install when you close Composer."
@@ -1642,6 +1645,9 @@
   },
   "fromtemplatename_does_not_exist_d429483c": {
     "message": "fromTemplateName does not exist"
+  },
+  "full_description_for_fd03dbf8": {
+    "message": "full description for"
   },
   "gb_7570760e": {
     "message": "GB"
@@ -2546,11 +2552,17 @@
   "open_inline_editor_a5aabcfa": {
     "message": "Open inline editor"
   },
+  "open_manifest_ffb556af": {
+    "message": "Open Manifest"
+  },
   "open_notification_panel_5796edb3": {
     "message": "Open notification panel"
   },
   "open_start_bots_panel_f7f87200": {
     "message": "Open start bots panel"
+  },
+  "open_teams_416aae5c": {
+    "message": "Open Teams"
   },
   "open_web_chat_23601990": {
     "message": "Open Web Chat"
@@ -3245,6 +3257,9 @@
   "share_resource_request_afc3e465": {
     "message": "Share resource request"
   },
+  "short_description_for_6abb9a1b": {
+    "message": "short description for"
+  },
   "show_all_diagnostics_c11f4e09": {
     "message": "Show All Diagnostics"
   },
@@ -3430,6 +3445,12 @@
   },
   "tb_149f379c": {
     "message": "TB"
+  },
+  "teams_manifest_59d7fb0e": {
+    "message": "Teams Manifest"
+  },
+  "teams_manifest_for_your_bot_7d0ec7ea": {
+    "message": "Teams manifest for your bot:"
   },
   "template_name_c37cf8d9": {
     "message": "Template name: "
@@ -4024,6 +4045,9 @@
   },
   "your_new_bot_is_almost_ready_1bb596e": {
     "message": "Your new bot is almost ready!"
+  },
+  "your_teams_adapter_is_configured_for_your_publishe_e84e9275": {
+    "message": "Your Teams adapter is configured for your published bot. Copy the manifest, open App Studio in Teams and add the manifest so you can test your bot in Teams"
   },
   "your_template_requires_qna_maker_to_access_content_a4ca6f76": {
     "message": "Your template requires QnA Maker to access content for your bot."

--- a/Composer/packages/server/src/locales/en-US.json
+++ b/Composer/packages/server/src/locales/en-US.json
@@ -815,6 +815,9 @@
   "copy_project_location_to_clipboard_eb85c474": {
     "message": "Copy project location to clipboard"
   },
+  "copy_skill_manifest_url_8f9371d0": {
+    "message": "Copy Skill Manifest URL"
+  },
   "could_not_connect_to_storage_50411de0": {
     "message": "Could not connect to storage."
   },

--- a/extensions/azurePublish/src/node/index.ts
+++ b/extensions/azurePublish/src/node/index.ts
@@ -3,6 +3,7 @@
 
 import path from 'path';
 
+import formatMessage from 'format-message';
 import md5 from 'md5';
 import { copy, rmdir, emptyDir, readJson, pathExists, writeJson, mkdirSync, writeFileSync } from 'fs-extra';
 import { Debugger } from 'debug';
@@ -20,7 +21,7 @@ import { authConfig, ResourcesItem } from '../types';
 
 import { AzureResourceTypes, AzureResourceDefinitions } from './resourceTypes';
 import { mergeDeep } from './mergeDeep';
-import { BotProjectDeploy, getAbsSettings, isProfileComplete } from './deploy';
+import { BotProjectDeploy, getAbsSettings } from './deploy';
 import { BotProjectProvision } from './provision';
 import { BackgroundProcessManager } from './backgroundProcessManager';
 import { ProvisionConfig } from './provision';
@@ -505,6 +506,36 @@ export default async (composer: IExtensionRegistration): Promise<void> => {
       const resourcekey = md5([project.name, name, environment].join());
 
       try {
+        // verify the profile has been provisioned at least once
+        if (!this.isProfileProvisioned(config)) {
+          throw new Error(
+            formatMessage(
+              'There was a problem publishing {projectName}/{profileName}. The profile has not been provisioned yet.',
+              { projectName: project.name, profileName }
+            )
+          );
+        }
+
+        // verify the publish profile has the required resources configured
+        const resources = await this.getResources(project, user);
+
+        const missingResourceNames = resources.reduce((result, resource) => {
+          if (resource.required && !this.isResourceProvisionedInProfile(resource, config)) {
+            result.push(resource.text);
+          }
+          return result;
+        }, []);
+
+        if (missingResourceNames.length > 0) {
+          const missingResourcesText = missingResourceNames.join(',');
+          throw new Error(
+            formatMessage(
+              'There was a problem publishing {projectName}/{profileName}. These required resources have not been provisioned: {missingResourcesText}',
+              { projectName: project.name, profileName, missingResourcesText }
+            )
+          );
+        }
+
         // authenticate with azure
         const accessToken = config.accessToken || (await getAccessToken(authConfig.arm));
 
@@ -515,8 +546,6 @@ export default async (composer: IExtensionRegistration): Promise<void> => {
         if (!settings) {
           throw new Error('Required field `settings` is missing from publishing profile.');
         }
-        // verify publish profile
-        isProfileComplete(config);
 
         this.asyncPublish({ ...config, accessToken, luResources, qnaResources, abs }, project, resourcekey, jobId);
 
@@ -671,6 +700,54 @@ export default async (composer: IExtensionRegistration): Promise<void> => {
       });
 
       return recommendedResources;
+    };
+
+    private isProfileProvisioned = (profile: PublishConfig): boolean => {
+      //TODO: Post-migration we can check for profile?.tenantId
+      return profile?.resourceGroup && profile?.subscriptionId && profile?.region;
+    };
+
+    // While the provisioning process may return more information for various resources than is checked here,
+    // this tries to verify the minimum settings are present and that cannot be empty strings.
+    private isResourceProvisionedInProfile = (resource: ResourcesItem, profile: PublishConfig): boolean => {
+      switch (resource.key) {
+        case AzureResourceTypes.APPINSIGHTS:
+          // InstrumentationKey is Pascal-cased for some unknown reason
+          return profile?.settings?.applicationInsights?.InstrumentationKey;
+        case AzureResourceTypes.APP_REGISTRATION:
+          // MicrosoftAppId and MicrosoftAppPassword are Pascal-cased for some unknown reason
+          return profile?.settings?.MicrosoftAppId && profile?.settings?.MicrosoftAppPassword;
+        case AzureResourceTypes.BLOBSTORAGE:
+          // name is not checked (not in schema.ts)
+          // container property is not checked (empty may be a valid value)
+          return profile?.settings?.blobStorage?.connectionString;
+        case AzureResourceTypes.BOT_REGISTRATION:
+          return profile?.botName;
+        case AzureResourceTypes.COSMOSDB:
+          // collectionId is not checked (not in schema.ts)
+          // databaseId and containerId are not checked (empty may be a valid value)
+          return profile?.settings?.cosmosDB?.authKey && profile?.settings?.cosmosDB?.cosmosDBEndpoint;
+        case AzureResourceTypes.LUIS_AUTHORING:
+          // region is not checked (empty may be a valid value)
+          return profile?.settings?.luis?.authoringKey && profile?.settings?.luis?.authoringEndpoint;
+        case AzureResourceTypes.LUIS_PREDICTION:
+          // region is not checked (empty may be a valid value)
+          return profile?.settings?.luis?.endpointKey && profile?.settings?.luis?.endpoint;
+        case AzureResourceTypes.QNA:
+          // endpoint is not checked (it is in schema.ts and provision() returns the value, but it is not set in the config)
+          // qnaRegion is not checked (empty may be a valid value)
+          return profile?.settings?.qna?.subscriptionKey;
+        case AzureResourceTypes.SERVICE_PLAN:
+          // no settings exist to verify the service plan was created
+          return true;
+        case AzureResourceTypes.AZUREFUNCTIONS:
+        case AzureResourceTypes.WEBAPP:
+          return profile?.hostname;
+        default:
+          throw new Error(
+            formatMessage('Azure resource type {resourceKey} is not handled.', { resourceKey: resource.key })
+          );
+      }
     };
 
     private addProvisionHistory = (botId: string, profileName: string, newValue: ProcessStatus) => {


### PR DESCRIPTION
## Description

This provides the basic link and copies the manifest URL to the clipboard.
A future PR will improve the copy experience to include a callout when copied via a more general purpose mechanism.

## Task Item

closes #6597 

## Screenshots

![image](https://user-images.githubusercontent.com/28762486/113455968-d581f580-93c0-11eb-85ad-176023d7b4cd.png)
