### PR TITLE
fix: quote and escape input to avoid problems in exec

### DIFF
--- a/extensions/localPublish/src/index.ts
+++ b/extensions/localPublish/src/index.ts
@@ -344,7 +344,9 @@ class LocalPublisher implements PublishPlugin<PublishConfig> {
     const configList: string[] = [];
     if (config.MicrosoftAppPassword) {
       configList.push('--MicrosoftAppPassword');
-      configList.push(`"${config.MicrosoftAppPassword}"`);
+      // since the password could conceivably contain quote marks, make sure they are properly escaped
+      const escapedPassword = config.MicrosoftAppPassword.replace(/"/g, '\\"');
+      configList.push(`"${escapedPassword}"`);
     }
     if (config.luis && (config.luis.endpointKey || config.luis.authoringKey)) {
       configList.push('--luis:endpointKey');

--- a/extensions/runtimes/src/index.ts
+++ b/extensions/runtimes/src/index.ts
@@ -27,7 +27,12 @@ const execTimeout = 5 * 60 * 1000; // timeout after 5 minutes
 const writeLocalFunctionsSetting = async (name: string, value: string, cwd: string, log) => {
   // only set if there is both a setting and a value.
   if (name && value && cwd) {
-    const { stderr: err } = await execAsync(`func settings add ${name} ${value}`, { cwd: cwd });
+    // since these values could conceivably contain quote marks, make sure they are properly escaped
+    const escapedName = name.replace(/"/g, '\\"');
+    const escapedValue = value.replace(/"/g, '\\"');
+    const command = `func settings add "${escapedName}" "${escapedValue}"`;
+    log('EXEC: ', command);
+    const { stderr: err } = await execAsync(command, { cwd: cwd });
     if (err) {
       log('Error calling func settings add', err);
       throw new Error(err);


### PR DESCRIPTION
## Description

Wrap the value in quotes (and escape any quotes in the string) to prevent against characters in the MicrosoftAppPassword from breaking the exec

## Task Item

Fix #8709

