### PR TITLE
fix: remove appsettings file from default gitignore

### DIFF
--- a/extensions/samples/assets/shared/.gitignore
+++ b/extensions/samples/assets/shared/.gitignore
@@ -1,5 +1,2 @@
-# prevent appsettings.json get checked in
-**/appsettings.json
-
 # files generated during the lubuild process
 generated/


### PR DESCRIPTION
## Description

Remove the appsettings file from the default .gitignore file that is inserted as part of the boilerplate content.

This change is necessary because the appsettings file contains settings that are critical to the function of the bot -- OUTSIDE of the various keys and credentials that may be present.

## Task Item

fix #7677
