### PR TITLE
fix: electron build failed to copy runtime folder

### DIFF
--- a/Composer/packages/electron-server/scripts/copy-artifacts.js
+++ b/Composer/packages/electron-server/scripts/copy-artifacts.js
@@ -26,8 +26,6 @@ const sources = [
     // ignore hostedBots in localPublish extension
     opts: { exclude: [/^node_modules/, /^src/, /^hostedBots/] },
   },
-  // runtimes
-  { source: path.resolve(__dirname, '../../../../runtime'), dest: 'runtime', opts: { exclude: [/^node_modules/] } },
   // form-dialog templates
   {
     source: path.resolve(__dirname, '../../../node_modules/@microsoft/bf-generate-library/templates'),


### PR DESCRIPTION
## Description
![image](https://user-images.githubusercontent.com/39758135/122775247-828f4e80-d2dc-11eb-9265-68d118ee526f.png)

**root cause**
runtime folder has been removed in #7870. But the electron build still copy the runtime folder and will throw error
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
#minor
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
