### PR TITLE
fix: handle protocol launches on macos from cold start

### DIFF
--- a/Composer/packages/electron-server/src/main.ts
+++ b/Composer/packages/electron-server/src/main.ts
@@ -321,24 +321,20 @@ async function run() {
     }
   });
 
-  app.on('will-finish-launching', () => {
-    // Protocol handler for osx
-    app.on('open-url', (event, url) => {
-      event.preventDefault();
-      if (ElectronWindow.isBrowserWindowCreated) {
-        waitForMainWindowToShow
-          .then(() => {
-            log('[Mac] Main window is now showing. Processing deep link if any.');
-            const deeplinkUrl = parseDeepLinkUrl(url);
-            log('[Mac] Loading deeplink: %s', deeplinkUrl);
-            const mainWindow = ElectronWindow.getInstance().browserWindow;
-            mainWindow?.loadURL(getBaseUrl() + deeplinkUrl);
-          })
-          .catch((e) =>
-            console.error('[Mac] Error while waiting for main window to show before processing deep link: ', e)
-          );
-      }
-    });
+  // Protocol handler for osx
+  app.on('open-url', (event, url) => {
+    event.preventDefault();
+    waitForMainWindowToShow
+      .then(() => {
+        log('[Mac] Main window is now showing. Processing deep link if any.');
+        const deeplinkUrl = parseDeepLinkUrl(url);
+        log('[Mac] Loading deeplink: %s', deeplinkUrl);
+        const mainWindow = ElectronWindow.getInstance().browserWindow;
+        mainWindow?.loadURL(getBaseUrl() + deeplinkUrl);
+      })
+      .catch((e) =>
+        console.error('[Mac] Error while waiting for main window to show before processing deep link: ', e)
+      );
   });
 }
 


### PR DESCRIPTION
## Description

Fixes an issue where deeplinks would not work correctly on mac when Composer was not already running.

## Task Item

fixes #6616 
