### PR TITLE
PVA V2 Demo: Apply PVA styling to header and left nav

### DIFF
--- a/Composer/packages/client/src/components/AppComponents/SideBar.tsx
+++ b/Composer/packages/client/src/components/AppComponents/SideBar.tsx
@@ -50,12 +50,6 @@ const sideBar = (isExpand: boolean) => css`
   flex-shrink: 0;
 `;
 
-const dividerTop = css`
-  width: 100%;
-  border-bottom: 1px solid ${NeutralColors.gray40};
-  margin: 0 auto;
-`;
-
 const leftNavBottom = () => css`
   height: 90px;
 `;
@@ -94,7 +88,6 @@ export const SideBar: React.FC<RouteComponentProps> = () => {
             }}
           />
         </TooltipHost>
-        <div css={dividerTop} />{' '}
         <FocusZone allowFocusRoot>
           {topLinks.map((link, index) => {
             const navItem = (

--- a/Composer/packages/client/src/components/AppComponents/SideBar.tsx
+++ b/Composer/packages/client/src/components/AppComponents/SideBar.tsx
@@ -51,7 +51,7 @@ const sideBar = (isExpand: boolean) => css`
 `;
 
 const leftNavBottom = () => css`
-  height: 90px;
+  height: 40px;
 `;
 
 const divider = (isExpand: boolean) => css`

--- a/Composer/packages/client/src/components/BotRuntimeController/BotController.tsx
+++ b/Composer/packages/client/src/components/BotRuntimeController/BotController.tsx
@@ -36,7 +36,7 @@ const iconSectionContainer = css`
   display: flex;
   align-items: flex-end;
   flex-direction: row;
-  background: #0b556a;
+  background: ${CommunicationColors.tint10};
   :before {
     content: '';
     position: relative;
@@ -241,14 +241,14 @@ const BotController: React.FC<BotControllerProps> = ({ onHideController, isContr
             menuAs={() => null}
             styles={{
               root: {
-                backgroundColor: '#0b556a',
+                backgroundColor: CommunicationColors.tint10,
                 display: 'flex',
                 alignItems: 'center',
                 minWidth: '229px',
                 height: '36px',
                 flexDirection: 'row',
                 padding: '0 7px',
-                border: `1px solid #0b556a`,
+                border: `1px solid ${CommunicationColors.tint10}`,
                 width: '100%',
               },
               rootHovered: {
@@ -290,11 +290,11 @@ const BotController: React.FC<BotControllerProps> = ({ onHideController, isContr
                 root: {
                   color: NeutralColors.white,
                   height: '36px',
-                  background: isControllerHidden ? '#0b556a' : transparentBackground,
+                  background: isControllerHidden ? CommunicationColors.tint10 : transparentBackground,
                   selectors: {
                     ':disabled .ms-Button-icon': {
                       opacity: 0.6,
-                      backgroundColor: '#0b556a',
+                      backgroundColor: CommunicationColors.tint10,
                       color: `${NeutralColors.white}`,
                     },
                   },

--- a/Composer/packages/client/src/components/BotRuntimeController/BotController.tsx
+++ b/Composer/packages/client/src/components/BotRuntimeController/BotController.tsx
@@ -36,7 +36,7 @@ const iconSectionContainer = css`
   display: flex;
   align-items: flex-end;
   flex-direction: row;
-  background: ${CommunicationColors.tint10};
+  background: #0b556a;
   :before {
     content: '';
     position: relative;
@@ -241,14 +241,14 @@ const BotController: React.FC<BotControllerProps> = ({ onHideController, isContr
             menuAs={() => null}
             styles={{
               root: {
-                backgroundColor: CommunicationColors.tint10,
+                backgroundColor: '#0b556a',
                 display: 'flex',
                 alignItems: 'center',
                 minWidth: '229px',
                 height: '36px',
                 flexDirection: 'row',
                 padding: '0 7px',
-                border: `1px solid ${CommunicationColors.tint10}`,
+                border: `1px solid #0b556a`,
                 width: '100%',
               },
               rootHovered: {
@@ -290,11 +290,11 @@ const BotController: React.FC<BotControllerProps> = ({ onHideController, isContr
                 root: {
                   color: NeutralColors.white,
                   height: '36px',
-                  background: isControllerHidden ? CommunicationColors.tint10 : transparentBackground,
+                  background: isControllerHidden ? '#0b556a' : transparentBackground,
                   selectors: {
                     ':disabled .ms-Button-icon': {
                       opacity: 0.6,
-                      backgroundColor: CommunicationColors.tint10,
+                      backgroundColor: '#0b556a',
                       color: `${NeutralColors.white}`,
                     },
                   },

--- a/Composer/packages/client/src/components/Header.tsx
+++ b/Composer/packages/client/src/components/Header.tsx
@@ -54,6 +54,7 @@ const headerContainer = css`
 
 const botName = css`
   font-size: 16px;
+  font-weight: 600;
   color: #fff;
   padding-left: 20px;
 `;
@@ -75,8 +76,6 @@ const headerTextContainer = css`
   justify-content: flex-start;
   min-width: 600px;
   width: 50%;
-  font-size: 16px;
-  font-weight: 600;
 `;
 
 const rightSection = css`

--- a/Composer/packages/client/src/components/Header.tsx
+++ b/Composer/packages/client/src/components/Header.tsx
@@ -108,7 +108,7 @@ const buttonStyles: IButtonStyles = {
     backgroundColor: 'rgba(255, 255, 255, 0.6)',
   },
   rootDisabled: {
-    backgroundColor: `${CommunicationColors.primary}`,
+    backgroundColor: `#0b556a`,
   },
 };
 

--- a/Composer/packages/client/src/components/Header.tsx
+++ b/Composer/packages/client/src/components/Header.tsx
@@ -255,7 +255,7 @@ export const Header = () => {
       <div css={headerTextContainer}>
         {projectName && (
           <Fragment>
-            <span css={botName}>{projectName}</span>
+            <span css={botName}>Power Virtual Agents v2 | {projectName}</span>
             {languageListOptions.length > 1 && (
               <span
                 css={botLocale}

--- a/Composer/packages/client/src/components/Header.tsx
+++ b/Composer/packages/client/src/components/Header.tsx
@@ -28,7 +28,6 @@ import {
   allRequiredRecognizersSelector,
   showGetStartedTeachingBubbleState,
 } from '../recoilModel';
-import composerIcon from '../images/composerIcon.svg';
 import { AppUpdaterStatus } from '../constants';
 import TelemetryClient from '../telemetry/TelemetryClient';
 import { useBotControllerBar } from '../hooks/useControllerBar';
@@ -246,14 +245,12 @@ export const Header = () => {
     }
   };
 
-  const logoLabel = formatMessage('Composer Logo');
   const testLabel = formatMessage('Test your bot');
   const rocketLabel = formatMessage('Recommended actions');
   const updateLabel = formatMessage('Update available');
 
   return (
     <div css={headerContainer} role="banner">
-      <img alt={logoLabel} aria-label={logoLabel} src={composerIcon} style={{ marginLeft: '9px' }} />
       <div css={headerTextContainer}>
         {projectName && (
           <Fragment>

--- a/Composer/packages/client/src/components/Header.tsx
+++ b/Composer/packages/client/src/components/Header.tsx
@@ -75,6 +75,8 @@ const headerTextContainer = css`
   justify-content: flex-start;
   min-width: 600px;
   width: 50%;
+  font-size: 16px;
+  font-weight: 600;
 `;
 
 const rightSection = css`

--- a/Composer/packages/client/src/components/Header.tsx
+++ b/Composer/packages/client/src/components/Header.tsx
@@ -46,7 +46,7 @@ export const actionButton = css`
 const headerContainer = css`
   position: relative;
   background: #0b556a;
-  height: 50px;
+  height: 48px;
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -85,6 +85,26 @@ const rightSection = css`
   width: 50%;
   margin: 0 10px;
 `;
+
+const appLaucherButtonStyle: IButtonStyles = {
+  icon: {
+    color: '#fff',
+    fontSize: FontSizes.size16,
+  },
+  root: {
+    height: '48px',
+    width: '48px',
+    selectors: {
+      ':disabled .ms-Button-icon': {
+        opacity: 0.4,
+        color: `${NeutralColors.white}`,
+      },
+    },
+  },
+  rootHovered: {
+    backgroundColor: 'rgba(255, 255, 255, 0.6)',
+  },
+};
 
 const buttonStyles: IButtonStyles = {
   icon: {
@@ -173,7 +193,9 @@ export const Header = () => {
   }, [requiredStuff, botProjectSolutionLoaded]);
   // ... end of get started stuff
 
-  const isShow = useBotControllerBar();
+  // NOTE: disabled for August demo
+  // const isShow = useBotControllerBar();
+  const isShow = false;
 
   useEffect(() => {
     if (!isShow) {
@@ -246,16 +268,25 @@ export const Header = () => {
     }
   };
 
+  const appLauncherLabel = formatMessage('App launcher');
   const testLabel = formatMessage('Test your bot');
   const rocketLabel = formatMessage('Recommended actions');
   const updateLabel = formatMessage('Update available');
 
   return (
     <div css={headerContainer} role="banner">
+      <TooltipHost content={appLauncherLabel} directionalHint={DirectionalHint.bottomRightEdge}>
+            <IconButton
+              ariaLabel={appLauncherLabel}
+              iconProps={{ iconName: 'WaffleOffice365' }}
+              id="appLauncher"
+              styles={appLaucherButtonStyle}
+            />
+          </TooltipHost>
       <div css={headerTextContainer}>
         {projectName && (
           <Fragment>
-            <span css={botName}>Power Virtual Agents v2 | {projectName}</span>
+            <span css={botName}>Power Virtual Agents v2 Demo | {projectName}</span>
             {languageListOptions.length > 1 && (
               <span
                 css={botLocale}

--- a/Composer/packages/client/src/components/Header.tsx
+++ b/Composer/packages/client/src/components/Header.tsx
@@ -46,7 +46,7 @@ export const actionButton = css`
 // -------------------- Styles -------------------- //
 const headerContainer = css`
   position: relative;
-  background: ${SharedColors.cyanBlue10};
+  background: #0b556a;
   height: 50px;
   display: flex;
   flex-direction: row;

--- a/Composer/packages/client/src/components/NavItem.tsx
+++ b/Composer/packages/client/src/components/NavItem.tsx
@@ -31,7 +31,7 @@ const link = (active: boolean, disabled: boolean) => css`
   ${active
     ? `background-color: ${NeutralColors.white};
 
-     border-left: 3px solid ${CommunicationColors.primary};
+     border-left: 3px solid #0b556a;
     `
     : `
      background-color: transparent;

--- a/Composer/packages/client/src/components/NavItem.tsx
+++ b/Composer/packages/client/src/components/NavItem.tsx
@@ -25,6 +25,8 @@ const link = (active: boolean, disabled: boolean) => css`
   text-decoration: none;
   color: ${disabled ? '#999' : '#4f4f4f'};
   position: relative;
+  font-size: 14px;
+  padding: 4px 0;
 
   width: 220px;
 
@@ -32,6 +34,7 @@ const link = (active: boolean, disabled: boolean) => css`
     ? `background-color: ${NeutralColors.white};
 
      border-left: 3px solid #0b556a;
+     font-weight: 600;
     `
     : `
      background-color: transparent;

--- a/Composer/packages/client/src/utils/pageLinks.ts
+++ b/Composer/packages/client/src/utils/pageLinks.ts
@@ -41,18 +41,10 @@ export const topLinks = (
     },
     {
       to: linkBase + `dialogs/${openedDialogId}`,
-      iconName: 'SplitObject',
-      labelName: formatMessage('Create'),
+      iconName: 'CannedChat',
+      labelName: formatMessage('Topics'),
       disabled: !botLoaded,
       match: /(bot\/[0-9.]+)$|(bot\/[0-9.]+\/skill\/[0-9.]+)$/,
-      isDisabledForPVA: false,
-    },
-    {
-      to: `/bot/${rootProjectId || projectId}/botProjectsSettings`,
-      iconName: 'BotProjectsSettings',
-      labelName: formatMessage('Configure'),
-      disabled: !botLoaded,
-      match: /botProjectsSettings/,
       isDisabledForPVA: false,
     },
     {
@@ -61,7 +53,7 @@ export const topLinks = (
       labelName: formatMessage('User input'),
       disabled: !botLoaded || skillIsRemote,
       match: /language-understanding\/[a-zA-Z0-9_-]+$/,
-      isDisabledForPVA: false,
+      isDisabledForPVA: true,
     },
     {
       to: linkBase + `language-generation/${openedDialogId}`,
@@ -69,7 +61,7 @@ export const topLinks = (
       labelName: formatMessage('Bot responses'),
       disabled: !botLoaded || skillIsRemote,
       match: /language-generation\/[a-zA-Z0-9_-]+$/,
-      isDisabledForPVA: false,
+      isDisabledForPVA: true,
     },
     {
       to: linkBase + `knowledge-base/${openedDialogId}`,
@@ -77,7 +69,7 @@ export const topLinks = (
       labelName: formatMessage('Knowledge base'),
       disabled: !botLoaded || skillIsRemote,
       match: /knowledge-base\/[a-zA-Z0-9_-]+$/,
-      isDisabledForPVA: isPVASchema,
+      isDisabledForPVA: true,
     },
     ...(showFormDialog
       ? [
@@ -92,28 +84,37 @@ export const topLinks = (
       : []),
     {
       to: `/bot/${rootProjectId || projectId}/publish`,
-      iconName: 'CloudUpload',
+      iconName: 'PublishContent',
       labelName: formatMessage('Publish'),
       disabled: !botLoaded,
       isDisabledForPVA: false,
     },
+    {
+      to: `/bot/${rootProjectId || projectId}/botProjectsSettings`,
+      iconName: 'BotProjectsSettings',
+      labelName: formatMessage('Manage'),
+      disabled: !botLoaded,
+      match: /botProjectsSettings/,
+      isDisabledForPVA: false,
+    },
   ];
 
-  if (pluginPages.length > 0) {
-    pluginPages.forEach((p) => {
-      let disablePluginForPva = false;
-      if (p.bundleId === 'package-manager' && isPVASchema) {
-        disablePluginForPva = true;
-      }
-      links.push({
-        to: linkBase + `plugin/${p.id}/${p.bundleId}`,
-        iconName: p.icon ?? 'StatusCircleQuestionMark',
-        labelName: p.label,
-        disabled: !projectId,
-        isDisabledForPVA: disablePluginForPva,
-      });
-    });
-  }
+  // Disabled for V2 demo
+  // if (pluginPages.length > 0) {
+  //   pluginPages.forEach((p) => {
+  //     let disablePluginForPva = false;
+  //     if (p.bundleId === 'package-manager' && isPVASchema) {
+  //       disablePluginForPva = true;
+  //     }
+  //     links.push({
+  //       to: linkBase + `plugin/${p.id}/${p.bundleId}`,
+  //       iconName: p.icon ?? 'StatusCircleQuestionMark',
+  //       labelName: p.label,
+  //       disabled: !projectId,
+  //       isDisabledForPVA: disablePluginForPva,
+  //     });
+  //   });
+  // }
 
   return links;
 };


### PR DESCRIPTION
## Description

Add styling to the Composer header and left nav that resembles PVA v1.0, for purposes of next week's demo.

Header
- Updated background color to the PVA teal
- Updated font style of text
- Hid BotController buttons
- Added placeholder Office365 waffle icon (no onClick handler)
- Added "PVA 2.0" prefix to bot name

Left nav:
- Adjusted nav item styles and colors
- Changed nav item logo and name from Create to Topics
- Changed nav item logo for Publish to match PVA
- Changed nav item name from Configure to Manage
- Kept other Composer nav items there but in disabled state (pending feedback; could hide/replace with PVA placeholders)

## References
Figma: https://www.figma.com/file/frQviquVRVWnyr1JcAxrAz/Authoring-PVA-2.0?node-id=1238%3A7309

## Screenshots
Left nav collapsed:
![image](https://user-images.githubusercontent.com/12548624/129807670-fa679a80-b0b5-4ff2-b265-0bc2c0c6eaeb.png)

Left nav expanded:
![image](https://user-images.githubusercontent.com/12548624/129809708-9c667bfc-af2d-4603-9ff2-477e9ceab72f.png)