### PR TITLE
fix: can't connect to remote skill: "Cannot read property 'default' of undefined"

### DIFF
--- a/Composer/packages/client/src/pages/design/exportSkillModal/content/Description.tsx
+++ b/Composer/packages/client/src/pages/design/exportSkillModal/content/Description.tsx
@@ -98,7 +98,7 @@ export const Description: React.FC<ContentProps> = ({
         content: {
           $schema: SCHEMA_URI,
           $id: `${botName}-${uuid()}`,
-          endpoints: [{}],
+          endpoints: [],
           name: botName,
           ...rest,
         },


### PR DESCRIPTION
## Description

fix: can't connect to remote skill: "Cannot read property 'default' of undefined"

### reason
manifest content endpoints have an empty object item

### solution
initial set endpoints is empty array.

## Task Item

closes #8479

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
