### PR TITLE
PVA v2 Demo: Collapse Edit dropdown to individual action buttons

### DIFF
--- a/Composer/packages/client/src/components/Toolbar.tsx
+++ b/Composer/packages/client/src/components/Toolbar.tsx
@@ -33,9 +33,13 @@ export const rightActions = css`
 `;
 
 export const actionButton = css`
-  font-size: 16px;
-  margin-top: 2px;
-  margin-left: 15px;
+  height: 44px;
+  font-size: 14px;
+  margin-left: 7px;
+  &:hover {
+    background: ${NeutralColors.gray20};
+    color: ${NeutralColors.black};
+  }
 `;
 
 // -------------------- IToolbarItem -------------------- //

--- a/Composer/packages/client/src/pages/design/CommandBar.tsx
+++ b/Composer/packages/client/src/pages/design/CommandBar.tsx
@@ -136,10 +136,10 @@ const CommandBar: React.FC<CommandBarProps> = React.memo(({ projectId }) => {
         align: 'left',
         dataTestid: 'MoveButton',
         buttonProps: {
-          iconProps: { iconName: 'Copy' },
+          iconProps: { iconName: 'Export' },
           onClick: () => {
-            EditorAPI.Actions.CopySelection();
-            TelemetryClient.track('ToolbarButtonClicked', { name: 'copy' });
+            EditorAPI.Actions.MoveSelection();
+            TelemetryClient.track('ToolbarButtonClicked', { name: 'move' });
           },
         },
         disabled: !actionSelected,
@@ -158,40 +158,41 @@ const CommandBar: React.FC<CommandBarProps> = React.memo(({ projectId }) => {
         },
         disabled: !actionSelected,
       },
-      {
-        type: 'dropdown',
-        text: formatMessage('Disable'),
-        align: 'left',
-        disabled: !actionSelected,
-        buttonProps: {
-          iconProps: { iconName: 'RemoveOccurrence' },
-        },
-        menuProps: {
-          onMenuOpened: () => {
-            TelemetryClient.track('ToolbarButtonClicked', { name: 'disableDropdown' });
-          },
-          items: [
-            {
-              key: 'disable',
-              text: formatMessage('Disable'),
-              disabled: !showDisableBtn,
-              onClick: () => {
-                EditorAPI.Actions.DisableSelection();
-                TelemetryClient.track('ToolbarButtonClicked', { name: 'disable' });
-              },
-            },
-            {
-              key: 'enable',
-              text: formatMessage('Enable'),
-              disabled: !showEnableBtn,
-              onClick: () => {
-                EditorAPI.Actions.EnableSelection();
-                TelemetryClient.track('ToolbarButtonClicked', { name: 'enable' });
-              },
-            },
-          ],
-        },
-      },
+      // NOTE: Hidden for August v2 demo
+      // {
+      //   type: 'dropdown',
+      //   text: formatMessage('Disable'),
+      //   align: 'left',
+      //   disabled: !actionSelected,
+      //   buttonProps: {
+      //     iconProps: { iconName: 'RemoveOccurrence' },
+      //   },
+      //   menuProps: {
+      //     onMenuOpened: () => {
+      //       TelemetryClient.track('ToolbarButtonClicked', { name: 'disableDropdown' });
+      //     },
+      //     items: [
+      //       {
+      //         key: 'disable',
+      //         text: formatMessage('Disable'),
+      //         disabled: !showDisableBtn,
+      //         onClick: () => {
+      //           EditorAPI.Actions.DisableSelection();
+      //           TelemetryClient.track('ToolbarButtonClicked', { name: 'disable' });
+      //         },
+      //       },
+      //       {
+      //         key: 'enable',
+      //         text: formatMessage('Enable'),
+      //         disabled: !showEnableBtn,
+      //         onClick: () => {
+      //           EditorAPI.Actions.EnableSelection();
+      //           TelemetryClient.track('ToolbarButtonClicked', { name: 'enable' });
+      //         },
+      //       },
+      //     ],
+      //   },
+      // },
     ],
     [showDisableBtn, showEnableBtn, actionSelected, canUndo, canRedo, debugItems]
   );

