### PR TITLE
fix: Empty setting for recognizer configuration when switch bot

### DIFF
--- a/Composer/packages/client/src/recoilModel/Recognizers.tsx
+++ b/Composer/packages/client/src/recoilModel/Recognizers.tsx
@@ -26,7 +26,7 @@ import { crossTrainConfigState, filePersistenceState, settingsState } from './at
 import { dialogsSelectorFamily, luFilesSelectorFamily, qnaFilesSelectorFamily } from './selectors';
 import { recognizersSelectorFamily } from './selectors/recognizers';
 
-const isFilesUnparsed = (files: { isContentUnparsed: boolean }[]) => {
+const isAnyFileNotParsed = (files: { isContentUnparsed: boolean }[]) => {
   return files.some((file) => file.isContentUnparsed);
 };
 
@@ -209,7 +209,7 @@ export const Recognizer = React.memo((props: { projectId: string }) => {
 
   useEffect(() => {
     if (isEmpty(filePersistence)) return;
-    if (isFilesUnparsed(luFiles) || isFilesUnparsed(qnaFiles)) return;
+    if (isAnyFileNotParsed(luFiles) || isAnyFileNotParsed(qnaFiles)) return;
     let recognizers: RecognizerFile[] = [];
 
     dialogs

--- a/Composer/packages/client/src/recoilModel/Recognizers.tsx
+++ b/Composer/packages/client/src/recoilModel/Recognizers.tsx
@@ -26,6 +26,10 @@ import { crossTrainConfigState, filePersistenceState, settingsState } from './at
 import { dialogsSelectorFamily, luFilesSelectorFamily, qnaFilesSelectorFamily } from './selectors';
 import { recognizersSelectorFamily } from './selectors/recognizers';
 
+const isFilesUnparsed = (files: { isContentUnparsed: boolean }[]) => {
+  return files.some((file) => file.isContentUnparsed);
+};
+
 export const LuisRecognizerTemplate = (target: string, fileName: string) => ({
   $kind: SDKKinds.LuisRecognizer,
   id: `LUIS_${target}`,
@@ -205,6 +209,7 @@ export const Recognizer = React.memo((props: { projectId: string }) => {
 
   useEffect(() => {
     if (isEmpty(filePersistence)) return;
+    if (isFilesUnparsed(luFiles) || isFilesUnparsed(qnaFiles)) return;
     let recognizers: RecognizerFile[] = [];
 
     dialogs


### PR DESCRIPTION
## Description
### Root cause
Composer move lu and qna parse to the backend, the recognizers may be generated when the lu parse result is empty. 

### Fix 
generate the recognizers after all files are parsed.
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
closes #7141
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
