### PR TITLE
fix: UX/UI updates to comments

### DIFF
--- a/Composer/packages/adaptive-flow/src/adaptive-flow-editor/renderers/NodeWrapper.tsx
+++ b/Composer/packages/adaptive-flow/src/adaptive-flow-editor/renderers/NodeWrapper.tsx
@@ -151,7 +151,10 @@ export const ActionNodeWrapper = ({ id, tab, data, onEvent, hideComment, childre
         gapSpace: 4,
         beakWidth: 12,
         target: escapeId(`#${nodeId}-comment-target`),
-        styles: { container: { borderRadius: '2px' } },
+        styles: {
+          container: { borderRadius: '2px' },
+          calloutMain: { overflowWrap: 'break-word', whiteSpace: 'pre-line' },
+        },
       }}
       content={data.$designer?.comment}
     >

--- a/Composer/packages/adaptive-form/src/components/Comment.tsx
+++ b/Composer/packages/adaptive-form/src/components/Comment.tsx
@@ -11,8 +11,6 @@ import { IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
 
 import { ExpandableText } from './ExpandableText';
 
-export const MAX_CHARS_FOR_SINGLE_LINE = 65;
-
 const styles = {
   note: css`
     background-color: #fff4ce;
@@ -45,7 +43,6 @@ type CommentProps = {
 
 const Comment: React.FC<CommentProps> = ({ comment, onChange }) => {
   const [isEditing, setIsEditing] = useState(!comment);
-  const [isMultiline, setIsMultiline] = useState((comment ?? '').length >= MAX_CHARS_FOR_SINGLE_LINE);
   const textfieldRef = useRef<ITextField>(null);
   const editingStateRef = useRef<boolean>(isEditing);
 
@@ -60,7 +57,6 @@ const Comment: React.FC<CommentProps> = ({ comment, onChange }) => {
   const handleChange = useCallback(
     (_e, val?: string) => {
       onChange(val);
-      setIsMultiline(Boolean(val && val.length >= MAX_CHARS_FOR_SINGLE_LINE));
     },
     [onChange]
   );
@@ -98,8 +94,8 @@ const Comment: React.FC<CommentProps> = ({ comment, onChange }) => {
   return (
     <React.Fragment>
       <TextField
+        multiline
         componentRef={textfieldRef}
-        multiline={isMultiline}
         placeholder={formatMessage('Add a note')}
         resizable={false}
         rows={5}
@@ -108,8 +104,7 @@ const Comment: React.FC<CommentProps> = ({ comment, onChange }) => {
             display: isEditing ? undefined : 'none',
           },
           field: {
-            paddingRight: isMultiline ? '28px' : undefined,
-            paddingBottom: isMultiline ? '30px' : undefined,
+            paddingRight: '28px',
           },
         }}
         value={comment}
@@ -127,7 +122,9 @@ const Comment: React.FC<CommentProps> = ({ comment, onChange }) => {
               menuWidth={120}
             />
           </div>
-          <ExpandableText css={styles.noteBody}>{comment}</ExpandableText>
+          <ExpandableText css={styles.noteBody} maxLines={3}>
+            {comment}
+          </ExpandableText>
         </div>
       )}
     </React.Fragment>

--- a/Composer/packages/adaptive-form/src/components/Comment.tsx
+++ b/Composer/packages/adaptive-form/src/components/Comment.tsx
@@ -28,6 +28,7 @@ const styles = {
     margin: 0;
     padding-right: 18px;
     white-space: pre-line;
+    overflow-wrap: break-word;
   `,
   showMore: css`
     display: flex;

--- a/Composer/packages/adaptive-form/src/components/Comment.tsx
+++ b/Composer/packages/adaptive-form/src/components/Comment.tsx
@@ -123,9 +123,7 @@ const Comment: React.FC<CommentProps> = ({ comment, onChange }) => {
               menuWidth={120}
             />
           </div>
-          <ExpandableText css={styles.noteBody} maxLines={3}>
-            {comment}
-          </ExpandableText>
+          <ExpandableText css={styles.noteBody}>{comment}</ExpandableText>
         </div>
       )}
     </React.Fragment>

--- a/Composer/packages/adaptive-form/src/components/ExpandableText.tsx
+++ b/Composer/packages/adaptive-form/src/components/ExpandableText.tsx
@@ -10,6 +10,7 @@ import { Link } from './Link';
 
 const styles = {
   body: (maxLines = 5, isExpanded = false) => css`
+    overflow-wrap: break-word;
     // https://css-tricks.com/line-clampin/#weird-webkit-flexbox-way
     ${!isExpanded
       ? `

--- a/Composer/packages/adaptive-form/src/components/ExpandableText.tsx
+++ b/Composer/packages/adaptive-form/src/components/ExpandableText.tsx
@@ -10,7 +10,6 @@ import { Link } from './Link';
 
 const styles = {
   body: (maxLines = 5, isExpanded = false) => css`
-    overflow-wrap: break-word;
     // https://css-tricks.com/line-clampin/#weird-webkit-flexbox-way
     ${!isExpanded
       ? `

--- a/Composer/packages/adaptive-form/src/components/__tests__/Comment.test.tsx
+++ b/Composer/packages/adaptive-form/src/components/__tests__/Comment.test.tsx
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 
 import React from 'react';
-import { render, fireEvent, act, faker, userEvent } from '@botframework-composer/test-utils';
+import { render, act, faker, userEvent } from '@botframework-composer/test-utils';
 
-import { Comment, MAX_CHARS_FOR_SINGLE_LINE } from '../Comment';
+import { Comment } from '../Comment';
 
 describe('<Comment />', () => {
   let onChange: jest.Mock = jest.fn();
@@ -21,27 +21,6 @@ describe('<Comment />', () => {
     expect(textfield).toBeVisible();
 
     expect(queryByTestId('CommentCard')).not.toBeInTheDocument();
-  });
-
-  it('renders a textarea if the comment is more than 65 characters', async () => {
-    const { findByPlaceholderText } = render(<Comment onChange={onChange} />);
-
-    let textfield = await findByPlaceholderText('Add a note');
-    expect(textfield.tagName.toLowerCase()).toEqual('input');
-
-    const text = faker.lorem.paragraph(2).substring(0, MAX_CHARS_FOR_SINGLE_LINE - 1);
-    act(() => {
-      fireEvent.change(textfield, { target: { value: text } });
-    });
-    expect(textfield.tagName.toLowerCase()).toEqual('input');
-    expect(textfield).toHaveValue(text);
-
-    act(() => {
-      fireEvent.change(textfield, { target: { value: text + faker.lorem.words() } });
-    });
-
-    textfield = await findByPlaceholderText('Add a note');
-    expect(textfield.tagName.toLowerCase()).toEqual('textarea');
   });
 
   it('can edit an existing comment', async () => {

--- a/Composer/packages/client/src/pages/design/createDialogModal.tsx
+++ b/Composer/packages/client/src/pages/design/createDialogModal.tsx
@@ -80,7 +80,7 @@ export const CreateDialogModal: React.FC<CreateDialogModalProps> = (props) => {
 
   const seedNewDialog = (formData: DialogFormData) => {
     const seededContent = new DialogFactory(schemas.sdk?.content).create(SDKKinds.AdaptiveDialog, {
-      $designer: { name: formData.name, description: formData.description },
+      $designer: { name: formData.name, comment: formData.description },
       generator: `${formData.name}.lg`,
       recognizer: seedNewRecognizer(defaultRecognizer),
     });

--- a/Composer/packages/lib/shared/src/dialogFactory.ts
+++ b/Composer/packages/lib/shared/src/dialogFactory.ts
@@ -15,7 +15,7 @@ import { chooseIntentTemplatePrefix } from './constant';
 
 interface DesignerAttributes {
   name: string;
-  description: string;
+  comment: string;
 }
 
 const initialInputDialog = {


### PR DESCRIPTION
## Description

Updates various things found during the bug bash:
- Correctly wraps long words
- Preserves whitespace in the tooltip on the flow
- Uses the dialog description as a comment when creating a new dialog
- Updates the initial experience when creating a comment to be more user-friendly

## Task Item

fixes #8333 
fixes #8331 
closes #8328
closes #8327

## Screenshots

![Screen Shot 2021-07-14 at 10 52 20 AM](https://user-images.githubusercontent.com/3619060/125670425-1e549d76-bfd9-486f-852f-7cc2e79ae157.png)
![Screen Shot 2021-07-14 at 10 52 32 AM](https://user-images.githubusercontent.com/3619060/125670430-9e4dc919-3b05-4b63-a559-0bfa2fc54751.png)

