### PR TITLE
fix: generate manifest file when creating new publish target

### DIFF
--- a/Composer/packages/client/src/pages/botProject/CreatePublishProfileDialog.tsx
+++ b/Composer/packages/client/src/pages/botProject/CreatePublishProfileDialog.tsx
@@ -10,19 +10,31 @@ import formatMessage from 'format-message';
 import { ActionButton, DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { useBoolean } from '@uifabric/react-hooks';
 import Dialog, { DialogFooter } from 'office-ui-fabric-react/lib/Dialog';
+import { SharedColors } from '@uifabric/fluent-theme';
+import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
 
 import { dispatcherState, settingsState, publishTypesState } from '../../recoilModel';
 import { AuthDialog } from '../../components/Auth/AuthDialog';
 import { isShowAuthDialog } from '../../utils/auth';
 
 import { PublishProfileDialog } from './create-publish-profile/PublishProfileDialog';
-import { actionButton } from './styles';
 
 // -------------------- CreatePublishProfileDialog -------------------- //
 
 type CreatePublishProfileDialogProps = {
   projectId: string;
   onUpdateIsCreateProfileFromSkill: (isCreateProfileFromSkill: boolean) => void;
+};
+
+// -------------------- Style -------------------- //
+const actionButton = {
+  root: {
+    fontSize: 12,
+    fontWeight: FontWeights.regular,
+    color: SharedColors.cyanBlue10,
+    paddingLeft: 0,
+    marginLeft: 5,
+  },
 };
 
 export const CreatePublishProfileDialog: React.FC<CreatePublishProfileDialogProps> = (props) => {

--- a/Composer/packages/client/src/pages/design/exportSkillModal/constants.tsx
+++ b/Composer/packages/client/src/pages/design/exportSkillModal/constants.tsx
@@ -287,8 +287,7 @@ export const editorSteps: { [key in ManifestEditorSteps]: EditorStep } = {
       {
         primary: true,
         text: () => formatMessage('Next'),
-        onClick: ({ onNext, generateManifest }) => () => {
-          // generateManifest();
+        onClick: ({ onNext }) => () => {
           onNext();
         },
       },

--- a/Composer/packages/client/src/pages/design/exportSkillModal/generateSkillManifest.ts
+++ b/Composer/packages/client/src/pages/design/exportSkillModal/generateSkillManifest.ts
@@ -113,7 +113,7 @@ export const generateOtherActivities = (kind: SDKKinds): Activities => {
   return type ? { [type]: { type } } : {};
 };
 
-export const generateDispatchModels = (
+export const generateDispatchModels = async (
   schema: JSONSchema7,
   dialogs: DialogInfo[],
   selectedTriggers: any[],
@@ -121,7 +121,7 @@ export const generateDispatchModels = (
   qnaFiles: QnAFile[],
   target: PublishTarget,
   projectId: string
-): { dispatchModels?: DispatchModels } => {
+): Promise<{ dispatchModels?: DispatchModels }> => {
   const intents = selectedTriggers.filter(({ $kind }) => $kind === SDKKinds.OnIntent).map(({ intent }) => intent);
   const { id: rootId } = dialogs.find((dialog) => dialog?.isRoot) || {};
 
@@ -151,7 +151,7 @@ export const generateDispatchModels = (
       }
     });
     const mergedContents = contents.join('\n');
-    createManifestFile(projectId, currentFileName, mergedContents);
+    await createManifestFile(projectId, currentFileName, mergedContents);
   }
 
   const luLanguages = intents.length

--- a/Composer/packages/client/src/pages/design/exportSkillModal/generateSkillManifest.ts
+++ b/Composer/packages/client/src/pages/design/exportSkillModal/generateSkillManifest.ts
@@ -113,7 +113,7 @@ export const generateOtherActivities = (kind: SDKKinds): Activities => {
   return type ? { [type]: { type } } : {};
 };
 
-export const generateDispatchModels = async (
+export const generateDispatchModels = (
   schema: JSONSchema7,
   dialogs: DialogInfo[],
   selectedTriggers: any[],
@@ -121,7 +121,7 @@ export const generateDispatchModels = async (
   qnaFiles: QnAFile[],
   target: PublishTarget,
   projectId: string
-): Promise<{ dispatchModels?: DispatchModels }> => {
+): { dispatchModels?: DispatchModels } => {
   const intents = selectedTriggers.filter(({ $kind }) => $kind === SDKKinds.OnIntent).map(({ intent }) => intent);
   const { id: rootId } = dialogs.find((dialog) => dialog?.isRoot) || {};
 
@@ -151,7 +151,7 @@ export const generateDispatchModels = async (
       }
     });
     const mergedContents = contents.join('\n');
-    await createManifestFile(projectId, currentFileName, mergedContents);
+    createManifestFile(projectId, currentFileName, mergedContents);
   }
 
   const luLanguages = intents.length

--- a/Composer/packages/client/src/pages/design/exportSkillModal/index.tsx
+++ b/Composer/packages/client/src/pages/design/exportSkillModal/index.tsx
@@ -10,7 +10,7 @@ import { DefaultButton, PrimaryButton } from 'office-ui-fabric-react/lib/Button'
 import { JSONSchema7 } from '@bfc/extension-client';
 import { Link } from 'office-ui-fabric-react/lib/components/Link';
 import { useRecoilValue } from 'recoil';
-import { SkillManifestFile } from '@bfc/shared';
+import { PublishTarget, SkillManifestFile } from '@bfc/shared';
 import { navigate } from '@reach/router';
 import { isUsingAdaptiveRuntime } from '@bfc/shared';
 import cloneDeep from 'lodash/cloneDeep';
@@ -141,6 +141,7 @@ const ExportSkillModal: React.FC<ExportSkillModalProps> = ({ onSubmit, onDismiss
           );
         });
         if (isCreateProfileFromSkill && currentTarget) {
+          handleGenerateManifest(currentTarget);
           const skillPublishPenddingNotificationCard = getSkillPendingNotificationCardProps();
           publishNotificationRef.current = createNotification(skillPublishPenddingNotificationCard);
           addNotification(publishNotificationRef.current);
@@ -188,7 +189,7 @@ const ExportSkillModal: React.FC<ExportSkillModalProps> = ({ onSubmit, onDismiss
     [mergedSettings, projectId, isAdaptive, skillConfiguration, runtimeSettings]
   );
 
-  const handleGenerateManifest = () => {
+  const handleGenerateManifest = (currentTarget?: PublishTarget) => {
     const manifest = generateSkillManifest(
       schema,
       skillManifest,
@@ -198,7 +199,7 @@ const ExportSkillModal: React.FC<ExportSkillModalProps> = ({ onSubmit, onDismiss
       qnaFiles,
       selectedTriggers,
       selectedDialogs,
-      currentPublishTarget,
+      currentTarget || currentPublishTarget,
       projectId
     );
     setSkillManifest(manifest);


### PR DESCRIPTION
## Description
fix: generate manifest file when creating new publish target

Bind generateManifest & publish function after creating or selecting publish target.
![manifestFile](https://user-images.githubusercontent.com/5860999/117261521-d0620b80-ae82-11eb-9424-8bd15e5ff2ed.gif)


## Task Item

closes #7655 

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
