### PR TITLE
fix: Add support of suggesting all entities in multiple import levels

### DIFF
--- a/Composer/packages/tools/language-servers/language-understanding/src/LUServer.ts
+++ b/Composer/packages/tools/language-servers/language-understanding/src/LUServer.ts
@@ -253,7 +253,7 @@ export class LUServer {
     luFeatures: any
   ): Promise<string[]> {
     let content = '';
-    const result: string[] = [];
+    let result: string[] = [];
     for (const importFile of imports) {
       try {
         content = (await importResolver('.', importFile.id)).content;
@@ -262,11 +262,17 @@ export class LUServer {
       }
 
       let parsed: any;
+      let imported: any;
       try {
-        const { resource } = await this.luParser.parse(content, importFile.id, luFeatures);
+        const { resource, imports } = await this.luParser.parse(content, importFile.id, luFeatures);
         parsed = resource;
+        imported = imports;
       } catch (error) {
         // ignore if file not exist
+      }
+
+      if (imported && imported.length > 0) {
+        result = await this.findAllImportedEntities(imported, importResolver, luFeatures);
       }
 
       if (parsed) {


### PR DESCRIPTION
closes #8295 
For higher level imports, the LU editor now is able to suggest all entities defined. 
For example, in form dialog:
<img width="1380" alt="Screen Shot 2021-07-09 at 3 15 50 PM" src="https://user-images.githubusercontent.com/17074777/125039370-fc8b4a00-e0c8-11eb-8969-c4d0f5d456b6.png">

Another example:
Empty.en-us.lu imports test.en-us.lu, test.en-us.lu imports compact2.en-us.lu and level2.en-us.lu, level2.en-us.lu imports level3.en-us.lu. Once user editing in Empty.en-us.lu, the editor can suggest all entities defined in all imported files.
![image](https://user-images.githubusercontent.com/17074777/125039829-83d8bd80-e0c9-11eb-8c26-568ab79fa048.png)
