### PR TITLE
Added PVA web chat integration

### DIFF
--- a/Composer/packages/client/src/components/Header.tsx
+++ b/Composer/packages/client/src/components/Header.tsx
@@ -276,13 +276,13 @@ export const Header = () => {
   return (
     <div css={headerContainer} role="banner">
       <TooltipHost content={appLauncherLabel} directionalHint={DirectionalHint.bottomRightEdge}>
-            <IconButton
-              ariaLabel={appLauncherLabel}
-              iconProps={{ iconName: 'WaffleOffice365' }}
-              id="appLauncher"
-              styles={appLaucherButtonStyle}
-            />
-          </TooltipHost>
+        <IconButton
+          ariaLabel={appLauncherLabel}
+          iconProps={{ iconName: 'WaffleOffice365' }}
+          id="appLauncher"
+          styles={appLaucherButtonStyle}
+        />
+      </TooltipHost>
       <div css={headerTextContainer}>
         {projectName && (
           <Fragment>

--- a/Composer/packages/client/src/components/WebChat/WebChatPanel.tsx
+++ b/Composer/packages/client/src/components/WebChat/WebChatPanel.tsx
@@ -123,7 +123,8 @@ export const WebChatPanel: React.FC<WebChatPanelProps> = ({
       }
     };
 
-    bootstrapChat();
+    // we can't log traffic in the demo because we are no longer going through the mock DL channel
+    //bootstrapChat();
 
     return () => {
       webChatTrafficChannel.current?.close();
@@ -137,12 +138,14 @@ export const WebChatPanel: React.FC<WebChatPanelProps> = ({
   }, [botUrl]);
 
   useEffect(() => {
-    setIsRestartButtonDisabled(botStatus !== BotStatus.connected);
+    // NOTE: for the pva 2 demo
+    //setIsRestartButtonDisabled(botStatus !== BotStatus.connected);
   }, [botStatus]);
 
   const sendInitialActivities = async (chatData: ChatData) => {
     try {
-      await conversationService.sendInitialActivity(chatData.conversationId, [chatData.user]);
+      // we don't need to send the activities for the demo
+      //await conversationService.sendInitialActivity(chatData.conversationId, [chatData.user]);
     } catch (ex) {
       // DL errors are handled through socket above.
     }
@@ -191,7 +194,8 @@ export const WebChatPanel: React.FC<WebChatPanelProps> = ({
             oldChatData,
             requireNewUserId,
             activeLocale,
-            secret
+            secret,
+            projectId
           );
 
           TelemetryClient.track('WebChatConversationRestarted', {
@@ -272,7 +276,7 @@ export const WebChatPanel: React.FC<WebChatPanelProps> = ({
         chatData={chats[currentConversation]}
         conversationService={conversationService}
         currentConversation={currentConversation}
-        isDisabled={botStatus !== BotStatus.connected}
+        isDisabled={false /*botStatus !== BotStatus.connected*/}
       />
     </div>
   );

--- a/Composer/packages/client/src/pages/design/CommandBar.tsx
+++ b/Composer/packages/client/src/pages/design/CommandBar.tsx
@@ -30,6 +30,7 @@ const CommandBar: React.FC<CommandBarProps> = React.memo(({ projectId }) => {
   const { undo, redo, clearUndo } = useRecoilValue(undoFunctionState(projectId));
   const visualEditorSelection = useRecoilValue(visualEditorSelectionState);
   const [canUndo, canRedo] = useRecoilValue(undoStatusSelectorFamily(projectId));
+  const { setWebChatPanelVisibility: toggleWebChatPanel } = useRecoilValue(dispatcherState);
 
   const { onboardingAddCoachMarkRef } = useRecoilValue(dispatcherState);
 
@@ -176,6 +177,18 @@ const CommandBar: React.FC<CommandBarProps> = React.memo(({ projectId }) => {
               },
             },
           ],
+        },
+      },
+      {
+        // NOTE: for pva 2 demo
+        type: 'action',
+        align: 'right',
+        text: formatMessage('Test bot'),
+        buttonProps: {
+          iconProps: { iconName: 'ChatBot' },
+          onClick: () => {
+            toggleWebChatPanel(true);
+          },
         },
       },
     ],

--- a/Composer/packages/server/src/controllers/project.ts
+++ b/Composer/packages/server/src/controllers/project.ts
@@ -633,6 +633,16 @@ async function autoSave(req: Request, res: Response) {
   res.sendStatus(200);
 }
 
+// TEMPORARY -- for pva 2 demo only
+async function getProjectMetadata(req: Request, res: Response) {
+  const projectId = req.params.projectId;
+  if (!projectId) {
+    return res.status(400).send('"projectId" parameter missing in request.');
+  }
+  const metadata = BotProjectService.getProjectMetadata(projectId);
+  res.status(200).json(metadata);
+}
+
 export const ProjectController = {
   autoSave,
   getProjectById,
@@ -664,4 +674,5 @@ export const ProjectController = {
   backupProject,
   copyTemplateToExistingProject,
   getVariablesByProjectId,
+  getProjectMetadata,
 };

--- a/Composer/packages/server/src/router/api.ts
+++ b/Composer/packages/server/src/router/api.ts
@@ -54,6 +54,7 @@ router.post('/projects/:projectId/backup', ProjectController.backupProject);
 router.post('/projects/:projectId/copyTemplateToExisting', ProjectController.copyTemplateToExistingProject);
 router.get('/projects/:projectId/variables', ProjectController.getVariablesByProjectId);
 router.put('/projects/:projectId/autoSave', ProjectController.autoSave);
+router.get('/projects/:projectId/metadata', ProjectController.getProjectMetadata);
 
 // form dialog generation apis
 router.post('/formDialogs/expandJsonSchemaProperty', FormDialogController.expandJsonSchemaProperty);

--- a/Composer/packages/server/src/services/project.ts
+++ b/Composer/packages/server/src/services/project.ts
@@ -390,6 +390,10 @@ export class BotProjectService {
     BotProjectService.setProjectLocationData(projectId, { alias });
   };
 
+  public static getProjectMetadata = (projectId: string): any => {
+    return BotProjectService.projectLocationMap[projectId].additionalInfo || {};
+  };
+
   private static updateCurrentProjects = (project: BotProject): void => {
     const { id } = project;
     const idx = BotProjectService.currentBotProjects.findIndex((item) => item.id === id);


### PR DESCRIPTION
Adds the ability to talk to the current PVA bot via Web Chat.


![PVA-WC-Integration](https://user-images.githubusercontent.com/3452012/129965790-d53b0c4b-1ffe-40cb-b697-d3525a3faa2b.gif)

**Important notes:**

To make this work you must do the following:

1. Get an access token from the PVA portal and paste it into Local Storage via the dev tools window under the key `PVA-2-DEMO-TOKEN`
2. Add the PVA bot's metadata to the bot's entry in the project location map in `data.json`:

![image](https://user-images.githubusercontent.com/3452012/129966024-678fb04e-a12d-4528-92d9-f1d0a95f09da.png)
