### PR TITLE
fix: correct logic for validating connection modal

### DIFF
--- a/Composer/packages/client/__tests__/pages/botProjectsSettings/AdapterSettings.test.tsx
+++ b/Composer/packages/client/__tests__/pages/botProjectsSettings/AdapterSettings.test.tsx
@@ -41,6 +41,7 @@ const mockSchemas = {
               default: 'Adapter.Full.Type.Mock',
             },
           },
+          required: ['exampleName'],
         },
       },
     },
@@ -148,6 +149,21 @@ describe('ExternalAdapterSettings', () => {
         type: 'Adapter.Full.Type.Mock',
       },
     });
+  });
+
+  it('does not proceed if required settings are missing', async () => {
+    const { getByTestId } = renderWithRecoilAndCustomDispatchers(
+      <ExternalAdapterSettings projectId={PROJECT_ID} />,
+      initRecoilState
+    );
+    const container = getByTestId('adapterSettings');
+    const configureButton = within(container).queryAllByText('Configure')[0];
+    act(() => {
+      fireEvent.click(configureButton);
+    });
+
+    const modal = getByTestId('adapterModal');
+    expect(within(modal).getByText('Configure')).toBeDisabled();
   });
 
   it('disables an adapter', async () => {

--- a/Composer/packages/client/src/pages/botProject/adapters/ExternalAdapterModal.tsx
+++ b/Composer/packages/client/src/pages/botProject/adapters/ExternalAdapterModal.tsx
@@ -34,7 +34,7 @@ type Props = {
 
 export function hasRequired(testObject: { [key: string]: JSONSchema7Type | undefined }, fields?: string[]) {
   if (fields == null || fields.length === 0) return true;
-  return fields.every((field: string) => field in testObject);
+  return fields.every((field: string) => field in testObject && testObject[field] != null);
 }
 
 function makeDefault(schema: JSONSchema7) {


### PR DESCRIPTION
## Description

The adapter modal was interpreting `{field: undefined}` as that field still being present, so this fixes that and adds a unit test to make sure this doesn't happen again.

## Task Item

closes #7224

## Screenshots

![image](https://user-images.githubusercontent.com/61990921/116153636-7f8d2e80-a69c-11eb-821e-42ffa360bc76.png)
