### PR TITLE
fix: trigger creation LUIS entity labelling

### DIFF
--- a/Composer/packages/client/src/components/TriggerCreationModal/TriggerCreationModal.tsx
+++ b/Composer/packages/client/src/components/TriggerCreationModal/TriggerCreationModal.tsx
@@ -57,6 +57,7 @@ export const TriggerCreationModal: React.FC<TriggerCreationModalProps> = (props)
 
   const [formData, setFormData] = useState(initialFormData);
   const [selectedType, setSelectedType] = useState<string>(SDKKinds.OnIntent);
+  const [localeLuFile, setLocaleLuFile] = useState(luFile);
 
   const onClickSubmitButton = (e) => {
     e.preventDefault();
@@ -82,7 +83,8 @@ export const TriggerCreationModal: React.FC<TriggerCreationModalProps> = (props)
     userSettings,
     projectId,
     dialogId,
-    luFile
+    localeLuFile,
+    setLocaleLuFile
   );
 
   return (

--- a/Composer/packages/client/src/components/TriggerCreationModal/resolveTriggerWidget.tsx
+++ b/Composer/packages/client/src/components/TriggerCreationModal/resolveTriggerWidget.tsx
@@ -1,13 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import React from 'react';
+import React, { useState } from 'react';
 import formatMessage from 'format-message';
 import { Label } from 'office-ui-fabric-react/lib/Label';
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import { PlaceHolderSectionName } from '@bfc/indexers/lib/utils/luUtil';
 import { UserSettings, DialogInfo, SDKKinds, LuFile } from '@bfc/shared';
 import { LuEditor, inlineModePlaceholder } from '@bfc/code-editor';
+import { luUtil } from '@bfc/indexers';
 
 import { TriggerFormData, TriggerFormDataErrors } from '../../utils/dialogUtil';
 import { isRegExRecognizerType, isLUISnQnARecognizerType, isPVARecognizerType } from '../../utils/dialogValidator';
@@ -29,6 +30,8 @@ export function resolveTriggerWidget(
   const isRegEx = isRegExRecognizerType(dialogFile);
   const isLUISnQnA = isLUISnQnARecognizerType(dialogFile) || isPVARecognizerType(dialogFile);
   const showTriggerPhrase = selectedType === SDKKinds.OnIntent && !isRegEx;
+
+  const [localeLuFile, setLocaleLuFile] = useState(luFile);
 
   const onNameChange = (e: React.FormEvent, name: string | undefined) => {
     const errors: TriggerFormDataErrors = {};
@@ -56,6 +59,20 @@ export function resolveTriggerWidget(
       errors.triggerPhrases = '';
     }
     setFormData({ ...formData, triggerPhrases: body, errors: { ...formData.errors, ...errors } });
+
+    if (localeLuFile) {
+      const shadowLuFile = luUtil.updateIntent(
+        localeLuFile,
+        PlaceHolderSectionName,
+        {
+          Name: PlaceHolderSectionName,
+          Body: body,
+        },
+        {}
+      );
+
+      setLocaleLuFile(shadowLuFile);
+    }
   };
 
   const handleEventNameChange = (event: React.FormEvent, value?: string) => {
@@ -101,7 +118,7 @@ export function resolveTriggerWidget(
         editorSettings={userSettings.codeEditor}
         errorMessage={formData.errors.triggerPhrases}
         height={225}
-        luFile={luFile}
+        luFile={localeLuFile}
         luOption={{
           projectId,
           fileId: dialogId,

--- a/Composer/packages/client/src/components/TriggerCreationModal/resolveTriggerWidget.tsx
+++ b/Composer/packages/client/src/components/TriggerCreationModal/resolveTriggerWidget.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import React, { useState } from 'react';
+import React from 'react';
 import formatMessage from 'format-message';
 import { Label } from 'office-ui-fabric-react/lib/Label';
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
@@ -25,13 +25,12 @@ export function resolveTriggerWidget(
   userSettings: UserSettings,
   projectId: string,
   dialogId: string,
-  luFile?: LuFile
+  luFile?: LuFile,
+  setLuFile?: (data: LuFile) => void
 ) {
   const isRegEx = isRegExRecognizerType(dialogFile);
   const isLUISnQnA = isLUISnQnARecognizerType(dialogFile) || isPVARecognizerType(dialogFile);
   const showTriggerPhrase = selectedType === SDKKinds.OnIntent && !isRegEx;
-
-  const [localeLuFile, setLocaleLuFile] = useState(luFile);
 
   const onNameChange = (e: React.FormEvent, name: string | undefined) => {
     const errors: TriggerFormDataErrors = {};
@@ -60,9 +59,9 @@ export function resolveTriggerWidget(
     }
     setFormData({ ...formData, triggerPhrases: body, errors: { ...formData.errors, ...errors } });
 
-    if (localeLuFile) {
+    if (luFile && setLuFile) {
       const shadowLuFile = luUtil.updateIntent(
-        localeLuFile,
+        luFile,
         PlaceHolderSectionName,
         {
           Name: PlaceHolderSectionName,
@@ -70,8 +69,7 @@ export function resolveTriggerWidget(
         },
         {}
       );
-
-      setLocaleLuFile(shadowLuFile);
+      setLuFile(shadowLuFile);
     }
   };
 
@@ -118,7 +116,7 @@ export function resolveTriggerWidget(
         editorSettings={userSettings.codeEditor}
         errorMessage={formData.errors.triggerPhrases}
         height={225}
-        luFile={localeLuFile}
+        luFile={luFile}
         luOption={{
           projectId,
           fileId: dialogId,


### PR DESCRIPTION
## Description

Fix by maintain a shadow lufile appending  created trigger intent, then editor will get the context.

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
close #7517 
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots
![image](https://user-images.githubusercontent.com/49866537/120744976-c3424600-c52e-11eb-94fd-707c0818603d.png)

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
