### PR TITLE
fix: Problems pane reset

### DIFF
--- a/Composer/packages/client/src/components/DropdownWithAllOption/DropdownWithAllOption.tsx
+++ b/Composer/packages/client/src/components/DropdownWithAllOption/DropdownWithAllOption.tsx
@@ -24,12 +24,11 @@ export const DropdownWithAllOption: React.FC<DropdownWithAllOptionProps> = (prop
 
   const currentOptions = useMemo(() => {
     const allOptions = [...dropdownOptions];
-    if (allOptions.length > 1) {
-      allOptions.unshift({
-        key: optionAll.key,
-        text: optionAll.text,
-      });
-    }
+
+    allOptions.unshift({
+      key: optionAll.key,
+      text: optionAll.text,
+    });
 
     return allOptions;
   }, [dropdownOptions]);

--- a/Composer/packages/client/src/components/DropdownWithAllOption/DropdownWithAllOption.tsx
+++ b/Composer/packages/client/src/components/DropdownWithAllOption/DropdownWithAllOption.tsx
@@ -23,14 +23,13 @@ export const DropdownWithAllOption: React.FC<DropdownWithAllOptionProps> = (prop
   const { selectedKeys, onChange, placeholder, options: dropdownOptions, optionAll } = props;
 
   const currentOptions = useMemo(() => {
-    const allOptions = [...dropdownOptions];
-
-    allOptions.unshift({
-      key: optionAll.key,
-      text: optionAll.text,
-    });
-
-    return allOptions;
+    return [
+      {
+        key: optionAll.key,
+        text: optionAll.text,
+      },
+      ...dropdownOptions,
+    ];
   }, [dropdownOptions]);
 
   const onOptionSelectionChange = (event: React.FormEvent<HTMLDivElement>, item: IDropdownOption | undefined): void => {

--- a/Composer/packages/client/src/pages/design/DebugPanel/TabExtensions/DiagnosticsTab/DiagnosticFilters.tsx
+++ b/Composer/packages/client/src/pages/design/DebugPanel/TabExtensions/DiagnosticsTab/DiagnosticFilters.tsx
@@ -86,6 +86,7 @@ export const DiagnosticsFilters: React.FC<DiagnosticsFiltersProps> = (props) => 
   } = props;
   const projects = useRecoilValue(outputsDebugPanelSelector);
   const rootBotProjectId = useRecoilValue(rootBotProjectIdSelector);
+  const optionAll = getOptionAll();
 
   useEffect(() => {
     if (rootBotProjectId) {
@@ -100,6 +101,11 @@ export const DiagnosticsFilters: React.FC<DiagnosticsFiltersProps> = (props) => 
         text: botName,
       };
     });
+  }, [projects]);
+
+  useEffect(() => {
+    const allProjects = projects.map((project) => project.projectId);
+    onProjectFilterChange([...allProjects, optionAll.key]);
   }, [projects]);
 
   if (!rootBotProjectId) {
@@ -143,7 +149,7 @@ export const DiagnosticsFilters: React.FC<DiagnosticsFiltersProps> = (props) => 
         }}
       >
         <DropdownWithAllOption
-          optionAll={getOptionAll()}
+          optionAll={optionAll}
           options={projectSelectorOptions}
           placeholder={formatMessage('Select bots')}
           selectedKeys={projectsToFilter}

--- a/Composer/packages/client/src/pages/design/DebugPanel/TabExtensions/DiagnosticsTab/DiagnosticsTabContent.tsx
+++ b/Composer/packages/client/src/pages/design/DebugPanel/TabExtensions/DiagnosticsTab/DiagnosticsTabContent.tsx
@@ -63,6 +63,7 @@ export const DiagnosticsContent: React.FC<DebugPanelTabHeaderProps> = ({ isActiv
   if (!isActive) {
     return null;
   }
+
   return (
     <Stack verticalFill>
       <Stack.Item

--- a/Composer/packages/client/src/recoilModel/atoms/appState.ts
+++ b/Composer/packages/client/src/recoilModel/atoms/appState.ts
@@ -363,7 +363,7 @@ export const showErrorDiagnosticsState = atom<boolean>({
 
 export const showWarningDiagnosticsState = atom<boolean>({
   key: getFullyQualifiedKey('showWarningDiagnostics'),
-  default: false,
+  default: true,
 });
 
 export const projectsForDiagnosticsFilterState = atom<string[]>({

--- a/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
@@ -79,6 +79,8 @@ import {
   warnAboutDotNetState,
   warnAboutFunctionsState,
   showGetStartedTeachingBubbleState,
+  showErrorDiagnosticsState,
+  showWarningDiagnosticsState,
 } from '../../atoms';
 import * as botstates from '../../atoms/botState';
 import lgWorker from '../../parsers/lgWorker';
@@ -108,6 +110,8 @@ export const resetBotStates = async ({ reset }: CallbackInterface, projectId: st
     reset(currentRecoilAtom(projectId));
   });
   reset(botEndpointsState);
+  reset(showErrorDiagnosticsState);
+  reset(showWarningDiagnosticsState);
 };
 
 export const setErrorOnBotProject = async (


### PR DESCRIPTION
## Description
This PR
1. Resets the show warning and show error states in the DebuPane to true when swapping bots
2. When a bot project is opened it defaults to "All" option to show errors and warnings across bots. When a new skill is added to the solution it sets it again to "All" option.

## Task Item
Fixes #8345