### PR TITLE
feat: use trigger schema to populate $designer.name for new triggers

### DIFF
--- a/Composer/packages/client/src/components/TriggerCreationModal/TriggerCreationModal.tsx
+++ b/Composer/packages/client/src/components/TriggerCreationModal/TriggerCreationModal.tsx
@@ -9,6 +9,7 @@ import { Dialog, DialogType, DialogFooter } from 'office-ui-fabric-react/lib/Dia
 import { PrimaryButton, DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { SDKKinds, RegexRecognizer } from '@bfc/shared';
 import { useRecoilValue } from 'recoil';
+import { useTriggerConfig, TriggerUISchema } from '@bfc/extension-client';
 
 import { TriggerFormData, TriggerFormDataErrors } from '../../utils/dialogUtil';
 import { userSettingsState } from '../../recoilModel/atoms';
@@ -22,6 +23,13 @@ import { resolveTriggerWidget } from './resolveTriggerWidget';
 import { TriggerDropdownGroup } from './TriggerDropdownGroup';
 
 const hasError = (errors: TriggerFormDataErrors) => Object.values(errors).some((msg) => !!msg);
+
+const resolveSchemaLabel = ($kind: string, schema: TriggerUISchema): string | undefined => {
+  const options = schema[$kind];
+  if (options) {
+    return options.label;
+  }
+};
 
 export const initialFormData: TriggerFormData = {
   errors: {},
@@ -43,6 +51,7 @@ interface TriggerCreationModalProps {
 export const TriggerCreationModal: React.FC<TriggerCreationModalProps> = (props) => {
   const { isOpen, onDismiss, onSubmit, dialogId, projectId } = props;
   const dialogs = useRecoilValue(dialogsSelectorFamily(projectId));
+  const triggerUISchema = useTriggerConfig();
 
   const userSettings = useRecoilValue(userSettingsState);
   const dialogFile = dialogs.find((dialog) => dialog.id === dialogId);
@@ -68,7 +77,7 @@ export const TriggerCreationModal: React.FC<TriggerCreationModalProps> = (props)
       return;
     }
     onDismiss();
-    onSubmit(dialogId, { ...formData, $kind: selectedType });
+    onSubmit(dialogId, { ...formData, $kind: selectedType, label: resolveSchemaLabel(selectedType, triggerUISchema) });
     TelemetryClient.track('AddNewTriggerCompleted', { kind: formData.$kind });
   };
 
@@ -106,6 +115,7 @@ export const TriggerCreationModal: React.FC<TriggerCreationModalProps> = (props)
           recognizerType={recognizer$kind}
           setTriggerType={setSelectedType}
           triggerType={selectedType}
+          triggerUISchema={triggerUISchema}
         />
         {triggerWidget}
       </div>

--- a/Composer/packages/client/src/components/TriggerCreationModal/TriggerDropdownGroup.tsx
+++ b/Composer/packages/client/src/components/TriggerCreationModal/TriggerDropdownGroup.tsx
@@ -9,7 +9,7 @@ import { Dropdown } from 'office-ui-fabric-react/lib/Dropdown';
 import { IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import { SDKKinds } from '@bfc/shared';
-import { useTriggerConfig } from '@bfc/extension-client';
+import { TriggerUISchema } from '@bfc/extension-client';
 import formatMessage from 'format-message';
 
 import { dropdownStyles, optionStyles, warningIconStyles } from './styles';
@@ -21,13 +21,18 @@ import {
 } from './TriggerOptionTree';
 import { checkRecognizerCompatibility } from './checkRecognizerCompatibility';
 
-export interface TriggerDropwdownGroupProps {
+export interface TriggerDropdownGroupProps {
   recognizerType: SDKKinds | undefined;
   triggerType: string;
   setTriggerType: (type: string) => void;
+  triggerUISchema: TriggerUISchema;
 }
 
-export const TriggerDropdownGroup: FC<TriggerDropwdownGroupProps> = ({ recognizerType, setTriggerType }) => {
+export const TriggerDropdownGroup: FC<TriggerDropdownGroupProps> = ({
+  recognizerType,
+  setTriggerType,
+  triggerUISchema,
+}) => {
   const renderDropdownOption = useCallback(
     (option?: IDropdownOption) => {
       if (!option) return null;
@@ -42,7 +47,6 @@ export const TriggerDropdownGroup: FC<TriggerDropwdownGroupProps> = ({ recognize
     [recognizerType]
   );
 
-  const triggerUISchema = useTriggerConfig();
   const triggerOptionTree = useMemo(() => {
     return generateTriggerOptionTree(
       triggerUISchema,

--- a/Composer/packages/client/src/utils/__tests__/auth.test.ts
+++ b/Composer/packages/client/src/utils/__tests__/auth.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { isTokenExpired } from '../../src/utils/auth';
+import { isTokenExpired } from '../auth';
 
 // token that expires on Sep 5, 2019 @ 14:00 PDT
 const jwtToken =

--- a/Composer/packages/client/src/utils/__tests__/buildUtil.test.ts
+++ b/Composer/packages/client/src/utils/__tests__/buildUtil.test.ts
@@ -3,7 +3,7 @@
 
 import { DialogInfo, LuFile } from '@bfc/shared';
 
-import { createCrossTrainConfig } from '../../src/utils/buildUtil';
+import { createCrossTrainConfig } from '../buildUtil';
 
 describe('createCrossTrainConfig', () => {
   it('should create crosstrain config', () => {

--- a/Composer/packages/client/src/utils/__tests__/dialogUtil.test.ts
+++ b/Composer/packages/client/src/utils/__tests__/dialogUtil.test.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { DialogInfo } from '@bfc/shared';
+
 import {
   getDialogData,
   setDialogData,
@@ -11,7 +13,7 @@ import {
   deleteTrigger,
   getBreadcrumbLabel,
   getSelected,
-} from '../../src/utils/dialogUtil';
+} from '../dialogUtil';
 
 const dialogsMap = {
   Dialog1: {
@@ -36,7 +38,7 @@ const dialogsMap = {
   },
 };
 
-const dialogs = [
+const dialogs = ([
   {
     content: {
       $kind: 'kind1',
@@ -55,7 +57,7 @@ const dialogs = [
     displayName: 'toBeCleaned',
     id: 'id3',
   },
-];
+] as unknown) as DialogInfo[];
 
 describe('getDialogData', () => {
   it('return empty string if no dialogId', () => {
@@ -143,6 +145,8 @@ describe('generateNewDialog', () => {
       errors: { triggerPhrases: '' },
       event: 'aaaa',
       triggerPhrases: '',
+      intent: '',
+      regEx: '',
     };
     const schema = {};
     const length = dialogs[0].content.triggers.length;
@@ -173,13 +177,13 @@ describe('deleteTrigger', () => {
   it('delete trigger', () => {
     const length = dialogs[0].content.triggers.length;
     const dialogContent = deleteTrigger(dialogs, 'id1', 2);
-    expect(dialogContent.triggers.length).toBe(length - 1);
+    expect(dialogContent?.triggers.length).toBe(length - 1);
   });
 });
 
 describe('getBreadcrumbLabel', () => {
   it('return breadcrumb label', () => {
-    const name = getBreadcrumbLabel(dialogs, 'id1', null, null);
+    const name = getBreadcrumbLabel(dialogs, 'id1', '', '');
     expect(name).toBe('MainDialog');
   });
 });

--- a/Composer/packages/client/src/utils/__tests__/fileUtil.test.ts
+++ b/Composer/packages/client/src/utils/__tests__/fileUtil.test.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { getExtension, getBaseName, upperCaseName, loadLocale, getUniqueName } from '../../src/utils/fileUtil';
-import httpClient from '../../src/utils/httpUtil';
+import { getExtension, getBaseName, upperCaseName, loadLocale, getUniqueName } from '../fileUtil';
+import httpClient from '../httpUtil';
 
 const files = ['a.text', 'a.b.text', 1] as string[];
 

--- a/Composer/packages/client/src/utils/__tests__/luFileStatusStorage.test.ts
+++ b/Composer/packages/client/src/utils/__tests__/luFileStatusStorage.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import luFileStatusStorage from '../../src/utils/luFileStatusStorage';
+import luFileStatusStorage from '../luFileStatusStorage';
 
 const fileIds = ['1', '2', '3', '4'];
 const projectId = '11111.11111111';

--- a/Composer/packages/client/src/utils/__tests__/luUtil.test.ts
+++ b/Composer/packages/client/src/utils/__tests__/luUtil.test.ts
@@ -3,7 +3,7 @@
 
 import { LuFile, DialogInfo, Diagnostic, DiagnosticSeverity } from '@bfc/shared';
 
-import { getReferredLuFiles, checkLuisBuild } from '../../src/utils/luUtil';
+import { getReferredLuFiles, checkLuisBuild } from '../luUtil';
 
 describe('getReferredLuFiles', () => {
   it('returns referred luFiles from dialog', () => {

--- a/Composer/packages/client/src/utils/__tests__/navigation.test.ts
+++ b/Composer/packages/client/src/utils/__tests__/navigation.test.ts
@@ -3,7 +3,7 @@
 
 import { PromptTab } from '@bfc/shared';
 
-import { getUrlSearch, checkUrl, getFocusPath, convertPathToUrl } from './../../src/utils/navigation';
+import { getUrlSearch, checkUrl, getFocusPath, convertPathToUrl } from '../navigation';
 
 const projectId = '123a-sdf123';
 const skillId = '98765.4321';

--- a/Composer/packages/client/src/utils/convertUtils/__tests__/designerPathEncoder.test.ts
+++ b/Composer/packages/client/src/utils/convertUtils/__tests__/designerPathEncoder.test.ts
@@ -3,10 +3,7 @@
 
 import { SDKKinds } from '@bfc/shared';
 
-import {
-  decodeDesignerPathToArrayPath,
-  encodeArrayPathToDesignerPath,
-} from '../../../src/utils/convertUtils/designerPathEncoder';
+import { decodeDesignerPathToArrayPath, encodeArrayPathToDesignerPath } from '../designerPathEncoder';
 
 const dialog = {
   triggers: [

--- a/Composer/packages/client/src/utils/convertUtils/__tests__/parsePathToFocused.test.ts
+++ b/Composer/packages/client/src/utils/convertUtils/__tests__/parsePathToFocused.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License
 
-import { parsePathToFocused } from '../../../src/utils/convertUtils/parsePathToFocused';
+import { parsePathToFocused } from '../parsePathToFocused';
 
 describe('parsePathToFocused', () => {
   it('should return focusedPath', () => {

--- a/Composer/packages/client/src/utils/convertUtils/__tests__/parsePathToSelected.test.ts
+++ b/Composer/packages/client/src/utils/convertUtils/__tests__/parsePathToSelected.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License
 
-import { parsePathToSelected } from '../../../src/utils/convertUtils/parsePathToSelected';
+import { parsePathToSelected } from '../parsePathToSelected';
 
 describe('parsePathToSelected', () => {
   it('should return selected path', () => {

--- a/Composer/packages/client/src/utils/convertUtils/__tests__/parseTypeToFragment.test.ts
+++ b/Composer/packages/client/src/utils/convertUtils/__tests__/parseTypeToFragment.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License
 import { PromptTab } from '@bfc/shared';
 
-import { parseTypeToFragment } from '../../../src/utils/convertUtils/parseTypeToFragment';
+import { parseTypeToFragment } from '../parseTypeToFragment';
 
 describe('parseTypeToFragment', () => {
   it('should return corrent tab name', () => {

--- a/Composer/packages/client/src/utils/dialogUtil.ts
+++ b/Composer/packages/client/src/utils/dialogUtil.ts
@@ -33,6 +33,7 @@ export interface TriggerFormData {
   intent: string;
   triggerPhrases: string;
   regEx: string;
+  label?: string;
 }
 
 export interface TriggerFormDataErrors {
@@ -70,6 +71,11 @@ function generateNewTrigger(data: TriggerFormData, factory: DialogFactory) {
     optionalAttributes.intent = data.intent;
     optionalAttributes.$designer.name = data.intent;
   }
+
+  if (!optionalAttributes.$designer.name && data.label) {
+    optionalAttributes.$designer.name = data.label;
+  }
+
   const newStep = factory.create(data.$kind as SDKKinds, optionalAttributes);
   return newStep;
 }
@@ -234,7 +240,7 @@ export function setDialogData(dialogsMap: DialogsMap, dialogId: string, dataPath
   return set(dialog, dataPath, data);
 }
 
-export function getSelected(focused: string): string {
+export function getSelected(focused?: string): string {
   if (!focused) return '';
   return focused.split('.')[0];
 }

--- a/Composer/packages/integration-tests/cypress/integration/DesignPage.spec.ts
+++ b/Composer/packages/integration-tests/cypress/integration/DesignPage.spec.ts
@@ -123,7 +123,7 @@ context('breadcrumb', () => {
     cy.findByText('Select an activity type').click();
     cy.findByText('Activities (Activity received)').click();
     cy.findByTestId('triggerFormSubmit').click();
-    cy.findAllByText('Activities').should('exist');
+    cy.findAllByText('Activities (Activity received)').should('exist');
   });
 
   it('can find Visual Designer default trigger in container', () => {


### PR DESCRIPTION
## Description

Falls back to the label defined in the trigger ui schema when creating new triggers unless there is a more appropriate name.

## Task Item

closes #7943 

## Screenshots

![image](https://user-images.githubusercontent.com/3619060/123305073-8c7ba200-d4d4-11eb-9e29-68aa589933a9.png)

