### PR TITLE
fix: multilang lu editing bug

### DIFF
--- a/Composer/packages/client/src/recoilModel/dispatchers/multilang.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/multilang.ts
@@ -28,12 +28,20 @@ const copyLanguageResources = (files: any[], fromLanguage: string, toLanguages: 
 
   for (const file of copyOriginFiles) {
     for (const toLanguage of toLanguages) {
+      const copiedFile = cloneDeep(file);
       // eslint-disable-next-line security/detect-non-literal-regexp
-      const id = file.id.replace(new RegExp(`${fromLanguage}$`), toLanguage);
-      copiedFiles.push({
-        ...file,
-        id,
+      const idReplacerReg = new RegExp(`${fromLanguage}$`);
+
+      copiedFile.id = file.id.replace(idReplacerReg, toLanguage);
+
+      copiedFile.intents?.forEach((item) => {
+        item.fileId = item.fileId.replace(idReplacerReg, toLanguage);
       });
+      copiedFile.allIntents?.forEach((item) => {
+        item.fileId = item.fileId.replace(idReplacerReg, toLanguage);
+      });
+
+      copiedFiles.push(copiedFile);
     }
   }
 


### PR DESCRIPTION
## Description

luEditor use intent.fileId, it need to be updated when add a language lu file.

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
close #8003 
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
