### PR TITLE
fix: Add suggestion for imported entities in Lu editing

### DIFF
--- a/Composer/packages/tools/language-servers/language-understanding/src/LUServer.ts
+++ b/Composer/packages/tools/language-servers/language-understanding/src/LUServer.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import path from 'path';
 
+import uniq from 'lodash/uniq';
 import URI from 'vscode-uri';
 import { FoldingRangeParams, IConnection, TextDocuments } from 'vscode-languageserver';
 import {
@@ -273,7 +274,7 @@ export class LUServer {
       }
     }
 
-    return Promise.resolve(Array.from(new Set(result)));
+    return Promise.resolve(uniq(result));
   }
 
   protected getLUDocument(document: TextDocument): LUDocument | undefined {
@@ -556,8 +557,8 @@ export class LUServer {
       luisJson = await this.extractLUISContent(textExceptCurLine);
     }
 
-    const suggestionEntityList = Array.from(
-      new Set(util.getSuggestionEntities(luisJson, util.suggestionAllEntityTypes).concat(this._importedEntitties))
+    const suggestionEntityList = uniq(
+      util.getSuggestionEntities(luisJson, util.suggestionAllEntityTypes).concat(this._importedEntitties)
     );
     const regexEntityList = util.getRegexEntities(luisJson);
 


### PR DESCRIPTION
closes #8215 
In this PR, Lu editor would be capable to suggest entities defined in a imported lu file.
For example:
There is 3 entities defined in common.en-us.lu
```
@ ml myname
@ ml yourname
@ ml testExpr
```

In current lu file, it could suggest both imported entities and entities defined in the current file:
![image](https://user-images.githubusercontent.com/17074777/124567638-c6568c00-de76-11eb-9641-64ee3642328a.png)
