### PR TITLE
fix: prefer the botName field instead of the name field when managing connections

### DIFF
--- a/Composer/packages/client/src/pages/botProject/adapters/ABSChannels.tsx
+++ b/Composer/packages/client/src/pages/botProject/adapters/ABSChannels.tsx
@@ -139,8 +139,8 @@ export const ABSChannels: React.FC<RuntimeSettingsProps> = (props) => {
         const config = JSON.parse(profile.configuration);
         setCurrentResource({
           microsoftAppId: config?.settings?.MicrosoftAppId,
-          resourceName: config.name,
-          resourceGroupName: config.resourceGroup || config.name,
+          resourceName: config.botName || config.name,
+          resourceGroupName: config.resourceGroup || config.botName || config.name,
           subscriptionId: config.subscriptionId,
         });
       }


### PR DESCRIPTION
## Description

Prefer the `botName` field over the `name` field if set, when dealing with connections.

This allows the name to be different than botName, which is the case in the ABS handoff scenario.


## Task Item

Fixes #7158 
