### PR TITLE
fix: race condition on finding port while starting all bots

### DIFF
--- a/extensions/localPublish/src/index.ts
+++ b/extensions/localPublish/src/index.ts
@@ -127,6 +127,11 @@ class LocalPublisher implements PublishPlugin<PublishConfig> {
         // Portfinder is the stablest amongst npm libraries for finding ports. https://github.com/http-party/node-portfinder/issues/61. It does not support supplying an array of ports to pick from as we can have a race conidtion when starting multiple bots at the same time. As a result, getting the max port number out of the range and starting the range from the max.
         const maxPort = max(map(LocalPublisher.runningBots, 'port')) ?? 3979;
         port = await portfinder.getPortPromise({ port: maxPort + 1, stopPort: 6000 });
+        const updatedBotData: RunningBot = {
+          ...LocalPublisher.runningBots[botId],
+          port,
+        };
+        LocalPublisher.runningBots[botId] = updatedBotData;
       }
 
       const runtime = this.composer.getRuntimeByProject(project);

--- a/extensions/localPublish/src/index.ts
+++ b/extensions/localPublish/src/index.ts
@@ -136,9 +136,12 @@ class LocalPublisher implements PublishPlugin<PublishConfig> {
       if (!port) {
         // Portfinder is the stablest amongst npm libraries for finding ports. https://github.com/http-party/node-portfinder/issues/61. It does not support supplying an array of ports to pick from as we can have a race conidtion when starting multiple bots at the same time. As a result, getting the max port number out of the range and starting the range from the max.
         const maxPort = max(map(LocalPublisher.runningBots, 'port')) ?? 3979;
+        const retry = 10;
+        let i = 0;
         do {
           port = await portfinder.getPortPromise({ port: maxPort + 1, stopPort: 6000 });
-        } while (this.isPortUsed(port));
+          i++;
+        } while (this.isPortUsed(port) && i < retry);
 
         const updatedBotData: RunningBot = {
           ...LocalPublisher.runningBots[botId],


### PR DESCRIPTION
## Description
should set running bots' port to avoid the conflict during finding a port for each request.
## Task Item
Closes #7765

## Screenshots
![test](https://user-images.githubusercontent.com/24380525/123754052-0b197a80-d8ed-11eb-800e-42b69186eb31.gif)

