### PR TITLE
fix: Added support for GCC env to PVA publishing

### DIFF
--- a/Composer/packages/server/src/externalContentProvider/powerVirtualAgentsProvider.ts
+++ b/Composer/packages/server/src/externalContentProvider/powerVirtualAgentsProvider.ts
@@ -75,6 +75,12 @@ const getBaseUrl = () => {
       return url;
     }
 
+    case 'gcc': {
+      const url = 'https://gcc.api.powerva.microsoft.us/api/botmanagement/v1';
+      log('GCC env detected, grabbing PVA content from %s', url);
+      return url;
+    }
+
     default: {
       const url = 'https://bots.int.customercareintelligence.net/api/botmanagement/v1';
       log('No env flag detected, grabbing PVA content from %s', url);

--- a/extensions/pvaPublish/src/node/constants.ts
+++ b/extensions/pvaPublish/src/node/constants.ts
@@ -4,6 +4,8 @@
 const COMPOSER_1P_APP_ID = 'ce48853e-0605-4f77-8746-d70ac63cc6bc';
 export const API_VERSION = 'v1';
 
+// TODO: factor this out into one location that the import and publish can both pull from
+// so we don't have to modify in multiple places
 export const AUTH_CREDENTIALS = {
   INT: {
     // web auth flow
@@ -23,10 +25,16 @@ export const AUTH_CREDENTIALS = {
     scopes: ['96ff4394-9197-43aa-b393-6a41652e21f8/.default'],
     targetResource: '96ff4394-9197-43aa-b393-6a41652e21f8',
   },
+  GCC: {
+    clientId: COMPOSER_1P_APP_ID,
+    scopes: ['9315aedd-209b-43b3-b149-2abff6a95d59/.default'],
+    targetResource: '9315aedd-209b-43b3-b149-2abff6a95d59',
+  },
 };
 
 export const BASE_URLS = {
-  INT: `https://bots.int.customercareintelligence.net/`,
-  PPE: `https://bots.ppe.customercareintelligence.net/`,
-  PROD: `https://powerva.microsoft.com/`,
+  INT: 'https://bots.int.customercareintelligence.net/',
+  PPE: 'https://bots.ppe.customercareintelligence.net/',
+  PROD: 'https://powerva.microsoft.com/',
+  GCC: 'https://gcc.api.powerva.microsoft.us/',
 };

--- a/extensions/pvaPublish/src/node/utils.spec.ts
+++ b/extensions/pvaPublish/src/node/utils.spec.ts
@@ -36,6 +36,11 @@ describe('should return the proper PVA base URL for the environment', () => {
     Object.assign(process.env, { COMPOSER_PVA_PUBLISH_ENV: 'PROD' });
     expect(getBaseUrl()).toBe(BASE_URLS.PROD);
   });
+
+  it('gcc', () => {
+    Object.assign(process.env, { COMPOSER_PVA_PUBLISH_ENV: 'GCC' });
+    expect(getBaseUrl()).toBe(BASE_URLS.GCC);
+  });
 });
 
 describe('it should return the proper PVA auth parameters for the base URL', () => {
@@ -60,5 +65,10 @@ describe('it should return the proper PVA auth parameters for the base URL', () 
   it('prod', () => {
     const url = 'https://powerva.microsoft.com/api/botmanagement/v1';
     expect(getAuthCredentials(url)).toEqual(AUTH_CREDENTIALS.PROD);
+  });
+
+  it('gcc', () => {
+    const url = 'https://gcc.api.powerva.microsoft.us/api/botmanagement/v1';
+    expect(getAuthCredentials(url)).toEqual(AUTH_CREDENTIALS.GCC);
   });
 });

--- a/extensions/pvaPublish/src/node/utils.ts
+++ b/extensions/pvaPublish/src/node/utils.ts
@@ -28,6 +28,12 @@ export const getBaseUrl = () => {
       return url;
     }
 
+    case 'gcc': {
+      const url = BASE_URLS.GCC;
+      logger.log('gcc pva publish env detected, operation using PVA url: ', url);
+      return url;
+    }
+
     default: {
       const url = BASE_URLS.PROD;
       logger.log('No pva publish env detected, operation using PVA url: ', url);
@@ -46,9 +52,10 @@ export const getAuthCredentials = (baseUrl = '') => {
 
     if (host === 'bots.int.customercareintelligence.net') {
       return AUTH_CREDENTIALS.INT;
-    }
-    if (host === 'bots.ppe.customercareintelligence.net') {
+    } else if (host === 'bots.ppe.customercareintelligence.net') {
       return AUTH_CREDENTIALS.PPE;
+    } else if (host === 'gcc.api.powerva.microsoft.us') {
+      return AUTH_CREDENTIALS.GCC;
     }
   }
   // fall back to prod


### PR DESCRIPTION
## Description

Follow-up PR to #8169

Forgot to add GCC support to publish as well.

#minor

## Screenshots

![image](https://user-images.githubusercontent.com/3452012/123302322-75878080-d4d1-11eb-8789-21430377c368.png)

![image](https://user-images.githubusercontent.com/3452012/123302888-08281f80-d4d2-11eb-8d78-3762268b9751.png)


Response payload from publish (notice the testUrl):

```
{
  operationId: '1d13b314-1e8d-49c2-bbf1-baf0096624e1',
  startTimeUtc: '2021-06-24T16:43:35.9768906+00:00',
  lastUpdateTimeUtc: '2021-06-24T16:44:04.0133777+00:00',
  diagnostics: [
    {
      code: 'FileIsIgnored',
      range: null,
      severity: 'Warning',
      source: 'fresh-bot-for-composer.botproj',
      message: "File 'fresh-bot-for-composer.botproj' is unknown for the system and was ignored during the import."
    }
  ],
  state: 'Done',
  comment: null,
  importedContentEtag: 'W/"none"',
  testUrl: 'https://gcc.api.powerva.microsoft.us/environments/2d90f6e4-1a37-474e-b573-d0048387debb/bots/37f66313-8c31-4f6c-a84b-6d36151095c1/topics/all'
}
```
