### PR TITLE
fix: categorizing LUIS and QNA resources correctly as required or optional in provision flow

### DIFF
--- a/Composer/packages/client/src/pages/botProject/create-publish-profile/PublishProfileDialog.tsx
+++ b/Composer/packages/client/src/pages/botProject/create-publish-profile/PublishProfileDialog.tsx
@@ -18,7 +18,7 @@ import { defaultPublishSurface, pvaPublishSurface, azurePublishSurface } from '.
 import TelemetryClient from '../../../telemetry/TelemetryClient';
 import { AuthClient } from '../../../utils/authClient';
 import { graphScopes } from '../../../constants';
-import { dispatcherState } from '../../../recoilModel';
+import { allRequiredRecognizersSelector, dispatcherState } from '../../../recoilModel';
 import { createNotification } from '../../../recoilModel/dispatchers/notification';
 
 import { ProfileFormDialog } from './ProfileFormDialog';
@@ -68,6 +68,7 @@ export const PublishProfileDialog: React.FC<PublishProfileDialogProps> = (props)
   const [selectedType, setSelectType] = useState<PublishType | undefined>();
 
   const [dialogTitle, setTitle] = useState(formatDialogTitle(current));
+  const requiresRecognizers = useRecoilValue(allRequiredRecognizersSelector);
 
   useEffect(() => {
     const ty = types.find((t) => t.name === current?.item.type);
@@ -120,6 +121,9 @@ export const PublishProfileDialog: React.FC<PublishProfileDialogProps> = (props)
     };
     PluginAPI.publish.setTenantId = (value) => {
       setTenantId(value);
+    };
+    PluginAPI.publish.getRequiredRecognizers = () => {
+      return requiresRecognizers;
     };
   }, []);
 

--- a/Composer/packages/client/src/plugins/api.ts
+++ b/Composer/packages/client/src/plugins/api.ts
@@ -40,6 +40,11 @@ interface PublishAPI {
   userShouldProvideTokens?: () => boolean;
   getTenantIdFromCache?: () => string;
   setTenantId?: (value: string) => void;
+  getRequiredRecognizers?: () => {
+    projectId: string;
+    requiresLUIS: boolean;
+    requiresQNA: boolean;
+  }[];
 }
 
 class API implements IAPI {
@@ -67,6 +72,7 @@ class API implements IAPI {
       userShouldProvideTokens: undefined,
       getTenantIdFromCache: undefined,
       setTenantId: undefined,
+      getRequiredRecognizers: undefined,
     };
   }
 }

