### PR TITLE
fix: allow dashes for pva bot names

### DIFF
--- a/Composer/packages/client/src/components/CreationFlow/v2/DefineConversation.tsx
+++ b/Composer/packages/client/src/components/CreationFlow/v2/DefineConversation.tsx
@@ -21,7 +21,7 @@ import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
 import camelCase from 'lodash/camelCase';
 import upperFirst from 'lodash/upperFirst';
 
-import { DialogCreationCopy, nameRegexV2 } from '../../../constants';
+import { DialogCreationCopy, nameRegexV2, nameRegex } from '../../../constants';
 import { FieldConfig, useForm } from '../../../hooks/useForm';
 import { StorageFolder } from '../../../recoilModel/types';
 import { createNotification } from '../../../recoilModel/dispatchers/notification';
@@ -159,7 +159,9 @@ const DefineConversationV2: React.FC<DefineConversationProps> = (props) => {
     name: {
       required: true,
       validate: (value) => {
-        if (!value || !nameRegexV2.test(`${value}`)) {
+        const isPvaBot = templateId === 'pva';
+        const namePattern = isPvaBot ? nameRegex : nameRegexV2;
+        if (!value || !namePattern.test(`${value}`)) {
           // botName is used as used when generating runtime namespaces which cannot start with a number
           if (value && !isNaN(+value.toString().charAt(0))) {
             return formatMessage('Bot name cannot start with a number or space');

--- a/Composer/packages/client/src/components/ImportModal/ImportModal.tsx
+++ b/Composer/packages/client/src/components/ImportModal/ImportModal.tsx
@@ -12,6 +12,7 @@ import axios from 'axios';
 
 import { dispatcherState } from '../../recoilModel';
 import { createNotification } from '../../recoilModel/dispatchers/notification';
+import { invalidNameCharRegex } from '../../constants';
 
 import { ImportStatus } from './ImportStatus';
 import { ImportSuccessNotificationWrapper } from './ImportSuccessNotification';
@@ -75,7 +76,8 @@ export const ImportModal: React.FC<RouteComponentProps> = (props) => {
 
     const searchParams = new URLSearchParams();
     if (name) {
-      searchParams.set('name', encodeURIComponent(name));
+      const validName = source === 'pva' ? name.replace(invalidNameCharRegex, '-') : name;
+      searchParams.set('name', encodeURIComponent(validName));
     }
     if (description) {
       searchParams.set('description', encodeURIComponent(description));

--- a/Composer/packages/client/src/constants.ts
+++ b/Composer/packages/client/src/constants.ts
@@ -421,7 +421,7 @@ export const nameRegex = /^[a-zA-Z0-9-_]+$/;
 export const nameRegexV2 = /^[a-zA-Z0-9_]+$/;
 
 export const invalidNameCharRegex = /[^a-zA-Z0-9-_]/g;
-export const invalidNameCharRegexV2 = /[^a-zA-Z0-9-_]/g;
+export const invalidNameCharRegexV2 = /[^a-zA-Z0-9_]/g;
 
 export const authConfig = {
   // for web login

--- a/Composer/packages/client/src/constants.ts
+++ b/Composer/packages/client/src/constants.ts
@@ -420,7 +420,8 @@ export const nameRegex = /^[a-zA-Z0-9-_]+$/;
 
 export const nameRegexV2 = /^[a-zA-Z0-9_]+$/;
 
-export const invalidNameCharRegex = /[^a-z^A-Z^0-9^_]/g;
+export const invalidNameCharRegex = /[^a-zA-Z0-9-_]/g;
+export const invalidNameCharRegexV2 = /[^a-zA-Z0-9-_]/g;
 
 export const authConfig = {
   // for web login


### PR DESCRIPTION
## Description

The naming constraints for BF created bots do not apply for PVA bots. Dashes are allowed.

Also converts invalid characters to dashes upon import so there is no error.

## Task Item

fixes #7486 
