### PR TITLE
fix: add trigger to the root dialog when adding a new skill

### DIFF
--- a/Composer/packages/client/src/components/AddRemoteSkillModal/CreateSkillModal.tsx
+++ b/Composer/packages/client/src/components/AddRemoteSkillModal/CreateSkillModal.tsx
@@ -23,6 +23,7 @@ import {
   luFilesSelectorFamily,
   publishTypesState,
   botProjectFileState,
+  rootDialogSelector,
 } from '../../recoilModel';
 import { addSkillDialog } from '../../constants';
 import httpClient from '../../utils/httpUtil';
@@ -141,6 +142,7 @@ export const CreateSkillModal: React.FC<CreateSkillModalProps> = (props) => {
     settingsState(projectId)
   );
   const { dialogId } = useRecoilValue(designPageLocationState(projectId));
+  const rootDialog = useRecoilValue(rootDialogSelector(projectId));
   const luFiles = useRecoilValue(luFilesSelectorFamily(projectId));
   const { updateRecognizer, setMicrosoftAppProperties, setPublishTargets } = useRecoilValue(dispatcherState);
   const { content: botProjectFile } = useRecoilValue(botProjectFileState(projectId));
@@ -196,16 +198,22 @@ export const CreateSkillModal: React.FC<CreateSkillModalProps> = (props) => {
     TelemetryClient.track('AddNewSkillCompleted');
     // if added remote skill fail, just not addTrigger to root.
     const skillId = location.href.match(/skill\/([^/]*)/)?.[1];
+
+    //if the root dialog is orchestrator recoginzer type or user chooses orchestrator type before connecting,
+    //add the trigger to the root dialog.
+    const boundId =
+      rootDialog && (rootDialog.luProvider === SDKKinds.OrchestratorRecognizer || enable) ? rootDialog.id : dialogId;
+
     if (skillId) {
       // add trigger with connect to skill action to root bot
       const triggerFormData = getTriggerFormData(skillManifest.name, content);
-      await addTriggerToRoot(dialogId, triggerFormData, skillId);
+      await addTriggerToRoot(boundId, triggerFormData, skillId);
       TelemetryClient.track('AddNewTriggerCompleted', { kind: 'Microsoft.OnIntent' });
     }
 
     if (enable) {
       // update recognizor type to orchestrator
-      await updateRecognizer(projectId, dialogId, SDKKinds.OrchestratorRecognizer);
+      await updateRecognizer(projectId, boundId, SDKKinds.OrchestratorRecognizer);
     }
   };
 

--- a/Composer/packages/client/src/recoilModel/selectors/dialogs.ts
+++ b/Composer/packages/client/src/recoilModel/selectors/dialogs.ts
@@ -6,6 +6,8 @@ import { selectorFamily } from 'recoil';
 
 import { dialogIdsState, dialogState } from '../atoms';
 
+import { dialogsWithLuProviderSelectorFamily } from './validatedDialogs';
+
 export const dialogsSelectorFamily = selectorFamily<DialogInfo[], string>({
   key: 'dialogs',
   get: (projectId: string) => ({ get }) => {
@@ -60,5 +62,14 @@ export const currentDialogState = selectorFamily<DialogInfo | undefined, { proje
     }
 
     return get(dialogsSelectorFamily(projectId))?.[0];
+  },
+});
+
+export const rootDialogSelector = selectorFamily<DialogInfo | undefined, string>({
+  key: 'luFiles',
+  get: (projectId: string) => ({ get }) => {
+    const dialogs = get(dialogsWithLuProviderSelectorFamily(projectId));
+
+    return dialogs.find((d) => d.isRoot);
   },
 });


### PR DESCRIPTION
## Description

**in the PR**
if the root dialog is orchestrator recognizer type or user chooses orchestrator type before connecting the skill, add the trigger to the root dialog.
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
closes #7448
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots
![trigger](https://user-images.githubusercontent.com/39758135/123088636-919b0b80-d458-11eb-9abd-b34412f982c8.gif)

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
