### PR TITLE
release: 2.1.1

### DIFF
--- a/Composer/packages/electron-server/package.json
+++ b/Composer/packages/electron-server/package.json
@@ -2,7 +2,7 @@
   "name": "@bfc/electron-server",
   "license": "MIT",
   "author": "Microsoft Corporation",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Electron wrapper around Composer that launches Composer as a desktop application.",
   "main": "./build/main.js",
   "engines": {

--- a/releases/2.1.1.md
+++ b/releases/2.1.1.md
@@ -1,0 +1,27 @@
+# 2.1.1
+
+## Changelog
+
+#### Added
+
+- feat: Add ability to configure template feed ([#8553](https://github.com/microsoft/BotFramework-Composer/pull/8553)) ([@pavolum](https://github.com/pavolum))
+- feat: support remote $refs in dialog schema. ([#8456](https://github.com/microsoft/BotFramework-Composer/pull/8456)) ([@a-b-r-o-w-n](https://github.com/a-b-r-o-w-n))
+- Added support to import / publish flows for PVA GCC High env ([#8554](https://github.com/microsoft/BotFramework-Composer/pull/8554)) ([@tonyanziano](https://github.com/tonyanziano
+
+#### Fixed
+
+- fix: Add null check to avoid asserting on undefined process obj ([#8587](https://github.com/microsoft/BotFramework-Composer/pull/8587)) ([@pavolum](https://github.com/pavolum))
+- fix: <Dropdown/> syntax error in form editor ([#8560](https://github.com/microsoft/BotFramework-Composer/pull/8560)) ([@lei9444](https://github.com/lei9444))
+- fix: Update Orchestrator core and extensions Tar dependency to 6.1.6 ([#8537](https://github.com/microsoft/BotFramework-Composer/pull/8537)) ([@taicchoumsft](https://github.com/taicchoumsft))
+- Issue 8427: give the qna maker service plan a unique name ([#8581](https://github.com/microsoft/BotFramework-Composer/pull/8581)) Natalie Garcia
+- Fix bug where enumerations were not displayed. ([#8628](https://github.com/microsoft/BotFramework-Composer/pull/8628)) ([@chrimc62](https://github.com/chrimc62))
+- fix #8188 - protect against missing field in npm feeds ([#8478](https://github.com/microsoft/BotFramework-Composer/pull/8478)) ([@benbrown](https://github.com/benbrown))
+- Issue 8489: fix how we form the publishEndpoint. Check for undefined or empty scmHostDomain value. ([#8532](https://github.com/microsoft/BotFramework-Composer/pull/8532)) Natalie Garcia
+- initial set endpoints: [] ([#8486](https://github.com/microsoft/BotFramework-Composer/pull/8486)) ([@alanlong9278](https://github.com/alanlong9278)
+
+#### Other
+
+- chore: add select all to select intents modal ([#8451](https://github.com/microsoft/BotFramework-Composer/pull/8451)) ([@alanlong9278](https://github.com/alanlong9278))
+- docs: add ui schema documentation and examples ([#8440](https://github.com/microsoft/BotFramework-Composer/pull/8440)) ([@a-b-r-o-w-n](https://github.com/a-b-r-o-w-n))
+- chore: Use check box to select items ux ([#7963](https://github.com/microsoft/BotFramework-Composer/pull/7963)) ([@alanlong9278](https://github.com/alanlong9278))
+- Update CODEOWNERS ([#8619](https://github.com/microsoft/BotFramework-Composer/pull/8619)) ([@GeoffCoxMSFT](https://github.com/GeoffCoxMSFT)


### PR DESCRIPTION
# 2.1.1

## Changelog

#### Added

- feat: Add ability to configure template feed ([#8553](https://github.com/microsoft/BotFramework-Composer/pull/8553)) ([@pavolum](https://github.com/pavolum))
- feat: support remote $refs in dialog schema. ([#8456](https://github.com/microsoft/BotFramework-Composer/pull/8456)) ([@a-b-r-o-w-n](https://github.com/a-b-r-o-w-n))
- Added support to import / publish flows for PVA GCC High env ([#8554](https://github.com/microsoft/BotFramework-Composer/pull/8554)) ([@tonyanziano](https://github.com/tonyanziano

#### Fixed

- fix: Add null check to avoid asserting on undefined process obj ([#8587](https://github.com/microsoft/BotFramework-Composer/pull/8587)) ([@pavolum](https://github.com/pavolum))
- fix: <Dropdown/> syntax error in form editor ([#8560](https://github.com/microsoft/BotFramework-Composer/pull/8560)) ([@lei9444](https://github.com/lei9444))
- fix: Update Orchestrator core and extensions Tar dependency to 6.1.6 ([#8537](https://github.com/microsoft/BotFramework-Composer/pull/8537)) ([@taicchoumsft](https://github.com/taicchoumsft))
- Issue 8427: give the qna maker service plan a unique name ([#8581](https://github.com/microsoft/BotFramework-Composer/pull/8581)) Natalie Garcia
- Fix bug where enumerations were not displayed. ([#8628](https://github.com/microsoft/BotFramework-Composer/pull/8628)) ([@chrimc62](https://github.com/chrimc62))
- fix #8188 - protect against missing field in npm feeds ([#8478](https://github.com/microsoft/BotFramework-Composer/pull/8478)) ([@benbrown](https://github.com/benbrown))
- Issue 8489: fix how we form the publishEndpoint. Check for undefined or empty scmHostDomain value. ([#8532](https://github.com/microsoft/BotFramework-Composer/pull/8532)) Natalie Garcia
- initial set endpoints: [] ([#8486](https://github.com/microsoft/BotFramework-Composer/pull/8486)) ([@alanlong9278](https://github.com/alanlong9278)

#### Other

- chore: add select all to select intents modal ([#8451](https://github.com/microsoft/BotFramework-Composer/pull/8451)) ([@alanlong9278](https://github.com/alanlong9278))
- docs: add ui schema documentation and examples ([#8440](https://github.com/microsoft/BotFramework-Composer/pull/8440)) ([@a-b-r-o-w-n](https://github.com/a-b-r-o-w-n))
- chore: Use check box to select items ux ([#7963](https://github.com/microsoft/BotFramework-Composer/pull/7963)) ([@alanlong9278](https://github.com/alanlong9278))
- Update CODEOWNERS ([#8619](https://github.com/microsoft/BotFramework-Composer/pull/8619)) ([@GeoffCoxMSFT](https://github.com/GeoffCoxMSFT)
