### PR TITLE
PVA V2 Demo - Project tree expand/collapse

### DIFF
--- a/Composer/packages/client/src/components/ProjectTree/ProjectTreeHeader.tsx
+++ b/Composer/packages/client/src/components/ProjectTree/ProjectTreeHeader.tsx
@@ -28,15 +28,23 @@ const buttonStyle = css`
   height: 100%;
 `;
 
-const headerText = css`
+const headerTextContainer = css`
   border-bottom: 1px solid ${NeutralColors.gray30};
-  height: 45px;
+  padding-left: 20px;
+  height: 44px;
   border-radius: 0px;
-  text-align: left;
-  font-size: ${FontSizes.size12};
+  font-size: ${FontSizes.size14};
+  font-weight: 600;
   position: relative;
   display: flex;
+  flex-direction: row;
+`;
+
+const headerText = css`
+  position: absolute;
   margin: 0;
+  top: 50%;
+  transform: translateY(-50%);
 `;
 
 const commands = css`
@@ -118,8 +126,13 @@ export const ProjectTreeHeader: React.FC<ProjectTreeHeaderProps> = ({
   );
 
   return (
-    <div css={headerText}>
-      {showFilter ? (
+    <div css={headerTextContainer}>
+      <div css={headerText}>Topics</div>
+      {/* <div css={commands}>
+        <div>X</div>
+      </div> */}
+      { /* Disabled for demo */
+      /* {showFilter ? (
         <SearchBox
           underlined
           ariaLabel={ariaLabel}
@@ -145,7 +158,7 @@ export const ProjectTreeHeader: React.FC<ProjectTreeHeaderProps> = ({
             }}
           />
         </div>
-      )}
+      )} */}
     </div>
   );
 };

--- a/Composer/packages/client/src/components/ProjectTree/ProjectTreeHeader.tsx
+++ b/Composer/packages/client/src/components/ProjectTree/ProjectTreeHeader.tsx
@@ -9,11 +9,11 @@ import formatMessage from 'format-message';
 import { CommandButton, IButtonProps } from 'office-ui-fabric-react/lib/Button';
 import { IOverflowSetItemProps } from 'office-ui-fabric-react/lib/OverflowSet';
 import { ISearchBox, ISearchBoxStyles, SearchBox } from 'office-ui-fabric-react/lib/SearchBox';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import { DisableFeatureToolTip } from '../DisableFeatureToolTip';
 import { usePVACheck } from '../../hooks/usePVACheck';
-import { rootBotProjectIdSelector } from '../../recoilModel';
+import { rootBotProjectIdSelector, showProjectTreePanelState } from '../../recoilModel';
 
 const searchBox: ISearchBoxStyles = {
   root: {
@@ -89,6 +89,7 @@ export const ProjectTreeHeader: React.FC<ProjectTreeHeaderProps> = ({
   const [showFilter, setShowFilter] = useState(false);
   const searchBoxRef = useRef<ISearchBox>(null);
   const rootBotId = useRecoilValue(rootBotProjectIdSelector) ?? '';
+  const setShowTreePanel = useSetRecoilState(showProjectTreePanelState);
   const isPVABot = usePVACheck(rootBotId);
 
   useEffect(() => {
@@ -145,7 +146,7 @@ export const ProjectTreeHeader: React.FC<ProjectTreeHeaderProps> = ({
             iconProps={{ iconName: 'ChromeClose' }}
             tabIndex={0}
             onClick={() => {
-              // DO STUFF
+              setShowTreePanel(false);
             }}
           />
       </div>

--- a/Composer/packages/client/src/components/ProjectTree/ProjectTreeHeader.tsx
+++ b/Composer/packages/client/src/components/ProjectTree/ProjectTreeHeader.tsx
@@ -6,7 +6,7 @@ import { jsx, css } from '@emotion/core';
 import { useEffect, useRef, useState } from 'react';
 import { FontSizes, NeutralColors } from '@uifabric/fluent-theme';
 import formatMessage from 'format-message';
-import { CommandButton } from 'office-ui-fabric-react/lib/Button';
+import { CommandButton, IButtonProps } from 'office-ui-fabric-react/lib/Button';
 import { IOverflowSetItemProps } from 'office-ui-fabric-react/lib/OverflowSet';
 import { ISearchBox, ISearchBoxStyles, SearchBox } from 'office-ui-fabric-react/lib/SearchBox';
 import { useRecoilValue } from 'recoil';
@@ -45,6 +45,17 @@ const headerText = css`
   margin: 0;
   top: 50%;
   transform: translateY(-50%);
+`;
+
+const closeButtonContainer = css`
+  position: absolute;
+  right: 0px;
+  margin: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  padding-right: 5px;
+  font-size: ${FontSizes.size12};
+  color: ${NeutralColors.black};
 `;
 
 const commands = css`
@@ -128,9 +139,16 @@ export const ProjectTreeHeader: React.FC<ProjectTreeHeaderProps> = ({
   return (
     <div css={headerTextContainer}>
       <div css={headerText}>Topics</div>
-      {/* <div css={commands}>
-        <div>X</div>
-      </div> */}
+      <div css={closeButtonContainer}>
+        <CommandButton
+            ariaLabel={formatMessage('Close')}
+            iconProps={{ iconName: 'ChromeClose' }}
+            tabIndex={0}
+            onClick={() => {
+              // DO STUFF
+            }}
+          />
+      </div>
       { /* Disabled for demo */
       /* {showFilter ? (
         <SearchBox

--- a/Composer/packages/client/src/components/Toolbar.tsx
+++ b/Composer/packages/client/src/components/Toolbar.tsx
@@ -39,6 +39,7 @@ export const rightActions = css`
 export const actionButton = css`
   font-size: 14px;
   margin-left: 7px;
+  height: 44px;
   &:hover {
     background: ${NeutralColors.gray20};
     color: ${NeutralColors.black};
@@ -48,17 +49,15 @@ export const actionButton = css`
 export const expandButton = css`
   font-size: 14px;
   margin: 0;
+  padding: 0 7px;
+  height: 44px;
   &:hover {
     background: ${NeutralColors.gray20};
     color: ${NeutralColors.black};
   }
 `;
 
-export const divider = css`
-  font-size: 14px;
-`;
-
-const dividerStyles = {
+export const dividerStyles = {
   divider: {
     height: '32px',
   },
@@ -142,22 +141,24 @@ export const Toolbar = (props: ToolbarProps) => {
 
   return (
     <div aria-label={formatMessage('toolbar')} css={headerSub} role="region" {...rest}>
-      <div css={leftActions}>
-        {!showTreePanel ? (
-          <div>
-            <ActionButton
-              css={expandButton}
-              data-testid={'Expand'}
-              iconProps={{ iconName: 'DockLeft' }}
-              onClick={() => {
-                setShowTreePanel(true);
-              }}
-            ></ActionButton>
-            <VerticalDivider css={divider} styles={dividerStyles} />
+      {!showTreePanel ? (
+        <div css={leftActions}>
+          <ActionButton
+            css={expandButton}
+            data-testid={'Expand'}
+            iconProps={{ iconName: 'DockLeft' }}
+            onClick={() => {
+              setShowTreePanel(true);
+            }}
+          ></ActionButton>
+          <div css={{ height: '44px' }}>
+            <VerticalDivider styles={dividerStyles} />
           </div>
-        ) : null}
-        <div>{left.map(renderItemList)}</div>
-      </div>
+          {left.map(renderItemList)}
+        </div>
+      ) : (
+        <div css={leftActions}>{left.map(renderItemList)}</div>
+      )}
       <div css={rightActions}>{right.map(renderItemList)}</div>
     </div>
   );

--- a/Composer/packages/client/src/components/Toolbar.tsx
+++ b/Composer/packages/client/src/components/Toolbar.tsx
@@ -7,7 +7,11 @@ import { Fragment } from 'react';
 import formatMessage from 'format-message';
 import { NeutralColors } from '@uifabric/fluent-theme';
 import { ActionButton, CommandButton } from 'office-ui-fabric-react/lib/Button';
+import { VerticalDivider } from 'office-ui-fabric-react/lib/Divider';
 import { IContextualMenuProps, IIconProps } from 'office-ui-fabric-react/lib';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+
+import { showProjectTreePanelState } from '../recoilModel';
 
 // -------------------- Styles -------------------- //
 
@@ -33,7 +37,6 @@ export const rightActions = css`
 `;
 
 export const actionButton = css`
-  height: 44px;
   font-size: 14px;
   margin-left: 7px;
   &:hover {
@@ -41,6 +44,25 @@ export const actionButton = css`
     color: ${NeutralColors.black};
   }
 `;
+
+export const expandButton = css`
+  font-size: 14px;
+  margin: 0;
+  &:hover {
+    background: ${NeutralColors.gray20};
+    color: ${NeutralColors.black};
+  }
+`;
+
+export const divider = css`
+  font-size: 14px;
+`;
+
+const dividerStyles = {
+  divider: {
+    height: '32px',
+  },
+};
 
 // -------------------- IToolbarItem -------------------- //
 
@@ -100,6 +122,9 @@ type ToolbarProps = {
 // action = {type:action/element, text, align, element, buttonProps: use
 // fabric-ui IButtonProps interface}
 export const Toolbar = (props: ToolbarProps) => {
+  const showTreePanel = useRecoilValue(showProjectTreePanelState);
+  const setShowTreePanel = useSetRecoilState(showProjectTreePanelState);
+
   const { toolbarItems = [], ...rest } = props;
 
   const left: IToolbarItem[] = [];
@@ -117,7 +142,22 @@ export const Toolbar = (props: ToolbarProps) => {
 
   return (
     <div aria-label={formatMessage('toolbar')} css={headerSub} role="region" {...rest}>
-      <div css={leftActions}>{left.map(renderItemList)} </div>
+      <div css={leftActions}>
+        {!showTreePanel ? (
+          <div>
+            <ActionButton
+              css={expandButton}
+              data-testid={'Expand'}
+              iconProps={{ iconName: 'DockLeft' }}
+              onClick={() => {
+                setShowTreePanel(true);
+              }}
+            ></ActionButton>
+            <VerticalDivider css={divider} styles={dividerStyles} />
+          </div>
+        ) : null}
+        <div>{left.map(renderItemList)}</div>
+      </div>
       <div css={rightActions}>{right.map(renderItemList)}</div>
     </div>
   );

--- a/Composer/packages/client/src/pages/design/DesignPage.tsx
+++ b/Composer/packages/client/src/pages/design/DesignPage.tsx
@@ -2,11 +2,12 @@
 // Licensed under the MIT License.
 
 /** @jsx jsx */
-import { jsx } from '@emotion/core';
+import { jsx, css } from '@emotion/core';
 import { RouteComponentProps } from '@reach/router';
 import { useRecoilValue } from 'recoil';
 import { Split, SplitMeasuredSizes } from '@geoffcox/react-splitter';
 import { useEffect, useRef } from 'react';
+import { NeutralColors } from '@uifabric/fluent-theme';
 
 import { dispatcherState, currentDialogState, showProjectTreePanelState } from '../../recoilModel';
 import { renderThinSplitter } from '../../components/Split/ThinSplitter';
@@ -55,18 +56,36 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
     };
   }, [autoSaveTimer, projectId]);
 
+  const designPanelWidth = showTreePanel ? '80%' : '100%';
+
+  const treePanelStyle = css`
+    display: flex;
+    position: relative;
+    width: 20%;
+    min-width: 200px;
+    height: 100%;
+    border-right: 1px solid ${NeutralColors.gray30};
+  `;
+  const designPanelStyle = css`
+    display: flex;
+    position: relative;
+    width: ${designPanelWidth};
+    height: 100%;
+  `;
+
+  const parentWrapper = css`
+    display: flex;
+    flex-direction: row;
+    flex-grow: 1;
+    height: 100%;
+    position: relative;
+    label: DesignPageContent;
+  `;
+
   return (
-    <div css={contentWrapper} role="main">
-      <Split
-        resetOnDoubleClick
-        initialPrimarySize="20%"
-        minPrimarySize="200px"
-        minSecondarySize="800px"
-        renderSplitter={renderThinSplitter}
-        splitterSize="5px"
-        onMeasuredSizesChanged={onMeasuredSizesChanged}
-      >
-        {showTreePanel ? (
+    <div css={parentWrapper} role="main">
+      {showTreePanel ? (
+        <div css={treePanelStyle}>
           <div css={contentWrapper}>
             <div css={splitPaneContainer}>
               <div css={splitPaneWrapper}>
@@ -74,10 +93,9 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
               </div>
             </div>
           </div>
-        ) : (
-          <div>HIDE</div>
-        )}
-
+        </div>
+      ) : null}
+      <div css={designPanelStyle}>
         <div css={contentWrapper} role="main">
           <CommandBar projectId={activeBot} />
           <Conversation css={splitPaneContainer}>
@@ -86,7 +104,7 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
             </div>
           </Conversation>
         </div>
-      </Split>
+      </div>
       <Modals projectId={activeBot} rootBotId={projectId} />
     </div>
   );

--- a/Composer/packages/client/src/pages/design/DesignPage.tsx
+++ b/Composer/packages/client/src/pages/design/DesignPage.tsx
@@ -8,7 +8,7 @@ import { useRecoilValue } from 'recoil';
 import { Split, SplitMeasuredSizes } from '@geoffcox/react-splitter';
 import { useEffect, useRef } from 'react';
 
-import { dispatcherState, currentDialogState } from '../../recoilModel';
+import { dispatcherState, currentDialogState, showProjectTreePanelState } from '../../recoilModel';
 import { renderThinSplitter } from '../../components/Split/ThinSplitter';
 import { Conversation } from '../../components/Conversation';
 import { useSurveyNotification } from '../../components/Notifications/useSurveyNotification';
@@ -33,6 +33,7 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
   useEmptyPropsHandler(projectId, location, skillId, dialogId);
   const { setPageElementState } = useRecoilValue(dispatcherState);
   const currentDialog = useRecoilValue(currentDialogState({ dialogId, projectId }));
+  const showTreePanel = useRecoilValue(showProjectTreePanelState);
 
   const onMeasuredSizesChanged = (sizes: SplitMeasuredSizes) => {
     setPageElementState('dialogs', { leftSplitWidth: sizes.primary });
@@ -65,13 +66,17 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
         splitterSize="5px"
         onMeasuredSizesChanged={onMeasuredSizesChanged}
       >
-        <div css={contentWrapper}>
-          <div css={splitPaneContainer}>
-            <div css={splitPaneWrapper}>
-              <SideBar projectId={activeBot} />
+        {showTreePanel ? (
+          <div css={contentWrapper}>
+            <div css={splitPaneContainer}>
+              <div css={splitPaneWrapper}>
+                <SideBar projectId={activeBot} />
+              </div>
             </div>
           </div>
-        </div>
+        ) : (
+          <div>HIDE</div>
+        )}
 
         <div css={contentWrapper} role="main">
           <CommandBar projectId={activeBot} />

--- a/Composer/packages/client/src/pages/design/VisualPanelHeader.tsx
+++ b/Composer/packages/client/src/pages/design/VisualPanelHeader.tsx
@@ -171,16 +171,20 @@ const VisualPanelHeader: React.FC<VisualPanelHeaderProps> = React.memo((props) =
 
   const items = breadcrumbs.map(createBreadcrumbItem);
 
+  const displayTitle = items.length ? breadcrumbs[breadcrumbs.length - 1].label : '';
+
   return (
     <div css={pageStyles.visualPanelHeaderContainer}>
-      <div style={{ width: '85%' }}>
+      <div css={pageStyles.visualPanelHeaderLabel}>{displayTitle}</div>
+      {/* NOTE: Breadcrumbs disabled for demo */}
+      {/* <div style={{ width: '85%' }}>
         <Breadcrumb
           ariaLabel={formatMessage('Navigation Path')}
           data-testid="Breadcrumb"
           items={items}
           styles={pageStyles.breadcrumbClass}
         />
-      </div>
+      </div> */}
       {/* <div css={pageStyles.visualPanelHeaderShowCodeButton}>
         <ActionButton onClick={onShowCodeClick}>
           {showCode ? formatMessage('Hide code') : formatMessage('Show code')}

--- a/Composer/packages/client/src/pages/design/styles.ts
+++ b/Composer/packages/client/src/pages/design/styles.ts
@@ -107,8 +107,14 @@ export const formEditor = css`
 export const visualPanelHeaderContainer = css`
   display: flex;
   align-items: center;
-  height: 65px;
+  height: 38px;
   border-bottom: 1px solid ${NeutralColors.gray30};
+`;
+
+export const visualPanelHeaderLabel = css`
+  padding-left: 20px;
+  font-size: 14px;
+  font-weight: 600;
 `;
 
 export const visualPanelHeaderShowCodeButton = css`

--- a/Composer/packages/client/src/recoilModel/atoms/appState.ts
+++ b/Composer/packages/client/src/recoilModel/atoms/appState.ts
@@ -375,3 +375,8 @@ export const selectedTemplateVersionState = atom<string>({
   key: getFullyQualifiedKey('selectedTemplateVersion'),
   default: '',
 });
+
+export const showProjectTreePanelState = atom<boolean>({
+  key: getFullyQualifiedKey('showProjectTreePanel'),
+  default: true,
+});


### PR DESCRIPTION
## Description

PVA v2 Demo styling updates for a few components:
- Replaced "Add" and "Filter" buttons in project tree header with header title
- Added ability to expand / collapse the project tree using "X" button in project tree header and an expand button in the design Toolbar.
- Removed the <Split> component for the demo; note this means that the tree width cannot be resized.
- Replaced the breadcrumb header with a simple label indicating the dialog name.

## Reference
https://www.figma.com/file/frQviquVRVWnyr1JcAxrAz/Authoring-PVA-2.0?node-id=1240%3A7582

## Screenshots
![pvav2testbot3](https://user-images.githubusercontent.com/12548624/130116784-b81f1b2c-dc55-4f19-8744-00a99a3b90ac.gif)

