### PR TITLE
fix: a11y anchor focus ring color contrast in electron

### DIFF
--- a/Composer/packages/client/src/index.css
+++ b/Composer/packages/client/src/index.css
@@ -44,3 +44,11 @@ code {
   font-weight: 200;
   src: url("./fonts/segoe-ui-light.woff2") format("woff2");
 }
+
+/*
+  Make anchor outline color consistent across browsers
+  Fixes anchor focus outline color in Electron doesn't meet contrast ratio
+*/
+a:focus {
+  outline-color: #000000;
+}


### PR DESCRIPTION
## Description

Fix anchor focus ring color in Electron by overriding user-agent specified color with `#000000`. This makes anchor focus outline color consistent across browsers as well.

We use plain anchors in different places. To me this seems the best option to fix issues bellow.

## Task Item
[VSTS 70089](https://fuselabs.visualstudio.com/Composer/_workitems/edit/70089)
[VSTS 70440](https://fuselabs.visualstudio.com/Composer/_workitems/edit/70440)
<!-- #minor -->

## Screenshots
### Before
![MAS1 4 11_Luminosity contrast ratio of focus indicator is less than required standard in ‘view Readme’ button](https://user-images.githubusercontent.com/2841858/144467014-f29cdfd6-4fe7-4d9f-9657-5a5a0ec42765.jpg)
![MAS1 4 11-Luminosity ratio of focus indicator with adjacent color on below links under Tutorials tab section is less](https://user-images.githubusercontent.com/2841858/144467022-816b2843-8c18-470b-ac4e-b29b362f8af8.png)

### After
![Screenshot from 2021-12-02 18-01-31](https://user-images.githubusercontent.com/2841858/144467161-276eed42-0ca0-4733-b27d-61b392610473.png)
![Screenshot from 2021-12-02 18-01-58](https://user-images.githubusercontent.com/2841858/144467169-26d6a37d-e4ee-47bb-bae8-9fd234c13ae1.png)
![Screenshot from 2021-12-02 18-02-33](https://user-images.githubusercontent.com/2841858/144467170-863cc4b2-8191-4799-99e3-6da718dc8b49.png)
![Screenshot from 2021-12-02 18-02-46](https://user-images.githubusercontent.com/2841858/144467174-41d9a93c-f536-4186-87df-52a3cce6e254.png)


