### PR TITLE
fix: Fixed the buttons position on the provisioning modal & removed the sign out button when not required.

### DIFF
--- a/extensions/azurePublish/src/components/azureProvisionDialog.tsx
+++ b/extensions/azurePublish/src/components/azureProvisionDialog.tsx
@@ -74,10 +74,19 @@ type ProvisionFormData = {
 };
 
 // ---------- Styles ---------- //
+type ProvisonActionsStylingProps = {
+  showSignout: boolean;
+};
 
 const AddResourcesSectionName = styled(Text)`
   font-size: ${FluentTheme.fonts.mediumPlus.fontSize};
 `;
+
+const ProvisonActions = styled.div<ProvisonActionsStylingProps>((props) => ({
+  display: 'flex',
+  flexFlow: 'row nowrap',
+  justifyContent: props.showSignout ? 'space-between' : 'flex-end',
+}));
 
 const ConfigureResourcesSectionName = styled(Text)`
   font-size: ${FluentTheme.fonts.mediumPlus.fontSize};
@@ -993,28 +1002,18 @@ export const AzureProvisionDialog: React.FC = () => {
   );
 
   const PageFooter = useMemo(() => {
+    const isSignedInAndCreateCreationType = currentUser && formData.creationType === 'create';
     if (page === PageTypes.ChooseAction) {
       return (
-        <div style={{ display: 'flex', flexFlow: 'row nowrap', justifyContent: 'space-between' }}>
-          {currentUser ? (
+        <ProvisonActions showSignout={isSignedInAndCreateCreationType}>
+          {isSignedInAndCreateCreationType ? (
             <Persona
               secondaryText={formatMessage('Sign out')}
               size={PersonaSize.size40}
               text={currentUser.name}
               onRenderSecondaryText={onRenderSecondaryText}
             />
-          ) : (
-            <div
-              style={{ color: 'blue', cursor: 'pointer' }}
-              onClick={() => {
-                clearAll();
-                closeDialog();
-                logOut();
-              }}
-            >
-              Sign out
-            </div>
-          )}
+          ) : null}
           <div>
             <DefaultButton
               style={{ margin: '0 4px' }}
@@ -1053,11 +1052,11 @@ export const AzureProvisionDialog: React.FC = () => {
               }}
             />
           </div>
-        </div>
+        </ProvisonActions>
       );
     } else if (page === PageTypes.ConfigProvision) {
       return (
-        <div style={{ display: 'flex', flexFlow: 'row nowrap', justifyContent: 'space-between' }}>
+        <ProvisonActions showSignout={isSignedInAndCreateCreationType}>
           {currentUser ? (
             <Persona
               secondaryText={formatMessage('Sign out')}
@@ -1065,18 +1064,7 @@ export const AzureProvisionDialog: React.FC = () => {
               text={currentUser.name}
               onRenderSecondaryText={onRenderSecondaryText}
             />
-          ) : (
-            <div
-              style={{ color: 'blue', cursor: 'pointer' }}
-              onClick={() => {
-                clearAll();
-                closeDialog();
-                logOut();
-              }}
-            >
-              {formatMessage('Sign out')}
-            </div>
-          )}
+          ) : null}
           <div>
             <DefaultButton
               style={{ margin: '0 4px' }}
@@ -1120,12 +1108,12 @@ export const AzureProvisionDialog: React.FC = () => {
               }}
             />
           </div>
-        </div>
+        </ProvisonActions>
       );
     } else if (page === PageTypes.AddResources) {
       return (
-        <div style={{ display: 'flex', flexFlow: 'row nowrap', justifyContent: 'space-between' }}>
-          {currentUser ? (
+        <ProvisonActions showSignout={isSignedInAndCreateCreationType}>
+          {isSignedInAndCreateCreationType ? (
             <Persona
               secondaryText={formatMessage('Sign out')}
               size={PersonaSize.size40}
@@ -1180,11 +1168,11 @@ export const AzureProvisionDialog: React.FC = () => {
               }}
             />
           </div>
-        </div>
+        </ProvisonActions>
       );
     } else if (page === PageTypes.ReviewResource) {
       return (
-        <div style={{ display: 'flex', flexFlow: 'row nowrap', justifyContent: 'space-between' }}>
+        <ProvisonActions showSignout={isSignedInAndCreateCreationType}>
           {currentUser ? (
             <Persona
               secondaryText={formatMessage('Sign out')}
@@ -1227,7 +1215,7 @@ export const AzureProvisionDialog: React.FC = () => {
               }}
             />
           </div>
-        </div>
+        </ProvisonActions>
       );
     } else {
       return (


### PR DESCRIPTION
## Description

1. Moved the buttons to the right when the sign out button is not shown.
2. Removed the sign out button, when is user is not signed in.

## Task Item
fixes #7236 
fixes #7162 

## Screenshots
![image](https://user-images.githubusercontent.com/12182973/116457148-e7b44f80-a817-11eb-919d-69c856ebd238.png)
![image](https://user-images.githubusercontent.com/12182973/116457193-f3a01180-a817-11eb-8bac-0ec22913c441.png)
![image](https://user-images.githubusercontent.com/12182973/116457315-1b8f7500-a818-11eb-9cc5-705aea9c4d98.png)

