### PR TITLE
Added getResourceConfigs

### DIFF
--- a/extensions/azurePublishNew/src/node/__tests__/provisioning.test.ts
+++ b/extensions/azurePublishNew/src/node/__tests__/provisioning.test.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { getResourceConfigs, ProvisionConfig2, ResourceGroupResourceConfig2 } from '../provisioning';
+
+describe('provisioning', () => {
+  describe('getResourceConfigs', () => {
+    it('returns resourceGroup when no other resource', () => {
+      const config: ProvisionConfig2 = {
+        accessToken: '',
+        graphToken: '',
+        externalResources: [],
+        hostname: '',
+        location: '',
+        luisLocation: '',
+        name: '',
+        resourceGroup: 'resourceGroup',
+        subscription: '',
+        type: '',
+        appServiceOperatingSystem: '',
+      };
+
+      const actual = getResourceConfigs(config);
+
+      expect(actual).toBeDefined();
+      expect(actual.length).toEqual(1);
+      expect(actual[0].key).toEqual('resourceGroup');
+      expect((actual[0] as ResourceGroupResourceConfig2).name).toEqual('resourceGroup');
+    });
+  });
+});

--- a/extensions/azurePublishNew/src/node/__tests__/provisioning.test.ts
+++ b/extensions/azurePublishNew/src/node/__tests__/provisioning.test.ts
@@ -1,31 +1,244 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { getResourceConfigs, ProvisionConfig2, ResourceGroupResourceConfig2 } from '../provisioning';
+import { getResourceConfigs, ProvisionConfig2 } from '../provisioning';
+
+const testConfig: ProvisionConfig2 = {
+  accessToken: 'test-accessToken',
+  graphToken: 'test-graphToken',
+  externalResources: [],
+  hostname: 'test-hostname',
+  location: 'test-location',
+  luisLocation: 'test-luisLocation',
+  name: 'test-name',
+  resourceGroup: 'test-resourceGroup',
+  subscription: 'test-subscription',
+  type: 'test-type',
+  appServiceOperatingSystem: 'test-operatingSystem',
+  workerRuntime: 'test-workerRuntime',
+};
+
+const expectedTestResources = {
+  applicationInsights: {
+    key: 'applicationInsights',
+    hostname: testConfig.hostname,
+    location: testConfig.location,
+  },
+  appRegistration: {
+    key: 'appRegistration',
+    hostname: testConfig.hostname,
+  },
+  azureFunctions: {
+    key: 'azureFunctions',
+    location: testConfig.location,
+    name: testConfig.hostname,
+    workerRuntime: testConfig.workerRuntime,
+    operatingSystem: testConfig.appServiceOperatingSystem,
+  },
+  blobStorage: {
+    key: 'blobStorage',
+    containerName: 'transcripts',
+    hostname: testConfig.hostname,
+    location: testConfig.location,
+  },
+  botRegistration: {
+    key: 'botRegistration',
+    hostname: testConfig.hostname,
+    location: testConfig.location,
+  },
+  cosmosDb: {
+    key: 'cosmosDb',
+    containerName: 'botstate-container',
+    databaseName: 'botstate-db',
+    hostname: testConfig.hostname,
+    location: testConfig.location,
+  },
+  luisAuthoring: {
+    key: 'luisAuthoring',
+    hostname: testConfig.hostname,
+    location: testConfig.location,
+  },
+  luisPrediction: {
+    key: 'luisPrediction',
+    hostname: testConfig.hostname,
+    location: testConfig.location,
+  },
+  qna: {
+    key: 'qna',
+    hostname: testConfig.hostname,
+    location: testConfig.location,
+  },
+  resourceGroup: {
+    key: 'resourceGroup',
+    name: testConfig.resourceGroup,
+  },
+  servicePlan: {
+    key: 'servicePlan',
+    name: testConfig.hostname,
+    location: testConfig.location,
+    operatingSystem: testConfig.appServiceOperatingSystem,
+  },
+  webApp: {
+    key: 'webApp',
+    hostname: testConfig.hostname,
+    location: testConfig.location,
+    operatingSystem: testConfig.appServiceOperatingSystem,
+  },
+};
 
 describe('provisioning', () => {
   describe('getResourceConfigs', () => {
-    it('returns resourceGroup when no other resource', () => {
-      const config: ProvisionConfig2 = {
-        accessToken: '',
-        graphToken: '',
+    it.each([
+      {
         externalResources: [],
-        hostname: '',
-        location: '',
-        luisLocation: '',
-        name: '',
-        resourceGroup: 'resourceGroup',
-        subscription: '',
-        type: '',
-        appServiceOperatingSystem: '',
+        expected: [expectedTestResources.resourceGroup],
+      },
+      {
+        externalResources: [{ key: 'applicationInsights' }],
+        expected: [
+          expectedTestResources.resourceGroup,
+          expectedTestResources.servicePlan,
+          expectedTestResources.webApp,
+          expectedTestResources.appRegistration,
+          expectedTestResources.botRegistration,
+          expectedTestResources.applicationInsights,
+        ],
+      },
+      {
+        externalResources: [{ key: 'appRegistration' }],
+        expected: [expectedTestResources.resourceGroup, expectedTestResources.appRegistration],
+      },
+      {
+        externalResources: [{ key: 'azureFunctions' }],
+        expected: [
+          expectedTestResources.resourceGroup,
+          expectedTestResources.appRegistration,
+          expectedTestResources.azureFunctions,
+        ],
+      },
+      {
+        externalResources: [{ key: 'blobStorage' }],
+        expected: [expectedTestResources.resourceGroup, expectedTestResources.blobStorage],
+      },
+      {
+        externalResources: [{ key: 'botRegistration' }],
+        expected: [
+          expectedTestResources.resourceGroup,
+          expectedTestResources.servicePlan,
+          expectedTestResources.webApp,
+          expectedTestResources.appRegistration,
+          expectedTestResources.botRegistration,
+        ],
+      },
+      {
+        externalResources: [{ key: 'cosmosDb' }],
+        expected: [expectedTestResources.resourceGroup, expectedTestResources.cosmosDb],
+      },
+      {
+        externalResources: [{ key: 'luisAuthoring' }],
+        expected: [expectedTestResources.resourceGroup, expectedTestResources.luisAuthoring],
+      },
+      {
+        externalResources: [{ key: 'luisPrediction' }],
+        expected: [expectedTestResources.resourceGroup, expectedTestResources.luisPrediction],
+      },
+      {
+        externalResources: [{ key: 'qna' }],
+        expected: [expectedTestResources.resourceGroup, expectedTestResources.qna],
+      },
+      {
+        externalResources: [{ key: 'servicePlan' }],
+        expected: [expectedTestResources.resourceGroup, expectedTestResources.servicePlan],
+      },
+      {
+        externalResources: [{ key: 'webApp' }],
+        expected: [
+          expectedTestResources.resourceGroup,
+          expectedTestResources.servicePlan,
+          expectedTestResources.webApp,
+        ],
+      },
+      {
+        externalResources: [
+          { key: 'applicationInsights' },
+          { key: 'appRegistration' },
+          { key: 'blobStorage' },
+          { key: 'botRegistration' },
+          { key: 'cosmosDb' },
+          { key: 'luisAuthoring' },
+          { key: 'luisPrediction' },
+          { key: 'qna' },
+          { key: 'servicePlan' },
+          { key: 'webApp' },
+        ],
+        expected: [
+          expectedTestResources.resourceGroup,
+          expectedTestResources.qna,
+          expectedTestResources.luisPrediction,
+          expectedTestResources.luisAuthoring,
+          expectedTestResources.cosmosDb,
+          expectedTestResources.blobStorage,
+          expectedTestResources.servicePlan,
+          expectedTestResources.webApp,
+          expectedTestResources.appRegistration,
+          expectedTestResources.botRegistration,
+          expectedTestResources.applicationInsights,
+        ],
+      },
+      {
+        externalResources: [
+          { key: 'applicationInsights' },
+          { key: 'appRegistration' },
+          { key: 'blobStorage' },
+          { key: 'botRegistration' },
+          { key: 'cosmosDb' },
+          { key: 'luisAuthoring' },
+          { key: 'luisPrediction' },
+          { key: 'qna' },
+          { key: 'azureFunctions' },
+        ],
+        expected: [
+          expectedTestResources.resourceGroup,
+          expectedTestResources.qna,
+          expectedTestResources.luisPrediction,
+          expectedTestResources.luisAuthoring,
+          expectedTestResources.cosmosDb,
+          expectedTestResources.blobStorage,
+          expectedTestResources.appRegistration,
+          expectedTestResources.azureFunctions,
+          expectedTestResources.botRegistration,
+          expectedTestResources.applicationInsights,
+        ],
+      },
+    ])('returns correct resources %#', ({ externalResources, expected }) => {
+      const config: ProvisionConfig2 = {
+        ...testConfig,
+        externalResources,
       };
 
       const actual = getResourceConfigs(config);
 
       expect(actual).toBeDefined();
-      expect(actual.length).toEqual(1);
-      expect(actual[0].key).toEqual('resourceGroup');
-      expect((actual[0] as ResourceGroupResourceConfig2).name).toEqual('resourceGroup');
+      expect(actual.length).toEqual(expected.length);
+      expect(actual).toStrictEqual(expected);
     });
+  });
+
+  it('throw if both web app and azure function requested', () => {
+    const config: ProvisionConfig2 = {
+      ...testConfig,
+      externalResources: [{ key: 'webApp' }, { key: 'azureFunctions' }],
+    };
+
+    expect(() => getResourceConfigs(config)).toThrow();
+  });
+
+  it('throw if unknown resource key requested', () => {
+    const config: ProvisionConfig2 = {
+      ...testConfig,
+      externalResources: [{ key: 'invalidResource' }],
+    };
+
+    expect(() => getResourceConfigs(config)).toThrow();
   });
 });

--- a/extensions/azurePublishNew/src/node/provisioning.ts
+++ b/extensions/azurePublishNew/src/node/provisioning.ts
@@ -1,0 +1,267 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import toposort from 'toposort';
+import { ResourceConfig } from './types';
+
+// --------------------------------------------------------------------------------
+// In this section are things that need to be moved and have overlaps resolved.
+// --------------------------------------------------------------------------------
+
+// This is what we have to remain compatible with
+export type ProvisionConfig2 = {
+  accessToken: string;
+  graphToken: string;
+  tenantId?: string;
+  hostname: string; // for previous bot, it's ${name}-${environment}
+  externalResources: { key: string }[];
+  location: string;
+  luisLocation: string;
+  appServiceOperatingSystem?: string;
+  subscription: string;
+  resourceGroup?: string;
+  logger?: (string) => any;
+  name: string; // profile name
+  type: string; // webapp or function
+  /**
+   * The worker runtime language for Azure functions.
+   * Currently documented values: dotnet, node, java, python, or powershell
+   */
+  workerRuntime?: string;
+  choice?: string;
+  [key: string]: any;
+};
+
+export type AppInsightsResourceConfig2 = ResourceConfig & {
+  key: 'applicationInsights';
+  hostname: string;
+  location?: string;
+};
+
+export type AppRegistrationResourceConfig2 = ResourceConfig & {
+  key: 'appRegistration';
+  hostname: string;
+};
+
+export type AzureFunctionResourceConfig2 = ResourceConfig & {
+  key: 'azureFunctions';
+  location?: string;
+  name: string;
+  operatingSystem: string;
+  workerRuntime: string;
+};
+
+export type BlobStorageResourceConfig2 = ResourceConfig & {
+  key: 'blobStorage';
+  containerName: string;
+  hostname: string;
+  location?: string;
+};
+
+export type BotRegistrationResourceConfig2 = ResourceConfig & {
+  key: 'botRegistration';
+  displayName: string;
+  hostname: string;
+  location?: string;
+};
+
+export type CosmosDbResourceConfig2 = ResourceConfig & {
+  key: 'cosmosDb';
+  containerName: string;
+  databaseName: string;
+  hostname: string;
+  location?: string;
+};
+
+export type LuisAuthoringResourceConfig2 = ResourceConfig & {
+  key: 'luisAuthoring';
+  hostname: string;
+  location?: string;
+};
+
+export type LuisPredictionResourceConfig2 = ResourceConfig & {
+  key: 'luisPrediction';
+  hostname: string;
+  location?: string;
+};
+
+export type QnAResourceConfig2 = ResourceConfig & {
+  key: 'qna';
+  hostname: string;
+  location?: string;
+};
+
+export type ResourceGroupResourceConfig2 = ResourceConfig & {
+  key: 'resourceGroup';
+  name: string;
+};
+
+export type ServicePlanResourceConfig2 = ResourceConfig & {
+  key: 'servicePlan';
+  location?: string;
+  name: string;
+  operatingSystem: string;
+};
+
+export type WebAppResourceConfig2 = ResourceConfig & {
+  key: 'webApp';
+  hostname: string;
+  location?: string;
+  operatingSystem: string;
+};
+
+// TODO: These need to be put in the resource definitions rather than the services
+const getResourceDependencies = (key: string) => {
+  switch (key) {
+    case 'applicationInsights':
+      return ['botRegistration'];
+    case 'appRegistration':
+      return ['resourceGroup'];
+    case 'azureFunctions':
+      return ['appRegistration', 'resourceGroup'];
+    case 'blobStorage':
+      return ['resourceGroup'];
+    case 'botRegistration':
+      return ['appRegistration', 'resourceGroup', 'webApp'];
+    case 'cosmosDb':
+      return ['resourceGroup'];
+    case 'luisAuthoring':
+      return ['resourceGroup'];
+    case 'luisPrediction':
+      return ['resourceGroup'];
+    case 'qna':
+      return ['resourceGroup'];
+    case 'servicePlan':
+      return ['resourceGroup'];
+    case 'webApp':
+      return ['resourceGroup', 'servicePlan'];
+    case 'resourceGroup':
+    default:
+      return [];
+  }
+};
+
+// --------------------------------------------------------------------------------
+// End of section
+// --------------------------------------------------------------------------------
+
+/**
+ * Given a provisioning config this returns an ordered list of resource configurations.
+ */
+export const getResourceConfigs = (config: ProvisionConfig2): ResourceConfig[] => {
+  const resources: ResourceConfig[] = [];
+
+  const resourceKeys = config.externalResources.map((r) => r.key).concat('resourceGroup');
+
+  console.log(resourceKeys);
+
+  var dependencies: ReadonlyArray<[string, string | undefined]> = resourceKeys.reduce((result, key) => {
+    const deps = getResourceDependencies(key);
+    deps.length > 0 ? deps.forEach((d) => result.push([key, d])) : result.push([key, undefined]);
+    return result;
+  }, []);
+
+  console.log(dependencies);
+
+  const order = toposort(dependencies).filter(Boolean);
+
+  console.log(order);
+
+  order.forEach((key) => {
+    switch (key) {
+      case 'applicationInsights':
+        resources.push({
+          key,
+          location: config.location,
+          hostname: config.hostname,
+        } as AppInsightsResourceConfig2);
+        break;
+      case 'appRegistration':
+        resources.push({
+          key,
+          hostname: config.hostname,
+        } as AppRegistrationResourceConfig2);
+        break;
+      case 'azureFunctions':
+        resources.push({
+          location: config.location,
+          name: config.hostname,
+          workerRuntime: config.workerRuntime,
+          operatingSystem: config.appServiceOperatingSystem,
+        } as AzureFunctionResourceConfig2);
+        break;
+      case 'blobStorage':
+        resources.push({
+          key,
+          containerName: 'transcripts',
+          hostname: config.hostname,
+          location: config.location,
+        } as BlobStorageResourceConfig2);
+        break;
+      case 'botRegistration':
+        resources.push({
+          key,
+          location: config.location,
+          hostname: config.hostname,
+          displayName: config.hostname,
+        } as BotRegistrationResourceConfig2);
+        break;
+      case 'cosmosDb':
+        resources.push({
+          key,
+          containerName: 'botstate-container',
+          databaseName: 'botstate-db',
+          hostname: config.hostname,
+          location: config.location,
+        } as CosmosDbResourceConfig2);
+        break;
+      case 'luisAuthoring':
+        resources.push({
+          key,
+          hostname: config.hostname,
+          location: config.location,
+        } as LuisAuthoringResourceConfig2);
+        break;
+      case 'luisPrediction':
+        resources.push({
+          key,
+          hostname: config.hostname,
+          location: config.location,
+        } as LuisPredictionResourceConfig2);
+        break;
+      case 'qna':
+        resources.push({
+          key,
+          hostname: config.hostname,
+          location: config.location,
+        } as QnAResourceConfig2);
+        break;
+      case 'resourceGroup':
+        resources.push({
+          key: 'resourceGroup',
+          name: config.resourceGroup ?? config.hostname,
+        } as ResourceGroupResourceConfig2);
+        break;
+      case 'servicePlan':
+        resources.push({
+          key,
+          name: config.hostname,
+          location: config.location,
+          operatingSystem: config.appServiceOperatingSystem,
+        } as ServicePlanResourceConfig2);
+        break;
+      case 'webApp':
+        resources.push({
+          key,
+          hostname: config.hostname,
+          location: config.location,
+          operatingSystem: config.appServiceOperatingSystem,
+        } as WebAppResourceConfig2);
+        break;
+      default:
+        break;
+    }
+  });
+
+  return resources;
+};

--- a/extensions/azurePublishNew/yarn.lock
+++ b/extensions/azurePublishNew/yarn.lock
@@ -2352,6 +2352,11 @@
   dependencies:
     "@types/react-test-renderer" "*"
 
+"@types/toposort@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/toposort/-/toposort-2.0.3.tgz#dc490842b77c3e910c8d727ff0bdb2fb124cb41b"
+  integrity sha512-jRtyvEu0Na/sy0oIxBW0f6wPQjidgVqlmCTJVHEGTNEUdL1f0YSvdPzHY7nX7MUWAZS6zcAa0KkqofHjy/xDZQ==
+
 "@types/tough-cookie@*":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.0.tgz#fef1904e4668b6e5ecee60c52cc6a078ffa6697d"
@@ -8484,6 +8489,11 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
+
+toposort@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
+  integrity sha1-riF2gXXRVZ1IvvNUILL0li8JwzA=
 
 tough-cookie@^2.3.3, tough-cookie@^2.4.3, tough-cookie@~2.5.0:
   version "2.5.0"


### PR DESCRIPTION
## Description

This adds a getResourceConfigs method.  
- given the incoming ProvisionConfig (from the UI) it returns the set of sequenced ResourceConfig instances for provisioning
- uses a topographical sort to order by dependency
- each ResourceConfig instance is keyed and populated based on the existing provision.ts in the old extension
- a ResourceGroupResourceConfig has been added to handle the required resource group provisioning.

NOTE: Natalie and I discussed and she will extract the types and methods from this draft PR into her work and check-in.  We can then delete this draft.

## Task Item

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
