### PR TITLE
fix: Monaco editor allow scrolling

### DIFF
--- a/Composer/packages/lib/code-editor/src/BaseEditor.tsx
+++ b/Composer/packages/lib/code-editor/src/BaseEditor.tsx
@@ -17,6 +17,9 @@ import { isElectron } from './utils';
 
 const defaultOptions = {
   scrollBeyondLastLine: false,
+  scrollbar: {
+    alwaysConsumeMouseWheel: false,
+  },
   wordWrap: 'off',
   wordWrapColumn: 120,
   fontFamily: 'Courier',


### PR DESCRIPTION
## Description
Allow Monaco editor allow scrolling on parent elements.

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
close #7351 
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots
![2021-04-26 10 58 55](https://user-images.githubusercontent.com/49866537/116023420-a2a8e580-a67e-11eb-869d-c51017eaf639.gif)

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
