### PR TITLE
fix: Bumped OneAuth version to 1.36.0

### DIFF
--- a/Composer/packages/electron-server/scripts/installOneAuth.js
+++ b/Composer/packages/electron-server/scripts/installOneAuth.js
@@ -21,7 +21,7 @@ const { log } = require('./common');
  */
 
 let packageName = null;
-const packageVersion = process.env.ONEAUTH_VERSION || '1.15.0';
+const packageVersion = process.env.ONEAUTH_VERSION || '1.36.0';
 
 switch (process.platform) {
   case 'darwin':


### PR DESCRIPTION
## Description

This PR bumps the OneAuth library version from 1.15.0 to 1.36.0 which includes a lot of bug fixes. One of which caused an IcM to be opened on Composer.

## Task Item

Fixes #8708 


