### PR TITLE
fix: Support optional scm host domain for ASE

### DIFF
--- a/Composer/packages/lib/shared/src/settings.ts
+++ b/Composer/packages/lib/shared/src/settings.ts
@@ -70,5 +70,8 @@ export const applyPublishingProfileToSettings = (settings: DialogSetting, profil
   settings.MicrosoftAppId = profile.settings.MicrosoftAppId;
   settings.MicrosoftAppPassword = profile.settings.MicrosoftAppPassword;
 
+  // apply the SCM domain host
+  settings.scmHostDomain = profile.scmHostDomain;
+
   return settings;
 };

--- a/Composer/packages/types/src/publish.ts
+++ b/Composer/packages/types/src/publish.ts
@@ -155,6 +155,7 @@ export type PublishProfile = {
   resourceGroup?: string;
   subscriptionId?: string;
   region?: string;
+  scmHostDomain?: string;
   settings: {
     applicationInsights?: {
       InstrumentationKey: string;

--- a/extensions/azurePublish/src/node/deploy.ts
+++ b/extensions/azurePublish/src/node/deploy.ts
@@ -157,7 +157,7 @@ export class BotProjectDeploy {
         status: BotProjectDeployLoggerType.DEPLOY_INFO,
         message: 'Publishing to Azure ...',
       });
-      await this.deployZip(this.accessToken, this.zipPath, name, environment, hostname);
+      await this.deployZip(this.accessToken, this.zipPath, name, environment, hostname, settings?.scmHostDomain);
       this.logger({
         status: BotProjectDeployLoggerType.DEPLOY_SUCCESS,
         message: 'Published successfully!',
@@ -275,15 +275,22 @@ export class BotProjectDeploy {
 
   // Upload the zip file to Azure
   // DOCS HERE: https://docs.microsoft.com/en-us/azure/app-service/deploy-zip
-  private async deployZip(token: string, zipPath: string, name: string, env: string, hostname?: string) {
+  private async deployZip(
+    token: string,
+    zipPath: string,
+    name: string,
+    env: string,
+    hostname?: string,
+    scmHostDomain?: string
+  ) {
     this.logger({
       status: BotProjectDeployLoggerType.DEPLOY_INFO,
       message: `Uploading zip file... to ${hostname ? hostname : name + (env ? '-' + env : '')}`,
     });
 
-    const publishEndpoint = `https://${
-      hostname ? hostname : name + (env ? '-' + env : '')
-    }.scm.azurewebsites.net/zipdeploy/?isAsync=true`;
+    const publishEndpoint = `https://${hostname ? hostname : name + (env ? '-' + env : '')}.${
+      scmHostDomain ?? 'scm.azurewebsites.net'
+    }/zipdeploy/?isAsync=true`;
     // eslint-disable-next-line security/detect-non-literal-fs-filename
     const fileReadStream = fs.createReadStream(zipPath, { autoClose: true });
     fileReadStream.on('error', function (err) {
@@ -304,18 +311,12 @@ export class BotProjectDeploy {
     } catch (err) {
       // close file read stream
       fileReadStream.close();
-      if (err.statusCode === 403) {
-        throw createCustomizeError(
-          AzurePublishErrors.DEPLOY_ZIP_ERROR,
-          `Token expired, please run az account get-access-token, then replace the accessToken in your configuration`
-        );
-      } else {
-        const errorMessage = JSON.stringify(err, Object.getOwnPropertyNames(err));
-        throw createCustomizeError(
-          AzurePublishErrors.DEPLOY_ZIP_ERROR,
-          `There was a problem publishing bot assets (zip deploy). ${errorMessage}`
-        );
-      }
+
+      const errorMessage = JSON.stringify(err, Object.getOwnPropertyNames(err));
+      throw createCustomizeError(
+        AzurePublishErrors.DEPLOY_ZIP_ERROR,
+        `There was a problem publishing bot assets (zip deploy). ${errorMessage}`
+      );
     }
   }
 

--- a/extensions/azurePublish/src/node/schema.ts
+++ b/extensions/azurePublish/src/node/schema.ts
@@ -55,6 +55,10 @@ const schema: JSONSchema7 = {
       type: 'string',
       title: "The operating system for the App Service. 'windows' or 'linux'.",
     },
+    scmHostDomain: {
+      type: 'string',
+      title: "An optional host domain for SCM deployment URLs. Defaults to 'scm.azurewebsites.net'.",
+    },
     settings: {
       type: 'object',
       title: 'Settings for Azure resources',
@@ -155,6 +159,7 @@ const schema: JSONSchema7 = {
     subscriptionId: '<id of your subscription>',
     region: '<region of your resource group>',
     appServiceOperatingSystem: 'windows',
+    scmHostDomain: '',
     luisResource: '<name of your luis resource>',
     settings: {
       applicationInsights: {


### PR DESCRIPTION
## Description

Added field to the publish profile for customers with ASE deployments to use to set the custom ASE SCM host domain.

## Task Item

fixes #8400 

## Screenshots

![image](https://user-images.githubusercontent.com/28762486/125709654-2cb4ea89-d4c8-410a-b275-1f5385257cef.png)
