### PR TITLE
fix: <Dropdown/> syntax error in form editor

### DIFF
--- a/Composer/packages/adaptive-form/src/components/AdaptiveForm.tsx
+++ b/Composer/packages/adaptive-form/src/components/AdaptiveForm.tsx
@@ -66,7 +66,7 @@ export const AdaptiveForm: React.FC<AdaptiveFormProps> = function AdaptiveForm(p
           <SchemaField
             isRoot
             definitions={schema?.definitions}
-            id={formData?.$designer?.id ? `root[${formData?.$designer?.id}]` : 'root'}
+            id={formData?.$designer?.id ? `root-${formData?.$designer?.id}` : 'root'}
             name="root"
             rawErrors={errors}
             schema={schema}


### PR DESCRIPTION
## Description
**Root cause**
Form editor will use designer id to generate the < SchemaField /> id. And the < Dropdown /> will use the root id to generate some other tag id. Then < Dropdown /> will use document.querySelector to search some ids. But if the designerid in the pattern `root[designerid]` is start with digit, composer will throw syntax error. It's related to the querySelector and the css selector id

![image](https://user-images.githubusercontent.com/39758135/129509137-5e6107af-87a0-4659-9031-ca28e9274fa5.png)
**Fix**
use '-' to replace the '[]'
![image](https://user-images.githubusercontent.com/39758135/129509254-f6b5318b-d2c0-4bcc-b625-3af66752fd38.png)



<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
closes #8545
closes #8515
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
