### PR TITLE
chore: orchestrator-core changed to @microsoft/orchestrator-core

### DIFF
--- a/Composer/packages/electron-server/electron-builder-config.json
+++ b/Composer/packages/electron-server/electron-builder-config.json
@@ -15,15 +15,10 @@
     "build/templates",
     "resources/composerIcon_1024x1024.png",
     "resources/ms_logo.svg",
-    "**/node_modules/orchestrator-core/**/*",
+    "**/node_modules/@microsoft/orchestrator-core/**/*",
     "**/node_modules/@bfc/server-workers/**/*"
   ],
-  "files": [
-    "build",
-    "locales",
-    "resources/composerIcon_1024x1024.png",
-    "resources/ms_logo.svg"
-  ],
+  "files": ["build", "locales", "resources/composerIcon_1024x1024.png", "resources/ms_logo.svg"],
   "extraResources": [
     {
       "from": "resources/app-update.yml",
@@ -34,19 +29,14 @@
     {
       "name": "Bot Framework Composer",
       "role": "Viewer",
-      "schemes": [
-        "bfcomposer"
-      ]
+      "schemes": ["bfcomposer"]
     }
   ],
   "win": {
     "target": [
       {
         "target": "nsis",
-        "arch": [
-          "ia32",
-          "x64"
-        ]
+        "arch": ["ia32", "x64"]
       }
     ],
     "icon": "resources/composerIcon.ico",
@@ -75,9 +65,7 @@
     "target": [
       {
         "target": "AppImage",
-        "arch": [
-          "x64"
-        ]
+        "arch": ["x64"]
       }
     ]
   },
@@ -88,9 +76,7 @@
     "target": [
       {
         "target": "dmg",
-        "arch": [
-          "x64"
-        ]
+        "arch": ["x64"]
       }
     ]
   },


### PR DESCRIPTION
## Description
`orchestrator-core` changed to `@microsoft/orchestrator-core` for 4.14, the electron-builder config is updated to reflect this so that the mac/linux electron builds can start. Windows build does not have problems even without this fix because for some reason electron-builder's binary detection only works correctly in Windows for this lib.  

manual nightly build with this change here for verification: <https://fuselabs.visualstudio.com/Composer/_build/results?buildId=255945&view=results>

#minor