### PR TITLE
fix: show PVA topic's dialog options

### DIFF
--- a/Composer/packages/ui-plugins/schema-editor/src/schema.ts
+++ b/Composer/packages/ui-plugins/schema-editor/src/schema.ts
@@ -52,14 +52,6 @@ export const schema = (): JSONSchema7 => ({
 });
 
 export const valueTypeDefinitions: { [key: string]: JSONSchema7 } = {
-  expression: {
-    $role: 'expression',
-    type: 'string',
-    title: formatMessage('Expression'),
-    description: formatMessage('Expression to evaluate.'),
-    pattern: '^.*\\S.*',
-    examples: ['user.age > 13'],
-  },
   equalsExpression: {
     $role: 'expression',
     type: 'string',
@@ -68,26 +60,9 @@ export const valueTypeDefinitions: { [key: string]: JSONSchema7 } = {
     pattern: '^=.*\\S.*',
     examples: ['=user.name'],
   },
-  condition: {
-    $role: 'expression',
-    title: formatMessage('Boolean condition'),
-    description: formatMessage('Boolean constant or expression to evaluate.'),
-    oneOf: [
-      {
-        $ref: '#/definitions/expression',
-      },
-      {
-        type: 'boolean',
-        title: formatMessage('Boolean'),
-        description: formatMessage('Boolean value.'),
-        default: true,
-        examples: [false],
-      },
-    ],
-  },
   booleanExpression: {
     $role: 'expression',
-    title: formatMessage('Boolean or expression'),
+    title: formatMessage('Boolean'),
     description: formatMessage('Boolean constant or expression to evaluate.'),
     oneOf: [
       {
@@ -105,7 +80,7 @@ export const valueTypeDefinitions: { [key: string]: JSONSchema7 } = {
   },
   numberExpression: {
     $role: 'expression',
-    title: formatMessage('Number or expression'),
+    title: formatMessage('Number'),
     description: formatMessage('Number constant or expression to evaluate.'),
     oneOf: [
       {
@@ -123,7 +98,7 @@ export const valueTypeDefinitions: { [key: string]: JSONSchema7 } = {
   },
   integerExpression: {
     $role: 'expression',
-    title: formatMessage('Integer or expression'),
+    title: formatMessage('Integer'),
     description: formatMessage('Integer constant or expression to evaluate.'),
     oneOf: [
       {
@@ -141,7 +116,7 @@ export const valueTypeDefinitions: { [key: string]: JSONSchema7 } = {
   },
   stringExpression: {
     $role: 'expression',
-    title: formatMessage('String or expression'),
+    title: formatMessage('String'),
     description: formatMessage('Interpolated string or expression to evaluate.'),
     oneOf: [
       {
@@ -159,7 +134,7 @@ export const valueTypeDefinitions: { [key: string]: JSONSchema7 } = {
   },
   arrayExpression: {
     $role: 'expression',
-    title: formatMessage('Array or expression'),
+    title: formatMessage('Array'),
     description: formatMessage('Array or expression to evaluate.'),
     oneOf: [
       {
@@ -174,7 +149,7 @@ export const valueTypeDefinitions: { [key: string]: JSONSchema7 } = {
   },
   objectExpression: {
     $role: 'expression',
-    title: formatMessage('Object or expression'),
+    title: formatMessage('Object'),
     description: formatMessage('Object or expression to evaluate.'),
     oneOf: [
       {
@@ -189,7 +164,7 @@ export const valueTypeDefinitions: { [key: string]: JSONSchema7 } = {
   },
   valueExpression: {
     $role: 'expression',
-    title: formatMessage('Any or expression'),
+    title: formatMessage('Any'),
     description: formatMessage('Any constant or expression to evaluate.'),
     oneOf: [
       {

--- a/Composer/packages/ui-plugins/select-dialog/src/DialogOptionsField.tsx
+++ b/Composer/packages/ui-plugins/select-dialog/src/DialogOptionsField.tsx
@@ -81,9 +81,20 @@ const DialogOptionsField: React.FC<FieldProps> = ({
   onChange,
 }) => {
   const { dialog, options } = value;
-  const { dialogSchemas } = useShellApi();
+  const { dialogSchemas, topics } = useShellApi();
+
+  const topicIdMap = React.useMemo(() => {
+    return topics.reduce((all, t) => {
+      if (t.content?.id) {
+        all[t.content.id] = t.id;
+      }
+      return all;
+    }, {} as Record<string, string>);
+  }, [topics]);
+
+  const dialogId = (dialog && topicIdMap[dialog]) ?? dialog;
   const { content: rawSchema }: { content?: JSONSchema7 } = React.useMemo(
-    () => dialogSchemas.find(({ id }) => id === dialog) || {},
+    () => dialogSchemas.find(({ id }) => id === dialogId) || {},
     [dialog, dialogSchemas]
   );
   const [schema, setSchema] = React.useState<JSONSchema7 | undefined>(undefined);

--- a/Composer/packages/ui-plugins/select-dialog/src/SelectDialogMenu.tsx
+++ b/Composer/packages/ui-plugins/select-dialog/src/SelectDialogMenu.tsx
@@ -71,7 +71,8 @@ const buttonStyles: IButtonStyles = {
   rootExpanded: { backgroundColor: 'initial' },
   rootExpandedHovered: { backgroundColor: 'initial' },
   flexContainer: { justifyContent: 'space-between' },
-  label: { margin: '0', fontWeight: 'normal' },
+  textContainer: { overflow: 'hidden' },
+  label: { margin: '0', fontWeight: 'normal', overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' },
 };
 
 const searchFieldStyles: ISearchBoxStyles = {

--- a/Composer/packages/ui-plugins/select-dialog/src/__tests__/DialogOptions.test.tsx
+++ b/Composer/packages/ui-plugins/select-dialog/src/__tests__/DialogOptions.test.tsx
@@ -53,9 +53,27 @@ const renderDialogOptionsField = ({ value } = {}) => {
       { id: 'dialog2', displayName: 'dialog2' },
       { id: 'dialog3', displayName: 'dialog3' },
     ],
+    topics: [
+      { id: 'Display Name 1', displayName: 'Display Name 1', content: { id: 'topic_guid_1' } },
+      { id: 'Display Name 2', displayName: 'Display Name 2', content: { id: 'topic_guid_2' } },
+    ],
     dialogSchemas: [
       {
         id: 'dialog1',
+        content: {
+          type: 'object',
+          properties: {
+            foo: {
+              type: 'string',
+            },
+            bar: {
+              type: 'number',
+            },
+          },
+        },
+      },
+      {
+        id: 'Display Name 1',
         content: {
           type: 'object',
           properties: {
@@ -82,18 +100,27 @@ describe('DialogOptionsField', () => {
     const { findByText } = renderDialogOptionsField();
     await findByText('Dialog options');
   });
+
   it('should render the options form if the dialog schema is defined and options is not a string', async () => {
     const { findByText } = renderDialogOptionsField({ value: { dialog: 'dialog1', options: {} } });
     await findByText('Options Form');
   });
+
+  it('can find a dialog schema when the selected dialog is a topic', async () => {
+    const { findByText } = renderDialogOptionsField({ value: { dialog: 'topic_guid_1', options: {} } });
+    await findByText('Options Form');
+  });
+
   it('should render the JsonField if the dialog schema is undefined and options is not a string', async () => {
     const { findByText } = renderDialogOptionsField({ value: { dialog: 'dialog2', options: {} } });
     await findByText('Object Field');
   });
+
   it('should render the IntellisenseTextField if options is a string', async () => {
     const { findByText } = renderDialogOptionsField({ value: { dialog: 'dialog2', options: '=user.data' } });
     await findByText('Intellisense Text Field');
   });
+
   it('should be able to switch between fields', async () => {
     const { findByText } = renderDialogOptionsField({
       value: { dialog: 'dialog1', options: {} },

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,6 +65,8 @@ jobs:
         workingDirectory: Composer
   - job: security
     displayName: Security Analysis
+    pool:
+      vmImage: ubuntu-latest
     steps:
       - task: ComponentGovernanceComponentDetection@0
         displayName: Component Detection


### PR DESCRIPTION
## Description

The dialog schemas are indexed by dialog id which is the file name for composer dialogs and the display name for topics. The dialog data references the topics internal guid and was failing to find the dialog schema with this id.

<!---
#minor
---->

## Screenshots

![image](https://user-images.githubusercontent.com/3619060/140001470-0d9fd0e2-6eff-4cf7-8f9e-99f508c27463.png)
