### PR TITLE
fix: loading spinner text to be more readable, appSettings toggle overlap bug

### DIFF
--- a/Composer/packages/client/src/pages/botProject/BotProjectSettings.tsx
+++ b/Composer/packages/client/src/pages/botProject/BotProjectSettings.tsx
@@ -189,6 +189,16 @@ const BotProjectSettings: React.FC<RouteComponentProps<{ projectId: string; skil
     >
       <Suspense fallback={<LoadingSpinner />}>
         <div css={container}>
+          <Toggle
+            inlineLabel
+            checked={isAdvancedSettingsEnabled}
+            className={'advancedSettingsView'}
+            defaultChecked={false}
+            label={formatMessage('Advanced Settings View (json)')}
+            onChange={() => {
+              setAdvancedSettingsEnabled(!isAdvancedSettingsEnabled);
+            }}
+          />
           {isAdvancedSettingsEnabled ? (
             <JsonEditor
               key={'settingsjson'}
@@ -200,17 +210,6 @@ const BotProjectSettings: React.FC<RouteComponentProps<{ projectId: string; skil
           ) : (
             <BotProjectSettingsTabView projectId={currentProjectId} scrollToSectionId={props.location?.hash} />
           )}
-          <Toggle
-            inlineLabel
-            checked={isAdvancedSettingsEnabled}
-            className={'advancedSettingsView'}
-            defaultChecked={false}
-            label={formatMessage('Advanced Settings View (json)')}
-            styles={{ root: { position: 'absolute', left: '700px', top: '30px' } }}
-            onChange={() => {
-              setAdvancedSettingsEnabled(!isAdvancedSettingsEnabled);
-            }}
-          />
         </div>
       </Suspense>
     </Page>

--- a/Composer/packages/client/src/router.tsx
+++ b/Composer/packages/client/src/router.tsx
@@ -44,8 +44,7 @@ const BotCreationFlowRouterV2 = React.lazy(() => import('./components/CreationFl
 const FormDialogPage = React.lazy(() => import('./pages/form-dialog/FormDialogPage'));
 
 const modalControlGroup = css`
-  border: 1px solid rgb(237, 235, 233);
-  padding: 0.5rem 1rem 1rem 1rem;
+  padding: 10px;
 `;
 
 const Routes = (props) => {

--- a/Composer/packages/client/src/router.tsx
+++ b/Composer/packages/client/src/router.tsx
@@ -7,6 +7,7 @@ import React, { useEffect, Suspense } from 'react';
 import { Router, Redirect, RouteComponentProps } from '@reach/router';
 import { useRecoilValue } from 'recoil';
 import formatMessage from 'format-message';
+import { Dialog, DialogType } from 'office-ui-fabric-react/lib/Dialog';
 
 import { resolveToBasePath } from './utils/fileUtil';
 import { data } from './styles';
@@ -41,6 +42,11 @@ const Publish = React.lazy(() => import('./pages/publish/Publish'));
 const BotCreationFlowRouter = React.lazy(() => import('./components/CreationFlow/CreationFlow'));
 const BotCreationFlowRouterV2 = React.lazy(() => import('./components/CreationFlow/v2/CreationFlow'));
 const FormDialogPage = React.lazy(() => import('./pages/form-dialog/FormDialogPage'));
+
+const modalControlGroup = css`
+  border: 1px solid rgb(237, 235, 233);
+  padding: 0.5rem 1rem 1rem 1rem;
+`;
 
 const Routes = (props) => {
   const botOpening = useRecoilValue(botOpeningState);
@@ -112,7 +118,19 @@ const Routes = (props) => {
         <div
           css={{ position: 'absolute', top: 0, left: 0, bottom: 0, right: 0, background: 'rgba(255, 255, 255, 0.6)' }}
         >
-          <LoadingSpinner message={spinnerText} />
+          <Dialog
+            dialogContentProps={{
+              type: DialogType.normal,
+            }}
+            hidden={!botOpening}
+            modalProps={{
+              isBlocking: false,
+            }}
+          >
+            <div css={modalControlGroup}>
+              <LoadingSpinner message={spinnerText} />
+            </div>
+          </Dialog>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Description

Small UI changes to resolve two UI bugs. 

First bug is that the loading text was hard to read during bot creation so that has been formatted to be rendered in its own modal similar to the spinner one sees when installing a new package

Second bug was the positioning of the toggle for advanced settings which overlapped the json editor and led to character overlap between the toggle and text in the JSON editor. 

## Task Item

fixes #6663 
fixes #6801 

## Screenshots

![image](https://user-images.githubusercontent.com/22845013/114101811-43805e00-9894-11eb-96b7-71fc12a3ea64.png)

![image](https://user-images.githubusercontent.com/22845013/114101986-893d2680-9894-11eb-8f3b-d13c04850f2e.png)
