### PR TITLE
fix: hide recognizers if they don't exist in the app schema

### DIFF
--- a/Composer/packages/extension-client/src/hooks/__tests__/useRecognizerConfig.test.tsx
+++ b/Composer/packages/extension-client/src/hooks/__tests__/useRecognizerConfig.test.tsx
@@ -7,7 +7,10 @@ import { renderHook } from '@botframework-composer/test-utils/lib/hooks';
 import { useRecognizerConfig } from '../useRecognizerConfig';
 import { EditorExtensionContext } from '../../EditorExtensionContext';
 
-const shellData = { currentDialog: { content: {} } };
+const shellData = {
+  currentDialog: { content: {} },
+  schemas: { sdk: { content: { definitions: { foo: 'foo schema', bar: 'bar schema' } } } },
+};
 const plugins = {
   uiSchema: {
     foo: {
@@ -19,6 +22,11 @@ const plugins = {
       form: {},
       menu: {},
       recognizer: { displayName: 'recognizer 2' },
+    },
+    notInAppSchema: {
+      form: {},
+      menu: {},
+      recognizer: { displayName: 'not in app schema' },
     },
   },
 };
@@ -42,5 +50,10 @@ describe('useRecognizerConfig', () => {
         displayName: 'recognizer 2',
       },
     ]);
+  });
+
+  it("omits recognizer config that isn't in the schema", () => {
+    const { result } = renderHook(() => useRecognizerConfig(), { wrapper });
+    expect(Object.keys(result.current.recognizers)).not.toContain('notInAppSchema');
   });
 });

--- a/Composer/packages/extension-client/src/hooks/useRecognizerConfig.ts
+++ b/Composer/packages/extension-client/src/hooks/useRecognizerConfig.ts
@@ -58,13 +58,16 @@ export interface RecognizerSchemaConfig {
 
 export function useRecognizerConfig(): RecognizerSchemaConfig {
   const { plugins, shellData } = useContext(EditorExtensionContext);
+  const appSchema = shellData.schemas?.sdk?.content;
 
   const recognizers: RecognizerSchema[] = useMemo(() => {
     if (!plugins.uiSchema) return [];
 
     const recognizerWidgets = plugins.widgets?.recognizer ?? {};
     const schemas = Object.entries(plugins.uiSchema)
-      .filter(([_, uiOptions]) => uiOptions?.recognizer)
+      .filter(([$kind, uiOptions]) => {
+        return Boolean(uiOptions?.recognizer && appSchema?.definitions?.[$kind]);
+      })
       .map(([$kind, uiOptions]) => {
         const recognizerOptions = uiOptions?.recognizer as RecognizerOptions;
         const intentEditor = resolveRecognizerWidget(recognizerOptions.intentEditor, recognizerWidgets);


### PR DESCRIPTION
## Description

Hides recognizers if they do not exist in the app schema.

## Task Item

fixes #7468 
