### PR TITLE
fix: build publishEndpoint should check for empty string and undefined

### DIFF
--- a/extensions/azurePublish/src/node/deploy.ts
+++ b/extensions/azurePublish/src/node/deploy.ts
@@ -288,9 +288,7 @@ export class BotProjectDeploy {
       message: `Uploading zip file... to ${hostname ? hostname : name + (env ? '-' + env : '')}`,
     });
 
-    const publishEndpoint = `https://${hostname ? hostname : name + (env ? '-' + env : '')}.${
-      scmHostDomain ?? 'scm.azurewebsites.net'
-    }/zipdeploy/?isAsync=true`;
+    const publishEndpoint = this.buildPublishEndpoint(hostname, name, env, scmHostDomain);
     // eslint-disable-next-line security/detect-non-literal-fs-filename
     const fileReadStream = fs.createReadStream(zipPath, { autoClose: true });
     fileReadStream.on('error', function (err) {
@@ -319,6 +317,12 @@ export class BotProjectDeploy {
       );
     }
   }
+
+  private buildPublishEndpoint = (hostname: string, name: string, env: string, scmHostDomain: string) => {
+    const hostnameResult = hostname ? hostname : name + (env ? '-' + env : '');
+    const scmHostDomainResult = scmHostDomain ? scmHostDomain : 'scm.azurewebsites.net';
+    return `https://${hostnameResult}.${scmHostDomainResult}/zipdeploy/?isAsync=true`;
+  };
 
   /**
    * link the bot channel registration with azure web app service


### PR DESCRIPTION
## Description

Fix how we form the publishEndpoint. Check for undefined or empty scmHostDomain value.

Cause of the bug: the nullish coalescing operator (`??`) returns falsey for `undefined` but returns truthy for empty strings. All "Import Existing Resources" profiles include `scmHostDomain: ''` now so the expression would result in an invalid publishEndpoint URI.

## Task Item

fixes #8489 
