### PR TITLE
fix: Remove bot project from the recent projects list if it doesn't exist anymore

### DIFF
--- a/Composer/packages/server/src/services/project.ts
+++ b/Composer/packages/server/src/services/project.ts
@@ -183,6 +183,13 @@ export class BotProjectService {
     );
     const allRecentBots = BotProjectService.recentBotProjects;
 
+    // Filter the bot projects that don't exist anymore.
+    for (const locationRef of allRecentBots) {
+      if (!(await StorageService.checkBlob(locationRef.storageId ?? 'default', locationRef.path, user))) {
+        BotProjectService.deleteRecentProject(locationRef.path);
+      }
+    }
+
     const recentBots = allRecentBots
       .filter((bot) => !Path.basename(bot.path).includes('.botproj'))
       .map((bot) => ({


### PR DESCRIPTION
## Description

Remove bot project from the recent projects list if it doesn't exist anymore

## Task Item

#minor

