### PR TITLE
chore: add get started tests

### DIFF
--- a/Composer/packages/client/__tests__/components/getStarted.test.tsx
+++ b/Composer/packages/client/__tests__/components/getStarted.test.tsx
@@ -1,0 +1,268 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { fireEvent } from '@botframework-composer/test-utils';
+import React from 'react';
+
+import { DialogSetting } from '../../../types/lib';
+import { GetStarted } from '../../src/components/GetStarted/GetStarted';
+import { GetStartedLearn } from '../../src/components/GetStarted/GetStartedLearn';
+import {
+  currentProjectIdState,
+  botProjectIdsState,
+  dialogsSelectorFamily,
+  schemasState,
+  projectMetaDataState,
+  botProjectFileState,
+  projectReadmeState,
+  settingsState,
+} from '../../src/recoilModel';
+import { SAMPLE_DIALOG } from '../mocks/sampleDialog';
+import { renderWithRecoil } from '../testUtils';
+
+const projectId = '12345.6789';
+const dialogs = [SAMPLE_DIALOG];
+
+const luisConfig = {
+  name: '',
+  authoringKey: '12345',
+  authoringEndpoint: 'testAuthoringEndpoint',
+  endpointKey: '12345',
+  endpoint: 'testEndpoint',
+  authoringRegion: 'westus',
+  defaultLanguage: 'en-us',
+  environment: 'composer',
+};
+
+const qnaConfig = { subscriptionKey: '12345', endpointKey: '12345', qnaRegion: 'westus' };
+
+const linkToPackageManager = `/bot/${projectId}/plugin/package-manager/package-manager`;
+const linkToConnections = `/bot/${projectId}/botProjectsSettings/#connections`;
+const linkToPublish = `/bot/${projectId}/publish/all`;
+const linkToLUISSettings = `/bot/${projectId}/botProjectsSettings/#luisKey`;
+const linktoQNASettings = `/bot/${projectId}/botProjectsSettings/#qnaKey`;
+const linkToLGEditor = `/bot/${projectId}/language-generation`;
+const linkToLUEditor = `/bot/${projectId}/language-understanding`;
+const linkToReadme = `/bot/${projectId}/botProjectsSettings`;
+
+const mockNavigationTo = jest.fn();
+jest.mock('../../src/utils/navigation', () => ({
+  navigateTo: (...args) => mockNavigationTo(...args),
+}));
+
+const getMockSettingsState = (completePublishProf: boolean): DialogSetting => {
+  const publishTargetConfig = completePublishProf ? '{}' : '{"hostname":""}';
+  return {
+    luis: luisConfig,
+    qna: qnaConfig,
+    defaultLanguage: 'en-us',
+    languages: ['en-us'],
+    luFeatures: {},
+    runtime: {
+      key: '',
+      customRuntime: true,
+      path: '',
+      command: '',
+    },
+    importedLibraries: [],
+    customFunctions: [],
+    publishTargets: [{ name: 'target1', type: 'azurewebapp', configuration: publishTargetConfig }],
+  };
+};
+
+const getStartedProps = {
+  requiresLUIS: true,
+  requiresQNA: true,
+  showTeachingBubble: false,
+  projectId: projectId,
+  isOpen: true,
+  onBotReady: jest.fn(),
+  onDismiss: jest.fn(),
+};
+
+describe('<GetStartedLearn />', () => {
+  function renderComponent() {
+    return renderWithRecoil(<GetStartedLearn projectId="" onDismiss={jest.fn()} />);
+  }
+
+  it('should render the component', async () => {
+    const component = renderComponent();
+    expect(component.container).toHaveTextContent('Get started');
+    expect(component.container).toHaveTextContent('Quick references');
+  });
+});
+
+describe('<GetStarted />', () => {
+  const applyBaseState = (set: any) => {
+    set(currentProjectIdState, projectId);
+    set(botProjectIdsState, [projectId]);
+    set(dialogsSelectorFamily(projectId), dialogs);
+    set(schemasState(projectId), { sdk: { content: {} } });
+    set(projectMetaDataState(projectId), { isRootBot: true });
+    set(botProjectFileState(projectId), { foo: 'bar' });
+  };
+
+  it('should render the component', async () => {
+    const component = renderWithRecoil(<GetStarted {...getStartedProps} />, ({ set }) => {
+      applyBaseState(set);
+    });
+    expect(component.container).toBeDefined();
+  });
+
+  it('should render lg and lu steps (unconditional required steps)', async () => {
+    const component = renderWithRecoil(<GetStarted {...getStartedProps} />, ({ set }) => {
+      applyBaseState(set);
+    });
+    const lgNode = await component.queryByText('Edit bot responses');
+    expect(lgNode).toBeTruthy();
+    const luNode = await component.queryByText('Edit user input and triggers');
+    expect(luNode).toBeTruthy();
+  });
+
+  it('should render packages and insights steps (unconditional optional steps)', async () => {
+    const component = renderWithRecoil(<GetStarted {...getStartedProps} />, ({ set }) => {
+      applyBaseState(set);
+    });
+    const packagesNode = await component.queryByText('Add packages');
+    expect(packagesNode).toBeTruthy();
+    const appInsightsNode = await component.queryByText('Enable App Insights');
+    expect(appInsightsNode).toBeTruthy();
+  });
+
+  it('should render readMe next step', async () => {
+    const component = renderWithRecoil(<GetStarted {...getStartedProps} />, ({ set }) => {
+      applyBaseState(set);
+      set(projectReadmeState(projectId), '## test markdown');
+    });
+    const node = await component.findByText('Review your template readme');
+    expect(node).toBeTruthy();
+  });
+
+  it('should not render readMe next step', async () => {
+    const component = renderWithRecoil(<GetStarted {...getStartedProps} />, ({ set }) => {
+      applyBaseState(set);
+    });
+    const node = await component.queryByText('Review your template readme');
+    expect(node).toBeFalsy();
+  });
+
+  it('should render LUIS and QNA', async () => {
+    const component = renderWithRecoil(<GetStarted {...getStartedProps} />, ({ set }) => {
+      applyBaseState(set);
+    });
+    const luisNode = await component.queryByText('Set up Language Understanding');
+    expect(luisNode).toBeTruthy();
+    const qnaNode = await component.queryByText('Set up QnA Maker');
+    expect(qnaNode).toBeTruthy();
+  });
+
+  it('should not render LUIS and QNA', async () => {
+    const component = renderWithRecoil(
+      <GetStarted {...getStartedProps} requiresLUIS={false} requiresQNA={false} />,
+      ({ set }) => {
+        applyBaseState(set);
+      }
+    );
+    const luisNode = await component.queryByText('Set up Language Understanding');
+    expect(luisNode).toBeNull();
+    const qnaNode = await component.queryByText('Set up QnA Maker');
+    expect(qnaNode).toBeNull();
+  });
+
+  it('should render lu and qna checked', async () => {
+    const component = renderWithRecoil(<GetStarted {...getStartedProps} />, ({ set }) => {
+      applyBaseState(set);
+      set(settingsState(projectId), getMockSettingsState(true));
+    });
+    const checkedQna = await component.queryByTestId('qna-checked');
+    expect(checkedQna).toBeTruthy();
+    const checkedLuis = await component.queryByTestId('luis-checked');
+    expect(checkedLuis).toBeTruthy();
+  });
+
+  it('should render lu and qna unchecked', async () => {
+    const component = renderWithRecoil(<GetStarted {...getStartedProps} />, ({ set }) => {
+      applyBaseState(set);
+    });
+    const unCheckedQna = await component.queryByTestId('qna-unChecked');
+
+    expect(unCheckedQna).toBeTruthy();
+    const unCheckedLuis = await component.queryByTestId('luis-unChecked');
+    expect(unCheckedLuis).toBeTruthy();
+  });
+
+  it('should not render create publish profile step', async () => {
+    const component = renderWithRecoil(<GetStarted {...getStartedProps} />, ({ set }) => {
+      applyBaseState(set);
+      set(settingsState(projectId), getMockSettingsState(true));
+    });
+    const createPublishNode = await component.queryByText('Create a publishing profile');
+
+    expect(createPublishNode).toBeFalsy();
+  });
+
+  it('should render create publish profile step and not complete profile step', async () => {
+    const component = renderWithRecoil(<GetStarted {...getStartedProps} />, ({ set }) => {
+      applyBaseState(set);
+    });
+    const createPublishNode = await component.queryByText('Create a publishing profile');
+    expect(createPublishNode).toBeTruthy();
+    const completePublishNode = await component.queryByText('Complete your publishing profile');
+    expect(completePublishNode).toBeFalsy();
+  });
+  it('should render complete profile step', async () => {
+    const component = renderWithRecoil(<GetStarted {...getStartedProps} />, ({ set }) => {
+      applyBaseState(set);
+      set(settingsState(projectId), getMockSettingsState(false));
+    });
+    const createPublishNode = await component.queryByText('Complete your publishing profile');
+
+    expect(createPublishNode).toBeTruthy();
+  });
+
+  it('should render publish step and add Connections step', async () => {
+    const component = renderWithRecoil(<GetStarted {...getStartedProps} />, ({ set }) => {
+      applyBaseState(set);
+      set(settingsState(projectId), getMockSettingsState(true));
+    });
+    const createPublishNode = await component.queryByText('Publish your bot');
+    expect(createPublishNode).toBeTruthy();
+    const addConnectionsNode = await component.queryByText('Add connections');
+    expect(addConnectionsNode).toBeTruthy();
+  });
+
+  it('Deep links should nave to correct page', async () => {
+    const component = renderWithRecoil(<GetStarted {...getStartedProps} />, ({ set }) => {
+      applyBaseState(set);
+      set(settingsState(projectId), getMockSettingsState(true));
+    });
+    const createPublishNode = await component.queryByText('Publish your bot');
+    expect(createPublishNode).toBeTruthy();
+    const addConnectionsNode = await component.queryByText('Add connections');
+    expect(addConnectionsNode).toBeTruthy();
+  });
+
+  it('should have working deep links', () => {
+    const { getByTestId } = renderWithRecoil(<GetStarted {...getStartedProps} />, ({ set }) => {
+      applyBaseState(set);
+      set(settingsState(projectId), getMockSettingsState(true));
+      set(projectReadmeState(projectId), '## test markdown');
+    });
+    fireEvent.click(getByTestId('readme-unChecked'));
+    expect(mockNavigationTo).toHaveBeenCalledWith(linkToReadme);
+    fireEvent.click(getByTestId('luis-checked'));
+    expect(mockNavigationTo).nthCalledWith(2, linkToLUISSettings);
+    fireEvent.click(getByTestId('qna-checked'));
+    expect(mockNavigationTo).nthCalledWith(3, linktoQNASettings);
+    fireEvent.click(getByTestId('editlg-unChecked'));
+    expect(mockNavigationTo).nthCalledWith(4, linkToLGEditor);
+    fireEvent.click(getByTestId('editlu-unChecked'));
+    expect(mockNavigationTo).nthCalledWith(5, linkToLUEditor);
+    fireEvent.click(getByTestId('publish-unChecked'));
+    expect(mockNavigationTo).nthCalledWith(6, linkToPublish);
+    fireEvent.click(getByTestId('connections-unChecked'));
+    expect(mockNavigationTo).nthCalledWith(7, linkToConnections);
+    fireEvent.click(getByTestId('packages-unChecked'));
+    expect(mockNavigationTo).nthCalledWith(8, linkToPackageManager);
+  });
+});

