### PR TITLE
fix: Add null check to avoid asserting on undefined process obj

### DIFF
--- a/extensions/localPublish/src/index.ts
+++ b/extensions/localPublish/src/index.ts
@@ -428,7 +428,9 @@ class LocalPublisher implements PublishPlugin<PublishConfig> {
         setTimeout(async () => {
           killPort(port)
             .then(() => {
-              this.removeListener(proc);
+              if (proc) {
+                this.removeListener(proc);
+              }
               delete LocalPublisher.runningBots[botId];
               resolve('Stopped');
             })


### PR DESCRIPTION
## Description

There is a seemingly random occurring error in Composer with the message 'cannot read property stdout of undefined'. 

The issue is traced down to a call within the local publish extension where Composer does not null check a Process object prior to calling functions on it and there are times in which this function is called with a null process obj. 

Testing indicates that a simple null check fixes the issue and enables true errors to surface for bots that are erroneous as well as working bots to continue working without the error popping up as well.

## Task Item

fixes #8547 
fixes #8564 
