### PR TITLE
fix: plugin page router

### DIFF
--- a/Composer/packages/client/src/router.tsx
+++ b/Composer/packages/client/src/router.tsx
@@ -129,6 +129,14 @@ const Routes = (props) => {
                 <FormDialogPage path="forms/*" />
                 <DesignPage path="*" />
                 <Diagnostics path="diagnostics" />
+                {pluginPages.map((page) => (
+                  <PluginPageContainer
+                    key={`${page.id}/${page.bundleId}`}
+                    bundleId={page.bundleId}
+                    path={`plugin/${page.id}/${page.bundleId}`}
+                    pluginId={page.id}
+                  />
+                ))}
               </ProjectRouter>
               <SettingPage path="settings/*" />
               <ExtensionsPage path="extensions/*" />


### PR DESCRIPTION
## Description
fix unable to navigate to plugin page, introduced in #7330.

fixed by adding back route config in no skill case.

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
refs #7330
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

when select on root bot

<img width="943" alt="image" src="https://user-images.githubusercontent.com/49866537/116195434-cba3a600-a764-11eb-962d-4f7de474fff8.png">

when select on skill bot

<img width="1059" alt="image" src="https://user-images.githubusercontent.com/49866537/116195468-d5c5a480-a764-11eb-9965-c4c828d73b17.png">


<!---
Please include screenshots or gifs if your PR include UX changes.
--->
