### PR TITLE
fix: Region for Microsoft Bot Channels Registration is now 'global'

### DIFF
--- a/extensions/azurePublish/src/components/azureProvisionDialog.tsx
+++ b/extensions/azurePublish/src/components/azureProvisionDialog.tsx
@@ -171,6 +171,17 @@ const onRenderLabel = (props) => {
   );
 };
 
+const getResourceRegion = (item: ResourcesItem): string => {
+  const { key, region } = item;
+  switch (key) {
+    case AzureResourceTypes.APP_REGISTRATION:
+    case AzureResourceTypes.BOT_REGISTRATION:
+      return 'global';
+    default:
+      return region;
+  }
+};
+
 const reviewCols: IColumn[] = [
   {
     key: 'Icon',
@@ -235,7 +246,7 @@ const reviewCols: IColumn[] = [
     onRender: (item: ResourcesItem) => {
       return (
         <div style={{ whiteSpace: 'normal', fontSize: '12px', color: NeutralColors.gray130 }}>
-          {item.key === AzureResourceTypes.APP_REGISTRATION ? 'global' : item?.region}
+          {getResourceRegion(item)}
         </div>
       );
     },


### PR DESCRIPTION
## Description
      Region for Microsoft Bot Channels Registration resource type will now show as 'global' .

## Task Item

fixes #6680 

## Screenshots
![image](https://user-images.githubusercontent.com/12182973/115774656-b7c40280-a366-11eb-8c64-bb60b7749b17.png)
