### PR TITLE
chore: Remove LUIS text from Trigger Dialog

### DIFF
--- a/Composer/packages/client/src/components/TriggerCreationModal/resolveTriggerWidget.tsx
+++ b/Composer/packages/client/src/components/TriggerCreationModal/resolveTriggerWidget.tsx
@@ -92,7 +92,7 @@ export function resolveTriggerWidget(
       <TextField
         data-testid="TriggerName"
         errorMessage={formData.errors.intent}
-        label={formatMessage('What is the name of this trigger (LUIS)')}
+        label={formatMessage('What is the name of this trigger?')}
         styles={intentStyles}
         onChange={onNameChange}
       />

--- a/Composer/packages/server/src/locales/en-US.json
+++ b/Composer/packages/server/src/locales/en-US.json
@@ -662,6 +662,9 @@
   "common_7911ab4b": {
     "message": "Common"
   },
+  "complete_your_publishing_profile_7240d0d6": {
+    "message": "Complete your publishing profile"
+  },
   "component_stacktrace_e24b1983": {
     "message": "Component Stacktrace:"
   },
@@ -1598,6 +1601,9 @@
   "filter_e3398407": {
     "message": "Filter"
   },
+  "find_additional_template_specific_guidance_for_set_d7256573": {
+    "message": "Find additional template-specific guidance for setting up your bot."
+  },
   "find_and_install_more_external_services_to_your_bo_37ef3f0c": {
     "message": "Find and install more external services to your bot project in <a>package manager</a>. For further guidance, see documentation for <a2>adding external connections.</a2>"
   },
@@ -1612,6 +1618,9 @@
   },
   "find_tutorials_step_by_step_guides_discover_what_y_8f3e3863": {
     "message": "Find tutorials, step-by-step guides. Discover what you can build with Composer."
+  },
+  "finish_setting_up_your_environment_and_provisionig_11cdecda": {
+    "message": "Finish setting up your environment and provisionig resources so that you can publish your bot."
   },
   "firstselector_a3daca5d": {
     "message": "FirstSelector"
@@ -1732,9 +1741,6 @@
   },
   "get_started_with_bot_framework_composer_57a6d38b": {
     "message": "Get started with Bot Framework Composer"
-  },
-  "getting_help_ab6811b0": {
-    "message": "Getting Help"
   },
   "getting_template_910a4116": {
     "message": "Getting template"
@@ -2783,6 +2789,9 @@
   "progress_of_total_87de8616": {
     "message": "{ progress }% of { total }"
   },
+  "project_readme_68f88d88": {
+    "message": "Project Readme"
+  },
   "project_settings_42fe3f68": {
     "message": "Project settings"
   },
@@ -3074,6 +3083,9 @@
   "replace_this_dialog_e304015e": {
     "message": "Replace this dialog"
   },
+  "report_a_bug_or_request_a_feature_36eb52c7": {
+    "message": "Report a bug or request a feature"
+  },
   "reprompt_dialog_event_c42d2c33": {
     "message": "Reprompt dialog event"
   },
@@ -3124,6 +3136,9 @@
   },
   "review_and_generate_63dec712": {
     "message": "Review and generate"
+  },
+  "review_your_template_readme_2d6eae1e": {
+    "message": "Review your template readme"
   },
   "rollback_26326307": {
     "message": "Rollback"
@@ -4079,11 +4094,11 @@
   "what_is_the_name_of_the_custom_event_b28a7b3": {
     "message": "What is the name of the custom event?"
   },
+  "what_is_the_name_of_this_trigger_1d6db01": {
+    "message": "What is the name of this trigger?"
+  },
   "what_is_the_name_of_this_trigger_2642266e": {
     "message": "What is the name of this trigger"
-  },
-  "what_is_the_name_of_this_trigger_luis_17b60a23": {
-    "message": "What is the name of this trigger (LUIS)"
   },
   "what_is_the_name_of_this_trigger_regex_f77376d7": {
     "message": "What is the name of this trigger (RegEx)"


### PR DESCRIPTION
## Description
Remove the `LUIS` text from the Trigger Dialog - minor change to imply this trigger can also be used for other recognizers.

## Task Item
fixes #7019

## Screenshots
Removed `(LUIS)` from the copy
![image](https://user-images.githubusercontent.com/61705609/116154831-0f7fa800-a69e-11eb-8c14-5d9da3de3e9c.png)
