### PR TITLE
fix: re-enable telemetry events in azure provision dialog

### DIFF
--- a/Composer/packages/client/src/components/PluginHost/PluginHost.tsx
+++ b/Composer/packages/client/src/components/PluginHost/PluginHost.tsx
@@ -5,13 +5,14 @@
 /** @jsx jsx */
 import { jsx, css } from '@emotion/core';
 import React, { useState, useEffect, useRef } from 'react';
-import { Shell, ExtensionSettings } from '@botframework-composer/types';
+import { ExtensionSettings } from '@botframework-composer/types';
 import { PluginType } from '@bfc/extension-client';
 import { useRecoilValue } from 'recoil';
 
 import { LoadingSpinner } from '../LoadingSpinner';
 import { PluginAPI } from '../../plugins/api';
 import { extensionSettingsState } from '../../recoilModel';
+import { useShell } from '../../shell';
 
 const containerStyles = css`
   position: relative;
@@ -38,7 +39,7 @@ interface PluginHostProps {
   pluginName: string;
   pluginType: PluginType;
   bundleId: string;
-  shell?: Shell;
+  projectId: string;
 }
 
 /** Binds closures around Composer client code to plugin iframe's window object */
@@ -76,9 +77,10 @@ function injectScript(doc: Document, id: string, src: string, async: boolean, on
  */
 export const PluginHost: React.FC<PluginHostProps> = (props) => {
   const targetRef = useRef<HTMLIFrameElement>(null);
-  const { pluginType, pluginName, bundleId, shell } = props;
+  const { pluginType, pluginName, bundleId, projectId } = props;
   const [isLoading, setIsLoading] = useState(true);
   const extensionSettings = useRecoilValue(extensionSettingsState);
+  const shell = useShell('DesignPage', projectId);
 
   useEffect(() => {
     const isReady = (ev) => {

--- a/Composer/packages/client/src/pages/botProject/create-publish-profile/PublishProfileDialog.tsx
+++ b/Composer/packages/client/src/pages/botProject/create-publish-profile/PublishProfileDialog.tsx
@@ -240,7 +240,12 @@ export const PublishProfileDialog: React.FC<PublishProfileDialogProps> = (props)
           <Fragment>
             <div style={{ marginBottom: '16px' }}>{dialogTitle.subText}</div>
             <div css={publishSurfaceStyles}>
-              <PluginHost bundleId={selectedType.bundleId} pluginName={selectedType.extensionId} pluginType="publish" />
+              <PluginHost
+                bundleId={selectedType.bundleId}
+                pluginName={selectedType.extensionId}
+                pluginType="publish"
+                projectId={projectId}
+              />
             </div>
           </Fragment>
         )}

--- a/Composer/packages/client/src/pages/plugin/PluginPageContainer.tsx
+++ b/Composer/packages/client/src/pages/plugin/PluginPageContainer.tsx
@@ -5,19 +5,17 @@ import React from 'react';
 import { RouteComponentProps } from '@reach/router';
 
 import { PluginHost } from '../../components/PluginHost/PluginHost';
-import { useShell } from '../../shell';
 
 const PluginPageContainer: React.FC<RouteComponentProps<{ pluginId: string; bundleId: string; projectId: string }>> = (
   props
 ) => {
   const { pluginId, bundleId, projectId } = props;
-  const shell = useShell('DesignPage', projectId as string);
 
   if (!pluginId || !bundleId || !projectId) {
     return null;
   }
 
-  return <PluginHost bundleId={bundleId} pluginName={pluginId} pluginType="page" shell={shell} />;
+  return <PluginHost bundleId={bundleId} pluginName={pluginId} pluginType="page" projectId={projectId} />;
 };
 
 export { PluginPageContainer };

--- a/extensions/azurePublish/src/components/azureProvisionDialog.tsx
+++ b/extensions/azurePublish/src/components/azureProvisionDialog.tsx
@@ -13,7 +13,6 @@ import {
   getARMTokenForTenant,
   useLocalStorage,
   useTelemetryClient,
-  TelemetryClient,
 } from '@bfc/extension-client';
 import { Subscription } from '@azure/arm-subscriptions/esm/models';
 import { DeployLocation, AzureTenant } from '@botframework-composer/types';
@@ -293,9 +292,7 @@ export const AzureProvisionDialog: React.FC = () => {
     getTenantIdFromCache,
     setTenantId,
   } = usePublishApi();
-  const telemetryClient: TelemetryClient = useTelemetryClient();
-
-  console.log('TELEMETRY CLIENT', telemetryClient);
+  const telemetryClient = useTelemetryClient();
 
   const { setItem, getItem, clearAll } = useLocalStorage();
   // set type of publish - azurePublish or azureFunctionsPublish
@@ -375,22 +372,22 @@ export const AzureProvisionDialog: React.FC = () => {
     setPage(page);
     switch (page) {
       case PageTypes.AddResources:
-        // telemetryClient.track('ProvisionAddResourcesNavigate');
+        telemetryClient?.track('ProvisionAddResourcesNavigate');
         setTitle(DialogTitle.ADD_RESOURCES);
         break;
       case PageTypes.ChooseAction:
         setTitle(DialogTitle.CHOOSE_ACTION);
         break;
       case PageTypes.ConfigProvision:
-        // telemetryClient.track('ProvisionConfigureResources');
+        telemetryClient?.track('ProvisionConfigureResources');
         setTitle(DialogTitle.CONFIG_RESOURCES);
         break;
       case PageTypes.EditJson:
-        // telemetryClient.track('ProvisionEditJSON');
+        telemetryClient?.track('ProvisionEditJSON');
         setTitle(DialogTitle.EDIT);
         break;
       case PageTypes.ReviewResource:
-        // telemetryClient.track('ProvisionReviewResources');
+        telemetryClient?.track('ProvisionReviewResources');
         setTitle(DialogTitle.REVIEW);
         break;
     }
@@ -717,11 +714,11 @@ export const AzureProvisionDialog: React.FC = () => {
   const onSubmit = useCallback((options) => {
     // call back to the main Composer API to begin this process...
 
-    // telemetryClient.track('ProvisionStart', {
-    //   region: options.location,
-    //   subscriptionId: options.subscription,
-    //   externalResources: options.externalResources,
-    // });
+    telemetryClient?.track('ProvisionStart', {
+      region: options.location,
+      subscriptionId: options.subscription,
+      externalResources: options.externalResources,
+    });
 
     startProvision(options);
     clearAll();
@@ -994,7 +991,7 @@ export const AzureProvisionDialog: React.FC = () => {
               style={{ margin: '0 4px' }}
               text={formatMessage('Cancel')}
               onClick={() => {
-                // telemetryClient.track('ProvisionCancel');
+                telemetryClient?.track('ProvisionCancel');
                 closeDialog();
               }}
             />
@@ -1090,7 +1087,7 @@ export const AzureProvisionDialog: React.FC = () => {
               text={formatMessage('Next')}
               onClick={() => {
                 if (formData.creationType === 'generate') {
-                  // telemetryClient.track('ProvisionShowHandoff');
+                  telemetryClient?.track('ProvisionShowHandoff');
                   setShowHandoff(true);
                 } else {
                   setPageAndTitle(PageTypes.ReviewResource);
@@ -1114,7 +1111,7 @@ export const AzureProvisionDialog: React.FC = () => {
               style={{ margin: '0 4px' }}
               text={formatMessage('Cancel')}
               onClick={() => {
-                // telemetryClient.track('ProvisionAddResourcesCancel');
+                telemetryClient?.track('ProvisionAddResourcesCancel');
                 closeDialog();
               }}
             />


### PR DESCRIPTION
## Description

Makes shell available in all plugin contexts which exposes the telemetry client.

## Task Item

fixes #7273 
