### PR TITLE
fix: detect "Get started" dependencies in all projects not just current project

### DIFF
--- a/Composer/packages/client/src/components/GetStarted/GetStartedNextSteps.tsx
+++ b/Composer/packages/client/src/components/GetStarted/GetStartedNextSteps.tsx
@@ -73,26 +73,26 @@ export const GetStartedNextSteps: React.FC<GetStartedProps> = (props) => {
   };
 
   const updateLuisSettings = (newLuisSettings) => {
-    setSettings(projectId, {
+    setSettings(rootBotProjectId, {
       ...mergedSettings,
       luis: { ...mergedSettings.luis, ...newLuisSettings },
     });
   };
 
   const updateQNASettings = (newQNASettings) => {
-    setSettings(projectId, {
+    setSettings(rootBotProjectId, {
       ...mergedSettings,
       qna: { ...mergedSettings.qna, ...newQNASettings },
     });
   };
 
-  const linkToPackageManager = `/bot/${projectId}/plugin/package-manager/package-manager`;
-  const linkToConnections = `/bot/${projectId}/botProjectsSettings/#connections`;
-  const linkToPublishProfile = `/bot/${projectId}/botProjectsSettings/#addNewPublishProfile`;
-  const linkToLUISSettings = `/bot/${projectId}/botProjectsSettings/#luisKey`;
-  const linktoQNASettings = `/bot/${projectId}/botProjectsSettings/#qnaKey`;
-  const linkToLGEditor = `/bot/${projectId}/language-generation`;
-  const linkToLUEditor = `/bot/${projectId}/language-understanding`;
+  const linkToPackageManager = `/bot/${rootBotProjectId}/plugin/package-manager/package-manager`;
+  const linkToConnections = `/bot/${rootBotProjectId}/botProjectsSettings/#connections`;
+  const linkToPublishProfile = `/bot/${rootBotProjectId}/botProjectsSettings/#addNewPublishProfile`;
+  const linkToLUISSettings = `/bot/${rootBotProjectId}/botProjectsSettings/#luisKey`;
+  const linktoQNASettings = `/bot/${rootBotProjectId}/botProjectsSettings/#qnaKey`;
+  const linkToLGEditor = `/bot/${rootBotProjectId}/language-generation`;
+  const linkToLUEditor = `/bot/${rootBotProjectId}/language-understanding`;
 
   useEffect(() => {
     const newNextSteps: NextSteps[] = [];

--- a/Composer/packages/client/src/components/Header.tsx
+++ b/Composer/packages/client/src/components/Header.tsx
@@ -177,7 +177,7 @@ export const Header = () => {
   // ... if the get started widget moves, this code should too!
   const requiredStuff = useRecoilValue(allRequiredRecognizersSelector);
   const requiresLUIS = requiredStuff.some((p) => p.requiresLUIS);
-  const requiresQNA = requiredStuff.filter((p) => p.requiresQNA)?.length ? true : false;
+  const requiresQNA = requiredStuff.some((p) => p.requiresQNA);
   // ... end of get started stuff
 
   const isShow = useBotControllerBar();

--- a/Composer/packages/client/src/components/Header.tsx
+++ b/Composer/packages/client/src/components/Header.tsx
@@ -14,7 +14,6 @@ import { NeutralColors, SharedColors, FontSizes, CommunicationColors } from '@ui
 import { useRecoilValue } from 'recoil';
 import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
 import { Panel, PanelType } from 'office-ui-fabric-react/lib/Panel';
-import { BotIndexer } from '@bfc/indexers';
 import { TeachingBubble } from 'office-ui-fabric-react/lib/TeachingBubble';
 
 import { useLocation } from '../utils/hooks';
@@ -26,12 +25,11 @@ import {
   botDisplayNameState,
   localeState,
   currentProjectIdState,
+  rootBotProjectIdSelector,
   settingsState,
   webChatEssentialsSelector,
   isWebChatPanelVisibleState,
-  dialogsWithLuProviderSelectorFamily,
-  luFilesSelectorFamily,
-  qnaFilesSelectorFamily,
+  allRequiredRecognizersSelector,
 } from '../recoilModel';
 import composerIcon from '../images/composerIcon.svg';
 import { AppUpdaterStatus } from '../constants';
@@ -155,6 +153,7 @@ const calloutDescription = css`
 export const Header = () => {
   const { setAppUpdateShowing, setLocale } = useRecoilValue(dispatcherState);
   const projectId = useRecoilValue(currentProjectIdState);
+  const rootBotProjectId = useRecoilValue(rootBotProjectIdSelector) || projectId;
   const projectName = useRecoilValue(botDisplayNameState(projectId));
   const locale = useRecoilValue(localeState(projectId));
   const appUpdate = useRecoilValue(appUpdateState);
@@ -176,11 +175,9 @@ export const Header = () => {
   // These are needed to determine if the bot needs LUIS or QNA
   // this data is passed into the GetStarted widget
   // ... if the get started widget moves, this code should too!
-  const dialogs = useRecoilValue(dialogsWithLuProviderSelectorFamily(projectId));
-  const luFiles = useRecoilValue(luFilesSelectorFamily(projectId));
-  const qnaFiles = useRecoilValue(qnaFilesSelectorFamily(projectId));
-  const requiresLUIS = BotIndexer.shouldUseLuis(dialogs, luFiles);
-  const requiresQNA = BotIndexer.shouldUseQnA(dialogs, qnaFiles);
+  const requiredStuff = useRecoilValue(allRequiredRecognizersSelector);
+  const requiresLUIS = requiredStuff.filter((p) => p.requiresLUIS)?.length ? true : false;
+  const requiresQNA = requiredStuff.filter((p) => p.requiresQNA)?.length ? true : false;
   // ... end of get started stuff
 
   const isShow = useBotControllerBar();
@@ -413,7 +410,7 @@ export const Header = () => {
         ) : null}
         <GetStarted
           isOpen={showGetStarted}
-          projectId={projectId}
+          projectId={rootBotProjectId}
           requiresLUIS={requiresLUIS}
           requiresQNA={requiresQNA}
           showTeachingBubble={showGetStartedTeachingBubble}

--- a/Composer/packages/client/src/components/Header.tsx
+++ b/Composer/packages/client/src/components/Header.tsx
@@ -176,7 +176,7 @@ export const Header = () => {
   // this data is passed into the GetStarted widget
   // ... if the get started widget moves, this code should too!
   const requiredStuff = useRecoilValue(allRequiredRecognizersSelector);
-  const requiresLUIS = requiredStuff.filter((p) => p.requiresLUIS)?.length ? true : false;
+  const requiresLUIS = requiredStuff.some((p) => p.requiresLUIS);
   const requiresQNA = requiredStuff.filter((p) => p.requiresQNA)?.length ? true : false;
   // ... end of get started stuff
 

--- a/Composer/packages/client/src/recoilModel/selectors/project.ts
+++ b/Composer/packages/client/src/recoilModel/selectors/project.ts
@@ -32,6 +32,7 @@ import {
 } from '../atoms';
 import {
   dialogsSelectorFamily,
+  botAssetsSelectFamily,
   buildEssentialsSelector,
   lgImportsSelectorFamily,
   luImportsSelectorFamily,
@@ -368,5 +369,22 @@ export const webChatEssentialsSelector = selector({
       activeLocale,
       botStatus,
     };
+  },
+});
+
+export const allRequiredRecognizersSelector = selector({
+  key: 'allRequiredRecognizersSelector',
+  get: ({ get }) => {
+    const ids = get(botProjectIdsState);
+    return ids.reduce((result: { projectId: string; requiresLUIS: boolean; requiresQNA: boolean }[], id: string) => {
+      const botAssets = get(botAssetsSelectFamily(id));
+      if (botAssets) {
+        const { dialogs, luFiles, qnaFiles } = botAssets;
+        const requiresLUIS = BotIndexer.shouldUseLuis(dialogs, luFiles);
+        const requiresQNA = BotIndexer.shouldUseQnA(dialogs, qnaFiles);
+        result.push({ projectId: id, requiresLUIS, requiresQNA });
+      }
+      return result;
+    }, []);
   },
 });


### PR DESCRIPTION
## Description

adjust the mechanism used to determine if a project needs LUIS or QNA to support multi-bot projects. This moves code from the header component into a recoil selector.

## Task Item

fixes #6649 

