### PR TITLE
chore: Resolve dns-packet to 1.3.4 to fix CVE-2021-23386

### DIFF
--- a/Composer/package.json
+++ b/Composer/package.json
@@ -18,7 +18,8 @@
     "y18n": "^5.0.5",
     "immer": "^8.0.1",
     "url-parse": "^1.5.1",
-    "underscore": "^1.12.1"
+    "underscore": "^1.12.1",
+    "dns-packet": "^1.3.4"
   },
   "engines": {
     "node": ">=12"

--- a/Composer/yarn.lock
+++ b/Composer/yarn.lock
@@ -10363,10 +10363,10 @@ dns-equal@^1.0.0:
   resolved "https://registry.yarnpkg.com/dns-equal/-/dns-equal-1.0.0.tgz#b39e7f1da6eb0a75ba9c17324b34753c47e0654d"
   integrity sha1-s55/HabrCnW6nBcySzR1PEfgZU0=
 
-dns-packet@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-1.3.1.tgz#12aa426981075be500b910eedcd0b47dd7deda5a"
-  integrity sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==
+dns-packet@^1.3.1, dns-packet@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-1.3.4.tgz#e3455065824a2507ba886c55a89963bb107dec6f"
+  integrity sha512-BQ6F4vycLXBvdrJZ6S3gZewt6rcrks9KBgM9vrhW+knGRqc8uEdT7fuCwloc7nny5xNoMJ17HGH0R/6fpo8ECA==
   dependencies:
     ip "^1.1.0"
     safe-buffer "^5.0.1"


### PR DESCRIPTION
## Description

Resolve dns-packet to 1.3.4 to fix CVE-2021-23386

## Task Item

#minor
