### PR TITLE
fix: Feed string, not int, to Switch per schema

### DIFF
--- a/Composer/packages/lib/shared/src/dialogFactory.ts
+++ b/Composer/packages/lib/shared/src/dialogFactory.ts
@@ -211,7 +211,7 @@ const initialDialogShape = () => ({
         $designer: {
           id: generateDesignerId(),
         },
-        condition: '=count(dialog.candidates)',
+        condition: '=string(count(dialog.candidates))',
         cases: [
           {
             value: '0',


### PR DESCRIPTION
## Description
Per Switch [schema](https://github.com/microsoft/botbuilder-dotnet/blob/402bc02b4cbbd2f4ec359134640e99211367e4a5/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.SwitchCondition.schema#L17), this conditional is expecting a `StringExpression`,  and I was feeding it an integer. 

Strangely, Composer did not show a validation error on this bug until recently.  Thanks @tdurnford  and @hatpick  for explaining the validation logic in Composer.

With this fix, template doesn't throw anymore errors and bot can be built.

## Task Item
fixes #7700 

