### PR TITLE
fix: sort multi-skill bots in list by first opening of root (without skills)

### DIFF
--- a/Composer/packages/client/src/pages/home/Home.tsx
+++ b/Composer/packages/client/src/pages/home/Home.tsx
@@ -65,11 +65,11 @@ const resources = [
 ];
 
 const Home: React.FC<RouteComponentProps> = () => {
-  const projectId = useRecoilValue(currentProjectIdState);
-  const botName = useRecoilValue(botDisplayNameState(projectId));
+  const projectId = useRecoilValue<string>(currentProjectIdState);
+  const botName = useRecoilValue<string>(botDisplayNameState(projectId));
   const recentProjects = useRecoilValue(recentProjectsState);
   const feed = useRecoilValue(feedState);
-  const templateId = useRecoilValue(templateIdState);
+  const templateId = useRecoilValue<string>(templateIdState);
   const { openProject, setCreationFlowStatus, setCreationFlowType } = useRecoilValue(dispatcherState);
 
   const onItemChosen = async (item) => {

--- a/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
@@ -348,10 +348,11 @@ export const loadProjectData = async (data) => {
 
 export const fetchProjectDataByPath = async (
   path: string,
-  storageId
+  storageId,
+  isRootBot: boolean
 ): Promise<{ botFiles: any; projectData: any; error: any }> => {
   try {
-    const response = await httpClient.put(`/projects/open`, { path, storageId });
+    const response = await httpClient.put(`/projects/open`, { path, storageId, isRootBot });
     const projectData = await loadProjectData(response.data);
     return projectData;
   } catch (ex) {
@@ -569,7 +570,7 @@ export const openRemoteSkill = async (
 
 export const openLocalSkill = async (callbackHelpers, pathToBot: string, storageId, botNameIdentifier: string) => {
   const { set } = callbackHelpers;
-  const { projectData, botFiles, error } = await fetchProjectDataByPath(pathToBot, storageId);
+  const { projectData, botFiles, error } = await fetchProjectDataByPath(pathToBot, storageId, false);
 
   if (error) {
     throw error;
@@ -790,7 +791,7 @@ export const postRootBotCreation = async (
 };
 
 export const openRootBotAndSkillsByPath = async (callbackHelpers: CallbackInterface, path: string, storageId) => {
-  const data = await fetchProjectDataByPath(path, storageId);
+  const data = await fetchProjectDataByPath(path, storageId, true);
   if (data.error) {
     throw data.error;
   }

--- a/Composer/packages/server/src/controllers/project.ts
+++ b/Composer/packages/server/src/controllers/project.ts
@@ -49,7 +49,7 @@ async function createProject(req: Request, res: Response) {
     await BotProjectService.cleanProject(locationRef);
     const newProjRef = await getNewProjRef(templateDir, templateId, locationRef, user, locale);
 
-    const id = await BotProjectService.openProject(newProjRef, user);
+    const id = await BotProjectService.openProject(newProjRef, user, true);
     // in the case of a remote template, we need to update the eTag and alias used by the import mechanism
     BotProjectService.setProjectLocationData(id, { alias, eTag });
     const currentProject = await BotProjectService.getProjectById(id, user);
@@ -207,7 +207,7 @@ async function openProject(req: Request, res: Response) {
   };
 
   try {
-    const id = await BotProjectService.openProject(location, user);
+    const id = await BotProjectService.openProject(location, user, req.body.isRootBot);
     const currentProject = await BotProjectService.getProjectById(id, user);
     if (currentProject !== undefined) {
       await currentProject.init();

--- a/Composer/packages/server/src/services/project.ts
+++ b/Composer/packages/server/src/services/project.ts
@@ -207,7 +207,11 @@ export class BotProjectService {
     }
   };
 
-  public static openProject = async (locationRef: LocationRef, user?: UserIdentity): Promise<string> => {
+  public static openProject = async (
+    locationRef: LocationRef,
+    user?: UserIdentity,
+    isRootBot?: boolean
+  ): Promise<string> => {
     BotProjectService.initialize();
 
     // TODO: this should be refactored or moved into the BotProject constructor so that it can use user auth amongst other things
@@ -224,7 +228,7 @@ export class BotProjectService {
       const projectLoc = BotProjectService.projectLocationMap[key];
       if (projectLoc && projectLoc.path === locationRef.path) {
         // TODO: this should probably move to getProjectById
-        BotProjectService.addRecentProject(locationRef.path);
+        if (isRootBot) BotProjectService.addRecentProject(locationRef.path);
         return key;
       }
     }
@@ -512,7 +516,7 @@ export class BotProjectService {
           return new Promise(async (resolve, reject) => {
             try {
               log('Open project', botRef);
-              const id = await BotProjectService.openProject(botRef, user);
+              const id = await BotProjectService.openProject(botRef, user, false);
 
               // in the case of remote project, we need to update the eTag and alias used by the import mechanism
               BotProjectService.setProjectLocationData(id, { alias, eTag });
@@ -548,7 +552,11 @@ export class BotProjectService {
 
       const rootBot = botsToProcess.find((b) => b.name === name);
       if (rootBot) {
-        const id = await BotProjectService.openProject({ storageId: rootBot?.storageId, path: rootBot.path }, user);
+        const id = await BotProjectService.openProject(
+          { storageId: rootBot?.storageId, path: rootBot.path },
+          user,
+          true
+        );
         const currentProject = await BotProjectService.getProjectById(id, user);
         const project = currentProject.getProject();
         log('Project created successfully.');


### PR DESCRIPTION
## Description

This is the second half of a fix; the first is #7140, which rearranges the order of bots in the Recent Bot List but does not handle multi-bot projects correctly. This extends that work to the multi-bot case.

[In draft until unit tests pass]

## Task Item

closes #7069

## Screenshots

![image](https://user-images.githubusercontent.com/61990921/115465206-195b6400-a1e3-11eb-8d22-c4efd82f896b.png)

