### PR TITLE
feature: add HaTS stuff to localStorage

### DIFF
--- a/Composer/packages/client/src/recoilModel/atoms/appState.ts
+++ b/Composer/packages/client/src/recoilModel/atoms/appState.ts
@@ -364,3 +364,8 @@ export const warnAboutFunctionsState = atom<boolean>({
   key: getFullyQualifiedKey('warnAboutFunctionsState'),
   default: false,
 });
+
+export const surveyEligibilityState = atom<boolean>({
+  key: getFullyQualifiedKey('surveyEligibilityState'),
+  default: false,
+});

--- a/Composer/packages/client/src/recoilModel/dispatchers/application.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/application.ts
@@ -18,6 +18,7 @@ import {
   debugPanelActiveTabState,
   userHasNodeInstalledState,
   applicationErrorState,
+  surveyEligibilityState,
 } from '../atoms/appState';
 import { AppUpdaterStatus, CreationFlowStatus, CreationFlowType } from '../../constants';
 import OnboardingState from '../../utils/onboardingStorage';
@@ -153,6 +154,10 @@ export const applicationDispatcher = () => {
     await flushExistingTasks(callbackHelpers);
   });
 
+  const setSurveyEligibility = useRecoilCallback(({ set }: CallbackInterface) => (eligible: boolean) => {
+    set(surveyEligibilityState, eligible);
+  });
+
   return {
     checkNodeVersion,
     setAppUpdateStatus,
@@ -169,5 +174,6 @@ export const applicationDispatcher = () => {
     setPageElementState,
     setDebugPanelExpansion,
     setActiveTabInDebugPanel,
+    setSurveyEligibility,
   };
 };


### PR DESCRIPTION
## Description

This addresses the issue of storing things on the client so we know when to display the HaTS survey; it will keep track, in local storage, of the number of unique calendar days that a user uses Composer. If this exceeds 5, it sets a flag in the Recoil store that can be read in a later step (to be written) to see if we should display the survey. Once the survey has been taken, we can use a similar mechanism to store the latest date the survey was taken and make sure we aren't showing the link to a user who's taken it in the last 90 days.

## Task Item

refs #8029

## Screenshots
Not really a UI change, but here are the (currently) two new values in localStorage.
![image](https://user-images.githubusercontent.com/61990921/121436975-5d8ef900-c936-11eb-9722-2c958a2f8386.png)

