### PR TITLE
fix: address missing links in provisioning, updated tags in package manager

### DIFF
--- a/extensions/azurePublish/src/components/ChooseProvisionAction.tsx
+++ b/extensions/azurePublish/src/components/ChooseProvisionAction.tsx
@@ -163,7 +163,7 @@ const ImportActionContent = () => {
           <Text>- {formatMessage('Microsoft QnA Maker')}</Text>
         </ResourceTitle>
       </Details>
-      <LearnMoreLink href="https://aka.ms/composer-publish-bot#import-existing-azure-resources">
+      <LearnMoreLink href="https://aka.ms/composer-getstarted-importpublishing" target="_blank">
         {formatMessage('Learn More')}
       </LearnMoreLink>
     </Content>
@@ -203,7 +203,7 @@ const GenerateActionContent = () => {
           </InstructionDetails>
         </Instruction>
       </Details>
-      <LearnMoreLink href="https://aka.ms/composer-publish-bot#handoff-to-admin">
+      <LearnMoreLink href="https://aka.ms/composer-publishingprofile-handoffadmin" target="_blank">
         {formatMessage('Learn More')}
       </LearnMoreLink>
     </Content>

--- a/extensions/packageManager/src/node/index.ts
+++ b/extensions/packageManager/src/node/index.ts
@@ -22,7 +22,8 @@ const hasSchema = (c) => {
     c.keywords?.includes('msbot-adapter') ||
     c.keywords?.includes('msbot-function') ||
     c.keywords?.includes('msbot-recognizer') ||
-    c.keywords?.includes('msbot-storage')
+    c.keywords?.includes('msbot-storage') ||
+    c.keywords?.includes('msbot-middleware')
   );
 };
 


### PR DESCRIPTION
## Description

* Adds target, updates href of some links in provisioning flow
* Adds `msbot-middleware` to list of tags used to identify a code-driven component

## Task Item

Fixes #7449 
Fixes #7454 

