### PR TITLE
fix: better display and logic around handling remote skills

### DIFF
--- a/Composer/packages/client/src/components/AddRemoteSkillModal/CreateSkillModal.tsx
+++ b/Composer/packages/client/src/components/AddRemoteSkillModal/CreateSkillModal.tsx
@@ -219,7 +219,6 @@ export const CreateSkillModal: React.FC<CreateSkillModalProps> = (props) => {
                   responsiveMode={ResponsiveMode.large}
                   onChange={(e, option?: IDropdownOption) => {
                     if (option) {
-                      console.log(option);
                       setFormData({
                         ...formData,
                         endpointName: option.key as string,

--- a/Composer/packages/client/src/components/ProjectTree/ExpandableNode.tsx
+++ b/Composer/packages/client/src/components/ProjectTree/ExpandableNode.tsx
@@ -7,7 +7,7 @@ import { useState, MouseEvent, KeyboardEvent } from 'react';
 import { NeutralColors } from '@uifabric/fluent-theme';
 
 type Props = {
-  children: React.ReactNode;
+  children?: React.ReactNode;
   summary: React.ReactNode;
   depth?: number;
   detailsRef?: (el: HTMLElement | null) => void;
@@ -16,13 +16,15 @@ type Props = {
   isActive?: boolean;
 };
 
-const listItemStyle = (isActive: boolean, isOpen: boolean) => css`
+const listItemStyle = (isActive: boolean, isOpen: boolean, hasChildren: boolean) => css`
   label: listItem;
   :hover {
     background: ${isActive ? NeutralColors.gray40 : NeutralColors.gray20};
   }
   background: ${isActive ? NeutralColors.gray30 : NeutralColors.white};
-  ${isOpen
+  ${!hasChildren
+    ? 'list-style: none'
+    : isOpen
     ? `list-style-image: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='UTF-8' standalone='no'%3F%3E%3Csvg xmlns='http://www.w3.org/2000/svg' version='1.1' height='16' width='16' viewBox='0 0 24 16'%3E%3Cpath style='fill:black%3B' d='M 8 8 h 16 l -8 8 l -8 -8'/%3E%3C/svg%3E");`
     : `list-style-image: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='UTF-8' standalone='no'%3F%3E%3Csvg xmlns='http://www.w3.org/2000/svg' version='1.1' height='16' width='16' viewBox='0 0 24 16'%3E%3Cpath style='fill:black%3B' d='M 16 0 v 16 l 8 -8 l -8 -8'/%3E%3C/svg%3E");`}
 `;
@@ -74,10 +76,10 @@ export const ExpandableNode = ({
       onKeyDown={handleKey}
     >
       {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/no-noninteractive-tabindex */}
-      <li css={listItemStyle(isActive, isExpanded)} data-testid={'summaryTag'}>
+      <li css={listItemStyle(isActive, isExpanded, children != null)} data-testid={'summaryTag'}>
         {summary}
       </li>
-      {isExpanded && <div role="group">{children}</div>}
+      {children != null && isExpanded && <div role="group">{children}</div>}
     </ul>
   );
 };

--- a/Composer/packages/client/src/components/ProjectTree/ProjectTree.tsx
+++ b/Composer/packages/client/src/components/ProjectTree/ProjectTree.tsx
@@ -759,7 +759,7 @@ export const ProjectTree: React.FC<Props> = ({
         </ExpandableNode>
       );
     } else if (options.showRemote) {
-      return projectHeader;
+      return <ExpandableNode key={key} summary={projectHeader} />;
     } else {
       return null;
     }

--- a/Composer/packages/client/src/router.tsx
+++ b/Composer/packages/client/src/router.tsx
@@ -74,6 +74,14 @@ const Routes = (props) => {
             <QnAPage path="knowledge-base/:dialogId/*" />
             <BotProjectSettings path="botProjectsSettings" />
             <Diagnostics path="diagnostics" />
+            {pluginPages.map((page) => (
+              <PluginPageContainer
+                key={`${page.id}/${page.bundleId}`}
+                bundleId={page.bundleId}
+                path={`plugin/${page.id}/${page.bundleId}`}
+                pluginId={page.id}
+              />
+            ))}
             <DesignPage path="*" />
           </ProjectRouter>
           <ProjectRouter path="/bot/:projectId">
@@ -90,14 +98,6 @@ const Routes = (props) => {
             <FormDialogPage path="forms/*" />
             <DesignPage path="*" />
             <Diagnostics path="diagnostics" />
-            {pluginPages.map((page) => (
-              <PluginPageContainer
-                key={`${page.id}/${page.bundleId}`}
-                bundleId={page.bundleId}
-                path={`plugin/${page.id}/${page.bundleId}`}
-                pluginId={page.id}
-              />
-            ))}
           </ProjectRouter>
           <SettingPage path="settings/*" />
           <ExtensionsPage path="extensions/*" />

--- a/Composer/packages/client/src/utils/hooks.ts
+++ b/Composer/packages/client/src/utils/hooks.ts
@@ -14,6 +14,7 @@ import {
   currentProjectIdState,
   pluginPagesSelector,
   featureFlagsState,
+  projectMetaDataState,
   rootBotProjectIdSelector,
   schemasState,
 } from '../recoilModel';
@@ -49,12 +50,13 @@ export const useLinks = () => {
   const designPageLocation = useRecoilValue(designPageLocationState(projectId));
   const pluginPages = useRecoilValue(pluginPagesSelector);
   const schemas = useRecoilValue(schemasState(projectId));
+  const { isRemote } = useRecoilValue(projectMetaDataState(projectId));
   const openedDialogId = designPageLocation.dialogId;
   const showFormDialog = useFeatureFlag('FORM_DIALOG');
 
   const pageLinks = useMemo(() => {
-    return topLinks(projectId, openedDialogId, pluginPages, showFormDialog, schemas.sdk, rootProjectId);
-  }, [projectId, openedDialogId, pluginPages, showFormDialog]);
+    return topLinks(projectId, openedDialogId, pluginPages, showFormDialog, schemas.sdk, isRemote, rootProjectId);
+  }, [projectId, openedDialogId, pluginPages, showFormDialog, isRemote]);
 
   return { topLinks: pageLinks, bottomLinks };
 };

--- a/Composer/packages/client/src/utils/pageLinks.ts
+++ b/Composer/packages/client/src/utils/pageLinks.ts
@@ -113,7 +113,7 @@ export const topLinks = (
         disablePluginForPva = true;
       }
       links.push({
-        to: `/bot/${projectId}/plugin/${p.id}/${p.bundleId}`,
+        to: `/bot/${rootProjectId || projectId}/plugin/${p.id}/${p.bundleId}`,
         iconName: p.icon ?? 'StatusCircleQuestionMark',
         labelName: p.label,
         disabled: !projectId,

--- a/Composer/packages/client/src/utils/pageLinks.ts
+++ b/Composer/packages/client/src/utils/pageLinks.ts
@@ -21,6 +21,7 @@ export const topLinks = (
   pluginPages: ExtensionPageConfig[],
   showFormDialog: boolean,
   schema: any,
+  skillIsRemote: boolean,
   rootProjectId?: string
 ) => {
   const isPVASchema = checkForPVASchema(schema);
@@ -50,7 +51,7 @@ export const topLinks = (
       to: linkBase + `language-generation/${openedDialogId}`,
       iconName: 'Robot',
       labelName: formatMessage('Bot responses'),
-      disabled: !botLoaded,
+      disabled: !botLoaded || skillIsRemote,
       match: /language-generation\/[a-zA-Z0-9_-]+$/,
       isDisabledForPVA: false,
     },
@@ -58,7 +59,7 @@ export const topLinks = (
       to: linkBase + `language-understanding/${openedDialogId}`,
       iconName: 'People',
       labelName: formatMessage('User input'),
-      disabled: !botLoaded,
+      disabled: !botLoaded || skillIsRemote,
       match: /language-understanding\/[a-zA-Z0-9_-]+$/,
       isDisabledForPVA: false,
     },
@@ -66,7 +67,7 @@ export const topLinks = (
       to: linkBase + `knowledge-base/${openedDialogId}`,
       iconName: 'QnAIcon',
       labelName: formatMessage('QnA'),
-      disabled: !botLoaded,
+      disabled: !botLoaded || skillIsRemote,
       match: /knowledge-base\/[a-zA-Z0-9_-]+$/,
       isDisabledForPVA: isPVASchema,
     },
@@ -99,7 +100,7 @@ export const topLinks = (
             to: `/bot/${projectId}/forms`,
             iconName: 'Table',
             labelName: formatMessage('Forms (preview)'),
-            disabled: !botLoaded,
+            disabled: !botLoaded && !skillIsRemote,
             isDisabledForPVA: false,
           },
         ]
@@ -113,7 +114,7 @@ export const topLinks = (
         disablePluginForPva = true;
       }
       links.push({
-        to: `/bot/${rootProjectId || projectId}/plugin/${p.id}/${p.bundleId}`,
+        to: linkBase + `plugin/${p.id}/${p.bundleId}`,
         iconName: p.icon ?? 'StatusCircleQuestionMark',
         labelName: p.label,
         disabled: !projectId,

--- a/Composer/packages/client/src/utils/pageLinks.ts
+++ b/Composer/packages/client/src/utils/pageLinks.ts
@@ -100,7 +100,7 @@ export const topLinks = (
             to: `/bot/${projectId}/forms`,
             iconName: 'Table',
             labelName: formatMessage('Forms (preview)'),
-            disabled: !botLoaded && !skillIsRemote,
+            disabled: !botLoaded || skillIsRemote,
             isDisabledForPVA: false,
           },
         ]

--- a/Composer/packages/server/src/models/bot/builder.ts
+++ b/Composer/packages/server/src/models/bot/builder.ts
@@ -207,7 +207,10 @@ export class Builder {
         TelemetryService.endEvent('OrchestratorBuildCompleted', 'OrchestratorBuilder');
 
         this.orchestratorSettings.orchestrator.models[modelData.lang] = modelPath;
-        this.orchestratorSettings.orchestrator.snapshots = snapshotData;
+        this.orchestratorSettings.orchestrator.snapshots = {
+          ...this.orchestratorSettings.orchestrator.snapshots,
+          ...snapshotData,
+        };
       }
     }
 

--- a/extensions/packageManager/src/pages/Library.tsx
+++ b/extensions/packageManager/src/pages/Library.tsx
@@ -64,9 +64,15 @@ export interface PackageSourceFeed extends IDropdownOption {
 
 const Library: React.FC = () => {
   const [items, setItems] = useState<LibraryRef[]>([]);
-  const { projectId, reloadProject, projectCollection } = useProjectApi();
+  const { projectId, reloadProject, projectCollection: allProjectCollection } = useProjectApi();
   const { setApplicationLevelError, navigateTo, confirm } = useApplicationApi();
   const telemetryClient: TelemetryClient = useTelemetryClient();
+
+  const projectCollection = allProjectCollection.filter((proj) => !proj.isRemote);
+
+  const startingProjectId = allProjectCollection.find((proj) => proj.projectId === projectId).isRemote
+    ? projectCollection[0].projectId // this should always exist, because there's always at least a root bot
+    : projectId;
 
   const [ejectedRuntime, setEjectedRuntime] = useState<boolean>(false);
   const [availableLibraries, updateAvailableLibraries] = useState<LibraryRef[] | undefined>(undefined);
@@ -81,7 +87,7 @@ const Library: React.FC = () => {
   const [selectedItem, setSelectedItem] = useState<LibraryRef>();
   const [selectedItemVersions, setSelectedItemVersions] = useState<string[]>([]);
   const [selectedVersion, setSelectedVersion] = useState<string>('');
-  const [currentProjectId, setCurrentProjectId] = useState<string>(projectId);
+  const [currentProjectId, setCurrentProjectId] = useState<string>(startingProjectId);
   const [working, setWorking] = useState<string>('');
   const [addDialogHidden, setAddDialogHidden] = useState(true);
   const [isModalVisible, setModalVisible] = useState<boolean>(false);

--- a/extensions/packageManager/src/pages/Library.tsx
+++ b/extensions/packageManager/src/pages/Library.tsx
@@ -196,7 +196,7 @@ const Library: React.FC = () => {
   };
 
   useEffect(() => {
-    setCurrentProjectId(projectId);
+    setCurrentProjectId(startingProjectId);
     getFeeds().then((feeds) => updateFeeds(feeds.data));
   }, []);
 
@@ -221,7 +221,7 @@ const Library: React.FC = () => {
   }, [feed, feeds, searchTerm]);
 
   useEffect(() => {
-    const settings = projectCollection.find((b) => b.projectId === currentProjectId).setting;
+    const settings = projectCollection.find((b) => b.projectId === currentProjectId)?.setting;
     if (settings?.runtime && settings.runtime.customRuntime === true && settings.runtime.path) {
       setEjectedRuntime(true);
       // detect programming language.


### PR DESCRIPTION
## Description

This fixes the logic around entering the plugin manager when a skill is focused; the URL now includes both the root and skill IDs as it does for many of the other links. This involved a change to the router, and some additional logic to make sure we disable parts of the sidebar that don't apply to remote skills. This also includes a cosmetic fix to the ProjectTree to make remote bots line up with everything else as they should.

## Task Item

closes #7159

## Screenshots

Correct indentation for remote bots, and no skill shown in the package manager list. Clicking on the package manager link now directs to the manager for the root bot, not whichever skill it's pointed to.
![image](https://user-images.githubusercontent.com/61990921/115922045-37b69f00-a431-11eb-8897-d8480e2fced0.png)

![image](https://user-images.githubusercontent.com/61990921/115922089-4bfa9c00-a431-11eb-80d3-7b659a4086d1.png)

Grayed-out sidebar icons
![image](https://user-images.githubusercontent.com/61990921/115936054-2e393100-a449-11eb-94a5-a3b161b4c6d6.png)
