### PR TITLE
chore: Upgrade bf-lu to latest dev version

### DIFF
--- a/Composer/packages/lib/indexers/package.json
+++ b/Composer/packages/lib/indexers/package.json
@@ -26,7 +26,7 @@
     "rimraf": "^2.6.3"
   },
   "dependencies": {
-    "@microsoft/bf-lu": "4.14.0-dev.20210408.1a5070e",
+    "@microsoft/bf-lu": "4.14.0-dev.20210602.be805a8",
     "adaptive-expressions": "4.12.0-rc1",
     "botbuilder-lg": "4.12.0-rc1",
     "lodash": "^4.17.19"

--- a/Composer/packages/tools/language-servers/language-understanding/package.json
+++ b/Composer/packages/tools/language-servers/language-understanding/package.json
@@ -21,7 +21,7 @@
     "@bfc/indexers": "*",
     "@bfc/shared": "*",
     "@microsoft/bf-cli-command": "^4.11.1",
-    "@microsoft/bf-lu": "4.14.0-dev.20210408.1a5070e",
+    "@microsoft/bf-lu": "4.14.0-dev.20210602.be805a8",
     "express": "^4.15.2",
     "monaco-languageclient": "^0.10.0",
     "normalize-url": "^2.0.1",

--- a/Composer/yarn.lock
+++ b/Composer/yarn.lock
@@ -4064,28 +4064,6 @@
     semver "^5.5.1"
     tslib "^2.0.3"
 
-"@microsoft/bf-lu@4.14.0-dev.20210408.1a5070e":
-  version "4.14.0-dev.20210408.1a5070e"
-  resolved "https://registry.yarnpkg.com/@microsoft/bf-lu/-/bf-lu-4.14.0-dev.20210408.1a5070e.tgz#fb4b9f0d8e79c4f7f6bd90d3f40c8920250fc7c0"
-  integrity sha512-eqV0xvBAciD9bAgFe9GHK4wt9z/p0ZmhIG46MsyY7bN92N0/TKG+IQy9fxnz/zv9ssqap5gpO+qdOzXEVReg6A==
-  dependencies:
-    "@types/node-fetch" "~2.5.5"
-    antlr4 "~4.8.0"
-    axios "~0.21.1"
-    axios-https-proxy "^0.1.1"
-    chalk "2.4.1"
-    console-stream "^0.1.1"
-    deep-equal "^1.0.1"
-    delay "^4.3.0"
-    fs-extra "^8.1.0"
-    get-stdin "^6.0.0"
-    globby "^10.0.1"
-    intercept-stdout "^0.1.2"
-    lodash "^4.17.19"
-    node-fetch "~2.6.0"
-    semver "^5.5.1"
-    tslib "^2.0.3"
-
 "@microsoft/bf-lu@4.14.0-dev.20210602.be805a8":
   version "4.14.0-dev.20210602.be805a8"
   resolved "https://botbuilder.myget.org/F/botbuilder-declarative/npm/@microsoft/bf-lu/-/@microsoft/bf-lu-4.14.0-dev.20210602.be805a8.tgz#dc35016c5ea1688fa5adf430a969d5c9ce817cc5"
@@ -6722,13 +6700,6 @@ aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
-
-axios-https-proxy@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/axios-https-proxy/-/axios-https-proxy-0.1.1.tgz#929ce6bbd669c940b025e0c7258318a63d66d5c4"
-  integrity sha512-slFaor1FTRhO6V6r2ewuWLBRIF33Lkg+wRmUVJPWRe0JRgBKevBSlgjDInp+AeKGKZjyT7k3l44l67CvEme1Cg==
-  dependencies:
-    https-proxy-agent "^2.2.1"
 
 axios@^0.18.0, axios@^0.21.1, axios@~0.21.1:
   version "0.21.1"


### PR DESCRIPTION
In https://github.com/microsoft/BotFramework-Composer/pull/7399, the bf-lu package was upgraded to dev-20210602 version. 
There are two more places using bf-lu. In this PR, I also upgraded the package version here.

#minor