### PR TITLE
fix: Add azure functions existing when hostname there

### DIFF
--- a/extensions/azurePublish/src/components/util.ts
+++ b/extensions/azurePublish/src/components/util.ts
@@ -34,6 +34,7 @@ export const getExistResources = (config) => {
     // If name or hostname is configured, it means the webapp is already created.
     if (config.hostname || config.name) {
       result.push(AzureResourceTypes.WEBAPP);
+      result.push(AzureResourceTypes.AZUREFUNCTIONS);
     }
     if (config.settings?.MicrosoftAppId) {
       result.push(AzureResourceTypes.BOT_REGISTRATION);


### PR DESCRIPTION
## Description

The utils was missing noting azure functions are provisioned when the hostname is present.

## Task Item

fixes #7453 

## Screenshots

N/A
