### PR TITLE
fix: disable telemetry calls in the provision dialog while we investigate …

### DIFF
--- a/extensions/azurePublish/src/components/azureProvisionDialog.tsx
+++ b/extensions/azurePublish/src/components/azureProvisionDialog.tsx
@@ -284,6 +284,8 @@ export const AzureProvisionDialog: React.FC = () => {
   } = usePublishApi();
   const telemetryClient: TelemetryClient = useTelemetryClient();
 
+  console.log('TELEMETRY CLIENT', telemetryClient);
+
   const { setItem, getItem, clearAll } = useLocalStorage();
   // set type of publish - azurePublish or azureFunctionsPublish
   const publishType = getType();
@@ -362,22 +364,22 @@ export const AzureProvisionDialog: React.FC = () => {
     setPage(page);
     switch (page) {
       case PageTypes.AddResources:
-        telemetryClient.track('ProvisionAddResourcesNavigate');
+        // telemetryClient.track('ProvisionAddResourcesNavigate');
         setTitle(DialogTitle.ADD_RESOURCES);
         break;
       case PageTypes.ChooseAction:
         setTitle(DialogTitle.CHOOSE_ACTION);
         break;
       case PageTypes.ConfigProvision:
-        telemetryClient.track('ProvisionConfigureResources');
+        // telemetryClient.track('ProvisionConfigureResources');
         setTitle(DialogTitle.CONFIG_RESOURCES);
         break;
       case PageTypes.EditJson:
-        telemetryClient.track('ProvisionEditJSON');
+        // telemetryClient.track('ProvisionEditJSON');
         setTitle(DialogTitle.EDIT);
         break;
       case PageTypes.ReviewResource:
-        telemetryClient.track('ProvisionReviewResources');
+        // telemetryClient.track('ProvisionReviewResources');
         setTitle(DialogTitle.REVIEW);
         break;
     }
@@ -704,11 +706,11 @@ export const AzureProvisionDialog: React.FC = () => {
   const onSubmit = useCallback((options) => {
     // call back to the main Composer API to begin this process...
 
-    telemetryClient.track('ProvisionStart', {
-      region: options.location,
-      subscriptionId: options.subscription,
-      externalResources: options.externalResources,
-    });
+    // telemetryClient.track('ProvisionStart', {
+    //   region: options.location,
+    //   subscriptionId: options.subscription,
+    //   externalResources: options.externalResources,
+    // });
 
     startProvision(options);
     clearAll();
@@ -981,7 +983,7 @@ export const AzureProvisionDialog: React.FC = () => {
               style={{ margin: '0 4px' }}
               text={formatMessage('Cancel')}
               onClick={() => {
-                telemetryClient.track('ProvisionCancel');
+                // telemetryClient.track('ProvisionCancel');
                 closeDialog();
               }}
             />
@@ -1077,7 +1079,7 @@ export const AzureProvisionDialog: React.FC = () => {
               text={formatMessage('Next')}
               onClick={() => {
                 if (formData.creationType === 'generate') {
-                  telemetryClient.track('ProvisionShowHandoff');
+                  // telemetryClient.track('ProvisionShowHandoff');
                   setShowHandoff(true);
                 } else {
                   setPageAndTitle(PageTypes.ReviewResource);
@@ -1101,7 +1103,7 @@ export const AzureProvisionDialog: React.FC = () => {
               style={{ margin: '0 4px' }}
               text={formatMessage('Cancel')}
               onClick={() => {
-                telemetryClient.track('ProvisionAddResourcesCancel');
+                // telemetryClient.track('ProvisionAddResourcesCancel');
                 closeDialog();
               }}
             />


### PR DESCRIPTION
## Description

For some reason, the telemetryclient is sometimes undefined inside the plugin.  This breaks the provision process right now.

## Task Item

Fixes #7250 
