### PR TITLE
feature: Pass workerRuntime value from runtime key when provisioning Azure functions

### DIFF
--- a/extensions/azurePublish/src/node/azureResourceManager/azureResourceManager.ts
+++ b/extensions/azurePublish/src/node/azureResourceManager/azureResourceManager.ts
@@ -883,7 +883,7 @@ export class AzureResourceMananger {
               },
               {
                 name: 'FUNCTIONS_WORKER_RUNTIME',
-                value: 'dotnet',
+                value: config.workerRuntime || 'dotnet',
               },
               {
                 name: 'APPINSIGHTS_INSTRUMENTATIONKEY',

--- a/extensions/azurePublish/src/node/azureResourceManager/azureResourceManagerConfig.ts
+++ b/extensions/azurePublish/src/node/azureResourceManager/azureResourceManagerConfig.ts
@@ -114,6 +114,11 @@ export interface AzureFunctionsConfig {
   appId?: string;
   appPwd?: string;
   instrumentationKey?: string;
+  /**
+   * The worker runtime language.
+   * Currently documented values: dotnet, node, java, python, or powershell
+   */
+  workerRuntime?: string;
 }
 
 export interface DeploymentsConfig {

--- a/extensions/azurePublish/src/node/provision.ts
+++ b/extensions/azurePublish/src/node/provision.ts
@@ -23,6 +23,11 @@ export interface ProvisionConfig {
   logger?: (string) => any;
   name: string; // profile name
   type: string; // webapp or function
+  /**
+   * The worker runtime language for Azure functions.
+   * Currently documented values: dotnet, node, java, python, or powershell
+   */
+  workerRuntime?: string;
   choice?: string;
   [key: string]: any;
 }
@@ -326,6 +331,7 @@ export class BotProjectProvision {
               resourceGroupName: resourceGroupName,
               location: config.location ?? provisionResults.resourceGroup.location,
               name: config.hostname,
+              workerRuntime: config.workerRuntime,
             });
             provisionResults.webApp = {
               hostname: functionsHostName,


### PR DESCRIPTION
## Description

Per the work item, parse the language from the runtime key and pass as workerRuntime to Azure functions provisioning.

## Task Item

closes #6528 

## Screenshots

N/A
