### PR TITLE
fix: update strings for Composer 2.0 update

### DIFF
--- a/Composer/packages/client/src/components/AppUpdater/AppUpdater.tsx
+++ b/Composer/packages/client/src/components/AppUpdater/AppUpdater.tsx
@@ -202,7 +202,7 @@ export const AppUpdater: React.FC<{}> = () => {
         return formatMessage('Update failed');
 
       case AppUpdaterStatus.UPDATE_IN_PROGRESS:
-        return formatMessage('Update in progress');
+        return formatMessage('Updating to Composer v{version}', { version });
 
       case AppUpdaterStatus.UPDATE_SUCCEEDED:
         return formatMessage('Update complete');

--- a/Composer/packages/client/src/components/AppUpdater/breakingUpdates/version1To2.tsx
+++ b/Composer/packages/client/src/components/AppUpdater/breakingUpdates/version1To2.tsx
@@ -76,7 +76,7 @@ export const Version1To2Content: React.FC<BreakingUpdateProps> = (props) => {
     <Dialog
       dialogContentProps={{
         styles: dialogContent,
-        title: formatMessage('Composer 2.0 is now available!'),
+        title: formatMessage('Update to Composer 2.0'),
         type: DialogType.largeHeader,
       }}
       hidden={false}
@@ -88,13 +88,13 @@ export const Version1To2Content: React.FC<BreakingUpdateProps> = (props) => {
     >
       <p>
         {formatMessage(
-          'Bot Framework Composer 2.0 provides more built-in capabilities so you can build complex bots quickly. Update to Composer 2.0 for advanced bot templates, prebuilt components, and a runtime that is fully extensible through packages.'
+          'Take advantage of new, advanced bot templates, reusable components and an extensible runtime available in Composer 2.0.'
         )}
       </p>
 
       <p>
         {formatMessage.rich(
-          'Note: If your bot is using custom actions, they will not be supported in Composer 2.0. <a>Learn more about updating to Composer 2.0.</a>',
+          'Custom actions created in previous versions might need to be recreated for Composer 2.0. <a>Learn more.</a>',
           {
             // TODO: needs real link
             a: ({ children }) => (
@@ -130,12 +130,12 @@ export const Version1To2Content: React.FC<BreakingUpdateProps> = (props) => {
     >
       <p css={updateCancelledCopy}>
         {formatMessage.rich(
-          'Update cancelled. Auto-update has been turned off for this release. You can update at any time by selecting <b>Help > Check for updates.</b>',
+          'Auto-update was cancelled. To update to Bot Framework Composer 2.0, select <b>Help > Check for updates.</b>',
           { b: ({ children }) => <b key="v2-breaking-changes-re-enable-auto-updates">{children}</b> }
         )}
       </p>
       <div css={buttonRow}>
-        <PrimaryButton css={gotItButton} text={formatMessage('Got it!')} onClick={onCancel} />
+        <PrimaryButton css={gotItButton} text={formatMessage('OK')} onClick={onCancel} />
       </div>
     </Dialog>
   );

--- a/Composer/packages/client/src/pages/design/exportSkillModal/constants.tsx
+++ b/Composer/packages/client/src/pages/design/exportSkillModal/constants.tsx
@@ -1,11 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import React from 'react';
 import formatMessage from 'format-message';
 import { JSONSchema7 } from '@bfc/extension-client';
 import { SkillManifestFile } from '@bfc/shared';
 import startCase from 'lodash/startCase';
 import { SDKKinds } from '@bfc/shared';
+import { Link } from 'office-ui-fabric-react/lib/Link';
 
 import { nameRegex } from '../../../constants';
 
@@ -175,6 +177,14 @@ const validate = ({ content, schema }) => {
     }, {});
 };
 
+function makeLink(url: string) {
+  return ({ children }) => (
+    <Link key={url} href={url} rel="noopener noreferrer" target="_blank">
+      {children}
+    </Link>
+  );
+}
+
 export const editorSteps: { [key in ManifestEditorSteps]: EditorStep } = {
   [ManifestEditorSteps.MANIFEST_DESCRIPTION]: {
     buttons: [cancelButton, nextButton],
@@ -243,8 +253,11 @@ export const editorSteps: { [key in ManifestEditorSteps]: EditorStep } = {
     editJson: false,
     content: AddCallers,
     subText: () =>
-      formatMessage(
-        'To ensure a secure connection, provide the App ID of the bots that can connect to your skill.  If you don’t have this information, you can also add this information in Skill Configuration. Learn more.'
+      formatMessage.rich(
+        'To ensure a secure connection, provide the App ID of the bots that can connect to your skill.  If you don’t have this information, you can also add this information in Skill Configuration. <link>Learn more.</link>',
+        {
+          link: makeLink('https://docs.microsoft.com/en-us/composer/how-to-connect-to-a-skill'),
+        }
       ),
     title: () => formatMessage('Which bots can connect to this skill?'),
   },
@@ -276,7 +289,10 @@ export const editorSteps: { [key in ManifestEditorSteps]: EditorStep } = {
     editJson: false,
     subText: () =>
       formatMessage(
-        'The capabilities of your bot are defined in its dialogs and triggers. Selected dialogs will be included in the manifest. Internal dialogs or actions may not be relevant to other bots. Learn more.'
+        'The capabilities of your bot are defined in its dialogs and triggers. Selected dialogs will be included in the manifest. Internal dialogs or actions may not be relevant to other bots. <link>Learn more.</link>',
+        {
+          link: makeLink('https://aka.ms/bfcomposer-2-exportskill'),
+        }
       ),
     title: () => formatMessage('Select dialogs'),
   },
@@ -297,7 +313,10 @@ export const editorSteps: { [key in ManifestEditorSteps]: EditorStep } = {
     editJson: false,
     subText: () =>
       formatMessage(
-        'Triggers selected below will enable other bots to access the capabilities of your skill. Learn more.'
+        'Triggers selected below will enable other bots to access the capabilities of your skill. <link>Learn more.</link>',
+        {
+          link: makeLink('https://aka.ms/bfcomposer-2-exportskill'),
+        }
       ),
     title: () => formatMessage('Select triggers'),
   },

--- a/Composer/packages/client/src/recoilModel/dispatchers/project.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/project.ts
@@ -248,11 +248,11 @@ export const projectDispatcher = () => {
   const forceMigrate = useRecoilCallback((callbackHelpers: CallbackInterface) => async (projectId: string) => {
     if (
       await OpenConfirmModal(
-        formatMessage('Convert your project to the latest format'),
+        formatMessage('Update this project to Composer 2.0'),
         formatMessage(
-          'This project was created in an older version of Composer. To open this project in Composer 2.0, we must copy your project and convert it to the latest format. Your original project will not be changed.'
+          'This project was created in an older version of Composer. To open this project in Composer 2.0, it needs to be updated and saved as a new project. Your original project will not be changed.'
         ),
-        { confirmText: formatMessage('Convert') }
+        { confirmText: formatMessage('Update this bot') }
       )
     ) {
       callbackHelpers.set(creationFlowStatusState, CreationFlowStatus.MIGRATE);


### PR DESCRIPTION
## Description

These are more string updates for the Electron auto-updater, plus a few "Learn more" links that were left behind from a previous update. One string (`In triggers[1].action[1] MultiplyDialog: Schema definition no found in sdk.schema.`) comes from the SDK and will need to be dealt with separately, but this covers the rest of that tab.

## Task Item

closes #7600
refs #7587

## Screenshots

[pending; this is a place that's hard to get screenshots of]

