### PR TITLE
fix: Update Blank bot to Empty bot

### DIFF
--- a/Composer/packages/server/src/utility/creation.ts
+++ b/Composer/packages/server/src/utility/creation.ts
@@ -5,7 +5,7 @@ import { BotTemplate, QnABotTemplateId } from '@bfc/shared';
 import union from 'lodash/union';
 
 export const templateSortOrder = [
-  { generatorName: '@microsoft/generator-bot-empty', displayName: 'Blank bot' },
+  { generatorName: '@microsoft/generator-bot-empty', displayName: 'Empty bot' },
   { generatorName: '@microsoft/generator-bot-conversational-core', displayName: 'Basic conversational bot' },
   { generatorName: '@microsoft/generator-bot-assistant-core', displayName: 'Basic assistant' },
   { generatorName: '@microsoft/generator-bot-enterprise-assistant', displayName: 'Enterprise assistant' },


### PR DESCRIPTION
Following the longstanding ASP.Net tradition, we must change this to "Empty Bot", just like ASP.Net does for new projects. 

Blank Bot, while it aligns with Powerpoint, is a graphical canvas, not a development term.

## Description

The name of "Blank bot" doesn't align with ASP.Net and/or other development ecosystems. 

## Task Item

Fixes #6978