### PR TITLE
fix: Add a warning about the luis authoring key 1000/month limit 

### DIFF
--- a/Composer/packages/client/src/pages/botProject/RootBotExternalService.tsx
+++ b/Composer/packages/client/src/pages/botProject/RootBotExternalService.tsx
@@ -420,7 +420,7 @@ export const RootBotExternalService: React.FC<RootBotExternalServiceProps> = (pr
         {localRootLuisKey && !rootLuisEndpointKey && (
           <MessageBar messageBarType={MessageBarType.info} styles={{ root: { width: '75%', marginTop: 20 } }}>
             {formatMessage.rich(
-              'Your bot is configured with only a LUIS authoring key, which has a limit of 1,000 calls per month. If your bot hits this limit, publish it to Azure using a<a>publishing profile</a> to continue testing.<a2>Learn more</a2>',
+              'Your bot is configured with only a LUIS authoring key, which has a limit of 1,000 calls per month. If your bot hits this limit, publish it to Azure using a <a>publishing profile</a> to continue testing.<a2>Learn more</a2>',
               {
                 a: ({ children }) => (
                   <Link key="luis-endpoint-key-info" href={linkToPublishProfile}>

--- a/Composer/packages/client/src/pages/botProject/RootBotExternalService.tsx
+++ b/Composer/packages/client/src/pages/botProject/RootBotExternalService.tsx
@@ -17,6 +17,7 @@ import { FontSizes } from 'office-ui-fabric-react/lib/Styling';
 import { NeutralColors, SharedColors } from '@uifabric/fluent-theme';
 import { PrimaryButton } from 'office-ui-fabric-react/lib/Button';
 import { Link } from 'office-ui-fabric-react/lib/Link';
+import { MessageBar, MessageBarType } from 'office-ui-fabric-react/lib/MessageBar';
 
 import {
   dispatcherState,
@@ -151,6 +152,9 @@ export const RootBotExternalService: React.FC<RootBotExternalServiceProps> = (pr
 
   const groupLUISAuthoringKey = get(sensitiveGroupManageProperty, 'luis.authoringKey', {});
   const rootLuisKey = groupLUISAuthoringKey.root;
+  const groupLUISEndpointKey = get(sensitiveGroupManageProperty, 'luis.endpointKey', {});
+  const rootLuisEndpointKey = groupLUISEndpointKey.root;
+
   const groupLUISRegion = get(sensitiveGroupManageProperty, 'luis.authoringRegion', {});
   const rootLuisRegion = groupLUISRegion.root;
   const groupQnAKey = get(sensitiveGroupManageProperty, 'qna.subscriptionKey', {});
@@ -179,6 +183,7 @@ export const RootBotExternalService: React.FC<RootBotExternalServiceProps> = (pr
   const luisKeyFieldRef = useRef<HTMLDivElement>(null);
   const luisRegionFieldRef = useRef<HTMLDivElement>(null);
   const qnaKeyFieldRef = useRef<HTMLDivElement>(null);
+  const linkToPublishProfile = `/bot/${rootBotProjectId}/publish/all#addNewPublishProfile`;
 
   const handleRootLUISKeyOnChange = (e, value) => {
     if (value) {
@@ -412,6 +417,29 @@ export const RootBotExternalService: React.FC<RootBotExternalServiceProps> = (pr
             setDisplayManageLuis(true);
           }}
         />
+        {localRootLuisKey && !rootLuisEndpointKey && (
+          <MessageBar messageBarType={MessageBarType.info} styles={{ root: { width: '75%', marginTop: 20 } }}>
+            {formatMessage.rich(
+              'Your bot is configured with only a LUIS authoring key, which has a limit of 1,000 calls per month. If your bot hits this limit, publish it to Azure using a<a>publishing profile</a> to continue testing.<a2>Learn more</a2>',
+              {
+                a: ({ children }) => (
+                  <Link key="luis-endpoint-key-info" href={linkToPublishProfile}>
+                    {children}
+                  </Link>
+                ),
+                a2: ({ children }) => (
+                  <Link
+                    key="luis-endpoint-key-info"
+                    href={'https://aka.ms/composer-settings-luislimits'}
+                    target="_blank"
+                  >
+                    {children}
+                  </Link>
+                ),
+              }
+            )}
+          </MessageBar>
+        )}
         <div css={title}>{formatMessage('QnA Maker')}</div>
         <div css={subtext}>
           {formatMessage.rich(


### PR DESCRIPTION
## Description

By default, a local bot will be set up with ONLY a LUIS authoring key. The authoring key can be used up to 1000 times a month as an endpoint key, which works for local testing.

However, if this limit is reached, the bot will stop working and throw LUIS errors.

This PR introduces a warning thaat appears on the bot settings page if a LUIS authoring key is set without an endpoint key.

The warning tells the user to publish to Azure if this limit is reached, and links to information about the key limits.

## Task Item

Fixes #7146

## Screenshots

![Screen Shot 2021-04-27 at 3 13 43 PM](https://user-images.githubusercontent.com/729873/116307053-761ec780-a76b-11eb-82c8-103b7fa6db14.png)
