### PR TITLE
fix: Update conversation object when secret and locale changes

### DIFF
--- a/Composer/packages/client/src/components/WebChat/WebChatPanel.tsx
+++ b/Composer/packages/client/src/components/WebChat/WebChatPanel.tsx
@@ -134,7 +134,7 @@ export const WebChatPanel: React.FC<WebChatPanelProps> = ({
     if (botUrl) {
       setCurrentConversation('');
     }
-  }, [botUrl, secret]);
+  }, [botUrl]);
 
   useEffect(() => {
     setIsRestartButtonDisabled(botStatus !== BotStatus.connected);
@@ -210,7 +210,7 @@ export const WebChatPanel: React.FC<WebChatPanelProps> = ({
       1000,
       { leading: true }
     ),
-    []
+    [secret, activeLocale]
   );
 
   const onSaveTranscriptClick = async (conversationId: string) => {

--- a/Composer/packages/client/src/pages/design/DebugPanel/TabExtensions/DiagnosticsTab/DiagnosticFilters.tsx
+++ b/Composer/packages/client/src/pages/design/DebugPanel/TabExtensions/DiagnosticsTab/DiagnosticFilters.tsx
@@ -26,7 +26,7 @@ const countStyle: any = {
 const getOptionAll = () => {
   return {
     key: 'All',
-    text: formatMessage('All projects'),
+    text: formatMessage('All bots'),
   };
 };
 
@@ -145,7 +145,7 @@ export const DiagnosticsFilters: React.FC<DiagnosticsFiltersProps> = (props) => 
         <DropdownWithAllOption
           optionAll={getOptionAll()}
           options={projectSelectorOptions}
-          placeholder={formatMessage('Select a project')}
+          placeholder={formatMessage('Select bots')}
           selectedKeys={projectsToFilter}
           onChange={(_, items: string[]) => {
             onProjectFilterChange(items);

--- a/Composer/packages/client/src/pages/design/DebugPanel/TabExtensions/RuntimeOutputLog/RuntimeOutputLog.tsx
+++ b/Composer/packages/client/src/pages/design/DebugPanel/TabExtensions/RuntimeOutputLog/RuntimeOutputLog.tsx
@@ -3,7 +3,7 @@
 
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
-import { NeutralColors } from '@uifabric/fluent-theme';
+import { NeutralColors, FontSizes } from '@uifabric/fluent-theme';
 import { useRecoilValue } from 'recoil';
 import { default as AnsiUp } from 'ansi_up';
 import { useEffect, useRef } from 'react';
@@ -55,7 +55,7 @@ export const RuntimeOutputLog: React.FC<{ projectId: string }> = ({ projectId })
             margin: 0,
             wordBreak: 'break-all',
             whiteSpace: 'pre-wrap',
-            lineHeight: '20px',
+            fontSize: FontSizes.size12,
           }}
           // eslint-disable-next-line react/no-danger
           dangerouslySetInnerHTML={createMarkup(runtimeData.standardOutput)}

--- a/Composer/packages/client/src/pages/design/DebugPanel/WatchVariablePicker/WatchVariablePicker.tsx
+++ b/Composer/packages/client/src/pages/design/DebugPanel/WatchVariablePicker/WatchVariablePicker.tsx
@@ -132,9 +132,9 @@ export const WatchVariablePicker = React.memo((props: WatchVariablePickerProps) 
           event?.preventDefault();
           onToggleExpand(node.id, !propertyTreeExpanded[node.id]);
         } else {
+          event?.preventDefault();
           const path = paths[node.id];
           setQuery(path);
-          event?.preventDefault();
           setErrorMessage('');
           TelemetryClient.track('StateWatchPropertyAdded', { property: path });
           setWatchedVariables(currentProjectId, { ...watchedVariables, [variableId]: path });
@@ -166,6 +166,7 @@ export const WatchVariablePicker = React.memo((props: WatchVariablePickerProps) 
       onClick: (event) => {
         event?.preventDefault();
         const path = paths[node.id];
+        setQuery(path);
         setErrorMessage('');
         TelemetryClient.track('StateWatchPropertyAdded', { property: path });
         setWatchedVariables(currentProjectId, { ...watchedVariables, [variableId]: path });


### PR DESCRIPTION
## Description
Allow restart conversation to take the updated secret and locale when restarting the webchat conversation.

@boydc2014  @luhan2017 Could you give this branch a test before we merge?

In addition, this PR has some misc style fixes
![Screen Shot 2021-07-01 at 12 50 27 PM](https://user-images.githubusercontent.com/13004779/124182769-2f4f9580-da6c-11eb-9ce1-d68cfb41f080.png)
![Screen Shot 2021-07-01 at 12 44 58 PM](https://user-images.githubusercontent.com/13004779/124182777-3080c280-da6c-11eb-8bbe-d6ab95d378bd.png)

Fixes #8226 