### PR TITLE
fix: refactor way we get COMPOSER_VERSION

### DIFF
--- a/Composer/packages/client/config/env.js
+++ b/Composer/packages/client/config/env.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
 const { execSync } = require('child_process');
 
@@ -49,6 +49,14 @@ function getGitSha() {
   }
 }
 
+function getComposerVersion() {
+  try {
+    return fs.readJSONSync(path.join(__dirname, '../../electron-server/package.json')).version;
+  } catch {
+    return 'unknown';
+  }
+}
+
 // We support resolving modules according to `NODE_PATH`.
 // This lets you use absolute paths in imports inside large monorepos:
 // https://github.com/facebook/create-react-app/issues/253.
@@ -88,7 +96,7 @@ function getClientEnvironment(publicUrl) {
         PUBLIC_URL: publicUrl,
         GIT_SHA: getGitSha().toString().replace('\n', ''),
         SDK_PACKAGE_VERSION: '4.12.2', // TODO: change this when Composer supports custom schema/custom runtime
-        COMPOSER_VERSION: '1.4.0',
+        COMPOSER_VERSION: getComposerVersion(),
         LOCAL_PUBLISH_PATH:
           process.env.LOCAL_PUBLISH_PATH || path.resolve(process.cwd(), '../../../extensions/localPublish/hostedBots'),
         WEBLOGIN_CLIENTID: process.env.WEBLOGIN_CLIENTID,

--- a/Composer/packages/client/src/pages/about/About.tsx
+++ b/Composer/packages/client/src/pages/about/About.tsx
@@ -33,7 +33,7 @@ export const About: React.FC<RouteComponentProps> = () => {
         <div css={about.version}>
           {formatMessage(`Release: `) +
             (isElectron()
-              ? (window as any).appVersion
+              ? process.env.COMPOSER_VERSION
               : `${process.env.COMPOSER_VERSION}-${process.env.GIT_SHA}` || 'Unknown')}
         </div>
         <div css={about.diagnosticsInfo}>

--- a/Composer/packages/electron-server/src/main.ts
+++ b/Composer/packages/electron-server/src/main.ts
@@ -141,6 +141,7 @@ function initializeAppUpdater(settings: AppUpdaterSettings) {
 }
 
 async function loadServer() {
+  process.env.COMPOSER_VERSION = app.getVersion();
   if (!isDevelopment) {
     // only change paths if packaged electron app
     const unpackedDir = getUnpackedAsarPath();

--- a/Composer/packages/electron-server/src/preload.js
+++ b/Composer/packages/electron-server/src/preload.js
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-const { app, ipcRenderer } = require('electron'); // eslint-disable-line
+const { ipcRenderer } = require('electron'); // eslint-disable-line
 
 // expose ipcRenderer to the browser
 window.ipcRenderer = ipcRenderer;
-// get the app version to hand into the client
-window.appVersion = app.getVersion();
 // flag to distinguish electron client from web app client
 window.__IS_ELECTRON__ = true;

--- a/Composer/packages/server/src/constants.ts
+++ b/Composer/packages/server/src/constants.ts
@@ -18,5 +18,3 @@ export enum ClaimNames {
 export const APPINSIGHTS_INSTRUMENTATIONKEY = process.env.APPINSIGHTS_INSTRUMENTATIONKEY;
 
 export const piiProperties = [];
-
-export const COMPOSER_VERSION = '1.4.0';

--- a/Composer/packages/server/src/models/bot/builder.ts
+++ b/Composer/packages/server/src/models/bot/builder.ts
@@ -17,7 +17,6 @@ import { IFileStorage } from '../storage/interface';
 import log from '../../logger';
 import { setEnvDefault } from '../../utility/setEnvDefault';
 import { useElectronContext } from '../../utility/electronContext';
-import { COMPOSER_VERSION } from '../../constants';
 import { TelemetryService } from '../../services/telemetry';
 
 import { IOrchestratorNLRList, IOrchestratorProgress, IOrchestratorSettings } from './interface';
@@ -52,7 +51,7 @@ export type DownSamplingConfig = {
 
 const getUserAgent = () => {
   const platform = useElectronContext() ? 'desktop' : 'web';
-  return `microsoft.bot.composer/${COMPOSER_VERSION} ${platform}`;
+  return `microsoft.bot.composer/${process.env.COMPOSER_VERSION} ${platform}`;
 };
 
 export class Builder {

--- a/Composer/packages/server/src/server.ts
+++ b/Composer/packages/server/src/server.ts
@@ -35,11 +35,13 @@ import { mountConversationsRoutes } from './directline/mountConversationRoutes';
 import { mountDirectLineRoutes } from './directline/mountDirectlineRoutes';
 import { mountAttachmentRoutes } from './directline/mountAttachmentRoutes';
 import { cleanHostedBots } from './utility/cleanHostedBots';
+import { getVersion } from './utility/getVersion';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const session = require('express-session');
 
 export async function start(electronContext?: ElectronContext): Promise<number | string> {
+  setEnvDefault('COMPOSER_VERSION', getVersion());
   if (electronContext) {
     setElectronContext(electronContext);
   }

--- a/Composer/packages/server/src/utility/getVersion.ts
+++ b/Composer/packages/server/src/utility/getVersion.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import path from 'path';
+
+import fs from 'fs-extra';
+
+const isProduction = process.env.NODE_ENV === 'production';
+
+export function getVersion(): string {
+  try {
+    const version = fs.readJSONSync(path.join(__dirname, '../../../electron-server/package.json')).version;
+    return isProduction ? version : `${version}-DEV`;
+  } catch {
+    return 'unknown';
+  }
+}


### PR DESCRIPTION
## Description

Fixes an issue where the preload.js script could not be loaded due to `app` being undefined in the renderer process.

<!---
#minor
---->
