### PR TITLE
fix: add defaults to and rename fields in skill export

### DIFF
--- a/Composer/packages/adaptive-form/src/utils/uiOptionsHelpers.ts
+++ b/Composer/packages/adaptive-form/src/utils/uiOptionsHelpers.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { FieldProps } from '@bfc/extension-client';
+import formatMessage from 'format-message';
 import startCase from 'lodash/startCase';
 
 export function getUiLabel(props: FieldProps): string | false | undefined {
@@ -34,6 +35,11 @@ export function getUiDescription(props: FieldProps): string | undefined {
   return description || schema?.description;
 }
 
+const EXAMPLE_HEADER = formatMessage({
+  default: 'ex.',
+  description: 'short for "example", used for example values in form fields',
+});
+
 export function getUiPlaceholder(props: FieldProps): string | undefined {
   const { uiOptions, schema, value, placeholder } = props;
 
@@ -52,13 +58,13 @@ export function getUiPlaceholder(props: FieldProps): string | undefined {
       }
       return example;
     });
-    fieldUIPlaceholder = `ex. ${examplesStrings.join(', ')}`;
+    fieldUIPlaceholder = `${EXAMPLE_HEADER} ${examplesStrings.join(', ')}`;
   }
 
   if (fieldUIPlaceholder && schema.pattern) {
-    const regex = `${schema.pattern}`;
+    const { pattern } = schema;
     const placeholderExamples = fieldUIPlaceholder.split(',').map((example) => example.trim());
-    const filteredExamples = placeholderExamples.filter((example) => example.match(regex));
+    const filteredExamples = placeholderExamples.filter((example) => example.match(pattern));
     fieldUIPlaceholder = filteredExamples.join(', ');
   }
 

--- a/Composer/packages/client/src/pages/design/exportSkillModal/constants.tsx
+++ b/Composer/packages/client/src/pages/design/exportSkillModal/constants.tsx
@@ -18,7 +18,6 @@ import { AddCallers } from './content/AddCallers';
 export const VERSION_REGEX = /\d\.\d+\.(\d+|preview-\d+)|\d\.\d+/i;
 
 export const SCHEMA_URIS = [
-  'http://localhost:3000/skill-manifest.json',
   'https://schemas.botframework.com/schemas/skills/v2.1/skill-manifest.json',
   'https://schemas.botframework.com/schemas/skills/skill-manifest-2.0.0.json',
 ];

--- a/Composer/packages/client/src/pages/design/exportSkillModal/constants.tsx
+++ b/Composer/packages/client/src/pages/design/exportSkillModal/constants.tsx
@@ -1,11 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import React from 'react';
 import formatMessage from 'format-message';
 import { JSONSchema7 } from '@bfc/extension-client';
 import { SkillManifestFile } from '@bfc/shared';
 import startCase from 'lodash/startCase';
 import { SDKKinds } from '@bfc/shared';
+import { Link } from 'office-ui-fabric-react/lib/Link';
 
 import { nameRegex } from '../../../constants';
 
@@ -16,6 +18,7 @@ import { AddCallers } from './content/AddCallers';
 export const VERSION_REGEX = /\d\.\d+\.(\d+|preview-\d+)|\d\.\d+/i;
 
 export const SCHEMA_URIS = [
+  'http://localhost:3000/skill-manifest.json',
   'https://schemas.botframework.com/schemas/skills/v2.1/skill-manifest.json',
   'https://schemas.botframework.com/schemas/skills/skill-manifest-2.0.0.json',
 ];
