### PR TITLE
fix: before fetching subscriptions, ensure modal is visible

### DIFF
--- a/Composer/packages/client/src/components/ManageService/ManageService.tsx
+++ b/Composer/packages/client/src/components/ManageService/ManageService.tsx
@@ -124,7 +124,6 @@ export const ManageService: React.FC<ManageServiceProps> = (props: ManageService
   const getSubscriptions = async (token: string): Promise<Array<Subscription>> => {
     const tokenCredentials = new TokenCredentials(token);
     try {
-      console.log('get subscriptions for manageservice');
       const subscriptionClient = new SubscriptionClient(tokenCredentials);
       const subscriptionsResult = await subscriptionClient.subscriptions.list();
       // eslint-disable-next-line no-underscore-dangle

--- a/Composer/packages/client/src/components/ManageService/ManageService.tsx
+++ b/Composer/packages/client/src/components/ManageService/ManageService.tsx
@@ -124,6 +124,7 @@ export const ManageService: React.FC<ManageServiceProps> = (props: ManageService
   const getSubscriptions = async (token: string): Promise<Array<Subscription>> => {
     const tokenCredentials = new TokenCredentials(token);
     try {
+      console.log('get subscriptions for manageservice');
       const subscriptionClient = new SubscriptionClient(tokenCredentials);
       const subscriptionsResult = await subscriptionClient.subscriptions.list();
       // eslint-disable-next-line no-underscore-dangle
@@ -135,7 +136,7 @@ export const ManageService: React.FC<ManageServiceProps> = (props: ManageService
   };
 
   useEffect(() => {
-    if (isAuthenticated) {
+    if (isAuthenticated && !props.hidden) {
       setAvailableSubscriptions([]);
       setSubscriptionsErrorMessage(undefined);
       getSubscriptions(currentUser.token)
@@ -153,7 +154,7 @@ export const ManageService: React.FC<ManageServiceProps> = (props: ManageService
           setSubscriptionsErrorMessage(err.message);
         });
     }
-  }, [isAuthenticated]);
+  }, [isAuthenticated, props.hidden]);
 
   useEffect(() => {
     // reset the ui

--- a/Composer/packages/client/src/components/QnA/CreateQnAModal.tsx
+++ b/Composer/packages/client/src/components/QnA/CreateQnAModal.tsx
@@ -155,7 +155,7 @@ export const CreateQnAModal: React.FC<CreateQnAModalProps> = (props) => {
   }, []);
 
   useEffect(() => {
-    if (isAuthenticated) {
+    if (isAuthenticated && showCreateQnAFrom) {
       setAvailableSubscriptions([]);
       setSubscriptionsErrorMessage(undefined);
       getSubscriptions(currentUser.token)
@@ -173,7 +173,7 @@ export const CreateQnAModal: React.FC<CreateQnAModalProps> = (props) => {
           setSubscriptionsErrorMessage(err.message);
         });
     }
-  }, [currentUser, isAuthenticated]);
+  }, [currentUser, isAuthenticated, showCreateQnAFrom]);
 
   useEffect(() => {
     // reset the ui

--- a/Composer/packages/client/src/components/QnA/ReplaceQnAFromModal.tsx
+++ b/Composer/packages/client/src/components/QnA/ReplaceQnAFromModal.tsx
@@ -136,7 +136,7 @@ export const ReplaceQnAFromModal: React.FC<ReplaceQnAModalProps> = (props) => {
   }, []);
 
   useEffect(() => {
-    if (isAuthenticated) {
+    if (isAuthenticated && !hidden) {
       setAvailableSubscriptions([]);
       setSubscriptionsErrorMessage(undefined);
       getSubscriptions(currentUser.token)
@@ -154,7 +154,7 @@ export const ReplaceQnAFromModal: React.FC<ReplaceQnAModalProps> = (props) => {
           setSubscriptionsErrorMessage(err.message);
         });
     }
-  }, [currentUser, isAuthenticated]);
+  }, [currentUser, isAuthenticated, hidden]);
 
   useEffect(() => {
     // reset the ui


### PR DESCRIPTION
## Description

Several modal components were firing API calls to fetch Azure subscriptions even if they were not visible on screen. This PR adds a check for the visibility to ensure we aren't doing unnecessary fetches.

This will prevent weird popups from appearing when a token expires.

## Task Item

fixes #8367