### PR TITLE
fix: change luis editor prebuilt entity error to warn

### DIFF
--- a/Composer/packages/lib/indexers/src/utils/luUtil.ts
+++ b/Composer/packages/lib/indexers/src/utils/luUtil.ts
@@ -123,6 +123,13 @@ export function convertLuParseResultToLuFile(
   }
 
   const syntaxDiagnostics = Errors.map((e) => convertLuDiagnostic(e, id)) as Diagnostic[];
+  for (const item of syntaxDiagnostics) {
+    const reseveredPrebuiltEntittyError = /.*The model name .* is reserved./g;
+    if (reseveredPrebuiltEntittyError.test(item.message)) {
+      item.severity = DiagnosticSeverity.Warning;
+    }
+  }
+
   const semanticDiagnostics = validateResource(resource, appliedluFeatures).map((e) =>
     convertLuDiagnostic(e, id)
   ) as Diagnostic[];


### PR DESCRIPTION
fixes #8475 
Change luis authoring a prebuilt entity name reserved error to warning.
![prebuilt_warn_editor](https://user-images.githubusercontent.com/17074777/145780644-afaa8f81-ca76-43b7-8e07-1f7404a55df6.png)
.
![image](https://user-images.githubusercontent.com/17074777/145780665-e994a39b-52d5-4964-b45c-e817a0736584.png)
