### PR TITLE
fix: the Value field of a Trace Activity is throwing warnings

### DIFF
--- a/Composer/packages/lib/indexers/src/validations/expressionValidation/validation.ts
+++ b/Composer/packages/lib/indexers/src/validations/expressionValidation/validation.ts
@@ -55,7 +55,10 @@ export const checkExpression = (exp: any, required: boolean, types: number[]): n
       break;
     }
     case 'string': {
-      returnType = checkStringExpression(exp, types.length === 1 && types[0] === ReturnType.String);
+      returnType = checkStringExpression(
+        exp,
+        types.some((type) => type & ReturnType.String)
+      );
       break;
     }
     default:


### PR DESCRIPTION
## Description
**Root cause**
In the current design, if the expression contain string type ,we don't parse the expression. And the the return type use binary number to store. But indexer only use the first element of the types and use "===" to check the type. we need to check all types in the array and use bit operation.

**Fix**
check all types and do bit operation

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item
closes #8472
<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