--- a/Composer/packages/extension-client/src/hooks/usePublishApi.ts
+++ b/Composer/packages/extension-client/src/hooks/usePublishApi.ts
@@ -58,6 +58,13 @@ export function usePublishApi() {
   function userShouldProvideTokens(): boolean {
     return window[ComposerGlobalName].userShouldProvideTokens();
   }
+  function getRequiredRecognizers(): {
+    projectId: string;
+    requiresLUIS: boolean;
+    requiresQNA: boolean;
+  }[] {
+    return window[ComposerGlobalName].getRequiredRecognizers();
+  }
   /** @deprecated use `userShouldProvideTokens` instead */
   function isGetTokenFromUser(): boolean {
     return window[ComposerGlobalName].userShouldProvideTokens();
@@ -78,5 +85,6 @@ export function usePublishApi() {
     userShouldProvideTokens,
     getTenantIdFromCache,
     setTenantId,
+    getRequiredRecognizers,
   };
 }

--- a/extensions/azurePublish/src/components/api.tsx
+++ b/extensions/azurePublish/src/components/api.tsx
@@ -15,6 +15,7 @@ import { CognitiveServicesManagementClient } from '@azure/arm-cognitiveservices'
 import { TokenCredentials } from '@azure/ms-rest-js';
 import debug from 'debug';
 import sortBy from 'lodash/sortBy';
+import { usePublishApi } from '@bfc/extension-client';
 
 import { AzureResourceTypes } from '../types';
 import {
@@ -391,13 +392,14 @@ export const CheckCognitiveResourceSku = async (
  * @param projectId
  * @param type
  */
-export const getResourceList = async (
-  projectId: string,
-  type: string,
-  requireQNA: boolean,
-  requireLUIS: boolean
-): Promise<ResourcesItem[]> => {
+export const getResourceList = async (projectId: string, type: string): Promise<ResourcesItem[]> => {
   try {
+    const { getRequiredRecognizers } = usePublishApi();
+    const requiredRecognizers = getRequiredRecognizers();
+
+    const requireLUIS = requiredRecognizers.some((p) => p.requiresLUIS);
+    const requireQNA = requiredRecognizers.some((p) => p.requiresQNA);
+
     const result = await axios.get(`/api/provision/${projectId}/${type}/resources`);
     const resourceList = result.data as ResourcesItem[];
     resourceList.push({

--- a/extensions/azurePublish/src/components/api.tsx
+++ b/extensions/azurePublish/src/components/api.tsx
@@ -24,6 +24,7 @@ import {
   LuisAuthoringSupportLocation,
   LuisPublishSupportLocation,
 } from '../types';
+import { AzureResourceDefinitions } from '../node/resourceTypes';
 
 import * as Images from './images';
 
@@ -390,10 +391,30 @@ export const CheckCognitiveResourceSku = async (
  * @param projectId
  * @param type
  */
-export const getResourceList = async (projectId: string, type: string): Promise<ResourcesItem[]> => {
+export const getResourceList = async (
+  projectId: string,
+  type: string,
+  requireQNA: boolean,
+  requireLUIS: boolean
+): Promise<ResourcesItem[]> => {
   try {
     const result = await axios.get(`/api/provision/${projectId}/${type}/resources`);
-    return result.data as ResourcesItem[];
+    const resourceList = result.data as ResourcesItem[];
+    resourceList.push({
+      ...AzureResourceDefinitions[AzureResourceTypes.LUIS_AUTHORING],
+      required: requireLUIS,
+    });
+
+    resourceList.push({
+      ...AzureResourceDefinitions[AzureResourceTypes.LUIS_PREDICTION],
+      required: requireLUIS,
+    });
+
+    resourceList.push({
+      ...AzureResourceDefinitions[AzureResourceTypes.QNA],
+      required: requireQNA,
+    });
+    return resourceList;
   } catch (error) {
     logger({
       status: AzureAPIStatus.ERROR,

--- a/extensions/azurePublish/src/components/azureProvisionDialog.tsx
+++ b/extensions/azurePublish/src/components/azureProvisionDialog.tsx
@@ -14,13 +14,12 @@ import {
   getARMTokenForTenant,
   useLocalStorage,
   useTelemetryClient,
-  TelemetryClient,
   useApplicationApi,
 } from '@bfc/extension-client';
 import { Subscription } from '@azure/arm-subscriptions/esm/models';
 import { DeployLocation, AzureTenant, Notification } from '@botframework-composer/types';
 import { FluentTheme, NeutralColors } from '@uifabric/fluent-theme';
-import { dialogStyle, LoadingSpinner, OpenConfirmModal, ProvisionHandoff } from '@bfc/ui-shared';
+import { LoadingSpinner, OpenConfirmModal, ProvisionHandoff } from '@bfc/ui-shared';
 import {
   ScrollablePane,
   ScrollbarVisibility,
@@ -321,11 +320,14 @@ export const AzureProvisionDialog: React.FC = () => {
     userShouldProvideTokens,
     getTenantIdFromCache,
     setTenantId,
+    getRequiredRecognizers,
   } = usePublishApi();
 
   const { projectCollection } = useProjectApi();
 
   const currentProjectId = getCurrentProjectId();
+
+  const requiredRecognizers = getRequiredRecognizers();
 
   const telemetryClient = useTelemetryClient();
 
@@ -601,7 +603,9 @@ export const AzureProvisionDialog: React.FC = () => {
 
   const getResources = async () => {
     try {
-      const resources = await getResourceList(currentProjectId, publishType);
+      const requireLUIS = requiredRecognizers.some((p) => p.requiresLUIS);
+      const requireQNA = requiredRecognizers.some((p) => p.requiresQNA);
+      const resources = await getResourceList(currentProjectId, publishType, requireQNA, requireLUIS);
       setExtensionResourceOptions(resources);
     } catch (err) {
       // todo: how do we handle API errors in this component

--- a/extensions/azurePublish/src/components/azureProvisionDialog.tsx
+++ b/extensions/azurePublish/src/components/azureProvisionDialog.tsx
@@ -320,14 +320,11 @@ export const AzureProvisionDialog: React.FC = () => {
     userShouldProvideTokens,
     getTenantIdFromCache,
     setTenantId,
-    getRequiredRecognizers,
   } = usePublishApi();
 
   const { projectCollection } = useProjectApi();
 
   const currentProjectId = getCurrentProjectId();
-
-  const requiredRecognizers = getRequiredRecognizers();
 
   const telemetryClient = useTelemetryClient();
 
@@ -603,9 +600,7 @@ export const AzureProvisionDialog: React.FC = () => {
 
   const getResources = async () => {
     try {
-      const requireLUIS = requiredRecognizers.some((p) => p.requiresLUIS);
-      const requireQNA = requiredRecognizers.some((p) => p.requiresQNA);
-      const resources = await getResourceList(currentProjectId, publishType, requireQNA, requireLUIS);
+      const resources = await getResourceList(currentProjectId, publishType);
       setExtensionResourceOptions(resources);
     } catch (err) {
       // todo: how do we handle API errors in this component

--- a/extensions/azurePublish/src/node/index.ts
+++ b/extensions/azurePublish/src/node/index.ts
@@ -579,25 +579,6 @@ export default async (composer: IExtensionRegistration): Promise<void> => {
         required: false,
       });
 
-      // TODO: determine if QNA or LUIS is REQUIRED or OPTIONAL
-      const requireLUIS = false;
-      const requireQNA = false;
-
-      recommendedResources.push({
-        ...AzureResourceDefinitions[AzureResourceTypes.LUIS_AUTHORING],
-        required: requireLUIS,
-      });
-
-      recommendedResources.push({
-        ...AzureResourceDefinitions[AzureResourceTypes.LUIS_PREDICTION],
-        required: requireLUIS,
-      });
-
-      recommendedResources.push({
-        ...AzureResourceDefinitions[AzureResourceTypes.QNA],
-        required: requireQNA,
-      });
-
       return recommendedResources;
     };
 

--- a/extensions/azurePublish/src/node/index.ts
+++ b/extensions/azurePublish/src/node/index.ts
@@ -579,6 +579,25 @@ export default async (composer: IExtensionRegistration): Promise<void> => {
         required: false,
       });
 
+      // luis and qna required values will be properly set by extension front end caller
+      const requireLUIS = false;
+      const requireQNA = false;
+
+      recommendedResources.push({
+        ...AzureResourceDefinitions[AzureResourceTypes.LUIS_AUTHORING],
+        required: requireLUIS,
+      });
+
+      recommendedResources.push({
+        ...AzureResourceDefinitions[AzureResourceTypes.LUIS_PREDICTION],
+        required: requireLUIS,
+      });
+
+      recommendedResources.push({
+        ...AzureResourceDefinitions[AzureResourceTypes.QNA],
+        required: requireQNA,
+      });
+
       return recommendedResources;
     };
 


### PR DESCRIPTION
## Description

AzurePublish extension was always adding luis and qna as optional resources instead of required resources in the provision flow regardless of the underlying bot needing LUIS or QNA.

There is already a selector in client recoil state that does the parsing to determine whether LUIS/QNA are required in the current bot files (`allRequiredRecognizersSelector`)

This PR adds an accessor function for `allRequiredRecognizersSelector` that can be called through the Publish Plugin API such that the plug in can correctly categorize whether or not LUIS and QNA are optional.

## Task Item

fixes #6775 

## Screenshots

![image](https://user-images.githubusercontent.com/22845013/124811500-62d06b00-df17-11eb-8a5e-472ad6727ee0.png)