@@ -182,8 +185,20 @@ export const editorSteps: { [key in ManifestEditorSteps]: EditorStep } = {
     editJson: false,
     title: () => formatMessage('Export your bot'),
     subText: () =>
-      formatMessage(
-        'A skill is a bot that can perform a set of tasks one or more bots.  To make your bot available as a skill, it needs a manifest - a JSON file that describes the actions the skill can perform.'
+      formatMessage.rich(
+        'A skill is a bot that can perform a set of tasks one or more bots.  To make your bot available as a skill, it needs a manifest - a JSON file that describes the actions the skill can perform. <link>Learn more.</link>',
+        {
+          link: ({ children }) => (
+            <Link
+              key="learn-about-skill-manifests"
+              href={'https://docs.microsoft.com/en-us/composer/how-to-export-a-skill'}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              {children}
+            </Link>
+          ),
+        }
       ),
     validate,
   },

--- a/Composer/packages/client/src/pages/design/exportSkillModal/content/Description.tsx
+++ b/Composer/packages/client/src/pages/design/exportSkillModal/content/Description.tsx
@@ -95,7 +95,15 @@ export const Description: React.FC<ContentProps> = ({
 
         return {
           hidden,
-          properties: { ...properties, [key]: { field: InlineLabelField, hideError: true, serializer } },
+          properties: {
+            ...properties,
+            [key]: {
+              field: InlineLabelField,
+              hideError: true,
+              serializer,
+              placeholder: schema.properties?.[key]?.placeholder,
+            },
+          },
         };
       },
       { hidden: [], properties: {} } as any
@@ -144,7 +152,6 @@ export const Description: React.FC<ContentProps> = ({
         $id: `${botName}-${uuid()}`,
         endpoints: [{}],
         skillName: botName,
-        ...mapValues(schema?.properties, 'default'),
         ...rest,
       },
     };

--- a/Composer/packages/client/src/pages/design/exportSkillModal/content/Description.tsx
+++ b/Composer/packages/client/src/pages/design/exportSkillModal/content/Description.tsx
@@ -13,6 +13,7 @@ import { Label } from 'office-ui-fabric-react/lib/Label';
 import formatMessage from 'format-message';
 import { Dropdown, IDropdownOption, ResponsiveMode } from 'office-ui-fabric-react/lib/Dropdown';
 import { LoadingSpinner } from '@bfc/ui-shared/lib/components/LoadingSpinner';
+import mapValues from 'lodash/mapValues';
 
 import { botDisplayNameState } from '../../../../recoilModel';
 import { ContentProps, SCHEMA_URIS, VERSION_REGEX } from '../constants';
@@ -121,18 +122,6 @@ export const Description: React.FC<ContentProps> = ({
   );
 
   useEffect(() => {
-    const skillManifest = skillManifests.find(
-      (manifest) => manifest.content.$schema === ($schema || SCHEMA_URIS[0])
-    ) || {
-      content: {
-        $schema: $schema || SCHEMA_URIS[0],
-        $id: `${botName}-${uuid()}`,
-        endpoints: [{}],
-        name: botName,
-        ...rest,
-      },
-    };
-    setSkillManifest(skillManifest);
     (async function () {
       try {
         if ($schema) {
@@ -147,7 +136,20 @@ export const Description: React.FC<ContentProps> = ({
         editJson();
       }
     })();
-  }, [$schema]);
+    const skillManifest = skillManifests.find(
+      (manifest) => manifest.content.$schema === ($schema || SCHEMA_URIS[0])
+    ) || {
+      content: {
+        $schema: $schema || SCHEMA_URIS[0],
+        $id: `${botName}-${uuid()}`,
+        endpoints: [{}],
+        skillName: botName,
+        ...mapValues(schema?.properties, 'default'),
+        ...rest,
+      },
+    };
+    setSkillManifest(skillManifest);
+  }, [$schema, isFetchCompleted]);
 
   const required = schema?.required || [];
 


### PR DESCRIPTION
## Description

This adds the ability for the export-a-skill modal to read default values from its skill manifest. This is needed for the fit-and-finish changes. I need to check if `defaults` is the right field to place these in; as it is, these values will be taken literally if a user leaves them in. There's probably a better way to do this. There will also be a matching PR in the SDK repo for the matching new version of the skill manifest JSON file.

## Task Item

refs #7587

## Screenshots

![MicrosoftTeams-image (2)](https://user-images.githubusercontent.com/61990921/117224327-80bd0a80-adc4-11eb-8d8f-d42f5ef6338d.png)