### PR TITLE
fix: Update the skillHostEndpoint when settings.skill has value

### DIFF
--- a/extensions/azurePublish/src/node/deploy.ts
+++ b/extensions/azurePublish/src/node/deploy.ts
@@ -64,7 +64,9 @@ export class BotProjectDeploy {
       }
 
       // Update skill host endpoint
-      settings.skillHostEndpoint = `https://${hostname}.azurewebsites.net/api/skills`;
+      if (Object.keys(settings?.skill).length > 0) {
+        settings.skillHostEndpoint = `https://${hostname}.azurewebsites.net/api/skills`;
+      }
 
       // STEP 1: CLEAN UP PREVIOUS BUILDS
       // cleanup any previous build

--- a/extensions/azurePublish/src/node/deploy.ts
+++ b/extensions/azurePublish/src/node/deploy.ts
@@ -64,9 +64,7 @@ export class BotProjectDeploy {
       }
 
       // Update skill host endpoint
-      if (settings.skillHostEndpoint) {
-        settings.skillHostEndpoint = `https://${hostname}.azurewebsites.net/api/skills`;
-      }
+      settings.skillHostEndpoint = `https://${hostname}.azurewebsites.net/api/skills`;
 
       // STEP 1: CLEAN UP PREVIOUS BUILDS
       // cleanup any previous build

--- a/extensions/azurePublish/src/node/deploy.ts
+++ b/extensions/azurePublish/src/node/deploy.ts
@@ -64,7 +64,7 @@ export class BotProjectDeploy {
       }
 
       // Update skill host endpoint
-      if (Object.keys(settings?.skill).length > 0) {
+      if (settings?.skill && Object.keys(settings?.skill).length > 0) {
         settings.skillHostEndpoint = `https://${hostname}.azurewebsites.net/api/skills`;
       }
 


### PR DESCRIPTION
## Description

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

Previously, the logic to reset skillHostEndpoint in the publish process is:
- when skillHostEndpoint has value, reset it to https://${hostname}.azurewebsites.net/api/skills
This will cause an issue that when the bot has never been started from local, it will not be set in the publish process. which will cause a runtime error. 


This fix is to Set skillHostEndpoint when settings.skill has value. 

Closes #7856 

## Task Item

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
