### PR TITLE
fix: Added in-code default bot project file to use for old bots

### DIFF
--- a/Composer/packages/server/src/models/asset/assetManager.ts
+++ b/Composer/packages/server/src/models/asset/assetManager.ts
@@ -23,6 +23,13 @@ import { BotProject } from '../bot/botProject';
 import { templateGeneratorPath } from '../../settings/env';
 import { BackgroundProcessManager } from '../../services/backgroundProcessManager';
 
+const defaultBotProjectFileContent = {
+  $schema:
+    'https://raw.githubusercontent.com/microsoft/BotFramework-Composer/main/Composer/packages/server/schemas/botproject.schema',
+  name: '',
+  skills: {},
+};
+
 export class AssetManager {
   public templateStorage: LocalDiskStorage;
   private _botProjectFileTemplate;
@@ -230,7 +237,7 @@ export class AssetManager {
 
   private getDefaultBotProjectTemplate() {
     if (!ExtensionContext.extensions.botTemplates.length) {
-      return undefined;
+      return defaultBotProjectFileContent;
     }
     const boilerplate = ExtensionContext.extensions.botTemplates[0];
 


### PR DESCRIPTION
## Description

In a recent change #7870, all the existing bot templates that existed in `/extensions/samples/assets/projects` were removed. There was a piece of code inside of `BotProject.init()` that would use the `.botproj` file of the first bot template in that directory as a skeleton to be filled out for old bots that needed to create a project file.

Since there are no longer any bot templates in that directory, this piece of code always returns `undefined` and no `.botproj` file is created for old bots. **This was causing bots imported from PVA to throw an error when being opened because of a missing project file**

This PR takes the old `.botproj` skeleton that was present in the EchoBot sample and puts it into the code to be referenced by old bots.

#minor

