### PR TITLE
fix: Enable auto format in packages under lib folder

### DIFF
--- a/Composer/.prettierignore
+++ b/Composer/.prettierignore
@@ -1,3 +1,2 @@
 node_modules
-lib
 dist


### PR DESCRIPTION
## Description

This is a short term fix, we need to eliminate that **lib** folder, it serves no purpose. We should move all those packages directly under **packages** folder

## Task Item

#minor
