### PR TITLE
fix: If/else conditions causes warning/error

### DIFF
--- a/Composer/packages/lib/indexers/__tests__/validations/expressionValidation.test.ts
+++ b/Composer/packages/lib/indexers/__tests__/validations/expressionValidation.test.ts
@@ -3,7 +3,7 @@
 import { LgFile } from '@bfc/shared';
 import { ReturnType } from 'adaptive-expressions';
 
-import { validate } from '../../src/validations/expressionValidation/validation';
+import { checkExpression, filterCustomFunctionError } from '../../src/validations/expressionValidation/validation';
 
 import { searchLgCustomFunction } from './../../src/validations/expressionValidation/index';
 
@@ -30,42 +30,43 @@ describe('search lg custom function', () => {
 
 describe('validate expression', () => {
   it('if string expression do nothing', () => {
-    const expression = { value: 'hello', required: false, path: 'test', types: [ReturnType.String] };
-    const result = validate(expression, []);
-    expect(result).toBeNull();
+    const result = checkExpression('hello', true, [ReturnType.String]);
+    expect(result).toBe(ReturnType.String);
   });
 
   it('if start with =, but type is not match', () => {
-    const expression = { value: '=13', required: false, path: 'test', types: [ReturnType.String] };
-    const result = validate(expression, []);
-    expect(result?.message).toBe('the return type does not match');
+    const result = checkExpression('=13', true, [ReturnType.String]);
+    expect(result).toBe(ReturnType.Number);
   });
 
   it('if start with =, and type is match', () => {
-    const expression = { value: '=13', required: false, path: 'test', types: [ReturnType.Number] };
-    const result = validate(expression, []);
-    expect(result).toBeNull();
-    expression.value = '=true';
-    expression.types[0] = 1;
-    const result1 = validate(expression, []);
-    expect(result1).toBeNull();
+    const result = checkExpression('=13', true, [ReturnType.Number]);
+    expect(result).toBe(ReturnType.Number);
+    const result1 = checkExpression('=true', true, [ReturnType.Boolean]);
+    expect(result1).toBe(ReturnType.Boolean);
   });
 
   it('use custom functions will not throw error', () => {
-    const expression = { value: '=foo.bar()', required: false, path: 'test', types: [ReturnType.Boolean] };
-    const result = validate(expression, []);
-    expect(result).toBeNull();
+    try {
+      checkExpression('=foo.bar()', true, [ReturnType.Boolean]);
+    } catch (error) {
+      expect(error.message).toBe(
+        "foo.bar does not have an evaluator, it's not a built-in function or a custom function."
+      );
+    }
   });
 
   it('use custom functions, and lg file does export', () => {
-    const expression = { value: '=foo.bar()', required: false, path: 'test', types: [ReturnType.Boolean] };
-    const result = validate(expression, ['foo.bar']);
-    expect(result).toBeNull();
+    try {
+      checkExpression('=foo.bar()', true, [ReturnType.Boolean]);
+    } catch (error) {
+      const message = filterCustomFunctionError(error.message, ['foo.bar']);
+      expect(message).toBe('');
+    }
   });
 
   it('built-in function return type', () => {
-    const expression = { value: "=concat('test', '1')", required: false, path: 'test', types: [ReturnType.String] };
-    const result = validate(expression, []);
-    expect(result).toBeNull();
+    const result = checkExpression("=concat('test', '1')", true, [ReturnType.String]);
+    expect(result).toBe(24);
   });
 });

--- a/Composer/packages/lib/indexers/src/validations/expressionValidation/index.ts
+++ b/Composer/packages/lib/indexers/src/validations/expressionValidation/index.ts
@@ -57,7 +57,7 @@ export const validateExpressions: ValidateFunc = (
     }
 
     if (errorMessage) diagnostics.push(new Diagnostic(errorMessage, '', DiagnosticSeverity.Error, path));
-    if (warningMessage) diagnostics.push(new Diagnostic(errorMessage, '', DiagnosticSeverity.Warning, path));
+    if (warningMessage) diagnostics.push(new Diagnostic(warningMessage, '', DiagnosticSeverity.Warning, path));
 
     return diagnostics;
   }, []);

--- a/Composer/packages/lib/indexers/src/validations/expressionValidation/validation.ts
+++ b/Composer/packages/lib/indexers/src/validations/expressionValidation/validation.ts
@@ -22,13 +22,13 @@ export const addReturnType = (currentType: number, newType: number) => {
 
 export const checkStringExpression = (exp: string, isStringType: boolean): number => {
   const origin = exp.trim();
-
+  const containsEqual = origin.startsWith('=');
   //no need to do parse if the string expression doesn't start with '='
-  if (!origin.startsWith('=') && isStringType) {
+  if (!containsEqual && isStringType) {
     return ReturnType.String;
   }
 
-  return Expression.parse(origin.substring(1)).returnType;
+  return Expression.parse(containsEqual ? origin.substring(1) : origin).returnType;
 };
 
 export const checkExpression = (exp: any, required: boolean, types: number[]): number => {


### PR DESCRIPTION
## Description
**root cause**
all expressions are considered as starting with "=", so the "string()" is cut off, and expression parser will check the function "tring()".

**fix**
1. check the "=" before parsing
2. update the unit tests
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
#minor
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
