### PR TITLE
fix: a11y add missing heading title for Create a bot project file section

### DIFF
--- a/Composer/packages/client/src/components/CreationFlow/FileSelector.tsx
+++ b/Composer/packages/client/src/components/CreationFlow/FileSelector.tsx
@@ -349,7 +349,7 @@ export const FileSelector: React.FC<FileSelectorProps> = (props) => {
     },
     {
       key: 'Edit',
-      name: 'Edit',
+      name: formatMessage('Edit'),
       fieldName: '',
       minWidth: 30,
       maxWidth: 30,

--- a/Composer/packages/client/src/components/CreationFlow/FileSelector.tsx
+++ b/Composer/packages/client/src/components/CreationFlow/FileSelector.tsx
@@ -349,7 +349,7 @@ export const FileSelector: React.FC<FileSelectorProps> = (props) => {
     },
     {
       key: 'Edit',
-      name: '',
+      name: 'Edit',
       fieldName: '',
       minWidth: 30,
       maxWidth: 30,


### PR DESCRIPTION
## Description

Adds a missing heading title for the 4th column on Create a bot project screen, files section.

## Task Item

- [VSTS 70096](https://fuselabs.visualstudio.com/Composer/_workitems/edit/70096)
<!-- #minor -->

## Screenshots
![image](https://user-images.githubusercontent.com/2841858/146190801-9261637e-8f23-4d6b-aff6-4d0a03a49144.png)
