### PR TITLE
fix: Quotes in node spawn arguments make the runtime fail

### DIFF
--- a/extensions/localPublish/src/index.ts
+++ b/extensions/localPublish/src/index.ts
@@ -281,7 +281,7 @@ class LocalPublisher implements PublishPlugin<PublishConfig> {
           cwd: botDir,
           stdio: ['ignore', 'pipe', 'pipe'],
           detached: !isWin, // detach in non-windows
-          shell: isWin, // run in a shell on windows so `npm start` doesn't need to be `npm.cmd start`
+          shell: true, // run in a shell on windows so `npm start` doesn't need to be `npm.cmd start`
         });
         this.composer.log('Started process %d', spawnProcess.pid);
         this.setBotStatus(botId, {


### PR DESCRIPTION
## Description
**root cause**
The system shell will strip off quotes around parameters, so the program gets the unquoted value at the end. Spawning a process bypasses this step as it bypasses the shell, so the program gets those literal quotes as part of the parameter and doesn't know how to handle them appropriately.

**fix**
use { shell: true }. This will pass the spawn request through the shell

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
fixes #8205 
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
