### PR TITLE
fix: Ensure manifest.json not found in zip displays error

### DIFF
--- a/Composer/packages/client/src/components/AddRemoteSkillModal/CreateSkillModal.tsx
+++ b/Composer/packages/client/src/components/AddRemoteSkillModal/CreateSkillModal.tsx
@@ -104,6 +104,8 @@ export const validateLocalZip = async (files: Record<string, JSZipObject>) => {
       const content = await manifestFiles[0].async('string');
       result.manifestContent = JSON.parse(content);
       result.zipContent = zipContent;
+    } else {
+      result.error = { manifestUrl: formatMessage('could not locate manifest.json in zip') };
     }
   } catch (err) {
     // eslint-disable-next-line format-message/literal-pattern
@@ -232,7 +234,7 @@ export const CreateSkillModal: React.FC<CreateSkillModalProps> = (props) => {
   };
 
   const validateUrl = useCallback(
-    (event) => {
+    async (event) => {
       event.preventDefault();
       setShowDetail(true);
       const localManifestPath = formData.manifestUrl.replace(/\\/g, '/');

--- a/Composer/packages/client/src/components/AddRemoteSkillModal/CreateSkillModal.tsx
+++ b/Composer/packages/client/src/components/AddRemoteSkillModal/CreateSkillModal.tsx
@@ -234,7 +234,7 @@ export const CreateSkillModal: React.FC<CreateSkillModalProps> = (props) => {
   };
 
   const validateUrl = useCallback(
-    async (event) => {
+    (event) => {
       event.preventDefault();
       setShowDetail(true);
       const localManifestPath = formData.manifestUrl.replace(/\\/g, '/');

--- a/Composer/packages/lib/shared/src/skillsUtils/index.ts
+++ b/Composer/packages/lib/shared/src/skillsUtils/index.ts
@@ -149,11 +149,13 @@ export const parseRuntimeKey = (
 
 export const isManifestJson = (content) => {
   try {
-    const urls = [
-      'https://schemas.botframework.com/schemas/skills/v2.1/skill-manifest.json',
-      'https://schemas.botframework.com/schemas/skills/v2.2/skill-manifest.json',
+    const versions = [
+      '/v2.0/',
+      '/v2.1/',
+      '/v2.2/',
     ];
-    return urls.includes(JSON.parse(content).$schema);
+    const schema = JSON.parse(content).$schema;
+    return versions.some(v => schema.includes(v));
   } catch (e) {
     return false;
   }

--- a/Composer/packages/lib/shared/src/skillsUtils/index.ts
+++ b/Composer/packages/lib/shared/src/skillsUtils/index.ts
@@ -149,13 +149,9 @@ export const parseRuntimeKey = (
 
 export const isManifestJson = (content) => {
   try {
-    const versions = [
-      '/v2.0/',
-      '/v2.1/',
-      '/v2.2/',
-    ];
+    const versions = ['/v2.0/', '/v2.1/', '/v2.2/'];
     const schema = JSON.parse(content).$schema;
-    return versions.some(v => schema.includes(v));
+    return versions.some((v) => schema.includes(v));
   } catch (e) {
     return false;
   }

--- a/Composer/packages/lib/shared/src/skillsUtils/index.ts
+++ b/Composer/packages/lib/shared/src/skillsUtils/index.ts
@@ -149,9 +149,9 @@ export const parseRuntimeKey = (
 
 export const isManifestJson = (content) => {
   try {
-    const versions = ['/v2.0/', '/v2.1/', '/v2.2/'];
+    const versions = ['/v2.1/skill-manifest.json', '/v2.2/skill-manifest.json'];
     const schema = JSON.parse(content).$schema;
-    return versions.some((v) => schema.includes(v));
+    return versions.some((v) => schema.endsWith(v));
   } catch (e) {
     return false;
   }


### PR DESCRIPTION
## Description

1) When a .zip is parsed, but the .json manifest is not found, display the exception
2) When checking schema compat, check just the version and not the entire schema path

## Task Item

fixes #8260
closes https://github.com/microsoft/BotFramework-Composer/issues/8260

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
