### PR TITLE
fix: resolving getting started teaching callout not rendering

### DIFF
--- a/Composer/packages/client/src/components/GetStarted/GetStartedNextSteps.tsx
+++ b/Composer/packages/client/src/components/GetStarted/GetStartedNextSteps.tsx
@@ -43,7 +43,7 @@ export const GetStartedNextSteps: React.FC<GetStartedProps> = (props) => {
   const readme = useRecoilValue(projectReadmeState(projectId));
   const [readmeHidden, setReadmeHidden] = useState<boolean>(true);
   const schemaDiagnostics = useRecoilValue(schemaDiagnosticsSelectorFamily(projectId));
-  const { setSettings, setQnASettings } = useRecoilValue(dispatcherState);
+  const { setSettings, setQnASettings, setShowGetStartedTeachingBubble } = useRecoilValue(dispatcherState);
   const rootBotProjectId = useRecoilValue(rootBotProjectIdSelector) || '';
   const settings = useRecoilValue(settingsState(projectId));
   const mergedSettings = mergePropertiesManagedByRootBot(projectId, rootBotProjectId, settings);
@@ -402,6 +402,7 @@ export const GetStartedNextSteps: React.FC<GetStartedProps> = (props) => {
             target="#luis"
             onDismiss={() => {
               setHighlightLUIS(false);
+              setShowGetStartedTeachingBubble(false);
             }}
           >
             {formatMessage('Continue setting up your development environment by adding LUIS keys.')}
@@ -415,6 +416,7 @@ export const GetStartedNextSteps: React.FC<GetStartedProps> = (props) => {
             target="#qna"
             onDismiss={() => {
               setHighlightQNA(false);
+              setShowGetStartedTeachingBubble(false);
             }}
           >
             {formatMessage('Just add a QnA key and you’ll be ready to talk to your bot.')}

--- a/Composer/packages/client/src/components/Header.tsx
+++ b/Composer/packages/client/src/components/Header.tsx
@@ -13,7 +13,6 @@ import { NeutralColors, SharedColors, FontSizes, CommunicationColors } from '@ui
 import { useRecoilValue } from 'recoil';
 import { TeachingBubble } from 'office-ui-fabric-react/lib/TeachingBubble';
 
-import { useLocation } from '../utils/hooks';
 import {
   dispatcherState,
   appUpdateState,
@@ -26,6 +25,7 @@ import {
   botProjectSpaceLoadedState,
   isWebChatPanelVisibleState,
   allRequiredRecognizersSelector,
+  showGetStartedTeachingBubbleState,
 } from '../recoilModel';
 import composerIcon from '../images/composerIcon.svg';
 import { AppUpdaterStatus } from '../constants';
@@ -141,8 +141,7 @@ export const Header = () => {
   const locale = useRecoilValue(localeState(projectId));
   const appUpdate = useRecoilValue(appUpdateState);
   const [teachingBubbleVisibility, setTeachingBubbleVisibility] = useState<boolean>();
-
-  const [showGetStartedTeachingBubble, setShowGetStartedTeachingBubble] = useState<boolean>(false);
+  const showGetStartedTeachingBubble = useRecoilValue(showGetStartedTeachingBubbleState);
   const settings = useRecoilValue(settingsState(projectId));
   const isWebChatPanelVisible = useRecoilValue(isWebChatPanelVisibleState);
   const botProjectSolutionLoaded = useRecoilValue(botProjectSpaceLoadedState);
@@ -151,15 +150,13 @@ export const Header = () => {
   const { showing, status } = appUpdate;
   const rootBotId = useRecoilValue(rootBotProjectIdSelector) ?? '';
   const webchatEssentials = useRecoilValue(webChatEssentialsSelector(rootBotId));
+  const { setWebChatPanelVisibility, setShowGetStartedTeachingBubble } = useRecoilValue(dispatcherState);
 
-  const { setWebChatPanelVisibility } = useRecoilValue(dispatcherState);
   const [hideBotController, hideBotStartController] = useState(true);
   const [showGetStarted, setShowGetStarted] = useState<boolean>(false);
   const [showTeachingBubble, setShowTeachingBubble] = useState<boolean>(false);
   const [requiresLUIS, setRequiresLUIS] = useState<boolean>(false);
   const [requiresQNA, setRequiresQNA] = useState<boolean>(false);
-
-  const { location } = useLocation();
 
   // These are needed to determine if the bot needs LUIS or QNA
   // this data is passed into the GetStarted widget
@@ -191,18 +188,16 @@ export const Header = () => {
   };
   const toggleGetStarted = (newvalue) => {
     hideTeachingBubble();
+    setShowGetStartedTeachingBubble(false);
     setShowGetStarted(newvalue);
   };
 
   // pop out get started if #getstarted is in the URL
   useEffect(() => {
-    if (location.hash === '#getstarted') {
-      setShowGetStartedTeachingBubble(true);
+    if (showGetStartedTeachingBubble) {
       setShowGetStarted(true);
-    } else {
-      setShowGetStartedTeachingBubble(false);
     }
-  }, [location]);
+  }, [showGetStartedTeachingBubble]);
 
   useEffect(() => {
     if (isWebChatPanelVisible) {

--- a/Composer/packages/client/src/recoilModel/atoms/appState.ts
+++ b/Composer/packages/client/src/recoilModel/atoms/appState.ts
@@ -364,3 +364,8 @@ export const warnAboutFunctionsState = atom<boolean>({
   key: getFullyQualifiedKey('warnAboutFunctionsState'),
   default: false,
 });
+
+export const showGetStartedTeachingBubbleState = atom<boolean>({
+  key: getFullyQualifiedKey('showGetStartedTeachingBubbleState'),
+  default: false,
+});

--- a/Composer/packages/client/src/recoilModel/dispatchers/application.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/application.ts
@@ -18,6 +18,7 @@ import {
   debugPanelActiveTabState,
   userHasNodeInstalledState,
   applicationErrorState,
+  showGetStartedTeachingBubbleState,
 } from '../atoms/appState';
 import { AppUpdaterStatus, CreationFlowStatus, CreationFlowType } from '../../constants';
 import OnboardingState from '../../utils/onboardingStorage';
@@ -153,6 +154,10 @@ export const applicationDispatcher = () => {
     await flushExistingTasks(callbackHelpers);
   });
 
+  const setShowGetStartedTeachingBubble = useRecoilCallback((callbackHelpers: CallbackInterface) => (show: boolean) => {
+    callbackHelpers.set(showGetStartedTeachingBubbleState, show);
+  });
+
   return {
     checkNodeVersion,
     setAppUpdateStatus,
@@ -169,5 +174,6 @@ export const applicationDispatcher = () => {
     setPageElementState,
     setDebugPanelExpansion,
     setActiveTabInDebugPanel,
+    setShowGetStartedTeachingBubble,
   };
 };

--- a/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
@@ -78,6 +78,7 @@ import {
   dispatcherState,
   warnAboutDotNetState,
   warnAboutFunctionsState,
+  showGetStartedTeachingBubbleState,
 } from '../../atoms';
 import * as botstates from '../../atoms/botState';
 import lgWorker from '../../parsers/lgWorker';
@@ -879,9 +880,9 @@ export const postRootBotCreation = async (
     newProfile && dispatcher.setPublishTargets([newProfile], projectId);
   }
   projectIdCache.set(projectId);
-
+  callbackHelpers.set(showGetStartedTeachingBubbleState, true);
   // navigate to the new get started section
-  navigateToBot(callbackHelpers, projectId, undefined, btoa('dialogs#getstarted'));
+  navigateToBot(callbackHelpers, projectId, undefined, btoa('dialogs'));
 };
 
 export const openRootBotAndSkillsByPath = async (callbackHelpers: CallbackInterface, path: string, storageId) => {


### PR DESCRIPTION
## Description

Issue
- Hash routing does not work with multi bot templates due to hash lost in redirects.
- We should use recoil state for things like detecting if panes are open or not

Solution
 -Move teachingbubble render state to recoil and respective calls to manage that new state value         

## Task Item

fixes #7734


