### PR TITLE
fix: Always use intermediate lg template for text and speak modalities

### DIFF
--- a/Composer/packages/lib/code-editor/src/lg/hooks/useStringArray.ts
+++ b/Composer/packages/lib/code-editor/src/lg/hooks/useStringArray.ts
@@ -76,9 +76,6 @@ export const useStringArray = <T extends ArrayBasedStructuredResponseItem>(
         setTemplateId(id);
         onUpdateResponseTemplate({ [kind]: { kind, value: [], valueType: 'direct' } });
         onRemoveTemplate(id);
-      } else if (fixedNewItems.length === 1 && !/\r?\n/g.test(fixedNewItems[0].value) && lgOption?.templateId) {
-        onUpdateResponseTemplate({ [kind]: { kind, value: [fixedNewItems[0].value], valueType: 'direct' } });
-        onTemplateChange(id, '');
       } else {
         setTemplateId(id);
         onUpdateResponseTemplate({ [kind]: { kind, value: [`\${${id}()}`], valueType: 'template' } });


### PR DESCRIPTION
## Description
Updates the `useStringArray` hook to always use an intermediate template for the text and speak modalities in the LG Response Editor.

## Task Item
Closes #7841

## Screenshots
![May-15-2021 07-34-42](https://user-images.githubusercontent.com/17039790/118363127-1c324600-b550-11eb-8e6c-953b1f4fe405.gif)

