### PR TITLE
Added some fixes to the PVA storage extension for the demo

### DIFF
--- a/Composer/packages/client/src/App.tsx
+++ b/Composer/packages/client/src/App.tsx
@@ -11,6 +11,7 @@ import { dispatcherState, userSettingsState } from './recoilModel';
 import { loadLocale } from './utils/fileUtil';
 import { useInitializeLogger } from './telemetry/useInitializeLogger';
 import { setupIcons } from './setupIcons';
+import httpClient from './utils/httpUtil';
 
 setupIcons();
 
@@ -45,6 +46,13 @@ export const App: React.FC = () => {
 
     ipcRenderer?.on('machine-info', (_event, info) => {
       setMachineInfo(info);
+    });
+
+    // NOTE: only for PVA 2 demo
+    // go get the demo token and store it in local storage to be used by Web Chat
+    httpClient.get(`/auth/getDemoToken`).then((res) => {
+      const demoToken = res.data;
+      window.localStorage.setItem('PVA-2-DEMO-TOKEN', demoToken);
     });
   }, []);
 

--- a/Composer/packages/server/src/controllers/auth.ts
+++ b/Composer/packages/server/src/controllers/auth.ts
@@ -87,10 +87,16 @@ async function getAccount(req: Request, res: Response) {
   }
 }
 
+// NOTE: only for the PVA 2 demo
+async function getDemoToken(req: Request, res: Response) {
+  res.status(200).send(process.env.PVA_DEMO_TOKEN || '');
+}
+
 export const AuthController = {
   getAccessToken,
   getTenants,
   getAccount,
   getARMTokenForTenant,
   logOut,
+  getDemoToken,
 };

--- a/Composer/packages/server/src/router/api.ts
+++ b/Composer/packages/server/src/router/api.ts
@@ -124,6 +124,7 @@ router.get('/auth/logOut', AuthController.logOut);
 router.get('/auth/getTenants', csrfProtection, AuthController.getTenants);
 router.get('/auth/getAccount', csrfProtection, AuthController.getAccount);
 router.get('/auth/getARMTokenForTenant', csrfProtection, AuthController.getARMTokenForTenant);
+router.get('/auth/getDemoToken', AuthController.getDemoToken);
 
 // FeatureFlags
 router.get('/featureFlags', FeatureFlagController.getFeatureFlags);

--- a/extensions/pvaStorage/src/pvaBotClient.ts
+++ b/extensions/pvaStorage/src/pvaBotClient.ts
@@ -75,7 +75,8 @@ export class PVABotClient {
         'X-CCI-BotId': pvaMetadata.botId,
         'X-CCI-TenantId': pvaMetadata.tenantId,
       },
-      body: JSON.stringify({ componentDeltaToken: this.botModel?.mostRecentContentSnapshot || '' }),
+      // TODO: why do we ever want to send the snapshot? we only want the most recent list of assets
+      body: JSON.stringify({ componentDeltaToken: '' /* this.botModel?.mostRecentContentSnapshot || ''*/ }),
     });
     if (res.status === 200) {
       const data: BotComponentResponse = await res.json();


### PR DESCRIPTION
## Description

This PR includes the following changes:

- When retrieving the OBI content from PVA, we now omit the content snapshot so we always get the most up-to-date assets (fixes failures on subsequent saves)
- The PVA token injected into the server via `process.env.PVA_DEMO_TOKEN` is now plumbed into the client and stored in local storage to be used by Web Chat
