### PR TITLE
fix: enumerations were not displayed.

### DIFF
--- a/Composer/packages/form-dialogs/src/components/property/PropertyCardContent.tsx
+++ b/Composer/packages/form-dialogs/src/components/property/PropertyCardContent.tsx
@@ -17,7 +17,7 @@ import { StringExampleContent } from './examples/StringExampleContent';
 
 const metaKeys = ['$comment'];
 
-const templateInfoKeysFilter = (key: string) => key.startsWith('$') && !metaKeys.includes(key);
+const templateInfoKeysFilter = (key: string) => !metaKeys.includes(key);
 
 type Props = {
   propertyName: string;


### PR DESCRIPTION
fixes #8627 

The issue was that the auto-field creation from templates was filtering out properties it should have included.