### PR TITLE
fix: Add Publish your bot to get started list

### DIFF
--- a/Composer/packages/client/src/components/GetStarted/GetStartedNextSteps.tsx
+++ b/Composer/packages/client/src/components/GetStarted/GetStartedNextSteps.tsx
@@ -297,6 +297,7 @@ export const GetStartedNextSteps: React.FC<GetStartedProps> = (props) => {
           key: 'publish',
           label: formatMessage('Publish your bot'),
           description: formatMessage('Once you publish your bot to Azure you will be ready to add connections.'),
+          learnMore: 'https://aka.ms/composer-getstarted-publishbot',
           checked: false,
           onClick: () => {
             TelemetryClient.track('GettingStartedActionClicked', { taskName: 'publish', priority: 'optional' });

--- a/Composer/packages/client/src/components/GetStarted/GetStartedNextSteps.tsx
+++ b/Composer/packages/client/src/components/GetStarted/GetStartedNextSteps.tsx
@@ -101,6 +101,7 @@ export const GetStartedNextSteps: React.FC<GetStartedProps> = (props) => {
   const linkToPackageManager = `/bot/${rootBotProjectId}/plugin/package-manager/package-manager`;
   const linkToConnections = `/bot/${rootBotProjectId}/botProjectsSettings/#connections`;
   const linkToPublishProfile = `/bot/${rootBotProjectId}/publish/all#addNewPublishProfile`;
+  const linkToPublish = `/bot/${rootBotProjectId}/publish/all`;
   const linkToCompletePublishProfile = `/bot/${rootBotProjectId}/publish/all#completePublishProfile`;
   const linkToLUISSettings = `/bot/${rootBotProjectId}/botProjectsSettings/#luisKey`;
   const linktoQNASettings = `/bot/${rootBotProjectId}/botProjectsSettings/#qnaKey`;
@@ -291,6 +292,20 @@ export const GetStartedNextSteps: React.FC<GetStartedProps> = (props) => {
     ];
 
     if (hasPublishingProfile) {
+      if (!hasPartialPublishingProfile) {
+        optSteps.push({
+          key: 'publish',
+          label: formatMessage('Publish your bot'),
+          description: formatMessage('Once you publish your bot to Azure you will be ready to add connections.'),
+          checked: false,
+          onClick: () => {
+            TelemetryClient.track('GettingStartedActionClicked', { taskName: 'publish', priority: 'optional' });
+            openLink(linkToPublish);
+          },
+          hideFeatureStep: isPVABot,
+        });
+      }
+
       optSteps.push({
         key: 'connections',
         label: formatMessage('Add connections'),


### PR DESCRIPTION
## Description

Adds an optional "Publish your bot" button to get started once a user has added a complete publishing profile.


## Task Item

Fixes #6555 


## Screenshots


<img width="405" alt="Screen Shot 2021-04-29 at 9 57 50 AM" src="https://user-images.githubusercontent.com/729873/116572551-b009de00-a8d1-11eb-9157-d05faa57c6a5.png">