### PR TITLE
fix: allower callers displayed like available to edit

### DIFF
--- a/Composer/packages/client/src/pages/design/exportSkillModal/content/AddCallers.tsx
+++ b/Composer/packages/client/src/pages/design/exportSkillModal/content/AddCallers.tsx
@@ -7,7 +7,7 @@ import { SharedColors } from '@uifabric/fluent-theme';
 import formatMessage from 'format-message';
 import { ActionButton } from 'office-ui-fabric-react/lib/Button';
 import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
-import { ITextField, ITextFieldProps, TextField, TextFieldBase } from 'office-ui-fabric-react/lib/TextField';
+import { ITextField, ITextFieldProps, TextField } from 'office-ui-fabric-react/lib/TextField';
 import React, { useEffect, useRef, useState } from 'react';
 
 import { tableColumnHeader, tableRow, tableRowItem } from '../../../botProject/styles';

--- a/Composer/packages/client/src/pages/design/exportSkillModal/content/AddCallers.tsx
+++ b/Composer/packages/client/src/pages/design/exportSkillModal/content/AddCallers.tsx
@@ -8,7 +8,7 @@ import formatMessage from 'format-message';
 import { ActionButton } from 'office-ui-fabric-react/lib/Button';
 import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
-import React from 'react';
+import React, { useState } from 'react';
 
 import { tableColumnHeader, tableRow, tableRowItem } from '../../../botProject/styles';
 import { ContentProps } from '../constants';
@@ -42,12 +42,16 @@ const removeCaller = {
 export const AddCallers: React.FC<ContentProps> = ({ projectId, callers, onUpdateCallers }) => {
   const handleRemove = (index) => {
     onUpdateCallers(callers.filter((_, i) => i !== index));
+    setFocusCallerIndex(undefined);
   };
   const handleAddNewAllowedCallerClick = () => {
     const currentCallers = callers.slice();
-    currentCallers?.push('0000-11111-00000-11111');
+    currentCallers?.push('');
     onUpdateCallers(currentCallers);
+    setFocusCallerIndex(currentCallers.length - 1);
   };
+
+  const [focusCallerIndex, setFocusCallerIndex] = useState<number | undefined>(0);
 
   return (
     <div>
@@ -59,12 +63,20 @@ export const AddCallers: React.FC<ContentProps> = ({ projectId, callers, onUpdat
           <div key={index} css={tableRow}>
             <div css={tableRowItem('90%')} title={caller}>
               <TextField
-                borderless
+                borderless={focusCallerIndex !== index}
                 value={caller}
+                onBlur={(_) => {
+                  if (focusCallerIndex === index) {
+                    setFocusCallerIndex(undefined);
+                  }
+                }}
                 onChange={(e, newValue) => {
                   const currentCallers = callers.slice();
                   currentCallers[index] = newValue ?? '';
                   onUpdateCallers(currentCallers);
+                }}
+                onFocus={() => {
+                  setFocusCallerIndex(index);
                 }}
               />
             </div>

--- a/Composer/packages/client/src/pages/design/exportSkillModal/content/AddCallers.tsx
+++ b/Composer/packages/client/src/pages/design/exportSkillModal/content/AddCallers.tsx
@@ -7,8 +7,8 @@ import { SharedColors } from '@uifabric/fluent-theme';
 import formatMessage from 'format-message';
 import { ActionButton } from 'office-ui-fabric-react/lib/Button';
 import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
-import { TextField } from 'office-ui-fabric-react/lib/TextField';
-import React, { useState } from 'react';
+import { ITextField, ITextFieldProps, TextField, TextFieldBase } from 'office-ui-fabric-react/lib/TextField';
+import React, { useEffect, useRef, useState } from 'react';
 
 import { tableColumnHeader, tableRow, tableRowItem } from '../../../botProject/styles';
 import { ContentProps } from '../constants';
@@ -39,6 +39,31 @@ const removeCaller = {
   },
 };
 
+interface BorderlessTextFieldProps extends Omit<ITextFieldProps, 'onChange' | 'onFocus' | 'onBlur'> {
+  componentFocusOnMount?: boolean;
+  onBlur?: () => void;
+  onChange: (e, newValue?: string) => void;
+  onFocus?: () => void;
+}
+const BorderlessTextField: React.FC<BorderlessTextFieldProps> = (props) => {
+  const { componentFocusOnMount, borderless, value, onBlur, onChange, onFocus } = props;
+  const fieldRef = useRef<ITextField>(null);
+  useEffect(() => {
+    if (componentFocusOnMount) {
+      fieldRef.current?.focus();
+    }
+  }, []);
+  return (
+    <TextField
+      borderless={borderless}
+      componentRef={fieldRef}
+      value={value}
+      onBlur={onBlur}
+      onChange={onChange}
+      onFocus={onFocus}
+    />
+  );
+};
 export const AddCallers: React.FC<ContentProps> = ({ projectId, callers, onUpdateCallers }) => {
   const handleRemove = (index) => {
     onUpdateCallers(callers.filter((_, i) => i !== index));
@@ -59,13 +84,15 @@ export const AddCallers: React.FC<ContentProps> = ({ projectId, callers, onUpdat
         <div css={tableColumnHeader()}>{formatMessage('Allowed Callers')}</div>
       </div>
       {callers?.map((caller, index) => {
+        const isFocus = focusCallerIndex === index;
         return (
           <div key={index} css={tableRow}>
             <div css={tableRowItem('90%')} title={caller}>
-              <TextField
-                borderless={focusCallerIndex !== index}
+              <BorderlessTextField
+                borderless={!isFocus}
+                componentFocusOnMount={isFocus}
                 value={caller}
-                onBlur={(_) => {
+                onBlur={() => {
                   if (focusCallerIndex === index) {
                     setFocusCallerIndex(undefined);
                   }

--- a/Composer/packages/electron-server/package.json
+++ b/Composer/packages/electron-server/package.json
@@ -2,7 +2,7 @@
   "name": "@bfc/electron-server",
   "license": "MIT",
   "author": "Microsoft Corporation",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "description": "Electron wrapper around Composer that launches Composer as a desktop application.",
   "main": "./build/main.js",
   "engines": {


### PR DESCRIPTION
## Description

fix: allower callers displayed like available to edit.
![callers](https://user-images.githubusercontent.com/5860999/116037059-245a3c80-a69a-11eb-8fd1-97934df06a28.gif)

## Task Item
closes #7147 



## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