--- a/Composer/packages/client/src/pages/design/CommandBar.tsx
+++ b/Composer/packages/client/src/pages/design/CommandBar.tsx
@@ -75,74 +75,88 @@ const CommandBar: React.FC<CommandBarProps> = React.memo(({ projectId }) => {
     () => [
       ...debugItems,
       {
-        type: 'dropdown',
-        text: formatMessage('Edit'),
+        type: 'action',
+        text: formatMessage('Undo'),
         align: 'left',
-        dataTestid: 'EditFlyout',
+        dataTestid: 'UndoButton',
         buttonProps: {
-          iconProps: { iconName: 'Edit' },
-        },
-        menuProps: {
-          onMenuOpened: () => {
-            TelemetryClient.track('ToolbarButtonClicked', { name: 'edit' });
+          iconProps: { iconName: 'Undo' },
+          onClick: () => {
+            undo();
+            TelemetryClient.track('ToolbarButtonClicked', { name: 'undo' });
           },
-          items: [
-            {
-              key: 'edit.undo',
-              text: formatMessage('Undo'),
-              disabled: !canUndo,
-              onClick: () => {
-                undo();
-                TelemetryClient.track('ToolbarButtonClicked', { name: 'undo' });
-              },
-            },
-            {
-              key: 'edit.redo',
-              text: formatMessage('Redo'),
-              disabled: !canRedo,
-              onClick: () => {
-                redo();
-                TelemetryClient.track('ToolbarButtonClicked', { name: 'redo' });
-              },
-            },
-            {
-              key: 'edit.cut',
-              text: formatMessage('Cut'),
-              disabled: !actionSelected,
-              onClick: () => {
-                EditorAPI.Actions.CutSelection();
-                TelemetryClient.track('ToolbarButtonClicked', { name: 'cut' });
-              },
-            },
-            {
-              key: 'edit.copy',
-              text: formatMessage('Copy'),
-              disabled: !actionSelected,
-              onClick: () => {
-                EditorAPI.Actions.CopySelection();
-                TelemetryClient.track('ToolbarButtonClicked', { name: 'copy' });
-              },
-            },
-            {
-              key: 'edit.move',
-              text: formatMessage('Move'),
-              disabled: !actionSelected,
-              onClick: () => {
-                EditorAPI.Actions.MoveSelection();
-                TelemetryClient.track('ToolbarButtonClicked', { name: 'move' });
-              },
-            },
-            {
-              key: 'edit.delete',
-              text: formatMessage('Delete'),
-              disabled: !actionSelected,
-              onClick: () => {
-                EditorAPI.Actions.DeleteSelection();
-                TelemetryClient.track('ToolbarButtonClicked', { name: 'delete' });
-              },
-            },
-          ],
         },
+        disabled: !canUndo,
+      },
+      {
+        type: 'action',
+        text: formatMessage('Redo'),
+        align: 'left',
+        dataTestid: 'RedoButton',
+        buttonProps: {
+          iconProps: { iconName: 'Redo' },
+          onClick: () => {
+            redo();
+            TelemetryClient.track('ToolbarButtonClicked', { name: 'redo' });
+          },
+        },
+        disabled: !canRedo,
+      },
+      {
+        type: 'action',
+        text: formatMessage('Cut'),
+        align: 'left',
+        dataTestid: 'CutButton',
+        buttonProps: {
+          iconProps: { iconName: 'Cut' },
+          onClick: () => {
+            EditorAPI.Actions.CutSelection();
+            TelemetryClient.track('ToolbarButtonClicked', { name: 'cut' });
+          },
+        },
+        disabled: !actionSelected,
+      },
+      {
+        type: 'action',
+        text: formatMessage('Copy'),
+        align: 'left',
+        dataTestid: 'CopyButton',
+        buttonProps: {
+          iconProps: { iconName: 'Copy' },
+          onClick: () => {
+            EditorAPI.Actions.CopySelection();
+            TelemetryClient.track('ToolbarButtonClicked', { name: 'copy' });
+          },
+        },
+        disabled: !actionSelected,
+      },
+      {
+        type: 'action',
+        text: formatMessage('Move'),
+        align: 'left',
+        dataTestid: 'MoveButton',
+        buttonProps: {
+          iconProps: { iconName: 'Copy' },
+          onClick: () => {
+            EditorAPI.Actions.CopySelection();
+            TelemetryClient.track('ToolbarButtonClicked', { name: 'copy' });
+          },
+        },
+        disabled: !actionSelected,
+      },
+      {
+        type: 'action',
+        text: formatMessage('Delete'),
+        align: 'left',
+        dataTestid: 'DeleteButton',
+        buttonProps: {
+          iconProps: { iconName: 'Delete' },
+          onClick: () => {
+            EditorAPI.Actions.DeleteSelection();
+            TelemetryClient.track('ToolbarButtonClicked', { name: 'delete' });
+          },
+        },
+        disabled: !actionSelected,
       },
       {
         type: 'dropdown',


### PR DESCRIPTION
## Description
- Collapse Edit dropdown in CommandBar over to individual action buttons and hide dropdowns
- Apply styling for buttons (including hover state)

## Reference
Figma: https://www.figma.com/file/frQviquVRVWnyr1JcAxrAz/Authoring-PVA-2.0?node-id=1196%3A2168

## Screenshots
![image](https://user-images.githubusercontent.com/12548624/129817639-959c6ade-105b-4aa0-a102-759f05848907.png)

Hover state:
![image](https://user-images.githubusercontent.com/12548624/129817718-bada80a2-9e85-46ae-baf3-ad494c137160.png)

