### PR TITLE
fix: ARM token for provisioning is now passed via body.

### DIFF
--- a/Composer/packages/client/src/recoilModel/dispatchers/provision.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/provision.ts
@@ -61,13 +61,12 @@ export const provisionDispatcher = () => {
     ) => {
       try {
         TelemetryClient.track('NewPublishingProfileStarted');
-        const result = await httpClient.post(
-          `/provision/${projectId}/${type}`,
-          { ...config, graphToken: graphToken, currentProfile },
-          {
-            headers: { Authorization: `Bearer ${armToken}` },
-          }
-        );
+        const result = await httpClient.post(`/provision/${projectId}/${type}`, {
+          ...config,
+          graphToken: graphToken,
+          currentProfile,
+          accessToken: armToken,
+        });
         // set notification
         const notification = createNotification(getProvisionPendingNotification(result.data.message));
         addNotificationInternal(callbackHelpers, notification);

--- a/Composer/packages/server/src/controllers/provision.ts
+++ b/Composer/packages/server/src/controllers/provision.ts
@@ -33,8 +33,6 @@ export const ProvisionController = {
     }
   },
   provision: async (req: Request, res) => {
-    const accessToken = req.headers.authorization?.substring('Bearer '.length);
-    // const graphToken = req.headers.graphtoken;
     const user = await ExtensionContext.getUserFromRequest(req);
     const type = req.params.type; // type is webapp or functions
     const projectId = req.params.projectId;
@@ -48,7 +46,7 @@ export const ProvisionController = {
           // call the method
           const result = await pluginMethod.call(
             null,
-            { ...req.body, accessToken },
+            { ...req.body },
             currentProject,
             user,
             authService.getAccessToken.bind(authService)


### PR DESCRIPTION
## Description

Some users were seeing a 431 HTTP response when attempting to provision Azure resources.

This applies the same fix from https://github.com/microsoft/BotFramework-Composer/pull/5700 to the provisioning endpoint.

## Task Item

#minor
