### PR TITLE
fix: page navigation items sort order

### DIFF
--- a/Composer/packages/client/src/utils/pageLinks.ts
+++ b/Composer/packages/client/src/utils/pageLinks.ts
@@ -48,11 +48,11 @@ export const topLinks = (
       isDisabledForPVA: false,
     },
     {
-      to: `/bot/${rootProjectId || projectId}/botProjectsSettings`,
-      iconName: 'BotProjectsSettings',
-      labelName: formatMessage('Configure'),
-      disabled: !botLoaded,
-      match: /botProjectsSettings/,
+      to: linkBase + `language-generation/${openedDialogId}`,
+      iconName: 'Robot',
+      labelName: formatMessage('Bot responses'),
+      disabled: !botLoaded || skillIsRemote,
+      match: /language-generation\/[a-zA-Z0-9_-]+$/,
       isDisabledForPVA: false,
     },
     {
@@ -64,20 +64,20 @@ export const topLinks = (
       isDisabledForPVA: false,
     },
     {
-      to: linkBase + `language-generation/${openedDialogId}`,
-      iconName: 'Robot',
-      labelName: formatMessage('Bot responses'),
-      disabled: !botLoaded || skillIsRemote,
-      match: /language-generation\/[a-zA-Z0-9_-]+$/,
-      isDisabledForPVA: false,
-    },
-    {
       to: linkBase + `knowledge-base/${openedDialogId}`,
       iconName: 'QnAIcon',
       labelName: formatMessage('Knowledge base'),
       disabled: !botLoaded || skillIsRemote,
       match: /knowledge-base\/[a-zA-Z0-9_-]+$/,
       isDisabledForPVA: isPVASchema,
+    },
+    {
+      to: `/bot/${rootProjectId || projectId}/botProjectsSettings`,
+      iconName: 'BotProjectsSettings',
+      labelName: formatMessage('Configure'),
+      disabled: !botLoaded,
+      match: /botProjectsSettings/,
+      isDisabledForPVA: false,
     },
     ...(showFormDialog
       ? [


### PR DESCRIPTION
## Description

Left page navigation icons are changed in #7609, this PR is putting them back. 

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
close #7688 
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<img width="105" alt="image" src="https://user-images.githubusercontent.com/49866537/118238890-b69c7600-b4cb-11eb-9ba3-431852d80930.png">

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
