### PR TITLE
fix: use iconUrl field instead of icon. 

### DIFF
--- a/extensions/packageManager/src/components/LibraryList.tsx
+++ b/extensions/packageManager/src/components/LibraryList.tsx
@@ -26,7 +26,7 @@ export interface LibraryRef {
   license?: string;
   repository?: string;
   copyright?: string;
-  icon?: string;
+  iconUrl?: string;
   description: string;
   type?: string;
   category?: string;
@@ -84,7 +84,7 @@ export const LibraryList: React.FC<ILibraryListProps> = (props) => {
       isResizable: false,
       data: 'string',
       onRender: (item: LibraryRef) => {
-        if (item.icon) return <img alt="icon" height="32" src={item.icon} width="32" />;
+        if (item.iconUrl) return <img alt="icon" height="32" src={item.iconUrl} width="32" />;
         return <LetterIcon letter={item.name[0]} />;
       },
     },

--- a/extensions/packageManager/src/pages/Library.tsx
+++ b/extensions/packageManager/src/pages/Library.tsx
@@ -732,8 +732,8 @@ const Library: React.FC = () => {
             <Fragment>
               <Stack horizontal tokens={{ childrenGap: 10 }}>
                 <Stack.Item align="center" grow={0} styles={{ root: { width: 32 } }}>
-                  {selectedItem.icon ? (
-                    <img alt="icon" height="32" src={selectedItem.icon} width="32" />
+                  {selectedItem.iconUrl ? (
+                    <img alt="icon" height="32" src={selectedItem.iconUrl} width="32" />
                   ) : (
                     <LetterIcon letter={selectedItem.name[0]} />
                   )}


### PR DESCRIPTION
## Description

This change prepares package manager to use the iconUrl field instead of the icon field currently returned by the dialog merge process.

(The icon field is a relative path to the icon, rather than a web accessible URL which is ALSO available in the package)


## Task Item

This fixes https://github.com/microsoft/botframework-components/issues/802