### PR TITLE
fix: use object url for json editor schema

### DIFF
--- a/extensions/azurePublish/src/node/schema.ts
+++ b/extensions/azurePublish/src/node/schema.ts
@@ -147,7 +147,7 @@ const schema: JSONSchema7 = {
       required: ['MicrosoftAppId', 'MicrosoftAppPassword'],
     },
   },
-  required: ['subscriptionID', 'publishName', 'provision'],
+  required: ['subscriptionId', 'name', 'settings', 'accessToken'],
   default: {
     name: '<unique name in your subscription>',
     environment: 'dev',


### PR DESCRIPTION
## Description

Allows the json editor to consume json schemas to validate data.

## Task Item

refs #8523
