### PR TITLE
fix: Add components field to migrated settings.

### DIFF
--- a/Composer/packages/server/src/services/project.ts
+++ b/Composer/packages/server/src/services/project.ts
@@ -528,6 +528,7 @@ export class BotProjectService {
         const newSettings: DialogSetting = {
           ...currentProject.settings,
           runtimeSettings: {
+            components: [],
             features: {
               showTyping: originalProject.settings?.feature?.UseShowTypingMiddleware || false,
               useInspection: originalProject.settings?.feature?.UseInspectionMiddleware || false,

--- a/extensions/packageManager/src/node/index.ts
+++ b/extensions/packageManager/src/node/index.ts
@@ -367,11 +367,6 @@ export default async (composer: IExtensionRegistration): Promise<void> => {
 
             const installedComponents = await loadPackageAssets(mergeResults.components.filter(isAdaptiveComponent));
             if (mergeResults) {
-              res.json({
-                success: true,
-                components: installedComponents,
-              });
-
               let runtimeLanguage = 'c#';
               if (
                 currentProject.settings.runtime.key === 'node-azurewebapp' ||
@@ -387,10 +382,14 @@ export default async (composer: IExtensionRegistration): Promise<void> => {
                 !currentProject.settings.runtimeSettings?.components?.find((p) => p.name === newlyInstalledPlugin.name)
               ) {
                 const newSettings = currentProject.settings;
+                // guard against missing settings keys
                 if (!newSettings.runtimeSettings) {
                   newSettings.runtimeSettings = {
                     components: [],
                   };
+                }
+                if (!newSettings.runtimeSettings.components) {
+                  newSettings.runtimeSettings.components = [];
                 }
                 newSettings.runtimeSettings.components.push({
                   name: newlyInstalledPlugin.name,
@@ -399,6 +398,11 @@ export default async (composer: IExtensionRegistration): Promise<void> => {
                 currentProject.updateEnvSettings(newSettings);
               }
               updateRecentlyUsed(installedComponents, runtimeLanguage);
+
+              res.json({
+                success: true,
+                components: installedComponents,
+              });
             } else {
               res.json({
                 success: false,


### PR DESCRIPTION
## Description

* Add the `components` field to the migrated settings during migration
* During the component install process, check against the fields absence and create if missing
* Move call to res.json below other tasks (this was causing errors to be swallowed)

## Task Item

Fixes #7670
