### PR TITLE
fix: Migration: adjust target blob transcript field names

### DIFF
--- a/Composer/packages/server/src/services/project.ts
+++ b/Composer/packages/server/src/services/project.ts
@@ -537,7 +537,10 @@ export class BotProjectService {
                 ? { voiceFontName: 'en-US-AriaNeural', fallbackToTextForSpeechIfEmpty: true }
                 : undefined,
               blobTranscript: originalProject.settings?.blobStorage?.connectionString
-                ? originalProject.settings?.blobStorage
+                ? {
+                    connectionString: originalProject.settings.blobStorage.connectionString,
+                    containerName: originalProject.settings.blobStorage.container,
+                  }
                 : {},
             },
             telemetry: {


### PR DESCRIPTION
Closes #7769 

Blob transcript field name on migration needs to have `connectionString` and `containerName`. Adjusting migration code to reflect that config transform.

Testing: Tested migration with blob transcript in old format, verified blob transcript properly migrated by visually inspecting the settings, plus verifying the storage in Azure

![image](https://user-images.githubusercontent.com/21318528/118539117-e3d36900-b703-11eb-85e7-b8ae2355daa1.png)

Also tested the migration where there is no blob transcript, and verified that the target project has no transcript.