### PR TITLE
fix: address a regression in the start bot button that caused final 'get started' bubb not to pop

### DIFF
--- a/Composer/packages/client/src/components/BotRuntimeController/BotController.tsx
+++ b/Composer/packages/client/src/components/BotRuntimeController/BotController.tsx
@@ -232,6 +232,7 @@ const BotController: React.FC<BotControllerProps> = ({ onHideController, isContr
                 },
               },
             }}
+            id={'startbot'}
             menuAs={() => null}
             styles={{
               root: {

--- a/Composer/packages/client/src/components/BotRuntimeController/BotController.tsx
+++ b/Composer/packages/client/src/components/BotRuntimeController/BotController.tsx
@@ -232,7 +232,7 @@ const BotController: React.FC<BotControllerProps> = ({ onHideController, isContr
                 },
               },
             }}
-            id={'startbot'}
+            id={'startBotPanelElement'}
             menuAs={() => null}
             styles={{
               root: {

--- a/Composer/packages/client/src/components/Header.tsx
+++ b/Composer/packages/client/src/components/Header.tsx
@@ -339,7 +339,7 @@ export const Header = () => {
             hasCondensedHeadline
             calloutProps={{ directionalHint: DirectionalHint.bottomAutoEdge }}
             headline={formatMessage('You’re ready to go!')}
-            target="#startbot"
+            target="#startBotPanelElement"
             onDismiss={hideTeachingBubble}
           >
             {formatMessage(


### PR DESCRIPTION
## Description

This PR adds an `id` field to the start bot so it can be targetted with the teaching bubble.

## Task Item

Fixes #7560 
