### PR TITLE
fix:  use resourceGroup name from publishing profile if one exists

### DIFF
--- a/Composer/packages/client/src/pages/botProject/adapters/ABSChannels.tsx
+++ b/Composer/packages/client/src/pages/botProject/adapters/ABSChannels.tsx
@@ -139,7 +139,7 @@ export const ABSChannels: React.FC<RuntimeSettingsProps> = (props) => {
         setCurrentResource({
           microsoftAppId: config?.settings?.MicrosoftAppId,
           resourceName: config.name,
-          resourceGroupName: config.name,
+          resourceGroupName: config.resourceGroup || config.name,
           subscriptionId: config.subscriptionId,
         });
       }


### PR DESCRIPTION
## Description

Applies the resourceGroup field from the publishing profile rather than using the "name" field during the connections configuration.  Previously, resourceGroup and name were always identical, but can now be different.

## Task Item

fixes #6731
