### PR TITLE
fix: fix publish target types missing in provision dialog

### DIFF
--- a/Composer/packages/client/src/pages/botProject/PublishTargets.tsx
+++ b/Composer/packages/client/src/pages/botProject/PublishTargets.tsx
@@ -64,7 +64,7 @@ type PublishTargetsProps = {
 export const PublishTargets: React.FC<PublishTargetsProps> = (props) => {
   const { projectId, scrollToSectionId = '' } = props;
   const { publishTargets } = useRecoilValue(settingsState(projectId));
-  const { getPublishTargetTypes, setPublishTargets } = useRecoilValue(dispatcherState);
+  const { setPublishTargets } = useRecoilValue(dispatcherState);
   const publishTypes = useRecoilValue(publishTypesState(projectId));
 
   const [showPublishDialog, setShowingPublishDialog] = useState(false);
@@ -89,12 +89,6 @@ export const PublishTargets: React.FC<PublishTargetsProps> = (props) => {
       }
     }
   }, [location, publishTargets]);
-
-  useEffect(() => {
-    if (projectId) {
-      getPublishTargetTypes(projectId);
-    }
-  }, [projectId]);
 
   useEffect(() => {
     if (publishTargetsRef.current && scrollToSectionId === '#addNewPublishProfile') {

--- a/Composer/packages/client/src/pages/publish/Publish.tsx
+++ b/Composer/packages/client/src/pages/publish/Publish.tsx
@@ -65,7 +65,6 @@ const Publish: React.FC<RouteComponentProps<{ projectId: string; targetName?: st
   const {
     getPublishHistory,
     getPublishStatusV2,
-    getPublishTargetTypes,
     setPublishTargets,
     publishToTarget,
     setQnASettings,
@@ -104,18 +103,6 @@ const Publish: React.FC<RouteComponentProps<{ projectId: string; targetName?: st
   const selectedBots = useMemo(() => {
     return currentBotList.filter((bot) => checkedSkillIds.some((id) => bot.id === id));
   }, [checkedSkillIds]);
-
-  // The publishTypes are loaded from the server and put into the publishTypesState per project
-  // The botProjectSpaceSelector maps the publishTypes to the project bots.
-  // The localBotsDataSelector uses botProjectSpaceSelector
-  // The botPropertyData uses localBotsDataSelector
-  // When the botPropertyData is used (like in the canPull method), the publishTypes must be loaded for the current project.
-  // Otherwise the botPropertyData publishTypes will always be empty and this component won't function properly.
-  useEffect(() => {
-    if (projectId) {
-      getPublishTargetTypes(projectId);
-    }
-  }, [projectId]);
 
   const canPull = useMemo(() => {
     return selectedBots.some((bot) => {

--- a/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
@@ -762,6 +762,8 @@ export const openRootBotAndSkills = async (callbackHelpers: CallbackInterface, d
 
   set(botNameIdentifierState(rootBotProjectId), camelCase(name));
   set(botProjectIdsState, [rootBotProjectId]);
+  // Get the publish types on opening
+  dispatcher.getPublishTargetTypes(rootBotProjectId);
   // Get the status of the bot on opening if it was opened and run in another window.
   dispatcher.getPublishStatus(rootBotProjectId, defaultPublishConfig);
   if (botFiles?.botProjectSpaceFiles?.length) {


### PR DESCRIPTION
## Description

base on #7519, fix publish target types missing in provision dialog

refs #7519

## Task Item

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
