### PR TITLE
fix: exclude items from the package manager list that do not have names

### DIFF
--- a/extensions/packageManager/src/node/index.ts
+++ b/extensions/packageManager/src/node/index.ts
@@ -28,7 +28,7 @@ const hasSchema = (c) => {
 };
 
 const isAdaptiveComponent = (c) => {
-  return hasSchema(c) || c.includesExports;
+  return c.name && c.version && (hasSchema(c) || c.includesExports);
 };
 
 const readFileAsync = async (path, encoding) => {


### PR DESCRIPTION
Fixes #7680  -

The schema merge process returns locally developed custom actions as if they were installed components.  These entries, however, lack all metadata including the name and version.

This PR filters items without both a name and a version from appearing in the package manager UI.