### PR TITLE
fix: silently ignore ResizeObserver errors

### DIFF
--- a/Composer/packages/client/src/components/ErrorBoundary.tsx
+++ b/Composer/packages/client/src/components/ErrorBoundary.tsx
@@ -35,6 +35,8 @@ interface ErrorBoundaryState {
   };
 }
 
+const patternsToIgnore = [/ResizeObserver/g];
+
 // only class component can be a error boundary
 export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   constructor(props: ErrorBoundaryProps) {
@@ -57,13 +59,12 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
   }
 
   onErrorHandler(message, source, lineno, colno, error) {
-    const patternsToIgnore = [/ResizeObserver/g];
-    if (patternsToIgnore.some((regex) => regex.test(message))) {
-      // skip the console and application-level steps and just say we handled it
-      return true;
-    }
     console.error({ message, source, lineno, colno, error });
-    this.props.setApplicationLevelError(formatToStateError(message));
+    // If this is one we don't want to ignore, then make sure we surface
+    // it to the app as well.
+    if (!patternsToIgnore.some((regex) => regex.test(message))) {
+      this.props.setApplicationLevelError(formatToStateError(message));
+    }
     return true;
   }
 

--- a/Composer/packages/client/src/components/ErrorBoundary.tsx
+++ b/Composer/packages/client/src/components/ErrorBoundary.tsx
@@ -57,6 +57,11 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
   }
 
   onErrorHandler(message, source, lineno, colno, error) {
+    const patternsToIgnore = [/ResizeObserver/g];
+    if (patternsToIgnore.some((regex) => regex.test(message))) {
+      // skip the console and application-level steps and just say we handled it
+      return true;
+    }
     console.error({ message, source, lineno, colno, error });
     this.props.setApplicationLevelError(formatToStateError(message));
     return true;


### PR DESCRIPTION
## Description

This will cause all ResizeObserver errors to get swallowed by the window's custom error handler. These events are harmless and have been leading to issues.

## Task Item

close #8361
