### PR TITLE
fix: a11y add headings for Configure and Create publishing profile pages

### DIFF
--- a/Composer/packages/client/src/pages/botProject/AllowedCallers.tsx
+++ b/Composer/packages/client/src/pages/botProject/AllowedCallers.tsx
@@ -19,7 +19,8 @@ import { useArrayItems } from '@bfc/adaptive-form';
 import { dispatcherState, rootBotProjectIdSelector, settingsState } from '../../recoilModel';
 import { mergePropertiesManagedByRootBot } from '../../recoilModel/dispatchers/utils/project';
 
-import { actionButton, subtext, title } from './styles';
+import { actionButton, subtext } from './styles';
+import { SettingTitle } from './shared/SettingTitle';
 
 const Input = styled(TextField)({
   width: '100%',
@@ -159,7 +160,7 @@ export const AllowedCallers: React.FC<Props> = ({ projectId }) => {
 
   return (
     <Fragment>
-      <div css={title}>{formatMessage('Allowed Callers')}</div>
+      <SettingTitle>{formatMessage('Allowed Callers')}</SettingTitle>
       <div css={subtext}>
         {formatMessage.rich(
           'Skills can be “called” by external bots. Allow other bots to call your skill by adding their App IDs to the list below. <a>Learn more</a>',

--- a/Composer/packages/client/src/pages/botProject/AppIdAndPassword.tsx
+++ b/Composer/packages/client/src/pages/botProject/AppIdAndPassword.tsx
@@ -18,7 +18,8 @@ import { dispatcherState, settingsState } from '../../recoilModel';
 import { mergePropertiesManagedByRootBot } from '../../recoilModel/dispatchers/utils/project';
 import { rootBotProjectIdSelector } from '../../recoilModel/selectors/project';
 
-import { inputFieldStyles, subtext, title } from './styles';
+import { inputFieldStyles, subtext } from './styles';
+import { SettingTitle } from './shared/SettingTitle';
 import { GetAppInfoFromPublishProfileDialog } from './GetAppInfoFromPublishProfileDialog';
 // -------------------- Styles -------------------- //
 
@@ -118,7 +119,7 @@ export const AppIdAndPassword: React.FC<AppIdAndPasswordProps> = (props) => {
 
   return (
     <Fragment>
-      <div css={title}>{formatMessage('Microsoft App ID')}</div>
+      <SettingTitle>{formatMessage('Microsoft App ID')}</SettingTitle>
       <div css={subtext}>
         {formatMessage.rich(
           'An App ID is used for communication between your bot and skills, services, websites or applications. Use an existing App ID or automatically generate an App ID when creating a publishing profile for this bot. <a>Learn more</a>',

--- a/Composer/packages/client/src/pages/botProject/RootBotExternalService.tsx
+++ b/Composer/packages/client/src/pages/botProject/RootBotExternalService.tsx
@@ -34,7 +34,8 @@ import { LUIS_REGIONS } from '../../constants';
 import { ManageLuis } from '../../components/ManageLuis/ManageLuis';
 import { ManageQNA } from '../../components/ManageQNA/ManageQNA';
 
-import { inputFieldStyles, subtext, title } from './styles';
+import { inputFieldStyles, subtext } from './styles';
+import { SettingTitle } from './shared/SettingTitle';
 
 // -------------------- Styles -------------------- //
 
@@ -336,7 +337,7 @@ export const RootBotExternalService: React.FC<RootBotExternalServiceProps> = (pr
 
   return (
     <Fragment>
-      <div css={title}>{formatMessage('Azure Language Understanding')}</div>
+      <SettingTitle>{formatMessage('Azure Language Understanding')}</SettingTitle>
       <div css={subtext}>
         {formatMessage.rich(
           'Language Understanding (LUIS) is an Azure Cognitive Service that uses machine learning to understand natural language input and direct the conversation flow. <a>Learn more.</a> Use an existing Language Understanding (LUIS) key from Azure or create a new key. <a2>Learn more</a2>',
@@ -440,7 +441,7 @@ export const RootBotExternalService: React.FC<RootBotExternalServiceProps> = (pr
             )}
           </MessageBar>
         )}
-        <div css={title}>{formatMessage('Azure QnA Maker')}</div>
+        <SettingTitle>{formatMessage('Azure QnA Maker')}</SettingTitle>
         <div css={subtext}>
           {formatMessage.rich(
             'QnA Maker is an Azure Cognitive services that can extract question-and-answer pairs from a website FAQ. <a>Learn more.</a> Use an existing key from Azure or create a new key. <a2>Learn more.</a2>',

--- a/Composer/packages/client/src/pages/botProject/RuntimeSettings.tsx
+++ b/Composer/packages/client/src/pages/botProject/RuntimeSettings.tsx
@@ -6,7 +6,7 @@ import React, { Fragment, useEffect, useRef } from 'react';
 import { jsx } from '@emotion/core';
 import formatMessage from 'format-message';
 
-import { title } from './styles';
+import { SettingTitle } from './shared/SettingTitle';
 import { RuntimeSettings as Runtime } from './runtime-settings/RuntimeSettings';
 
 // -------------------- RuntimeSettings -------------------- //
@@ -29,7 +29,7 @@ export const RuntimeSettings: React.FC<RuntimeSettingsProps> = (props) => {
 
   return (
     <Fragment>
-      <div css={title}>{formatMessage('Custom runtime')}</div>
+      <SettingTitle>{formatMessage('Custom runtime')}</SettingTitle>
       <div ref={containerRef}>
         <Runtime projectId={projectId} />
       </div>

--- a/Composer/packages/client/src/pages/botProject/SkillBotExternalService.tsx
+++ b/Composer/packages/client/src/pages/botProject/SkillBotExternalService.tsx
@@ -26,7 +26,9 @@ import { FieldWithCustomButton } from '../../components/FieldWithCustomButton';
 import { mergePropertiesManagedByRootBot } from '../../recoilModel/dispatchers/utils/project';
 import { LUIS_REGIONS } from '../../constants';
 
-import { subtext, title } from './styles';
+import { subtext } from './styles';
+import { SettingTitle } from './shared/SettingTitle';
+
 // -------------------- Styles -------------------- //
 
 const externalServiceContainerStyle = css`
@@ -139,7 +141,7 @@ export const SkillBotExternalService: React.FC<SkillBotExternalServiceProps> = (
 
   return (
     <Fragment>
-      <div css={title}>{formatMessage('Azure Language Understanding')}</div>
+      <SettingTitle>{formatMessage('Azure Language Understanding')}</SettingTitle>
       <div css={subtext}>
         {formatMessage.rich(
           'Language Understanding (LUIS) is an Azure Cognitive Service that uses machine learning to understand natural language input and direct the conversation flow. <a>Learn more.</a> Use an existing Language Understanding (LUIS) key from Azure or create a new key. <a2>Learn more</a2>',
@@ -201,7 +203,7 @@ export const SkillBotExternalService: React.FC<SkillBotExternalServiceProps> = (
             onBlur={handleLUISRegionOnBlur}
           />
         </div>
-        <div css={title}>{formatMessage('Azure QnA Maker')}</div>
+        <SettingTitle>{formatMessage('Azure QnA Maker')}</SettingTitle>
         <div css={subtext}>
           {formatMessage.rich(
             'QnA Maker is an Azure Cognitive services that can extract question-and-answer pairs from a website FAQ. <a>Learn more.</a> Use an existing key from Azure or create a new key. <a2>Learn more</a2>',

--- a/Composer/packages/client/src/pages/botProject/SkillHostEndPoint.tsx
+++ b/Composer/packages/client/src/pages/botProject/SkillHostEndPoint.tsx
@@ -17,7 +17,9 @@ import { dispatcherState, settingsState } from '../../recoilModel';
 import { rootBotProjectIdSelector } from '../../recoilModel/selectors/project';
 import { mergePropertiesManagedByRootBot } from '../../recoilModel/dispatchers/utils/project';
 
-import { subtext, title } from './styles';
+import { subtext } from './styles';
+import { SettingTitle } from './shared/SettingTitle';
+
 // -------------------- Styles -------------------- //
 
 const labelContainer = css`
@@ -83,7 +85,7 @@ export const SkillHostEndPoint: React.FC<SkillHostEndPointProps> = (props) => {
 
   return (
     <Fragment>
-      <div css={title}>{formatMessage('Call skills')}</div>
+      <SettingTitle>{formatMessage('Call skills')}</SettingTitle>
       <div css={subtext}>
         {formatMessage.rich(
           'Add a skill host endpoint so your skills can reliably connect to your root bot. <a>Learn more</a>.',

--- a/Composer/packages/client/src/pages/botProject/adapters/AdapterSection.tsx
+++ b/Composer/packages/client/src/pages/botProject/adapters/AdapterSection.tsx
@@ -7,7 +7,8 @@ import formatMessage from 'format-message';
 import { Stack } from 'office-ui-fabric-react/lib/Stack';
 import { Link } from 'office-ui-fabric-react/lib/Link';
 
-import { title, subtitle, subtext, headerText } from '../styles';
+import { subtitle, subtext, headerText } from '../styles';
+import { SettingTitle } from '../shared/SettingTitle';
 import { navigateTo } from '../../../utils/navigation';
 
 import ExternalAdapterSettings from './ExternalAdapterSettings';
@@ -41,14 +42,14 @@ const AdapterSection = ({ projectId, scrollToSectionId }: Props) => {
         )}
       </div>
       <Stack>
-        <div css={title}>{formatMessage('Azure connections')}</div>
+        <SettingTitle>{formatMessage('Azure connections')}</SettingTitle>
         <div css={subtitle}>
           {formatMessage('Connect your bot to Microsoft Teams and WebChat, or enable DirectLine Speech.')}
         </div>
         <ABSChannels projectId={projectId} />
       </Stack>
       <Stack>
-        <div css={title}>{formatMessage('External connections')}</div>
+        <SettingTitle>{formatMessage('External connections')}</SettingTitle>
         <div css={subtext}>
           {formatMessage.rich(
             'Find and install more external services to your bot project in <a>package manager</a>. For further guidance, see documentation for <a2>adding external connections.</a2>',

--- a/Composer/packages/client/src/pages/botProject/shared/SettingTitle.tsx
+++ b/Composer/packages/client/src/pages/botProject/shared/SettingTitle.tsx
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/** @jsx jsx */
+import { css, jsx } from '@emotion/core';
+import { FontSizes, FontWeights } from 'office-ui-fabric-react/lib/Styling';
+import { SectionTitle } from '@bfc/ui-shared';
+
+export const SettingTitle: React.FC = (props) => (
+  <SectionTitle
+    css={css`
+      display: inline-block;
+      font-size: ${FontSizes.large};
+      font-weight: ${FontWeights.semibold};
+      margin-top: 25px;
+      margin-bottom: 5px;
+    `}
+    level={4}
+    {...props}
+  />
+);

--- a/Composer/packages/client/src/pages/botProject/styles.ts
+++ b/Composer/packages/client/src/pages/botProject/styles.ts
@@ -5,13 +5,6 @@ import { css } from '@emotion/core';
 import { NeutralColors, SharedColors } from '@uifabric/fluent-theme';
 import { FontSizes, FontWeights, mergeStyleSets } from 'office-ui-fabric-react/lib/Styling';
 
-export const title = css`
-  font-size: ${FontSizes.large};
-  font-weight: ${FontWeights.semibold};
-  margin-top: 25px;
-  margin-bottom: 5px;
-`;
-
 export const tabContentContainer = css`
   margin-left: 10px;
   max-width: 580px;

--- a/Composer/packages/lib/ui-shared/src/components/SectionTitle.tsx
+++ b/Composer/packages/lib/ui-shared/src/components/SectionTitle.tsx
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/** @jsx jsx */
+import { jsx, css } from '@emotion/core';
+import { FluentTheme } from '@uifabric/fluent-theme';
+import { Text } from 'office-ui-fabric-react/lib/Text';
+
+interface SectionTitleProps {
+  level: 1 | 2 | 3 | 4 | 5 | 6;
+}
+
+export const SectionTitle: React.FC<SectionTitleProps> = ({ level, ...props }) => (
+  <Text
+    aria-level={level}
+    css={css`
+      font-size: ${FluentTheme.fonts.xLarge.fontSize};
+      margin: 8px 0;
+    `}
+    role="heading"
+    {...props}
+  />
+);

--- a/Composer/packages/lib/ui-shared/src/components/index.ts
+++ b/Composer/packages/lib/ui-shared/src/components/index.ts
@@ -12,3 +12,4 @@ export * from './DisplayMarkdownDialog/DisplayMarkdownDialog';
 export * from './tags/TagInput';
 export * from './IconMenu';
 export * from './CopyableText';
+export * from './SectionTitle';

--- a/extensions/azurePublish/src/components/ChooseProvisionAction.tsx
+++ b/extensions/azurePublish/src/components/ChooseProvisionAction.tsx
@@ -9,6 +9,7 @@ import { Stack } from 'office-ui-fabric-react/lib/Stack';
 import { Text } from 'office-ui-fabric-react/lib/Text';
 import { FluentTheme, NeutralColors } from '@uifabric/fluent-theme';
 import { Link } from 'office-ui-fabric-react/lib/Link';
+import { SectionTitle } from '@bfc/ui-shared';
 
 // ---------- Styles ---------- //
 
@@ -33,11 +34,6 @@ const ContentPane = styled(Stack)`
 
 const Content = styled(Stack)`
   padding: 0px 20px;
-`;
-
-const Title = styled(Text)`
-  font-size: ${FluentTheme.fonts.xLarge.fontSize};
-  margin: 8px 0;
 `;
 
 const Summary = styled.div`
@@ -75,7 +71,7 @@ const LearnMoreLink = styled(Link)`
 const CreateActionContent = () => {
   return (
     <Content>
-      <Title>{formatMessage('Create new resources')}</Title>
+      <SectionTitle level={2}>{formatMessage('Create new resources')}</SectionTitle>
       <Summary>
         <Text>
           {formatMessage(
@@ -133,7 +129,7 @@ const CreateActionContent = () => {
 const ImportActionContent = () => {
   return (
     <Content>
-      <Title>{formatMessage('Use existing resources')}</Title>
+      <SectionTitle level={2}>{formatMessage('Use existing resources')}</SectionTitle>
       <Summary>
         <p>
           <Text>
@@ -186,7 +182,7 @@ const ImportActionContent = () => {
 const GenerateActionContent = () => {
   return (
     <Content>
-      <Title>{formatMessage('Hand off to admin')}</Title>
+      <SectionTitle level={2}>{formatMessage('Hand off to admin')}</SectionTitle>
       <Summary>
         <Text>
           {formatMessage(

--- a/extensions/azurePublishNew/src/components/provisioningWizards/steps/CreateResourceInstructionsStep.tsx
+++ b/extensions/azurePublishNew/src/components/provisioningWizards/steps/CreateResourceInstructionsStep.tsx
@@ -7,14 +7,10 @@ import { Text } from 'office-ui-fabric-react/lib/Text';
 import styled from '@emotion/styled';
 import { FluentTheme } from '@uifabric/fluent-theme';
 import { Link, Stack } from 'office-ui-fabric-react';
+import { SectionTitle } from '@bfc/ui-shared';
 
 const Content = styled(Stack)`
   padding: 0px 20px;
-`;
-
-const Title = styled(Text)`
-  font-size: ${FluentTheme.fonts.xLarge.fontSize};
-  margin: 8px 0;
 `;
 
 const Summary = styled.div`
@@ -51,7 +47,7 @@ const urls = {
 export const CreateResourceInstructionsStep = () => {
   return (
     <Content>
-      <Title>{formatMessage('Create new resources')}</Title>
+      <SectionTitle level={2}>{formatMessage('Create new resources')}</SectionTitle>
       <Summary>
         <Text>
           {formatMessage(

--- a/extensions/azurePublishNew/src/components/provisioningWizards/steps/HandOffInstructionsStep.tsx
+++ b/extensions/azurePublishNew/src/components/provisioningWizards/steps/HandOffInstructionsStep.tsx
@@ -6,14 +6,10 @@ import formatMessage from 'format-message';
 import styled from '@emotion/styled';
 import { FluentTheme } from '@uifabric/fluent-theme';
 import { Link, Stack, Text } from 'office-ui-fabric-react';
+import { SectionTitle } from '@bfc/ui-shared';
 
 const Content = styled(Stack)`
   padding: 0px 20px;
-`;
-
-const Title = styled(Text)`
-  font-size: ${FluentTheme.fonts.xLarge.fontSize};
-  margin: 8px 0;
 `;
 
 const Summary = styled.div`
@@ -49,7 +45,7 @@ const urls = {
 export const HandOffInstructionsStep = () => {
   return (
     <Content>
-      <Title>{formatMessage('Hand off to admin')}</Title>
+      <SectionTitle level={2}>{formatMessage('Hand off to admin')}</SectionTitle>
       <Summary>
         <Text>
           {formatMessage(

--- a/extensions/azurePublishNew/src/components/provisioningWizards/steps/ImportInstructionsStep.tsx
+++ b/extensions/azurePublishNew/src/components/provisioningWizards/steps/ImportInstructionsStep.tsx
@@ -5,16 +5,11 @@ import * as React from 'react';
 import formatMessage from 'format-message';
 import { Text } from 'office-ui-fabric-react/lib/Text';
 import styled from '@emotion/styled';
-import { FluentTheme } from '@uifabric/fluent-theme';
 import { Link, Stack } from 'office-ui-fabric-react';
+import { SectionTitle } from '@bfc/ui-shared';
 
 const Content = styled(Stack)`
   padding: 0px 20px;
-`;
-
-const Title = styled(Text)`
-  font-size: ${FluentTheme.fonts.xLarge.fontSize};
-  margin: 8px 0;
 `;
 
 const Summary = styled.div`
@@ -37,7 +32,7 @@ const LearnMoreLink = styled(Link)`
 export const ImportInstructionsStep = () => {
   return (
     <Content>
-      <Title>{formatMessage('Use existing resources')}</Title>
+      <SectionTitle level={2}>{formatMessage('Use existing resources')}</SectionTitle>
       <Summary>
         <Text>
           {formatMessage(


### PR DESCRIPTION
## Description

Add accessible headings in place of visual headings to improve navigation when using a screen-reader. Added for Configure and Create publishing profile pages.

Added a shared component to handle titles as well.

Note: made `extensions/azurePublishNew` changes so it stays consistent to `extensions/azurePublish`, but wasn't able to test `extensions/azurePublishNew` changes. Even after enabling the publishing method on client side, it still doesn't render new UI reporting 404 errors back. Appreciate any help here.

## Task Item

- [VSTS 70096](https://fuselabs.visualstudio.com/Composer/_workitems/edit/70096)
- [VSTS 70110](https://fuselabs.visualstudio.com/Composer/_workitems/edit/70110)
<!-- #minor -->

## Screenshots
### Configure
![image](https://user-images.githubusercontent.com/2841858/145803549-64550891-739c-4b48-ace0-3135de266b1f.png)
![image](https://user-images.githubusercontent.com/2841858/145803593-ae4e98db-fbef-4f0c-96b9-9f8f3a773e7c.png)
![image](https://user-images.githubusercontent.com/2841858/145803644-4c807357-d886-4b98-aacb-c19960193686.png)
![image](https://user-images.githubusercontent.com/2841858/145803656-b03a6322-76a5-44f6-a149-e4c4b404d4c6.png)
![image](https://user-images.githubusercontent.com/2841858/145803709-0ed2ffa8-6f97-44ca-8cec-7466cc5afdd1.png)

### Create a publishing profile
![image](https://user-images.githubusercontent.com/2841858/145803857-415e8a9d-f3c4-4965-843b-2973997fdee0.png)
![image](https://user-images.githubusercontent.com/2841858/145803884-307b7a55-adc9-4c82-af6a-0c2ad2fd0d3e.png)
![image](https://user-images.githubusercontent.com/2841858/145803906-58477ac9-0da8-4b33-b34f-709fce3ad822.png)


