### PR TITLE
fix: update the expected responses placeholder

### DIFF
--- a/Composer/packages/ui-plugins/prompts/src/ExpectedResponsesField.tsx
+++ b/Composer/packages/ui-plugins/prompts/src/ExpectedResponsesField.tsx
@@ -3,19 +3,32 @@
 
 import React from 'react';
 import { FieldLabel, useAdaptiveFormContext } from '@bfc/adaptive-form';
-import { FieldProps, useRecognizerConfig, useShellApi } from '@bfc/extension-client';
+import { FieldProps, SDKKinds, useRecognizerConfig, useShellApi } from '@bfc/extension-client';
 import formatMessage from 'format-message';
 import { LuMetaData, LuType } from '@bfc/shared';
 
-const expectedResponsesPlaceholder = () =>
-  formatMessage(`> add some expected user responses:
-> - Please remind me to '{itemTitle=buy milk}'
-> - remind me to '{itemTitle}'
-> - add '{itemTitle}' to my todo list
->
-> entity definitions:
-> @ ml itemTitle
-`);
+const expectedResponsesPlaceholder = (id?: SDKKinds) => {
+  let placehold = '';
+  switch (id) {
+    case SDKKinds.CrossTrainedRecognizerSet:
+    case SDKKinds.LuisRecognizer:
+      placehold = formatMessage(`> add some expected user responses:
+      > - Please remind me to '{itemTitle=buy milk}'
+      > - remind me to '{itemTitle}'
+      > - add '{itemTitle}' to my todo list
+      >
+      > entity definitions:
+      > @ ml itemTitle
+      `);
+      break;
+    case SDKKinds.RegexRecognizer:
+      placehold = formatMessage('ex. Book a flight to(?<toCity>.*)');
+      break;
+    default:
+      break;
+  }
+  return placehold;
+};
 
 const ExpectedResponsesField: React.FC<FieldProps> = (props) => {
   const { id, description } = props;
@@ -36,7 +49,7 @@ const ExpectedResponsesField: React.FC<FieldProps> = (props) => {
       <Editor
         {...props}
         label={label}
-        placeholder={expectedResponsesPlaceholder()}
+        placeholder={expectedResponsesPlaceholder(currentRecognizer?.id as SDKKinds)}
         schema={schema}
         value={intentName}
         onChange={() => {}}

--- a/Composer/packages/ui-plugins/prompts/src/ExpectedResponsesField.tsx
+++ b/Composer/packages/ui-plugins/prompts/src/ExpectedResponsesField.tsx
@@ -22,7 +22,7 @@ const expectedResponsesPlaceholder = (id?: SDKKinds) => {
       `);
       break;
     case SDKKinds.RegexRecognizer:
-      placehold = formatMessage('ex. Book a flight to(?<toCity>.*)');
+      placehold = formatMessage('Add some regex patterns');
       break;
     default:
       break;

--- a/Composer/packages/ui-plugins/prompts/src/ExpectedResponsesField.tsx
+++ b/Composer/packages/ui-plugins/prompts/src/ExpectedResponsesField.tsx
@@ -8,11 +8,11 @@ import formatMessage from 'format-message';
 import { LuMetaData, LuType } from '@bfc/shared';
 
 const expectedResponsesPlaceholder = (id?: SDKKinds) => {
-  let placehold = '';
+  let placeholderText = '';
   switch (id) {
     case SDKKinds.CrossTrainedRecognizerSet:
     case SDKKinds.LuisRecognizer:
-      placehold = formatMessage(`> add some expected user responses:
+      placeholderText = formatMessage(`> add some expected user responses:
       > - Please remind me to '{itemTitle=buy milk}'
       > - remind me to '{itemTitle}'
       > - add '{itemTitle}' to my todo list
@@ -22,12 +22,12 @@ const expectedResponsesPlaceholder = (id?: SDKKinds) => {
       `);
       break;
     case SDKKinds.RegexRecognizer:
-      placehold = formatMessage('Add some regex patterns');
+      placeholderText = formatMessage('Add regex pattern');
       break;
     default:
       break;
   }
-  return placehold;
+  return placeholderText;
 };
 
 const ExpectedResponsesField: React.FC<FieldProps> = (props) => {


### PR DESCRIPTION
## Description
The expected responses' placeholder is the same under different recognizers. The placeholder of regex recognizer is like
![image](https://user-images.githubusercontent.com/39758135/118104390-a920b680-b40d-11eb-9930-0acb1a925a95.png)
this may confuse users.

**fix**
update the placeholder for regex recognizer

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
refs #7779
fixes #7816 
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots
![placehode](https://user-images.githubusercontent.com/39758135/118104673-01f04f00-b40e-11eb-8b80-002433c51639.gif)

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
