### PR TITLE
fix: Updated links on About page

### DIFF
--- a/Composer/packages/client/config/env.js
+++ b/Composer/packages/client/config/env.js
@@ -95,7 +95,7 @@ function getClientEnvironment(publicUrl) {
         // images into the `src` and `import` them in code to get their paths.
         PUBLIC_URL: publicUrl,
         GIT_SHA: getGitSha().toString().replace('\n', ''),
-        SDK_PACKAGE_VERSION: '4.12.2', // TODO: change this when Composer supports custom schema/custom runtime
+        SDK_PACKAGE_VERSION: '4.12.0', // TODO: change this when Composer supports custom schema/custom runtime
         COMPOSER_VERSION: getComposerVersion(),
         LOCAL_PUBLISH_PATH:
           process.env.LOCAL_PUBLISH_PATH || path.resolve(process.cwd(), '../../../extensions/localPublish/hostedBots'),

--- a/Composer/packages/client/src/pages/about/About.tsx
+++ b/Composer/packages/client/src/pages/about/About.tsx
@@ -41,7 +41,7 @@ export const About: React.FC<RouteComponentProps> = () => {
             <div css={about.diagnosticsInfoTextAlignLeft}>{formatMessage(`SDK runtime packages`)}</div>
             <div css={about.diagnosticsInfoTextAlignLeft}>
               <Link
-                href={`https://www.nuget.org/packages/Microsoft.Bot.Builder/${process.env.SDK_PACKAGE_VERSION}`}
+                href={`https://github.com/microsoft/botframework-sdk/releases/tag/${process.env.SDK_PACKAGE_VERSION}`}
                 style={{ marginLeft: '5px', textDecoration: 'underline' }}
                 target={'_blank'}
               >
@@ -52,12 +52,17 @@ export const About: React.FC<RouteComponentProps> = () => {
         </div>
       </div>
       <div css={about.linkRow}>
+        <Link href={'https://docs.microsoft.com/en-us/composer/introduction'} styles={about.helpLink} target={'_blank'}>
+          {formatMessage(`Documentation`)}
+        </Link>
+      </div>
+      <div css={about.linkRow}>
         <Link
           href={'https://github.com/microsoft/BotFramework-Composer/issues/new/choose'}
           styles={about.helpLink}
           target={'_blank'}
         >
-          {formatMessage(`Getting Help`)}
+          {formatMessage(`Report a bug or request a feature`)}
         </Link>
       </div>
       <div css={about.linkContainer}>


### PR DESCRIPTION

![Screen Shot 2021-04-23 at 2 26 14 PM](https://user-images.githubusercontent.com/1156704/115931409-e5c94580-a43f-11eb-9b66-0d54a9ec2e0d.png)

closes #6951
closes #6949 