--- a/Composer/packages/client/src/components/GetStarted/GetStartedLearn.tsx
+++ b/Composer/packages/client/src/components/GetStarted/GetStartedLearn.tsx
@@ -51,7 +51,9 @@ export const GetStartedLearn: React.FC<Props> = ({ projectId, onDismiss }) => {
   return (
     <ScrollablePane styles={{ root: { marginTop: 60 } }}>
       <div css={{ paddingTop: 20, paddingLeft: 27, paddingRight: 20 }}>
-        <h3 css={topH3Style}>{formatMessage('Get started')}</h3>
+        <h3 css={topH3Style} data-testid="getstarted-link-header">
+          {formatMessage('Get started')}
+        </h3>
         <ul style={ulStyle}>
           <li style={liStyle}>
             <Link target="_blank" onClick={onStartProductTourClicked}>
@@ -90,7 +92,9 @@ export const GetStartedLearn: React.FC<Props> = ({ projectId, onDismiss }) => {
           </li>
         </ul>
 
-        <h3 css={h3Style}>{formatMessage('Quick references')}</h3>
+        <h3 css={h3Style} data-testid="reference-link-header">
+          {formatMessage('Quick references')}
+        </h3>
         <ul style={ulStyle}>
           <li style={liStyle}>
             <Link href={linkToAdaptiveExpressions} target="_blank" onClick={linkClick}>

--- a/Composer/packages/client/src/components/GetStarted/GetStartedNextSteps.tsx
+++ b/Composer/packages/client/src/components/GetStarted/GetStartedNextSteps.tsx
@@ -36,22 +36,24 @@ type GetStartedProps = {
 
 export const GetStartedNextSteps: React.FC<GetStartedProps> = (props) => {
   const projectId = useRecoilValue(currentProjectIdState);
-  const botProjects = useRecoilValue(localBotsDataSelector);
-  const botProject = useMemo(() => botProjects.find((b) => b.projectId === projectId), [botProjects, projectId]);
-  const [displayManageLuis, setDisplayManageLuis] = useState<boolean>(false);
-  const [displayManageQNA, setDisplayManageQNA] = useState<boolean>(false);
-  const readme = useRecoilValue(projectReadmeState(projectId));
-  const [readmeHidden, setReadmeHidden] = useState<boolean>(true);
   const schemaDiagnostics = useRecoilValue(schemaDiagnosticsSelectorFamily(projectId));
   const { setSettings, setQnASettings, setShowGetStartedTeachingBubble } = useRecoilValue(dispatcherState);
   const rootBotProjectId = useRecoilValue(rootBotProjectIdSelector) || '';
   const settings = useRecoilValue(settingsState(projectId));
+  const readme = useRecoilValue(projectReadmeState(projectId));
+  const botProjects = useRecoilValue(localBotsDataSelector);
+  const setExpansion = useSetRecoilState(debugPanelExpansionState);
+  const setActiveTab = useSetRecoilState(debugPanelActiveTabState);
+
+  const botProject = useMemo(() => botProjects.find((b) => b.projectId === projectId), [botProjects, projectId]);
+  const [displayManageLuis, setDisplayManageLuis] = useState<boolean>(false);
+  const [displayManageQNA, setDisplayManageQNA] = useState<boolean>(false);
+  const [readmeHidden, setReadmeHidden] = useState<boolean>(true);
+
   const mergedSettings = mergePropertiesManagedByRootBot(projectId, rootBotProjectId, settings);
   const [requiredNextSteps, setRequiredNextSteps] = useState<NextStep[]>([]);
   const [recommendedNextSteps, setRecommendedNextSteps] = useState<NextStep[]>([]);
   const [optionalSteps, setOptionalSteps] = useState<NextStep[]>([]);
-  const setExpansion = useSetRecoilState(debugPanelExpansionState);
-  const setActiveTab = useSetRecoilState(debugPanelActiveTabState);
 
   const [highlightLUIS, setHighlightLUIS] = useState<boolean>(false);
   const [highlightQNA, setHighlightQNA] = useState<boolean>(false);
@@ -362,10 +364,9 @@ export const GetStartedNextSteps: React.FC<GetStartedProps> = (props) => {
     }
     return null;
   };
-
   return (
     <ScrollablePane styles={{ root: { marginTop: 60 } }}>
-      <div css={{ paddingTop: 20, paddingLeft: 27, paddingRight: 20 }}>
+      <div css={{ paddingTop: 20, paddingLeft: 27, paddingRight: 20 }} data-testid="nextSteps-list">
         <ManageLuis
           hidden={!displayManageLuis}
           onDismiss={hideManageLuis}

--- a/Composer/packages/client/src/components/GetStarted/GetStartedTask.tsx
+++ b/Composer/packages/client/src/components/GetStarted/GetStartedTask.tsx
@@ -31,6 +31,7 @@ const stepDescriptionStyle = css`
 
 export const GetStartedTask: React.FC<TaskProps> = (props) => {
   const icon = props.step.checked ? 'CompletedSolid' : props.step.required ? 'Error' : 'Completed';
+  const iconTestId = props.step.checked ? `${props.step.key}-checked` : `${props.step.key}-unChecked`;
   const color = props.step.checked
     ? FluentTheme.palette.green
     : props.step.required
@@ -39,6 +40,7 @@ export const GetStartedTask: React.FC<TaskProps> = (props) => {
   return (
     <div css={getStartedStepStyle(props.step.hideFeatureStep)}>
       <ActionButton
+        data-testid={iconTestId}
         iconProps={{ iconName: icon, id: props.step.key }}
         styles={{
           root: { padding: '0px', display: 'block', fontSize: 16 },


### PR DESCRIPTION
## Description

Developed unit tests for `GettingStarted` component:
  ```<GetStartedLearn />
    √ should render the component (142 ms)
  <GetStarted />
    √ should render the component (333 ms)
    √ should render lg and lu steps (unconditional required steps) (181 ms)
    √ should render packages and insights steps (unconditional optional steps) (159 ms)
    √ should render readMe next step (168 ms)
    √ should not render readMe next step (143 ms)
    √ should render LUIS and QNA (156 ms)
    √ should not render LUIS and QNA (134 ms)
    √ should render lu and qna checked (146 ms)
    √ should render lu and qna unchecked (124 ms)
    √ should not render create publish profile step (180 ms)
    √ should render create publish profile step and not complete profile step (153 ms)
    √ should render complete profile step (152 ms)
    √ should render publish step and add Connections step (132 ms)
    √ Deep links should nave to correct page (187 ms)
    √ should have working deep links (294 ms)
```

## Task Item

fixes #7900


