### PR TITLE
fix: Remove previous integration fix that is causing a problem

### DIFF
--- a/Composer/packages/integration-tests/cypress/integration/HomePage.spec.ts
+++ b/Composer/packages/integration-tests/cypress/integration/HomePage.spec.ts
@@ -60,8 +60,6 @@ context('Home Page ', () => {
     cy.wait(3000);
     cy.findByTestId('@microsoft/generator-bot-empty').click();
     cy.findByTestId('CreateBotNextStepButton').click();
-    cy.findByTestId('NewDialogRuntimeType').click();
-    cy.findByText('Azure Web App').click();
     cy.enterTextAndSubmit('NewDialogName', 'TestNewProject3', 'SubmitNewBotBtn');
     cy.wait(100000);
     cy.findByTestId('ProjectTree').within(() => {


### PR DESCRIPTION
## Description

The rollback of the runtime dropdown to default to web app broke integration tests.

## Task Item

#minor

## Screenshots

N/A
