### PR TITLE
a11y: fix controls contrast ratio

### DIFF
--- a/Composer/packages/adaptive-form/src/components/expressions/ExpressionSwitchWindow.tsx
+++ b/Composer/packages/adaptive-form/src/components/expressions/ExpressionSwitchWindow.tsx
@@ -6,13 +6,13 @@ import { css, jsx } from '@emotion/core';
 import { FontIcon } from 'office-ui-fabric-react/lib/Icon';
 import React from 'react';
 import formatMessage from 'format-message';
-import { SharedColors } from '@uifabric/fluent-theme';
+import { FluentTheme, SharedColors } from '@uifabric/fluent-theme';
 
 const styles = {
   fieldTypeText: css`
     height: 32px;
     font-style: italic;
-    color: #8a8886;
+    color: ${FluentTheme.palette.neutralSecondary};
     padding: 0 4px;
     width: 100%;
     display: flex;

--- a/Composer/packages/client/src/pages/botProject/BotProjectInfo.tsx
+++ b/Composer/packages/client/src/pages/botProject/BotProjectInfo.tsx
@@ -10,13 +10,14 @@ import { DisplayMarkdownDialog } from '@bfc/ui-shared';
 import formatMessage from 'format-message';
 import { Stack, StackItem } from 'office-ui-fabric-react/lib/Stack';
 import { Link } from 'office-ui-fabric-react/lib/Link';
+import { FluentTheme } from '@uifabric/fluent-theme';
 
 import { projectReadmeState, locationState } from '../../recoilModel/atoms';
 import { localBotsDataSelector } from '../../recoilModel/selectors/project';
 
 const labelStyle = css`
   font-size: 12px;
-  color: #828282;
+  color: ${FluentTheme.palette.neutralSecondary};
 `;
 
 const valueStyle = css`

--- a/Composer/packages/lib/code-editor/src/components/toolbar/ToolbarButtonMenu.tsx
+++ b/Composer/packages/lib/code-editor/src/components/toolbar/ToolbarButtonMenu.tsx
@@ -4,7 +4,7 @@
 import { buildInFunctionsMap, getBuiltInFunctionInsertText } from '@bfc/built-in-functions';
 import styled from '@emotion/styled';
 import { createSvgIcon } from '@fluentui/react-icons';
-import { FluentTheme, NeutralColors } from '@uifabric/fluent-theme';
+import { FluentTheme } from '@uifabric/fluent-theme';
 import formatMessage from 'format-message';
 import { IconButton } from 'office-ui-fabric-react/lib/Button';
 import {
@@ -19,6 +19,7 @@ import { IStackStyles, Stack } from 'office-ui-fabric-react/lib/Stack';
 import { Text } from 'office-ui-fabric-react/lib/Text';
 import { DirectionalHint } from 'office-ui-fabric-react/lib/Tooltip';
 import * as React from 'react';
+import { FontWeights } from 'office-ui-fabric-react';
 
 import { useNoSearchResultMenuItem } from '../../hooks/useNoSearchResultMenuItem';
 import { useSearchableMenuListCallback } from '../../hooks/useSearchableMenuListCallback';
@@ -54,7 +55,7 @@ const templateSvgIcon = (
 
 const defaultTreeItemHeight = 36;
 
-const buttonStyles = { menuIcon: { fontSize: 8, color: NeutralColors.black } };
+const buttonStyles = { menuIcon: { fontSize: 8, color: FluentTheme.palette.neutralPrimary } };
 const labelContainerStyle: IStackStyles = {
   root: { whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', height: defaultTreeItemHeight },
 };
@@ -81,8 +82,8 @@ const OneLiner = styled.div({
   padding: '0 8px',
 });
 
-const svgIconStyle = { fill: NeutralColors.black, margin: '0 4px', width: 16, height: 16 };
-const iconStyles = { root: { color: NeutralColors.black, margin: '0 4px', width: 16, height: 16 } };
+const svgIconStyle = { fill: FluentTheme.palette.neutralPrimary, margin: '0 4px', width: 16, height: 16 };
+const iconStyles = { root: { color: FluentTheme.palette.neutralPrimary, margin: '0 4px', width: 16, height: 16 } };
 
 type ToolbarButtonMenuProps = {
   payload: ToolbarButtonPayload;
@@ -399,9 +400,15 @@ export const ToolbarButtonMenu = React.memo((props: ToolbarButtonMenuProps) => {
                     <Text
                       key={`segment-${idx}`}
                       styles={{
-                        root: {
-                          color: idx === pathNodes.length - 1 ? NeutralColors.black : NeutralColors.gray70,
-                        },
+                        root:
+                          idx === pathNodes.length - 1
+                            ? {
+                                color: FluentTheme.palette.neutralPrimary,
+                              }
+                            : {
+                                fontWeight: FontWeights.semilight,
+                                color: FluentTheme.palette.neutralSecondary,
+                              },
                       }}
                       variant="small"
                     >

--- a/Composer/packages/lib/code-editor/src/components/toolbar/ToolbarButtonMenu.tsx
+++ b/Composer/packages/lib/code-editor/src/components/toolbar/ToolbarButtonMenu.tsx
@@ -19,7 +19,7 @@ import { IStackStyles, Stack } from 'office-ui-fabric-react/lib/Stack';
 import { Text } from 'office-ui-fabric-react/lib/Text';
 import { DirectionalHint } from 'office-ui-fabric-react/lib/Tooltip';
 import * as React from 'react';
-import { FontWeights } from 'office-ui-fabric-react';
+import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
 
 import { useNoSearchResultMenuItem } from '../../hooks/useNoSearchResultMenuItem';
 import { useSearchableMenuListCallback } from '../../hooks/useSearchableMenuListCallback';


### PR DESCRIPTION
## Description

Fixes contrast ratio issues found for some of controls, making text contrast ratio above 4.5. See screenshots and linked bugs for more details

Switched some places to `neutralPrimary` for text color as it is the preferred text color to `black`.

## Task Item

- [VSTS 70114](https://fuselabs.visualstudio.com/Composer/_workitems/edit/70114)
- [VSTS 70437](https://fuselabs.visualstudio.com/Composer/_workitems/edit/70437)
- [VSTS 70442](https://fuselabs.visualstudio.com/Composer/_workitems/edit/70442)

## Screenshots

### Before
![MAS1 4 3_Luminosity contrast ratio for the Bot location text is less than required](https://user-images.githubusercontent.com/2841858/145991493-832e6214-dcb6-46d9-b958-48e19fdb118d.jpg)
![MAS 1 4 3_Luminosity contrast ratio for the text ‘Start typing string or’  is 3 5 ratio 1](https://user-images.githubusercontent.com/2841858/145991536-582235a1-4dbc-4e66-a950-5525624a0b7d.png)
![MAS1 4 3_Luminosity contrast ratio for ‘Insert property reference’ option is less than 4 5 1](https://user-images.githubusercontent.com/2841858/145991577-5358ec5a-7b88-402c-8837-5d2e77b0fa5c.png)

### After
![Screenshot from 2021-12-13 13-49-23](https://user-images.githubusercontent.com/2841858/145991668-31dc4604-774e-4f70-bac4-4afa4ec7fcfa.png)
![Screenshot from 2021-12-13 14-48-21](https://user-images.githubusercontent.com/2841858/145991723-f7435d1d-0b14-4bd7-b566-a09e32e3ab58.png)
![Screenshot from 2021-12-13 14-38-35](https://user-images.githubusercontent.com/2841858/145991747-85dfc5bf-8ba8-402c-aab7-b331fa83c42e.png)

#minor