### PR TITLE
fix: fix begin skill action node

### DIFF
--- a/Composer/packages/adaptive-flow/src/adaptive-flow-renderer/widgets/ActionCard/ActionCardBody.tsx
+++ b/Composer/packages/adaptive-flow/src/adaptive-flow-renderer/widgets/ActionCard/ActionCardBody.tsx
@@ -38,14 +38,14 @@ interface ActionCardBodyProps extends WidgetContainerProps {
   hideComment?: boolean;
 }
 
-export const ActionCardBody: WidgetComponent<ActionCardBodyProps> = ({ body, colors, truncate, hideComment, data }) => {
+export const ActionCardBody: WidgetComponent<ActionCardBodyProps> = ({ body, truncate, hideComment, data }) => {
   const { flowCommentsVisible } = useShellApi();
   const comment = data.$designer?.comment;
 
   return (
-    <div css={containerStyle(colors?.theme)}>
+    <div css={containerStyle()}>
       {!hideComment && flowCommentsVisible && comment && <CardComment comment={comment} />}
-      <div css={textStyles(colors?.color, truncate)}>{body || ' '}</div>
+      <div css={textStyles(undefined, truncate)}>{body || ' '}</div>
     </div>
   );
 };


### PR DESCRIPTION
## Description

Reverts change to support node body background color. We will need to defer that work until the ui schema for BeginSkill is updated to be correct.

## Task Item

fixes #8253

## Screenshots

![image](https://user-images.githubusercontent.com/3619060/124652623-2cc8b380-de51-11eb-929e-211318f328af.png)

