### PR TITLE
fix: Provisioning hand-off should use resource name not resource group name

### DIFF
--- a/extensions/samples/assets/shared/scripts/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/extensions/samples/assets/shared/scripts/DeploymentTemplates/template-with-preexisting-rg.json
@@ -3,8 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "name": {
-      "type": "string",
-      "defaultValue": "[resourceGroup().name]"
+      "type": "string"
     },
     "appId": {
       "type": "string",
@@ -36,7 +35,7 @@
     },
     "cosmosDbName": {
       "type": "string",
-      "defaultValue": "[resourceGroup().name]"
+      "defaultValue": "[parameters('name')]"
     },
     "botId": {
       "type": "string",
@@ -57,7 +56,7 @@
     },
     "newAppServicePlanName": {
       "type": "string",
-      "defaultValue": "[resourceGroup().name]",
+      "defaultValue": "[parameters('name')]",
       "metadata": {
         "description": "The name of the new App Service Plan."
       }
@@ -90,14 +89,14 @@
     },
     "newWebAppName": {
       "type": "string",
-      "defaultValue": "[resourceGroup().name]",
+      "defaultValue": "[parameters('name')]",
       "metadata": {
         "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
       }
     },
     "appInsightsName": {
       "type": "string",
-      "defaultValue": "[resourceGroup().name]"
+      "defaultValue": "[parameters('name')]"
     },
     "location": {
       "type": "string",
@@ -113,11 +112,11 @@
     },
     "storageAccountName": {
       "type": "string",
-      "defaultValue": "[resourceGroup().name]"
+      "defaultValue": "[parameters('name')]"
     },
     "luisServiceName": {
       "type": "string",
-      "defaultValue": "[concat(resourceGroup().name, '-luis')]"
+      "defaultValue": "[concat(parameters('name'), '-luis')]"
     },
     "luisServiceAuthoringSku": {
       "type": "string",
@@ -142,7 +141,7 @@
     "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
     "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
     "storageAccountName": "[toLower(take(replace(replace(parameters('storageAccountName'), '-', ''), '_', ''), 24))]",
-    "LuisAuthoringAccountName": "[concat(parameters('luisServiceName'), '-Authoring')]"
+    "LuisAuthoringAccountName": "[concat(parameters('luisServiceName'), '-authoring')]"
   },
   "resources": [
     {
@@ -176,9 +175,7 @@
       "apiVersion": "2015-08-01",
       "location": "[variables('resourcesLocation')]",
       "kind": "app",
-      "dependsOn": [
-        "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
-      ],
+      "dependsOn": ["[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"],
       "name": "[variables('webAppName')]",
       "properties": {
         "name": "[variables('webAppName')]",
@@ -230,9 +227,7 @@
       "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases",
       "apiVersion": "2020-03-01",
       "name": "[concat(variables('cosmosDbAccountName'), '/botstate-db')]",
-      "dependsOn": [
-        "[resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosDbAccountName'))]"
-      ],
+      "dependsOn": ["[resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosDbAccountName'))]"],
       "properties": {
         "resource": {
           "id": "botstate-db"
@@ -267,9 +262,7 @@
             ]
           },
           "partitionKey": {
-            "paths": [
-              "/id"
-            ],
+            "paths": ["/id"],
             "kind": "Hash"
           },
           "conflictResolutionPolicy": {
@@ -301,9 +294,7 @@
         "publishingCredentials": null,
         "storageResourceId": null
       },
-      "dependsOn": [
-        "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
-      ]
+      "dependsOn": ["[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"]
     },
     {
       "comments": "app insights",

--- a/extensions/samples/assets/shared/scripts/provisionComposer.js
+++ b/extensions/samples/assets/shared/scripts/provisionComposer.js
@@ -211,11 +211,10 @@ const getTenantId = async (accessToken) => {
 };
 
 /**
- *
  * @param {*} appId the appId of application registration
  * @param {*} appPwd the app password of application registration
  * @param {*} location the locaiton of all resources
- * @param {*} name the name of resource group
+ * @param {*} name the base name of resources
  * @param {*} shouldCreateAuthoringResource
  * @param {*} shouldCreateLuisResource
  * @param {*} useAppInsights
@@ -236,6 +235,7 @@ const getDeploymentTemplateParam = (
   return {
     appId: pack(appId),
     appSecret: pack(appPwd),
+    name: pack(name),
     appServicePlanLocation: pack(location),
     botId: pack(name),
     shouldCreateAuthoringResource: pack(shouldCreateAuthoringResource),
@@ -638,22 +638,23 @@ const create = async (
     });
 
     const appinsightsClient = new ApplicationInsightsManagementClient(creds, subId);
-    const appComponents = await appinsightsClient.components.get(resourceGroupName, resourceGroupName);
+    const appInsightsName = name;
+    const appComponents = await appinsightsClient.components.get(resourceGroupName, appInsightsName);
     const appinsightsId = appComponents.appId;
     const appinsightsInstrumentationKey = appComponents.instrumentationKey;
     const apiKeyOptions = {
-      name: `${resourceGroupName}-provision-${timeStamp}`,
+      name: appInsightsName,
       linkedReadProperties: [
-        `/subscriptions/${subId}/resourceGroups/${resourceGroupName}/providers/microsoft.insights/components/${resourceGroupName}/api`,
-        `/subscriptions/${subId}/resourceGroups/${resourceGroupName}/providers/microsoft.insights/components/${resourceGroupName}/agentconfig`,
+        `/subscriptions/${subId}/resourceGroups/${resourceGroupName}/providers/microsoft.insights/components/${appInsightsName}/api`,
+        `/subscriptions/${subId}/resourceGroups/${resourceGroupName}/providers/microsoft.insights/components/${appInsightsName}/agentconfig`,
       ],
       linkedWriteProperties: [
-        `/subscriptions/${subId}/resourceGroups/${resourceGroupName}/providers/microsoft.insights/components/${resourceGroupName}/annotations`,
+        `/subscriptions/${subId}/resourceGroups/${resourceGroupName}/providers/microsoft.insights/components/${appInsightsName}/annotations`,
       ],
     };
     const appinsightsApiKeyResponse = await appinsightsClient.aPIKeys.create(
       resourceGroupName,
-      resourceGroupName,
+      appInsightsName,
       apiKeyOptions
     );
     const appinsightsApiKey = appinsightsApiKeyResponse.apiKey;


### PR DESCRIPTION
## Description

Customer reported that provisioning hand-off script defaults many resources to the resource group name.  Updated the script to pass the resource name to the ARM template.  Updated the arm template to default several values to the name parameter rather than defaulting to the resource group name.

## Task Item

fixes #7966

## Screenshots

A set of resources provisioned by Composer
![image](https://user-images.githubusercontent.com/28762486/122071169-6145d400-cdab-11eb-9cfb-c279528527c7.png)

A set of resources provisioned by the hand-off script before the fix
![image](https://user-images.githubusercontent.com/28762486/122071266-74f13a80-cdab-11eb-93f0-e5fb6883b492.png)

A set of resources provisioned by the hand-off script after the fix
![image](https://user-images.githubusercontent.com/28762486/122071367-8c302800-cdab-11eb-915e-93af2fb60ad9.png)


