### PR TITLE
fix: move publishing profiles into a tab on the publish page

### DIFF
--- a/Composer/packages/client/src/components/GetStarted/GetStartedNextSteps.tsx
+++ b/Composer/packages/client/src/components/GetStarted/GetStartedNextSteps.tsx
@@ -88,7 +88,7 @@ export const GetStartedNextSteps: React.FC<GetStartedProps> = (props) => {
 
   const linkToPackageManager = `/bot/${rootBotProjectId}/plugin/package-manager/package-manager`;
   const linkToConnections = `/bot/${rootBotProjectId}/botProjectsSettings/#connections`;
-  const linkToPublishProfile = `/bot/${rootBotProjectId}/botProjectsSettings/#addNewPublishProfile`;
+  const linkToPublishProfile = `/bot/${rootBotProjectId}/publish/all#addNewPublishProfile`;
   const linkToLUISSettings = `/bot/${rootBotProjectId}/botProjectsSettings/#luisKey`;
   const linktoQNASettings = `/bot/${rootBotProjectId}/botProjectsSettings/#qnaKey`;
   const linkToLGEditor = `/bot/${rootBotProjectId}/language-generation`;

--- a/Composer/packages/client/src/pages/botProject/BotProjectsSettingsTabView.tsx
+++ b/Composer/packages/client/src/pages/botProject/BotProjectsSettingsTabView.tsx
@@ -17,7 +17,6 @@ import { AppIdAndPassword } from './AppIdAndPassword';
 import { ExternalService } from './ExternalService';
 import { BotLanguage } from './BotLanguage';
 import { RuntimeSettings } from './RuntimeSettings';
-import { PublishTargets } from './PublishTargets';
 import AdapterSection from './adapters/AdapterSection';
 
 // -------------------- Styles -------------------- //
@@ -27,10 +26,6 @@ const container = css`
   flex-direction: column;
   max-width: 1000px;
   height: 100%;
-`;
-
-const publishTargetsWrap = (isLastComponent) => css`
-  margin-bottom: ${isLastComponent ? '120px' : 0};
 `;
 
 const idsInTab: Record<PivotItemKey, string[]> = {
@@ -93,10 +88,7 @@ export const BotProjectSettingsTabView: React.FC<RouteComponentProps<{
           headerText={formatMessage('Connections')}
           itemKey={PivotItemKey.Connections}
         >
-          <div css={publishTargetsWrap(!isRootBot)}>
-            <PublishTargets projectId={projectId} scrollToSectionId={scrollToSectionId} />
-            {isRootBot && <AdapterSection projectId={projectId} scrollToSectionId={scrollToSectionId} />}
-          </div>
+          {isRootBot && <AdapterSection projectId={projectId} scrollToSectionId={scrollToSectionId} />}
         </PivotItem>
         <PivotItem
           data-testid="skillsTab"

--- a/Composer/packages/client/src/pages/botProject/PublishTargets.tsx
+++ b/Composer/packages/client/src/pages/botProject/PublishTargets.tsx
@@ -13,17 +13,17 @@ import { SharedColors } from '@uifabric/fluent-theme';
 import { OpenConfirmModal } from '@bfc/ui-shared';
 
 import { dispatcherState, settingsState, publishTypesState } from '../../recoilModel';
-import { CollapsableWrapper } from '../../components/CollapsableWrapper';
 import { AuthDialog } from '../../components/Auth/AuthDialog';
 import { isShowAuthDialog } from '../../utils/auth';
 
 import { PublishProfileDialog } from './create-publish-profile/PublishProfileDialog';
-import { title, tableRow, tableRowItem, tableColumnHeader, columnSizes, actionButton } from './styles';
+import { tableRow, tableRowItem, tableColumnHeader, columnSizes, actionButton } from './styles';
 
 // -------------------- Styles -------------------- //
 
 const publishTargetsContainer = css`
   display: flex;
+  padding: 20px;
   flex-direction: column;
 `;
 
@@ -93,65 +93,63 @@ export const PublishTargets: React.FC<PublishTargetsProps> = (props) => {
 
   return (
     <Fragment>
-      <CollapsableWrapper title={formatMessage('Publish profiles')} titleStyle={title}>
-        <div ref={publishTargetsRef} css={publishTargetsContainer} id="addNewPublishProfile">
-          <div css={publishTargetsHeader}>
-            <div css={tableColumnHeader(columnSizes[0])}>{formatMessage('Name')} </div>
-            <div css={tableColumnHeader(columnSizes[1])}>{formatMessage('Target')} </div>
-            <div css={tableColumnHeader(columnSizes[2])}> </div>
-          </div>
-          {publishTargets?.map((p, index) => {
-            return (
-              <div key={index} css={tableRow}>
-                <div css={tableRowItem(columnSizes[0])} title={p.name}>
-                  {p.name}
-                </div>
-                <div css={tableRowItem(columnSizes[1])} title={p.type}>
-                  {p.type}
-                </div>
-                <div css={tableRowItem(columnSizes[2])}>
-                  <ActionButton
-                    data-testid={'editPublishProfile'}
-                    styles={editPublishProfile}
-                    onClick={() => {
-                      setCurrent({ item: p, index: index });
-                      if (isShowAuthDialog(true)) {
-                        setShowAuthDialog(true);
-                      } else {
-                        setDialogHidden(false);
-                      }
-                    }}
-                  >
-                    {formatMessage('Edit')}
-                  </ActionButton>
-                </div>
-                <div css={tableRowItem(columnSizes[2])}>
-                  <ActionButton
-                    data-testid={'deletePublishProfile'}
-                    styles={editPublishProfile}
-                    onClick={() => onDeletePublishTarget(p)}
-                  >
-                    {formatMessage('Delete')}
-                  </ActionButton>
-                </div>
-              </div>
-            );
-          })}
-          <ActionButton
-            data-testid={'addNewPublishProfile'}
-            styles={actionButton}
-            onClick={() => {
-              if (isShowAuthDialog(true)) {
-                setShowAuthDialog(true);
-              } else {
-                setDialogHidden(false);
-              }
-            }}
-          >
-            {formatMessage('Add new')}
-          </ActionButton>
+      <div ref={publishTargetsRef} css={publishTargetsContainer} id="addNewPublishProfile">
+        <div css={publishTargetsHeader}>
+          <div css={tableColumnHeader(columnSizes[0])}>{formatMessage('Name')} </div>
+          <div css={tableColumnHeader(columnSizes[1])}>{formatMessage('Target')} </div>
+          <div css={tableColumnHeader(columnSizes[2])}> </div>
         </div>
-      </CollapsableWrapper>
+        {publishTargets?.map((p, index) => {
+          return (
+            <div key={index} css={tableRow}>
+              <div css={tableRowItem(columnSizes[0])} title={p.name}>
+                {p.name}
+              </div>
+              <div css={tableRowItem(columnSizes[1])} title={p.type}>
+                {p.type}
+              </div>
+              <div css={tableRowItem(columnSizes[2])}>
+                <ActionButton
+                  data-testid={'editPublishProfile'}
+                  styles={editPublishProfile}
+                  onClick={() => {
+                    setCurrent({ item: p, index: index });
+                    if (isShowAuthDialog(true)) {
+                      setShowAuthDialog(true);
+                    } else {
+                      setDialogHidden(false);
+                    }
+                  }}
+                >
+                  {formatMessage('Edit')}
+                </ActionButton>
+              </div>
+              <div css={tableRowItem(columnSizes[2])}>
+                <ActionButton
+                  data-testid={'deletePublishProfile'}
+                  styles={editPublishProfile}
+                  onClick={() => onDeletePublishTarget(p)}
+                >
+                  {formatMessage('Delete')}
+                </ActionButton>
+              </div>
+            </div>
+          );
+        })}
+        <ActionButton
+          data-testid={'addNewPublishProfile'}
+          styles={actionButton}
+          onClick={() => {
+            if (isShowAuthDialog(true)) {
+              setShowAuthDialog(true);
+            } else {
+              setDialogHidden(false);
+            }
+          }}
+        >
+          {formatMessage('Add new')}
+        </ActionButton>
+      </div>
       {showAuthDialog && (
         <AuthDialog
           needGraph

--- a/Composer/packages/client/src/pages/publish/Publish.tsx
+++ b/Composer/packages/client/src/pages/publish/Publish.tsx
@@ -8,6 +8,8 @@ import { RouteComponentProps } from '@reach/router';
 import formatMessage from 'format-message';
 import { useRecoilValue } from 'recoil';
 import { PublishResult, PublishTarget } from '@bfc/shared';
+import { Pivot, PivotItem } from 'office-ui-fabric-react/lib/Pivot';
+import { Stack } from 'office-ui-fabric-react/lib/Stack';
 
 import { dispatcherState, localBotPublishHistorySelector, localBotsDataSelector } from '../../recoilModel';
 import { AuthDialog } from '../../components/Auth/AuthDialog';
@@ -22,11 +24,13 @@ import {
   getTenantIdFromCache,
 } from '../../utils/auth';
 // import { vaultScopes } from '../../constants';
+import { useLocation } from '../../utils/hooks';
 import { AuthClient } from '../../utils/authClient';
 import TelemetryClient from '../../telemetry/TelemetryClient';
 import { ApiStatus, PublishStatusPollingUpdater, pollingUpdaterList } from '../../utils/publishStatusPollingUpdater';
-import { navigateTo } from '../../utils/navigation';
+import { PublishTargets } from '../botProject/PublishTargets';
 
+import { ProjectList } from './components/projectList/ProjectList';
 import { PublishDialog } from './PublishDialog';
 import { ContentHeaderStyle, HeaderText, ContentStyle, contentEditor } from './styles';
 import { BotStatusList } from './BotStatusList';
@@ -43,7 +47,6 @@ import {
 
 const Publish: React.FC<RouteComponentProps<{ projectId: string; targetName?: string }>> = (props) => {
   const { projectId = '' } = props;
-
   const botProjectData = useRecoilValue(localBotsDataSelector);
   const publishHistoryList = useRecoilValue(localBotPublishHistorySelector);
   const {
@@ -57,10 +60,13 @@ const Publish: React.FC<RouteComponentProps<{ projectId: string; targetName?: st
     addNotification,
     deleteNotification,
   } = useRecoilValue(dispatcherState);
+  const { location } = useLocation();
 
   const pendingNotificationRef = useRef<Notification>();
   const showNotificationsRef = useRef<Record<string, boolean>>({});
 
+  const [activeTab, setActiveTab] = useState<string>('publish');
+  const [provisionProject, setProvisionProject] = useState(projectId);
   const [currentBotList, setCurrentBotList] = useState<Bot[]>([]);
   const [publishDialogVisible, setPublishDialogVisiblity] = useState(false);
   const [pullDialogVisible, setPullDialogVisiblity] = useState(false);
@@ -227,12 +233,16 @@ const Publish: React.FC<RouteComponentProps<{ projectId: string; targetName?: st
   };
 
   const manageSkillPublishProfile = (skillId: string) => {
-    const url =
-      skillId === projectId
-        ? `/bot/${projectId}/botProjectsSettings/#addNewPublishProfile`
-        : `bot/${projectId}/skill/${skillId}/botProjectsSettings/#addNewPublishProfile`;
-    navigateTo(url);
+    setActiveTab('provision');
+    setProvisionProject(skillId);
   };
+
+  // pop out get started if #getstarted is in the URL
+  useEffect(() => {
+    if (location.hash === '#addNewPublishProfile') {
+      setActiveTab('provision');
+    }
+  }, [location]);
 
   const isPublishingToAzure = (target?: PublishTarget) => {
     return target?.type === 'azurePublish' || target?.type === 'azureFunctionsPublish';
@@ -412,20 +422,45 @@ const Publish: React.FC<RouteComponentProps<{ projectId: string; targetName?: st
       <div css={ContentHeaderStyle}>
         <h1 css={HeaderText}>{formatMessage('Publish your bots')}</h1>
       </div>
-      <div css={ContentStyle} data-testid="Publish" role="main">
-        <div aria-label={formatMessage('List view')} css={contentEditor} role="region">
-          <BotStatusList
-            botPublishHistoryList={publishHistoryList}
-            botStatusList={botStatusList}
-            checkedIds={checkedSkillIds}
-            disableCheckbox={isPublishPending}
-            onChangePublishTarget={changePublishTarget}
-            onCheck={updateCheckedSkills}
-            onManagePublishProfile={manageSkillPublishProfile}
-            onRollbackClick={onRollbackToVersion}
-          />
-        </div>
-      </div>
+
+      <Pivot
+        selectedKey={activeTab}
+        styles={{ root: { marginLeft: 12 } }}
+        onLinkClick={(link) => setActiveTab(link?.props?.itemKey || '')}
+      >
+        <PivotItem headerText={formatMessage('Publish')} itemKey={'publish'}>
+          <div css={ContentStyle} data-testid="Publish" role="main">
+            <div aria-label={formatMessage('List view')} css={contentEditor} role="region">
+              <BotStatusList
+                botPublishHistoryList={publishHistoryList}
+                botStatusList={botStatusList}
+                checkedIds={checkedSkillIds}
+                disableCheckbox={isPublishPending}
+                onChangePublishTarget={changePublishTarget}
+                onCheck={updateCheckedSkills}
+                onManagePublishProfile={manageSkillPublishProfile}
+                onRollbackClick={onRollbackToVersion}
+              />
+            </div>
+          </div>
+        </PivotItem>
+        <PivotItem headerText={formatMessage('Publishing Profile')} itemKey={'provision'}>
+          <Stack horizontal verticalFill styles={{ root: { borderTop: '1px solid #CCC' } }}>
+            {botProjectData && botProjectData.length > 1 && (
+              <Stack.Item styles={{ root: { width: '175px', borderRight: '1px solid #CCC' } }}>
+                <ProjectList
+                  defaultSelected={provisionProject}
+                  projectCollection={botProjectData}
+                  onSelect={(link) => setProvisionProject(link.projectId)}
+                />
+              </Stack.Item>
+            )}
+            <Stack.Item align="stretch" styles={{ root: { flexGrow: 1, overflow: 'auto', maxHeight: '100%' } }}>
+              <PublishTargets projectId={provisionProject} />
+            </Stack.Item>
+          </Stack>
+        </PivotItem>
+      </Pivot>
     </Fragment>
   );
 };

--- a/Composer/packages/client/src/pages/publish/components/projectList/ListItem.tsx
+++ b/Composer/packages/client/src/pages/publish/components/projectList/ListItem.tsx
@@ -1,0 +1,116 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/** @jsx jsx */
+import { jsx, css } from '@emotion/core';
+import React from 'react';
+import { Icon } from 'office-ui-fabric-react/lib/Icon';
+import { NeutralColors } from '@uifabric/fluent-theme';
+
+import { ListLink } from './ProjectList';
+
+// -------------------- Styles -------------------- //
+
+const navItem = (isActive: boolean, padLeft: number) => css`
+  label: navItem;
+  position: relative;
+  height: 24px;
+  font-size: 12px;
+  font-weight: 600;
+  padding-left: ${padLeft}px;
+  color: '#545454';
+  background: ${isActive ? 'rgb(243, 242, 241)' : 'transparent'};
+
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  &:focus {
+    outline: rgb(102, 102, 102) solid 1px;
+    z-index: 1;
+    .ms-Fabric--isFocusVisible &::after {
+      top: 0px;
+      right: 1px;
+      bottom: 0px;
+      left: 1px;
+      content: '';
+      position: absolute;
+      z-index: 1;
+      border: 1px solid ${NeutralColors.white};
+      border-image: initial;
+      outline: rgb(102, 102, 102) solid 1px;
+    }
+  }
+`;
+
+export const overflowSet = css`
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  line-height: 24px;
+  justify-content: space-between;
+  display: flex;
+`;
+
+const itemName = (nameWidth: number) => css`
+  max-width: ${nameWidth}px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex-shrink: 1;
+`;
+
+// -------------------- ListItem -------------------- //
+
+interface Props {
+  link: ListLink;
+  isActive?: boolean;
+  icon?: string;
+  onSelect?: (link: ListLink) => void;
+  textWidth?: number;
+  padLeft?: number;
+}
+
+export const ListItem: React.FC<Props> = ({
+  link,
+  isActive = false,
+  icon,
+  onSelect,
+  textWidth = 100,
+  padLeft = 16,
+}) => {
+  const linkString = `${link.projectId}_ListItem`;
+
+  return (
+    <div
+      key={linkString}
+      data-is-focusable
+      aria-label={`${link.displayName}`}
+      css={navItem(isActive, padLeft)}
+      role="cell"
+      tabIndex={0}
+      onClick={() => {
+        onSelect?.(link);
+      }}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') {
+          onSelect?.(link);
+        }
+      }}
+    >
+      {icon != null && (
+        <Icon
+          iconName={icon}
+          styles={{
+            root: {
+              width: '12px',
+              marginRight: '8px',
+              outline: 'none',
+            },
+          }}
+          tabIndex={-1}
+        />
+      )}
+      <span css={itemName(textWidth)}>{link.displayName}</span>
+    </div>
+  );
+};

--- a/Composer/packages/client/src/pages/publish/components/projectList/ProjectList.tsx
+++ b/Composer/packages/client/src/pages/publish/components/projectList/ProjectList.tsx
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/** @jsx jsx */
+import React, { useState, useRef } from 'react';
+import { jsx, css } from '@emotion/core';
+import { FocusZone, FocusZoneDirection } from 'office-ui-fabric-react/lib/FocusZone';
+import formatMessage from 'format-message';
+
+import { ListItem } from './ListItem';
+// -------------------- Styles -------------------- //
+
+const root = css`
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  overflow-x: hidden;
+  .ms-List-cell {
+    min-height: 36px;
+  }
+`;
+
+const icons = {
+  BOT: 'CubeShape',
+  EXTERNAL_SKILL: 'Globe',
+};
+
+const listCSS = css`
+  height: 100%;
+  label: list;
+`;
+
+const headerCSS = (label: string) => css`
+  margin-top: -6px;
+  width: 100%;
+  label: ${label};
+`;
+
+// -------------------- ProjectList -------------------- //
+
+export type ListLink = {
+  displayName?: string;
+  projectId: string;
+};
+
+type BotInProject = {
+  projectId: string;
+  name: string;
+  isRemote: boolean;
+};
+
+type Props = {
+  onSelect?: (link: ListLink) => void;
+  defaultSelected?: string;
+  projectCollection: BotInProject[];
+};
+
+export const ProjectList: React.FC<Props> = ({ onSelect, defaultSelected, projectCollection }) => {
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const [selectedLink, setSelectedLink] = useState<string | undefined>(defaultSelected);
+
+  const createProjectList = () => {
+    return projectCollection.filter((p) => !p.isRemote).map(renderBotHeader);
+  };
+
+  const handleOnSelect = (link: ListLink) => {
+    // Skip state change when link not changed.
+    if (link.projectId === selectedLink) return;
+
+    setSelectedLink(link.projectId);
+    onSelect?.(link);
+  };
+
+  const renderBotHeader = (bot: BotInProject) => {
+    const link: ListLink = {
+      displayName: bot.name,
+      projectId: bot.projectId,
+    };
+
+    return (
+      <span key={bot.name} css={headerCSS('bot-header')} data-testid={`BotHeader-${bot.name}`} role="grid">
+        <ListItem
+          icon={bot.isRemote ? icons.EXTERNAL_SKILL : icons.BOT}
+          isActive={link.projectId === selectedLink}
+          link={link}
+          onSelect={handleOnSelect}
+        />
+      </span>
+    );
+  };
+
+  const projectList = createProjectList();
+
+  return (
+    <div
+      ref={listRef}
+      aria-label={formatMessage('Navigation pane')}
+      className="ProjectList"
+      css={root}
+      data-testid="ProjectList"
+      role="region"
+    >
+      <FocusZone isCircularNavigation direction={FocusZoneDirection.vertical}>
+        <div css={listCSS}>{projectList}</div>
+      </FocusZone>
+    </div>
+  );
+};


### PR DESCRIPTION
## Description

At long last, the publishing profiles rejoin the publishing functionality on the publish page... this time, in a TAB!


## Task Item

Fixes #6710 

## Screenshots

![EWCEC9OoBC](https://user-images.githubusercontent.com/729873/113940328-e668a780-97c2-11eb-806d-abb35ce24a48.gif)
