### PR TITLE
fix: correctly update time survey was taken

### DIFF
--- a/Composer/packages/client/src/App.tsx
+++ b/Composer/packages/client/src/App.tsx
@@ -28,7 +28,6 @@ export const App: React.FC = () => {
     fetchFeatureFlags,
     checkNodeVersion,
     performAppCleanupOnQuit,
-    setSurveyEligibility,
     setMachineInfo,
   } = useRecoilValue(dispatcherState);
 
@@ -46,7 +45,6 @@ export const App: React.FC = () => {
 
     ipcRenderer?.on('machine-info', (_event, info) => {
       setMachineInfo(info);
-      setSurveyEligibility();
     });
   }, []);
 

--- a/Composer/packages/client/src/components/Notifications/useSurveyNotification.ts
+++ b/Composer/packages/client/src/components/Notifications/useSurveyNotification.ts
@@ -9,7 +9,7 @@ import querystring from 'query-string';
 import { ClientStorage } from '../../utils/storage';
 import { surveyEligibilityState, dispatcherState, machineInfoState } from '../../recoilModel/atoms/appState';
 import { MachineInfo } from '../../recoilModel/types';
-import { SURVEY_EPOCH_KEY, SURVEY_URL_BASE } from '../../constants';
+import { LAST_SURVEY_KEY, SURVEY_URL_BASE } from '../../constants';
 import TelemetryClient from '../../telemetry/TelemetryClient';
 
 const buildUrl = (info: MachineInfo) => {
@@ -57,7 +57,7 @@ export const useSurveyNotification = () => {
               // This is safe; we control the URL that gets built
               // eslint-disable-next-line security/detect-non-literal-fs-filename
               window.open(url, '_blank');
-              surveyStorage.set(SURVEY_EPOCH_KEY, Date.now());
+              surveyStorage.set(LAST_SURVEY_KEY, Date.now());
               TelemetryClient.track('HATSSurveyAccepted');
               deleteNotification('survey');
             },

--- a/Composer/packages/client/src/components/Notifications/useSurveyNotification.ts
+++ b/Composer/packages/client/src/components/Notifications/useSurveyNotification.ts
@@ -63,14 +63,13 @@ const getSurveyEligibility = () => {
 
 export const useSurveyNotification = () => {
   const { addNotification, deleteNotification } = useRecoilValue(dispatcherState);
-  const surveyEligible = getSurveyEligibility();
   const machineInfo = useRecoilValue(machineInfoState);
 
   useEffect(() => {
     const url = buildUrl(machineInfo);
     deleteNotification('survey');
 
-    if (surveyEligible) {
+    if (getSurveyEligibility()) {
       const surveyStorage = new ClientStorage(window.localStorage, 'survey');
       TelemetryClient.track('HATSSurveyOffered');
 

--- a/Composer/packages/client/src/components/Notifications/useSurveyNotification.ts
+++ b/Composer/packages/client/src/components/Notifications/useSurveyNotification.ts
@@ -31,9 +31,11 @@ const buildUrl = (info: MachineInfo) => {
 };
 
 export const useSurveyNotification = () => {
-  const { addNotification, deleteNotification } = useRecoilValue(dispatcherState);
+  const { addNotification, deleteNotification, setSurveyEligibility } = useRecoilValue(dispatcherState);
   const surveyEligible = useRecoilValue(surveyEligibilityState);
   const machineInfo = useRecoilValue(machineInfoState);
+
+  setSurveyEligibility();
 
   useEffect(() => {
     const url = buildUrl(machineInfo);
@@ -55,6 +57,7 @@ export const useSurveyNotification = () => {
               // This is safe; we control the URL that gets built
               // eslint-disable-next-line security/detect-non-literal-fs-filename
               window.open(url, '_blank');
+              surveyStorage.set('epochLastTaken', Date.now());
               TelemetryClient.track('HATSSurveyAccepted');
               deleteNotification('survey');
             },

--- a/Composer/packages/client/src/components/Notifications/useSurveyNotification.ts
+++ b/Composer/packages/client/src/components/Notifications/useSurveyNotification.ts
@@ -9,7 +9,7 @@ import querystring from 'query-string';
 import { ClientStorage } from '../../utils/storage';
 import { surveyEligibilityState, dispatcherState, machineInfoState } from '../../recoilModel/atoms/appState';
 import { MachineInfo } from '../../recoilModel/types';
-import { SURVEY_URL_BASE } from '../../constants';
+import { SURVEY_EPOCH_KEY, SURVEY_URL_BASE } from '../../constants';
 import TelemetryClient from '../../telemetry/TelemetryClient';
 
 const buildUrl = (info: MachineInfo) => {
@@ -57,7 +57,7 @@ export const useSurveyNotification = () => {
               // This is safe; we control the URL that gets built
               // eslint-disable-next-line security/detect-non-literal-fs-filename
               window.open(url, '_blank');
-              surveyStorage.set('epochLastTaken', Date.now());
+              surveyStorage.set(SURVEY_EPOCH_KEY, Date.now());
               TelemetryClient.track('HATSSurveyAccepted');
               deleteNotification('survey');
             },

--- a/Composer/packages/client/src/constants.tsx
+++ b/Composer/packages/client/src/constants.tsx
@@ -533,4 +533,5 @@ export const SURVEY_PARAMETERS = {
   chanceToAppear: 0.3,
 };
 
+export const SURVEY_EPOCH_KEY = 'lastSurveyTakenOnTimestamp';
 export const SURVEY_URL_BASE = 'https://aka.ms/bfcomposersurvey';

--- a/Composer/packages/client/src/constants.tsx
+++ b/Composer/packages/client/src/constants.tsx
@@ -533,5 +533,5 @@ export const SURVEY_PARAMETERS = {
   chanceToAppear: 0.3,
 };
 
-export const SURVEY_EPOCH_KEY = 'lastSurveyTakenOnTimestamp';
+export const LAST_SURVEY_KEY = 'lastSurveyTakenOnTimestamp';
 export const SURVEY_URL_BASE = 'https://aka.ms/bfcomposersurvey';

--- a/Composer/packages/client/src/recoilModel/atoms/appState.ts
+++ b/Composer/packages/client/src/recoilModel/atoms/appState.ts
@@ -366,11 +366,6 @@ export const warnAboutFunctionsState = atom<boolean>({
   default: false,
 });
 
-export const surveyEligibilityState = atom<boolean>({
-  key: getFullyQualifiedKey('surveyEligibilityState'),
-  default: false,
-});
-
 export const machineInfoState = atom<MachineInfo>({
   key: getFullyQualifiedKey('machineInfoState'),
   default: null,

--- a/Composer/packages/client/src/recoilModel/dispatchers/application.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/application.ts
@@ -29,7 +29,7 @@ import {
   AppUpdaterStatus,
   CreationFlowStatus,
   CreationFlowType,
-  SURVEY_EPOCH_KEY,
+  LAST_SURVEY_KEY,
   SURVEY_PARAMETERS,
 } from '../../constants';
 import OnboardingState from '../../utils/onboardingStorage';
@@ -177,7 +177,7 @@ export const applicationDispatcher = () => {
 
     let days = surveyStorage.get('days', 0);
     const lastUsed = surveyStorage.get('dateLastUsed', null);
-    const lastTaken = surveyStorage.get(SURVEY_EPOCH_KEY, null);
+    const lastTaken = surveyStorage.get(LAST_SURVEY_KEY, null);
     const today = new Date().toDateString();
     if (lastUsed !== today) {
       days += 1;

--- a/Composer/packages/client/src/recoilModel/dispatchers/application.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/application.ts
@@ -25,7 +25,13 @@ import {
   showWarningDiagnosticsState,
   projectsForDiagnosticsFilterState,
 } from '../atoms/appState';
-import { AppUpdaterStatus, CreationFlowStatus, CreationFlowType, SURVEY_PARAMETERS } from '../../constants';
+import {
+  AppUpdaterStatus,
+  CreationFlowStatus,
+  CreationFlowType,
+  SURVEY_EPOCH_KEY,
+  SURVEY_PARAMETERS,
+} from '../../constants';
 import OnboardingState from '../../utils/onboardingStorage';
 import { StateError, AppUpdateState, MachineInfo } from '../../recoilModel/types';
 import { DebugDrawerKeys } from '../../pages/design/DebugPanel/TabExtensions/types';
@@ -171,7 +177,7 @@ export const applicationDispatcher = () => {
 
     let days = surveyStorage.get('days', 0);
     const lastUsed = surveyStorage.get('dateLastUsed', null);
-    const lastTaken = surveyStorage.get('epochLastTaken', null);
+    const lastTaken = surveyStorage.get(SURVEY_EPOCH_KEY, null);
     const today = new Date().toDateString();
     if (lastUsed !== today) {
       days += 1;

--- a/Composer/packages/client/src/recoilModel/dispatchers/application.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/application.ts
@@ -166,37 +166,6 @@ export const applicationDispatcher = () => {
     await flushExistingTasks(callbackHelpers);
   });
 
-  const setSurveyEligibility = useRecoilCallback(({ set }: CallbackInterface) => () => {
-    const surveyStorage = new ClientStorage(window.localStorage, 'survey');
-
-    const optedOut = surveyStorage.get('optedOut', false);
-    if (optedOut) {
-      set(surveyEligibilityState, false);
-      return;
-    }
-
-    let days = surveyStorage.get('days', 0);
-    const lastUsed = surveyStorage.get('dateLastUsed', null);
-    const lastTaken = surveyStorage.get(LAST_SURVEY_KEY, null);
-    const today = new Date().toDateString();
-    if (lastUsed !== today) {
-      days += 1;
-      surveyStorage.set('days', days);
-    }
-    if (
-      // To be eligible for the survey, the user needs to have used Composer
-      // some minimum number of days.
-      days >= SURVEY_PARAMETERS.daysUntilEligible &&
-      // Also, either the user must have never taken the survey before or
-      // the last time they took it must be long enough in the past.
-      (lastTaken == null || Date.now() - lastTaken > SURVEY_PARAMETERS.timeUntilNextSurvey)
-    ) {
-      // If the above conditions are true, there's a fixed chance the card will appear.
-      set(surveyEligibilityState, Math.random() < SURVEY_PARAMETERS.chanceToAppear);
-    }
-    surveyStorage.set('dateLastUsed', today);
-  });
-
   const setMachineInfo = useRecoilCallback((callbackHelpers: CallbackInterface) => (info: MachineInfo) => {
     callbackHelpers.set(machineInfoState, info);
   });
@@ -233,7 +202,6 @@ export const applicationDispatcher = () => {
     setPageElementState,
     setDebugPanelExpansion,
     setActiveTabInDebugPanel,
-    setSurveyEligibility,
     setMachineInfo,
     setShowGetStartedTeachingBubble,
     setErrorDiagnosticsFilter,

--- a/Composer/packages/client/src/recoilModel/dispatchers/application.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/application.ts
@@ -18,25 +18,17 @@ import {
   debugPanelActiveTabState,
   userHasNodeInstalledState,
   applicationErrorState,
-  surveyEligibilityState,
   machineInfoState,
   showGetStartedTeachingBubbleState,
   showErrorDiagnosticsState,
   showWarningDiagnosticsState,
   projectsForDiagnosticsFilterState,
 } from '../atoms/appState';
-import {
-  AppUpdaterStatus,
-  CreationFlowStatus,
-  CreationFlowType,
-  LAST_SURVEY_KEY,
-  SURVEY_PARAMETERS,
-} from '../../constants';
+import { AppUpdaterStatus, CreationFlowStatus, CreationFlowType } from '../../constants';
 import OnboardingState from '../../utils/onboardingStorage';
 import { StateError, AppUpdateState, MachineInfo } from '../../recoilModel/types';
 import { DebugDrawerKeys } from '../../pages/design/DebugPanel/TabExtensions/types';
 import httpClient from '../../utils/httpUtil';
-import { ClientStorage } from '../../utils/storage';
 
 import { setError } from './shared';
 import { flushExistingTasks } from './utils/project';


### PR DESCRIPTION
## Description

The HaTS survey wasn't saving the time it was taken to local storage, which was causing the "has it been long enough" check to always be true. Also, the useSurveyNotification hook wasn't recalculating eligibility, so if you were eligible once, you were eligible forever and the box would keep appearing.

## Task Item

#minor
