### PR TITLE
fix: a11y keyboard interactions for configure and publish screens

### DIFF
--- a/Composer/packages/client/src/pages/botProject/RootBotExternalService.tsx
+++ b/Composer/packages/client/src/pages/botProject/RootBotExternalService.tsx
@@ -410,7 +410,6 @@ export const RootBotExternalService: React.FC<RootBotExternalServiceProps> = (pr
           )}
         </div>
         <PrimaryButton
-          disabled={displayManageLuis || displayManageQNA}
           styles={{ root: { width: '250px', marginTop: '15px' } }}
           text={formatMessage('Set up Language Understanding')}
           onClick={() => {
@@ -479,7 +478,6 @@ export const RootBotExternalService: React.FC<RootBotExternalServiceProps> = (pr
           />
         </div>
         <PrimaryButton
-          disabled={displayManageLuis || displayManageQNA}
           styles={{ root: { width: '250px', marginTop: '15px' } }}
           text={formatMessage('Set up QnA Maker')}
           onClick={() => {

--- a/Composer/packages/client/src/pages/publish/BotStatusList.tsx
+++ b/Composer/packages/client/src/pages/publish/BotStatusList.tsx
@@ -125,9 +125,18 @@ export const BotStatusList: React.FC<BotStatusListProps> = ({
     }
   };
 
-  const handleChangePublishTarget = (item: BotStatus, option?: IDropdownOption): void => {
+  const isDropdownFocusEvent = (event: React.FormEvent<HTMLDivElement>) => event.type === 'focus';
+
+  const handleChangePublishTarget = (
+    event: React.FormEvent<HTMLDivElement>,
+    item: BotStatus,
+    option?: IDropdownOption
+  ): void => {
     if (option) {
       if (option.key === 'manageProfiles') {
+        // Focus events trigger onChange when no option selected
+        // This prevents navigation on focus events
+        if (isDropdownFocusEvent(event)) return;
         onManagePublishProfile(item.id);
       } else {
         onChangePublishTarget(option.text, item);
@@ -215,14 +224,14 @@ export const BotStatusList: React.FC<BotStatusListProps> = ({
       onRender: (item: BotStatus) => {
         return (
           <Dropdown
-            defaultSelectedKey={item.publishTarget}
             options={getPublishTargetOptions(item)}
             placeholder={formatMessage('Select a publish target')}
+            selectedKey={item.publishTarget}
             styles={{
               root: { width: '100%' },
               dropdownItems: { selectors: { '.ms-Button-flexContainer': { width: '100%' } } },
             }}
-            onChange={(_, option?: IDropdownOption) => handleChangePublishTarget(item, option)}
+            onChange={(event, option?: IDropdownOption) => handleChangePublishTarget(event, item, option)}
             onRenderOption={renderDropdownOption}
           />
         );


### PR DESCRIPTION
## Description

Fixes the following keyboard navigation issues:
- On "Configure your bot" screen, "Development Resources" tab keyboard focus gets lost after closing modals. The issue happens because modal trigger buttons get disabled when "Set up Language Understanding" and "Set up QnA Maker" modals are opened. Removed modal trigger buttons disabling logic to fix the issue.
- On "Publish your bots" screen, "Publish" tab, "Publish target" drop-down causes navigation to the "Publishing profile" tab when it receives a focus event. The issue is caused by Dropdown component triggering `onChange` handler when keyboard focus received. Fixed by ignoring focus events for the particular "Manage profiles" drop-down item. Turned the drop-down to controlled one, so it always follows `item.publishTarget` selection rather internal state which allowed "Manage profiles" to be selected.

## Task Item

- [VSTS 70447](https://fuselabs.visualstudio.com/Composer/_workitems/edit/70447)
- [VSTS 70092](https://fuselabs.visualstudio.com/Composer/_workitems/edit/70092)
<!-- #minor -->

## Screenshots
![preserve-focus-on-modals-kb webm](https://user-images.githubusercontent.com/2841858/145381739-48c82698-cf92-4a84-8877-031b197b135d.gif)
![fix-publish-profile-kb webm](https://user-images.githubusercontent.com/2841858/145381752-e5ee5f66-427c-4b3f-bc53-ed3ba4323b9b.gif)

