### PR TITLE
fix: Throttle restart conversation

### DIFF
--- a/Composer/packages/client/src/components/WebChat/WebChatHeader.tsx
+++ b/Composer/packages/client/src/components/WebChat/WebChatHeader.tsx
@@ -43,6 +43,7 @@ export type WebChatHeaderProps = {
   onSaveTranscript: (conversationId: string) => void;
   onOpenBotInEmulator: () => void;
   onCloseWebChat: () => void;
+  isRestartButtonDisabled: boolean;
 };
 
 export const WebChatHeader: React.FC<WebChatHeaderProps> = ({
@@ -54,6 +55,7 @@ export const WebChatHeader: React.FC<WebChatHeaderProps> = ({
   onOpenBotInEmulator: openBotInEmulator,
   onSetRestartOption,
   onCloseWebChat,
+  isRestartButtonDisabled,
 }) => {
   const menuProps: IContextualMenuProps = {
     items: [
@@ -114,6 +116,7 @@ export const WebChatHeader: React.FC<WebChatHeaderProps> = ({
         split
         aria-roledescription="split button"
         ariaLabel="restart-conversation"
+        disabled={isRestartButtonDisabled}
         iconProps={{ iconName: 'Refresh' }}
         menuProps={menuProps}
         splitButtonAriaLabel="See 2 other restart conversation options"
@@ -124,11 +127,11 @@ export const WebChatHeader: React.FC<WebChatHeaderProps> = ({
             : formatMessage('Restart Conversation - new user ID')
         }
         title="restart-conversation"
-        onClick={() => {
+        onClick={async () => {
           if (currentRestartOption === RestartOption.SameUserID) {
-            onRestartConversation(conversationId, false);
+            await onRestartConversation(conversationId, false);
           } else {
-            onRestartConversation(conversationId, true);
+            await onRestartConversation(conversationId, true);
           }
         }}
       />

--- a/Composer/packages/client/src/components/WebChat/WebChatHeader.tsx
+++ b/Composer/packages/client/src/components/WebChat/WebChatHeader.tsx
@@ -127,11 +127,11 @@ export const WebChatHeader: React.FC<WebChatHeaderProps> = ({
             : formatMessage('Restart Conversation - new user ID')
         }
         title="restart-conversation"
-        onClick={async () => {
+        onClick={() => {
           if (currentRestartOption === RestartOption.SameUserID) {
-            await onRestartConversation(conversationId, false);
+            onRestartConversation(conversationId, false);
           } else {
-            await onRestartConversation(conversationId, true);
+            onRestartConversation(conversationId, true);
           }
         }}
       />

--- a/Composer/packages/client/src/components/WebChat/WebChatPanel.tsx
+++ b/Composer/packages/client/src/components/WebChat/WebChatPanel.tsx
@@ -211,7 +211,7 @@ export const WebChatPanel: React.FC<WebChatPanelProps> = ({
           setIsRestartButtonDisabled(false);
         }
       },
-      700,
+      1000,
       { leading: true }
     ),
     []

--- a/Composer/packages/client/src/components/WebChat/WebChatPanel.tsx
+++ b/Composer/packages/client/src/components/WebChat/WebChatPanel.tsx
@@ -137,10 +137,10 @@ export const WebChatPanel: React.FC<WebChatPanelProps> = ({
   }, [botUrl]);
 
   useEffect(() => {
-    if (botStatus !== BotStatus.inactive && botStatus !== BotStatus.connected && botStatus !== BotStatus.failed) {
-      setIsRestartButtonDisabled(true);
-    } else {
+    if (botStatus === BotStatus.connected) {
       setIsRestartButtonDisabled(false);
+    } else {
+      setIsRestartButtonDisabled(true);
     }
   }, [botStatus]);
 

--- a/Composer/packages/client/src/components/WebChat/WebChatPanel.tsx
+++ b/Composer/packages/client/src/components/WebChat/WebChatPanel.tsx
@@ -137,11 +137,7 @@ export const WebChatPanel: React.FC<WebChatPanelProps> = ({
   }, [botUrl]);
 
   useEffect(() => {
-    if (botStatus === BotStatus.connected) {
-      setIsRestartButtonDisabled(false);
-    } else {
-      setIsRestartButtonDisabled(true);
-    }
+    setIsRestartButtonDisabled(botStatus !== BotStatus.connected);
   }, [botStatus]);
 
   const sendInitialActivities = async (chatData: ChatData) => {

--- a/Composer/packages/client/src/components/WebChat/__tests__/WebChatHeader.test.tsx
+++ b/Composer/packages/client/src/components/WebChat/__tests__/WebChatHeader.test.tsx
@@ -21,6 +21,7 @@ describe('<WebChatHeader />', () => {
     onSaveTranscript: mockOnSaveTranscript,
     onOpenBotInEmulator: jest.fn(),
     onCloseWebChat: jest.fn(),
+    isRestartButtonDisabled: false,
   };
 
   afterEach(() => {
@@ -43,6 +44,7 @@ describe('<WebChatHeader />', () => {
       onSaveTranscript: mockOnSaveTranscript,
       onOpenBotInEmulator: jest.fn(),
       onCloseWebChat: jest.fn(),
+      isRestartButtonDisabled: false,
     };
 
     const { findByText } = render(<WebChatHeader {...props} />);
@@ -68,6 +70,7 @@ describe('<WebChatHeader />', () => {
       onSaveTranscript: mockOnSaveTranscript,
       onOpenBotInEmulator: jest.fn(),
       onCloseWebChat: jest.fn(),
+      isRestartButtonDisabled: false,
     };
 
     const { findByText } = render(<WebChatHeader {...props} />);


### PR DESCRIPTION
## Description
This PR addresses a scenario where "Restart Conversation" was hit quite a few times in under a second. In certain situations, it freezes Composer. This is a partial fix to avoid Composer getting into this state by a) throttling the button (1s) b) Disabling it while the bot is being restarted c) Disabling the button until the asynchronous operation of restarting the conversation completes.

The second half of the fix would be in a separate PR. This would involve performing cleanup tasks on electron before-quit event. The cleanup tasks include code written to manually close the directline server, runtime log server and the express server. This could be leveraged for closing dangling bot runtimes as well.

## Task Item
Refs #7788 


