### PR TITLE
feat: Expose default search query, pre-release flag and type for each feed.

### DIFF
--- a/extensions/packageManager/src/components/FeedModal.tsx
+++ b/extensions/packageManager/src/components/FeedModal.tsx
@@ -15,6 +15,8 @@ import {
   IconButton,
   ActionButton,
   TextField,
+  Toggle,
+  Dropdown,
 } from 'office-ui-fabric-react';
 import { useState, useEffect, Fragment } from 'react';
 import { useApplicationApi, useTelemetryClient, TelemetryClient } from '@bfc/extension-client';
@@ -42,6 +44,18 @@ export interface WorkingModalProps {
   closeDialog: any;
   onUpdateFeed: any;
 }
+
+const FEED_TYPES = [
+  {
+    key: 'npm',
+    text: 'npm',
+  },
+  {
+    key: 'nuget',
+    text: 'NuGet',
+  },
+];
+
 export const FeedModal: React.FC<WorkingModalProps> = (props) => {
   const [selectedItem, setSelectedItem] = useState<PackageSourceFeed | undefined>(undefined);
   const [items, setItems] = useState<PackageSourceFeed[]>(props.feeds);
@@ -99,10 +113,32 @@ export const FeedModal: React.FC<WorkingModalProps> = (props) => {
       },
     },
     {
+      key: 'column1',
+      name: 'Type',
+      fieldName: 'text',
+      minWidth: 75,
+      maxWidth: 75,
+      height: 32,
+      isResizable: false,
+      onRender: (item: PackageSourceFeed) => {
+        if (!selectedItem || item.key !== selectedItem.key || !editRow) return <DisplayField text={item.type} />;
+        return (
+          <Dropdown
+            disabled={!selectedItem || selectedItem.readonly}
+            options={FEED_TYPES}
+            selectedKey={selectedItem?.type}
+            onChange={(event, item) => {
+              updateSelected('type')(event, item.key);
+            }}
+          />
+        );
+      },
+    },
+    {
       key: 'column2',
       name: 'URL',
       fieldName: 'url',
-      minWidth: 300,
+      minWidth: 200,
       isResizable: false,
       height: 32,
       onRender: (item: PackageSourceFeed) => {
@@ -120,6 +156,45 @@ export const FeedModal: React.FC<WorkingModalProps> = (props) => {
     },
     {
       key: 'column3',
+      name: 'Filter',
+      fieldName: 'defaultQuery.query',
+      minWidth: 200,
+      isResizable: false,
+      height: 32,
+      onRender: (item: PackageSourceFeed) => {
+        if (!selectedItem || item.key !== selectedItem.key || !editRow)
+          return <DisplayField text={item.defaultQuery?.query} />;
+        return (
+          <TextField
+            disabled={!selectedItem || selectedItem.readonly}
+            placeholder={formatMessage('Default Query')}
+            styles={{ field: { fontSize: 12 } }}
+            value={selectedItem ? selectedItem.defaultQuery?.query : ''}
+            onChange={updateSelectedDefaultQuery('query')}
+          />
+        );
+      },
+    },
+    {
+      key: 'column4',
+      name: 'Prerelease',
+      fieldName: 'defaultQuery.prerelease',
+      minWidth: 40,
+      maxWidth: 40,
+      isResizable: false,
+      height: 32,
+      onRender: (item: PackageSourceFeed) => {
+        return (
+          <Toggle
+            checked={item ? item.defaultQuery?.prerelease : false}
+            disabled={!selectedItem || selectedItem.readonly}
+            onChange={updateSelectedDefaultQuery('prerelease')}
+          />
+        );
+      },
+    },
+    {
+      key: 'column5',
       minWidth: 40,
       maxWidth: 40,
       isResizable: false,
@@ -150,6 +225,20 @@ export const FeedModal: React.FC<WorkingModalProps> = (props) => {
     };
   };
 
+  const updateSelectedDefaultQuery = (field: string) => {
+    return (evt, val) => {
+      const newSelection = {
+        ...selectedItem,
+        defaultQuery: {
+          ...selectedItem.defaultQuery,
+          [field]: val,
+        },
+      };
+      setSelectedItem(newSelection);
+      setItems(items.map((i) => (i.key === newSelection.key ? newSelection : i)));
+    };
+  };
+
   const savePendingEdits = () => {
     props.onUpdateFeed(items);
   };
@@ -159,6 +248,11 @@ export const FeedModal: React.FC<WorkingModalProps> = (props) => {
       key: uuid(),
       text: '',
       url: '',
+      defaultQuery: {
+        semVerLevel: '2.0.0',
+        prerelease: false,
+        query: '',
+      },
     } as PackageSourceFeed;
 
     const newItems = items.concat([newItem]);

--- a/extensions/packageManager/src/components/FeedModal.tsx
+++ b/extensions/packageManager/src/components/FeedModal.tsx
@@ -186,6 +186,7 @@ export const FeedModal: React.FC<WorkingModalProps> = (props) => {
       onRender: (item: PackageSourceFeed) => {
         return (
           <Toggle
+            ariaLabel={formatMessage('Include prerelease versions')}
             checked={item ? item.defaultQuery?.prerelease : false}
             disabled={!selectedItem || selectedItem.readonly}
             onChange={updateSelectedDefaultQuery('prerelease')}

--- a/extensions/packageManager/src/node/feeds/feedInterfaces.ts
+++ b/extensions/packageManager/src/node/feeds/feedInterfaces.ts
@@ -32,10 +32,9 @@ export interface IPackageSource {
   key: string;
   text: string;
   url: string;
-  searchUrl?: string;
   readonly?: boolean;
-  defaultQuery?: IPackageQuery;
-  type?: PackageSourceType.NuGet | PackageSourceType.NPM;
+  defaultQuery: IPackageQuery;
+  type: PackageSourceType.NuGet | PackageSourceType.NPM;
 }
 
 /**

--- a/extensions/packageManager/src/node/index.ts
+++ b/extensions/packageManager/src/node/index.ts
@@ -9,7 +9,7 @@ import formatMessage from 'format-message';
 import { IExtensionRegistration } from '@botframework-composer/types';
 import { SchemaMerger } from '@microsoft/bf-dialog/lib/library/schemaMerger';
 
-import { IFeed, IPackageDefinition, IPackageQuery, IPackageSource, PackageSourceType } from './feeds/feedInterfaces';
+import { IFeed, IPackageDefinition, IPackageSource, PackageSourceType } from './feeds/feedInterfaces';
 import { FeedFactory } from './feeds/feedFactory';
 
 const API_ROOT = '/api';
@@ -132,16 +132,24 @@ export default async (composer: IExtensionRegistration): Promise<void> => {
         {
           key: 'npm',
           text: formatMessage('npm'),
-          url: `https://registry.npmjs.org/-/v1/search?text=keywords:${botComponentTag}+scope:microsoft&size=100&from=0`,
-          searchUrl: `https://registry.npmjs.org/-/v1/search?text={{keyword}}+keywords:${botComponentTag}&size=100&from=0`,
+          url: `https://registry.npmjs.org/-/v1/search`,
           readonly: true,
+          defaultQuery: {
+            prerelease: true,
+            query: `keywords:${botComponentTag}+scope:microsoft`,
+          },
+          type: PackageSourceType.NPM,
         },
         {
           key: 'npm-community',
           text: formatMessage('JS community packages'),
-          url: `https://registry.npmjs.org/-/v1/search?text=keywords:${botComponentTag}&size=100&from=0`,
-          searchUrl: `https://registry.npmjs.org/-/v1/search?text={{keyword}}+keywords:${botComponentTag}&size=100&from=0`,
+          url: `https://registry.npmjs.org/-/v1/search`,
           readonly: true,
+          defaultQuery: {
+            prerelease: true,
+            query: `keywords:${botComponentTag}`,
+          },
+          type: PackageSourceType.NPM,
         },
       ];
 
@@ -209,15 +217,17 @@ export default async (composer: IExtensionRegistration): Promise<void> => {
       if (packageSource) {
         try {
           const feed: IFeed = await new FeedFactory(composer).build(packageSource);
-          const packageQuery: IPackageQuery = {
-            prerelease: true,
-            semVerLevel: '2.0.0',
-            query: 'tags:msbot-component',
-          };
 
-          composer.log('GETTING FEED', packageSource, packageSource.defaultQuery ?? packageQuery);
+          // append user specified query to defaultQuery
+          if (req.query.term) {
+            packageSource.defaultQuery.query = `${packageSource.defaultQuery.query}+${encodeURIComponent(
+              req.query.term
+            )}`;
+          }
 
-          const packages = await feed.getPackages(packageSource.defaultQuery ?? packageQuery);
+          composer.log('GETTING FEED', packageSource, packageSource.defaultQuery);
+
+          const packages = await feed.getPackages(packageSource.defaultQuery);
 
           if (Array.isArray(packages)) {
             combined.push(...packages);

--- a/extensions/packageManager/src/pages/Library.tsx
+++ b/extensions/packageManager/src/pages/Library.tsx
@@ -48,7 +48,12 @@ export interface PackageSourceFeed extends IDropdownOption {
   name: string;
   key: string;
   url: string;
-  searchUrl?: string;
+  type: string;
+  defaultQuery?: {
+    prerelease: boolean;
+    semVerLevel: string;
+    query: string;
+  };
   readonly?: boolean;
 }
 
@@ -444,10 +449,8 @@ const Library: React.FC = () => {
         telemetryClient.track('PackageSearch', { term: searchTerm });
 
         const response = await getSearchResults();
-        // if we are searching, but there is not a searchUrl, apply a local filter
-        if (!feeds.find((f) => f.key === feed)?.searchUrl) {
-          response.data.available = response.data.available.filter(applySearchTerm);
-        }
+        // if we are searching, apply a local filter
+        response.data.available = response.data.available.filter(applySearchTerm);
         updateAvailableLibraries(response.data.available);
         setRecentlyUsed(response.data.recentlyUsed);
       } else {


### PR DESCRIPTION
## Description

* Update package manager to expose the default search query field and pre-release option for each feed.
* Allow user to search against feeds using the feed's search capabilities

## Task Item

Fixes #6037 
Fixes #6038 

## Screenshots

![Screen Shot 2021-04-08 at 12 29 17 PM](https://user-images.githubusercontent.com/729873/114070849-12893480-9866-11eb-8b58-e0862be3141f.png)

