### PR TITLE
fix: use feature-specific tags rather than msbot-component

### DIFF
--- a/extensions/packageManager/src/node/index.ts
+++ b/extensions/packageManager/src/node/index.ts
@@ -15,7 +15,15 @@ import { FeedFactory } from './feeds/feedFactory';
 const API_ROOT = '/api';
 
 const hasSchema = (c) => {
-  return c.includesSchema || c.keywords?.includes('msbot-component');
+  return (
+    c.includesSchema ||
+    c.keywords?.includes('msbot-action') ||
+    c.keywords?.includes('msbot-trigger') ||
+    c.keywords?.includes('msbot-adapter') ||
+    c.keywords?.includes('msbot-function') ||
+    c.keywords?.includes('msbot-recognizer') ||
+    c.keywords?.includes('msbot-storage')
+  );
 };
 
 const isAdaptiveComponent = (c) => {


### PR DESCRIPTION
## Description

Part of the package install process is to write a line to the appsettings.components array for code-driven components.

Since these components may or may not have schema, we need to use the package TAGS to determine if they should be included.

A previous PR used the `msbot-component` tag, but this proved to be too broad as it includes the declarative-only components that SHOULD NOT be added to this list.

This PR changes the logic to look for one of a series of feature-specific tags.

## Task Item

Fixes #7403 
