### PR TITLE
fix: Dialog deletion warning shows undefined when removing a dialog without any callers

### DIFF
--- a/Composer/packages/client/src/pages/design/SideBar.tsx
+++ b/Composer/packages/client/src/pages/design/SideBar.tsx
@@ -4,7 +4,7 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import formatMessage from 'format-message';
-import { Diagnostic } from '@bfc/shared';
+import { Diagnostic, DialogInfo } from '@bfc/shared';
 import { useRecoilValue } from 'recoil';
 import { OpenConfirmModal, dialogStyle } from '@bfc/ui-shared';
 import { useSetRecoilState } from 'recoil';
@@ -47,13 +47,13 @@ function onRenderContent(subTitle, style) {
   );
 }
 
-function getAllRef(targetId, dialogs) {
-  let refs: string[] = [];
+function getAllRef(targetId: string, dialogs: DialogInfo[]) {
+  const refs: string[] = [];
+
+  // find target dialog's all parent
   dialogs.forEach((dialog) => {
-    if (dialog.id === targetId) {
-      refs = refs.concat(dialog.referredDialogs);
-    } else if (!dialog.referredDialogs.every((item) => item !== targetId)) {
-      refs.push(dialog.displayName || dialog.id);
+    if (dialog.referredDialogs?.some((name) => name === targetId)) {
+      refs.push(dialog.id);
     }
   });
   return refs;

--- a/Composer/packages/lib/indexers/src/dialogIndexer.ts
+++ b/Composer/packages/lib/indexers/src/dialogIndexer.ts
@@ -149,7 +149,7 @@ function extractReferredDialogs(dialog): string[] {
    * */
   const visitor: VisitorFunc = (path: string, value: any): boolean => {
     // it's a valid schema dialog node.
-    if (has(value, '$kind') && value.$kind === SDKKinds.BeginDialog) {
+    if (has(value, '$kind') && value.$kind === SDKKinds.BeginDialog && value.dialog) {
       const dialogName = value.dialog;
       dialogs.push(dialogName);
     }


### PR DESCRIPTION
## Description
**root cause**
1.  indexer doesn't check undefined value when finding the referred dialogs
2.  the warning use the children as the referred dialogs, but actually we need the parent 

**fix**
1. check the undefined value
2. find the correct references to a dialog
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
Closes #8342
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots
![delete](https://user-images.githubusercontent.com/39758135/125576224-3d12c410-ffa9-4d1a-b2ed-38d149165403.gif)

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
