### PR TITLE
fix: rephrase no-recent-bots box

### DIFF
--- a/Composer/packages/client/src/pages/home/Home.tsx
+++ b/Composer/packages/client/src/pages/home/Home.tsx
@@ -189,22 +189,19 @@ const Home: React.FC<RouteComponentProps> = () => {
                   src={noRecentBotsCover}
                 />
                 <div css={home.noRecentBotsDescription}>
-                  {formatMessage.rich(
-                    'Open the product tour to learn about Bot Framework Composer or <Link>create a new bot</Link>',
-                    {
-                      Link: ({ children }) => (
-                        <Link
-                          key="create-new-bot-link"
-                          onClick={() => {
-                            onClickNewBot();
-                            TelemetryClient.track('ToolbarButtonClicked', { name: 'new' });
-                          }}
-                        >
-                          {children}
-                        </Link>
-                      ),
-                    }
-                  )}
+                  {formatMessage.rich('<Link>Create a new bot to get started</Link>', {
+                    Link: ({ children }) => (
+                      <Link
+                        key="create-new-bot-link"
+                        onClick={() => {
+                          onClickNewBot();
+                          TelemetryClient.track('ToolbarButtonClicked', { name: 'new' });
+                        }}
+                      >
+                        {children}
+                      </Link>
+                    ),
+                  })}
                 </div>
               </div>
             )}


### PR DESCRIPTION
## Description

Replaces the no-longer-current "open the product tour" text on the home screen when there are no projects loaded with a rephrased link to starting a new bot.

## Task Item

closes #8337

## Screenshots

![image](https://user-images.githubusercontent.com/61990921/125538451-857ea401-4037-4ea1-8b70-36e6c06c587b.png)

