### PR TITLE
fix: Comment out skill manifest unit tests

### DIFF
--- a/Composer/packages/server/src/models/bot/__tests__/botProject.test.ts
+++ b/Composer/packages/server/src/models/bot/__tests__/botProject.test.ts
@@ -283,31 +283,31 @@ describe('qna operations', () => {
   });
 });
 
-describe('skill operations', () => {
-  afterEach(() => {
-    cleanup(Path.join(botDir, '/skills'));
-  });
+// describe('skill operations', () => {
+//   afterEach(() => {
+//     cleanup(Path.join(botDir, '/skills'));
+//   });
 
-  it('should create skill files', async () => {
-    await proj.init();
+//   it('should create skill files', async () => {
+//     await proj.init();
 
-    const url = 'https://luhantest0625.azurewebsites.net/manifests/Empty_45-2-1-manifest.json';
-    const skillName = 'manifest';
-    const file = await proj.createSkillFiles(url, skillName, {});
+//     const url = 'https://luhantest0625.azurewebsites.net/manifests/Empty_45-2-1-manifest.json';
+//     const skillName = 'manifest';
+//     const file = await proj.createSkillFiles(url, skillName, {});
 
-    expect(file).not.toBeUndefined();
-  }, 10000);
+//     expect(file).not.toBeUndefined();
+//   }, 10000);
 
-  it('should delete skill files', async () => {
-    const url = 'https://luhantest0625.azurewebsites.net/manifests/Empty_45-2-1-manifest.json';
-    const skillName = 'manifest';
-    await proj.createSkillFiles(url, skillName, {});
-    const fileLength = proj.luFiles.length;
+//   it('should delete skill files', async () => {
+//     const url = 'https://luhantest0625.azurewebsites.net/manifests/Empty_45-2-1-manifest.json';
+//     const skillName = 'manifest';
+//     await proj.createSkillFiles(url, skillName, {});
+//     const fileLength = proj.luFiles.length;
 
-    await proj.deleteSkillFiles(skillName);
-    expect(proj.luFiles.length).toBeLessThanOrEqual(fileLength);
-  }, 10000);
-});
+//     await proj.deleteSkillFiles(skillName);
+//     expect(proj.luFiles.length).toBeLessThanOrEqual(fileLength);
+//   }, 10000);
+// });
 
 describe('buildFiles', () => {
   it('should build lu & qna file successfully', async () => {

--- a/Composer/packages/server/src/models/bot/__tests__/botProject.test.ts
+++ b/Composer/packages/server/src/models/bot/__tests__/botProject.test.ts
@@ -283,32 +283,31 @@ describe('qna operations', () => {
   });
 });
 
-//TODO: Rework unit tests https://github.com/microsoft/BotFramework-Composer/pull/8267
-// describe('skill operations', () => {
-//   afterEach(() => {
-//     cleanup(Path.join(botDir, '/skills'));
-//   });
+describe('skill operations', () => {
+  afterEach(() => {
+    cleanup(Path.join(botDir, '/skills'));
+  });
 
-//   it('should create skill files', async () => {
-//     await proj.init();
+  xit('should create skill files', async () => {
+    await proj.init();
 
-//     const url = 'https://luhantest0625.azurewebsites.net/manifests/Empty_45-2-1-manifest.json';
-//     const skillName = 'manifest';
-//     const file = await proj.createSkillFiles(url, skillName, {});
+    const url = 'https://luhantest0625.azurewebsites.net/manifests/Empty_45-2-1-manifest.json';
+    const skillName = 'manifest';
+    const file = await proj.createSkillFiles(url, skillName, {});
 
-//     expect(file).not.toBeUndefined();
-//   }, 10000);
+    expect(file).not.toBeUndefined();
+  }, 10000);
 
-//   it('should delete skill files', async () => {
-//     const url = 'https://luhantest0625.azurewebsites.net/manifests/Empty_45-2-1-manifest.json';
-//     const skillName = 'manifest';
-//     await proj.createSkillFiles(url, skillName, {});
-//     const fileLength = proj.luFiles.length;
+  xit('should delete skill files', async () => {
+    const url = 'https://luhantest0625.azurewebsites.net/manifests/Empty_45-2-1-manifest.json';
+    const skillName = 'manifest';
+    await proj.createSkillFiles(url, skillName, {});
+    const fileLength = proj.luFiles.length;
 
-//     await proj.deleteSkillFiles(skillName);
-//     expect(proj.luFiles.length).toBeLessThanOrEqual(fileLength);
-//   }, 10000);
-// });
+    await proj.deleteSkillFiles(skillName);
+    expect(proj.luFiles.length).toBeLessThanOrEqual(fileLength);
+  }, 10000);
+});
 
 describe('buildFiles', () => {
   it('should build lu & qna file successfully', async () => {

--- a/Composer/packages/server/src/models/bot/__tests__/botProject.test.ts
+++ b/Composer/packages/server/src/models/bot/__tests__/botProject.test.ts
@@ -283,6 +283,7 @@ describe('qna operations', () => {
   });
 });
 
+//TODO: Rework unit tests https://github.com/microsoft/BotFramework-Composer/pull/8267
 // describe('skill operations', () => {
 //   afterEach(() => {
 //     cleanup(Path.join(botDir, '/skills'));


### PR DESCRIPTION
## Description
This PR comments out the unit tests in botproject that seem to make API calls to consume the manifest.
@alanlong9278 a couple of changes required
1. Let us not await on API calls in unit tests and instead just use mocked responses.
2. Lets not commit actual URL's to the repo.
3. The 10000ms waiting on the test ruins the efficiency of the test suite. Let us not force wait on the unit test beyond the default jest test timeout. 

Cc @luhan2017 



## Task Item
#minor
