### PR TITLE
fix: Filter recognizers to project ID

### DIFF
--- a/extensions/azurePublish/src/components/api.tsx
+++ b/extensions/azurePublish/src/components/api.tsx
@@ -395,7 +395,7 @@ export const CheckCognitiveResourceSku = async (
 export const getResourceList = async (projectId: string, type: string): Promise<ResourcesItem[]> => {
   try {
     const { getRequiredRecognizers } = usePublishApi();
-    const requiredRecognizers = getRequiredRecognizers();
+    const requiredRecognizers = getRequiredRecognizers().filter((p) => p.projectId === projectId);
 
     const requireLUIS = requiredRecognizers.some((p) => p.requiresLUIS);
     const requireQNA = requiredRecognizers.some((p) => p.requiresQNA);


### PR DESCRIPTION
## Description

The required LUIS or QnA needs to be filtered to the project being provisioned.

## Task Item

fixes #6775

## Screenshots

N/A
