### PR TITLE
fix: Updated mac .yml generation script

### DIFF
--- a/Composer/packages/electron-server/scripts/mac.js
+++ b/Composer/packages/electron-server/scripts/mac.js
@@ -1,12 +1,13 @@
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 const glob = require('glob');
+
 const common = require('./common.js');
 const { writeToDist } = common;
 
 writeLatestYmlFile().catch((e) => console.error(e));
 /** Generates latest-mac.yml */
 async function writeLatestYmlFile() {
-  glob('../**/*.zip', {}, (err, files) => writeToDist(err, files, 'latest-mac.yml'));
+  glob('../**/BotFramework-Composer*-mac.zip', {}, (err, files) => writeToDist(err, files, 'latest-mac.yml'));
 }


### PR DESCRIPTION
## Description

There was a recent change that is now generating a `mockManifest.zip` file inside of the `/electron-server/` directory, which is interfering with a build script that generates the `latest-mac.yml` file. It is causing the wrong content to be written to this .yml file which is breaking auto update for Mac.

**Correct contents:**

```yaml
version: 2.0.0-nightly.255969.45d2dd7
releaseDate: '2021-07-01T06:09:06.959Z'
githubArtifactName: BotFramework-Composer-2.0.0-nightly.255969.45d2dd7-mac.zip
path: BotFramework-Composer-2.0.0-nightly.255969.45d2dd7-mac.zip
sha512: >-
sgQT81CnThQ5AqQ17NO7e3Zfqizn7KNh6j+GYqsBdeO0UJbBtlQhlAa5FNgTxvsCdczg/oNTnFjbJ6xZzgAp3g==
```

**Incorrect contents:**

```yaml
version: 2.0.0-nightly.256348.6e1b66
releaseDate: '2021-07-02T17:52:53.628Z'
githubArtifactName: mockManifest.zip
path: mockManifest.zip
sha512: >-
vPxCZ08XRDmLph87PbUpl1V3D4Nk5NN17M8wPK/PAV7ZYbmmRzyWzImfxtxjnGW0N/lJBhxNwg22M+C3jRfwyQ==
```

This PR makes the glob pattern in the `mac.js` build script more specific so it doesn't accidentally pick up the `mockManifest.zip` file instead of the desired `BotFramework-Composer-<version>-mac.zip`.

## Task Item

#minor
