### PR TITLE
fix: restore line beneath page header

### DIFF
--- a/Composer/packages/client/src/components/Page.tsx
+++ b/Composer/packages/client/src/components/Page.tsx
@@ -5,6 +5,7 @@
 import { jsx, css, SerializedStyles } from '@emotion/core';
 import React, { useMemo } from 'react';
 import { FontWeights, FontSizes } from 'office-ui-fabric-react/lib/Styling';
+import { NeutralColors } from '@uifabric/fluent-theme';
 import { Toolbar, IToolbarItem } from '@bfc/ui-shared';
 import { useRecoilValue } from 'recoil';
 import { Split, SplitMeasuredSizes } from '@geoffcox/react-splitter';
@@ -52,6 +53,7 @@ export const header = css`
   flex-shrink: 0;
   justify-content: space-between;
   align-items: center;
+  border-bottom: 1px solid ${NeutralColors.gray30};
 
   label: PageHeader;
 `;

--- a/Composer/packages/client/src/pages/botProject/BotProjectSettings.tsx
+++ b/Composer/packages/client/src/pages/botProject/BotProjectSettings.tsx
@@ -26,14 +26,6 @@ import { BotProjectSettingsTabView } from './BotProjectsSettingsTabView';
 
 // -------------------- Styles -------------------- //
 
-const header = css`
-  padding: 5px 20px;
-  display: flex;
-  justify-content: space-between;
-  label: PageHeader;
-  border-bottom: 1px solid silver;
-`;
-
 const container = css`
   display: flex;
   flex-direction: column;
@@ -134,7 +126,6 @@ const BotProjectSettings: React.FC<RouteComponentProps<{ projectId: string; skil
     <Page
       useDebugPane
       data-testid="BotProjectsSettings"
-      headerStyle={header}
       mainRegionName={formatMessage('Bot projects settings list View')}
       navLinks={navLinks}
       navRegionName={formatMessage('Bot Projects Settings Navigation Pane')}


### PR DESCRIPTION
## Description

This adds some CSS to restore the gray border beneath the page header.

## Task Item

closes #7656

## Screenshots

![image](https://user-images.githubusercontent.com/61990921/117332910-3e8bdb80-ae4d-11eb-9ed2-482a61e78986.png)

