### PR TITLE
chore: Improve l10n build performance

### DIFF
--- a/Composer/babel.l10n.config.js
+++ b/Composer/babel.l10n.config.js
@@ -1,13 +1,34 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+// TODO: It would be nice to use the regular expression matching.
+// It would be nice to ignore the lib folders rather than listing them one at a time.
+// However, as of 4/2021 it doesn't seem to work.
+// We have the added complexity that packages/lib contains folders we DO want to process.
+//
+// /packages\/(?!lib$).+\/lib(\/.*)*/
+// This was the negative lookahead regex I tried, but bable never seemed to honor.
+// I verified this regex had the right behavior in a regex tester with many path variations.
 module.exports = {
   presets: ['@babel/react', ['@babel/typescript', { allowNamespaces: true }]],
   plugins: ['@babel/plugin-proposal-class-properties'],
   ignore: [
-    'packages/electron-server',
     'packages/**/__tests__',
+    'packages/**/build',
     'packages/**/node_modules',
-    'packages/**/build/**/*.js',
+    'packages/adaptive-flow/**/lib',
+    'packages/adaptive-form/**/lib',
+    'packages/client/public',
+    'packages/electron-server',
+    'packages/extension/**/lib',
+    'packages/extension-client/**/lib',
+    'packages/form-dialogs/**/lib',
+    'packages/intellisense/**/lib',
+    'packages/lib/**/lib',
+    'packages/server-workers/**/lib',
+    'packages/test-utils/**/lib',
+    'packages/tools/**/lib',
+    'packages/types/**/lib',
+    'packages/ui-plugins/**/lib',
   ],
 };


### PR DESCRIPTION
## Description

The l10n:babel extracts strings from the source code. 
It is currently including lib folders which contain built JS with the same formatMessage calls as the TS source.
This creates a lot of extra files in the l10ntemp folder which later l10n commands have to process - slowing the build.

This PR excludes those folders using the wildcard search pattern in the ignore section of the babel config file.
I tried to use the regex format, but it doesn't seem to work and babel won't output information about matches.

## Task Item

#minor 

## Screenshots

Old yarn l10n build time (on my dev machine): 115 s
New yarn l10n build time (on my dev machine): 95 s
Savings: 20 s
