### PR TITLE
fix: Added trace type to Web Chat log

### DIFF
--- a/Composer/packages/client/src/pages/design/DebugPanel/TabExtensions/WebChatLog/WebChatActivityLogItem.tsx
+++ b/Composer/packages/client/src/pages/design/DebugPanel/TabExtensions/WebChatLog/WebChatActivityLogItem.tsx
@@ -45,6 +45,7 @@ export const WebChatActivityLogItem: React.FC<WebChatActivityLogItemProps> = (pr
       {renderActivityArrow(item.activity)}
       <span css={clickableSegment}>{item.activity.type || 'unknown'}</span>
       {item.activity.type === 'message' ? <span css={emphasizedText}>{item.activity.text}</span> : null}
+      {item.activity.type === 'trace' ? <span css={emphasizedText}>{item.activity.label}</span> : null}
     </span>
   );
 };


### PR DESCRIPTION
## Description

This PR adds the trace type next to trace items in the Web Chat log.

## Task Item

Fixes #6749

## Screenshots

**BEFORE:**

![trace-before](https://user-images.githubusercontent.com/3452012/114239570-189d1500-993b-11eb-919b-1648723248e6.PNG)


**AFTER:**

![trace-after](https://user-images.githubusercontent.com/3452012/114239587-1b980580-993b-11eb-9b55-8b1e54aaccd2.PNG)
