### PR TITLE
a11y: Make labels and help tooltips more accessible

### DIFF
--- a/Composer/packages/adaptive-form/src/components/FieldLabel.tsx
+++ b/Composer/packages/adaptive-form/src/components/FieldLabel.tsx
@@ -3,17 +3,16 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import React, { useRef } from 'react';
-import { DirectionalHint, TooltipHost, TooltipDelay } from 'office-ui-fabric-react/lib/Tooltip';
-import { Icon } from 'office-ui-fabric-react/lib/Icon';
+import { DirectionalHint, TooltipDelay } from 'office-ui-fabric-react/lib/Tooltip';
 import { Label } from 'office-ui-fabric-react/lib/Label';
-import { NeutralColors } from '@uifabric/fluent-theme';
 import formatMessage from 'format-message';
 import { useShellApi } from '@bfc/extension-client';
+import { HelpTooltip } from '@bfc/ui-shared';
+import { FontSizes } from 'office-ui-fabric-react/lib/Styling';
 
 import { useAdaptiveFormContext } from '../AdaptiveFormContext';
 
 import { Link } from './Link';
-import { focusBorder } from './sharedStyles';
 
 interface DescriptionCalloutProps {
   title: string;
@@ -35,10 +34,17 @@ const DescriptionCallout: React.FC<DescriptionCalloutProps> = function Descripti
   }
 
   return (
-    <TooltipHost
+    <HelpTooltip
+      aria-label={title + '; ' + description}
+      data-testid="FieldLabelHelpTooltip"
       delay={TooltipDelay.zero}
       directionalHint={DirectionalHint.bottomAutoEdge}
-      styles={{ root: { display: 'inline-block' } }}
+      styles={{
+        helpIcon: {
+          fontSize: FontSizes.size12,
+          lineHeight: '15px',
+        },
+      }}
       tooltipProps={{
         styles: { root: { width: '288px', padding: '17px 28px' } },
         onRenderContent: () => (
@@ -83,26 +89,7 @@ const DescriptionCallout: React.FC<DescriptionCalloutProps> = function Descripti
           timeOpened.current = null;
         }
       }}
-    >
-      <div css={focusBorder} data-testid="FieldLabelDescriptionIcon" tabIndex={0}>
-        <Icon
-          aria-label={title + '; ' + description}
-          iconName={'Unknown'}
-          styles={{
-            root: {
-              width: '16px',
-              minWidth: '16px',
-              height: '16px',
-              color: NeutralColors.gray160,
-              fontSize: '12px',
-              marginBottom: '-2px',
-              paddingLeft: '4px',
-              paddingTop: '4px',
-            },
-          }}
-        />
-      </div>
-    </TooltipHost>
+    />
   );
 };
 

--- a/Composer/packages/adaptive-form/src/components/FieldLabel.tsx
+++ b/Composer/packages/adaptive-form/src/components/FieldLabel.tsx
@@ -36,9 +36,11 @@ const DescriptionCallout: React.FC<DescriptionCalloutProps> = function Descripti
   return (
     <HelpTooltip
       aria-label={title + '; ' + description}
-      data-testid="FieldLabelHelpTooltip"
       delay={TooltipDelay.zero}
       directionalHint={DirectionalHint.bottomAutoEdge}
+      iconProps={{
+        'data-testid': 'FieldLabelHelpIcon',
+      }}
       styles={{
         helpIcon: {
           fontSize: FontSizes.size12,

--- a/Composer/packages/adaptive-form/src/components/__tests__/FieldLabel.test.tsx
+++ b/Composer/packages/adaptive-form/src/components/__tests__/FieldLabel.test.tsx
@@ -23,6 +23,6 @@ describe('<FieldLabel />', () => {
       <FieldLabel description="my description" helpLink="https://aka.ms" label="My Label" />
     );
 
-    expect(await findByTestId('FieldLabelDescriptionIcon')).toBeInTheDocument();
+    expect(await findByTestId('FieldLabelHelpTooltip')).toBeInTheDocument();
   });
 });

--- a/Composer/packages/adaptive-form/src/components/__tests__/FieldLabel.test.tsx
+++ b/Composer/packages/adaptive-form/src/components/__tests__/FieldLabel.test.tsx
@@ -23,6 +23,6 @@ describe('<FieldLabel />', () => {
       <FieldLabel description="my description" helpLink="https://aka.ms" label="My Label" />
     );
 
-    expect(await findByTestId('FieldLabelHelpTooltip')).toBeInTheDocument();
+    expect(await findByTestId('FieldLabelHelpIcon')).toBeInTheDocument();
   });
 });

--- a/Composer/packages/client/__tests__/components/BotRuntimeController/publish-luis-modal.test.tsx
+++ b/Composer/packages/client/__tests__/components/BotRuntimeController/publish-luis-modal.test.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { fireEvent } from '@botframework-composer/test-utils';
 
-import { PublishDialog } from '../../../src/components/BotRuntimeController/publishDialog';
+import { _PublishDialog as PublishDialog } from '../../../src/components/BotRuntimeController/publishDialog';
 import { botDisplayNameState, settingsState, dispatcherState, currentProjectIdState } from '../../../src/recoilModel';
 import { renderWithRecoil } from '../../testUtils';
 

--- a/Composer/packages/client/src/components/BotRuntimeController/publishDialog.tsx
+++ b/Composer/packages/client/src/components/BotRuntimeController/publishDialog.tsx
@@ -8,15 +8,13 @@ import { Dialog, DialogType } from 'office-ui-fabric-react/lib/Dialog';
 import { FontWeights, FontSizes } from 'office-ui-fabric-react/lib/Styling';
 import { DialogFooter } from 'office-ui-fabric-react/lib/Dialog';
 import { PrimaryButton, DefaultButton } from 'office-ui-fabric-react/lib/Button';
-import { TextField, ITextFieldProps } from 'office-ui-fabric-react/lib/TextField';
 import { Link } from 'office-ui-fabric-react/lib/Link';
-import { IconButton } from 'office-ui-fabric-react/lib/Button';
 import { Stack } from 'office-ui-fabric-react/lib/Stack';
-import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
 import formatMessage from 'format-message';
 import { useRecoilValue } from 'recoil';
 import { IConfig, IPublishConfig, IQnAConfig } from '@bfc/shared';
 import { Dropdown, ResponsiveMode } from 'office-ui-fabric-react/lib/Dropdown';
+import { TextField } from '@bfc/ui-shared';
 
 import { Text, Tips, Links, nameRegex, LUIS_REGIONS } from '../../constants';
 import { FieldConfig, useForm } from '../../hooks/useForm';
@@ -25,9 +23,6 @@ import { getLuisBuildLuFiles } from '../../utils/luUtil';
 import { luFilesSelectorFamily, qnaFilesSelectorFamily, dialogsSelectorFamily } from '../../recoilModel';
 
 // -------------------- Styles -------------------- //
-const textFieldLabel = css`
-  font-weight: ${FontWeights.semibold};
-`;
 
 const dialogSubTitle = css`
   font-size: ${FontSizes.medium};
@@ -69,16 +64,6 @@ const validate = (value?: string) => {
   }
 };
 
-// eslint-disable-next-line react/display-name
-const onRenderLabel = (info: string) => (props?: ITextFieldProps) => (
-  <Stack horizontal verticalAlign="center">
-    <span css={textFieldLabel}>{props?.label}</span>
-    <TooltipHost calloutProps={{ gapSpace: 0 }} content={info}>
-      <IconButton iconProps={{ iconName: 'Info' }} styles={{ root: { marginBottom: -3 } }} />
-    </TooltipHost>
-  </Stack>
-);
-
 interface IPublishDialogProps {
   botName: string;
   isOpen: boolean;
@@ -88,7 +73,7 @@ interface IPublishDialogProps {
   projectId: string;
 }
 
-export const PublishDialog: React.FC<IPublishDialogProps> = (props) => {
+const PublishDialog: React.FC<IPublishDialogProps> = (props) => {
   const { isOpen, onDismiss, onPublish, botName, config, projectId } = props;
   const dialogs = useRecoilValue(dialogsSelectorFamily(projectId));
   const luFiles = useRecoilValue(luFilesSelectorFamily(projectId));
@@ -218,17 +203,17 @@ export const PublishDialog: React.FC<IPublishDialogProps> = (props) => {
             data-testid="ProjectNameInput"
             errorMessage={formErrors.name}
             label={formatMessage('What is the name of your bot?')}
+            tooltip={Tips.PROJECT_NAME}
             value={formData.name}
             onChange={(_e, val) => updateField('name', val)}
-            onRenderLabel={onRenderLabel(Tips.PROJECT_NAME)}
           />
           <TextField
             data-testid="EnvironmentInput"
             errorMessage={formErrors.environment}
             label={formatMessage('Environment')}
+            tooltip={Tips.ENVIRONMENT}
             value={formData.environment}
             onChange={(_e, val) => updateField('environment', val)}
-            onRenderLabel={onRenderLabel(Tips.ENVIRONMENT)}
           />
           {luConfigShow && (
             <Fragment>
@@ -236,9 +221,9 @@ export const PublishDialog: React.FC<IPublishDialogProps> = (props) => {
                 data-testid="AuthoringKeyInput"
                 errorMessage={formErrors.authoringKey}
                 label={formatMessage('LUIS authoring key:')}
+                tooltip={Tips.AUTHORING_KEY}
                 value={formData.authoringKey}
                 onChange={(_e, val) => updateField('authoringKey', val)}
-                onRenderLabel={onRenderLabel(Tips.AUTHORING_KEY)}
               />
               <Dropdown
                 data-testid="regionDropdown"
@@ -260,17 +245,17 @@ export const PublishDialog: React.FC<IPublishDialogProps> = (props) => {
                 data-testid="SubscriptionKeyInput"
                 errorMessage={formErrors.subscriptionKey}
                 label={formatMessage('QnA Maker subscription key:')}
+                tooltip={Tips.SUBSCRIPTION_KEY}
                 value={formData.subscriptionKey}
                 onChange={(_e, val) => updateField('subscriptionKey', val)}
-                onRenderLabel={onRenderLabel(Tips.SUBSCRIPTION_KEY)}
               />
               <TextField
                 disabled
                 readOnly
                 errorMessage={formErrors.qnaRegion}
                 label={formatMessage('QnA region')}
+                tooltip={Tips.AUTHORING_REGION}
                 value={formData.qnaRegion}
-                onRenderLabel={onRenderLabel(Tips.AUTHORING_REGION)}
               />
             </Fragment>
           )}
@@ -279,8 +264,8 @@ export const PublishDialog: React.FC<IPublishDialogProps> = (props) => {
             readOnly
             errorMessage={formErrors.defaultLanguage}
             label={formatMessage('Default language')}
+            tooltip={Tips.DEFAULT_LANGUAGE}
             value={formData.defaultLanguage}
-            onRenderLabel={onRenderLabel(Tips.DEFAULT_LANGUAGE)}
           />
         </Stack>
       </form>
@@ -291,3 +276,5 @@ export const PublishDialog: React.FC<IPublishDialogProps> = (props) => {
     </Dialog>
   );
 };
+
+export { PublishDialog as _PublishDialog };

--- a/Composer/packages/client/src/components/CreationFlow/DefineConversation.tsx
+++ b/Composer/packages/client/src/components/CreationFlow/DefineConversation.tsx
@@ -15,16 +15,13 @@ import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import { RouteComponentProps } from '@reach/router';
 import querystring from 'query-string';
 import { FontWeights } from '@uifabric/styling';
-import { DialogWrapper, DialogTypes } from '@bfc/ui-shared';
+import { DialogWrapper, DialogTypes, DropdownField } from '@bfc/ui-shared';
 import { useRecoilValue } from 'recoil';
 import { csharpFeedKey, FeedType, functionsRuntimeKey, nodeFeedKey, QnABotTemplateId } from '@bfc/shared';
 import { RuntimeType, webAppRuntimeKey, localTemplateId } from '@bfc/shared';
-import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
+import { IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
 import camelCase from 'lodash/camelCase';
 import upperFirst from 'lodash/upperFirst';
-import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
-import { Icon } from 'office-ui-fabric-react/lib/Icon';
-import { NeutralColors } from '@uifabric/fluent-theme';
 import { Label } from 'office-ui-fabric-react/lib/Label';
 
 import { CreationFlowStatus, DialogCreationCopy, nameRegex, botNameRegex } from '../../constants';
@@ -429,7 +426,8 @@ const DefineConversation: React.FC<DefineConversationProps> = (props) => {
               <StackItem grow={0} styles={halfstack}>
                 <Stack horizontal styles={stackinput} tokens={{ childrenGap: '2rem' }}>
                   <StackItem grow={0}>
-                    <Dropdown
+                    <DropdownField
+                      required
                       data-testid="NewDialogRuntimeType"
                       label={formatMessage('Runtime type')}
                       options={getSupportedRuntimesForTemplate()}
@@ -439,33 +437,16 @@ const DefineConversation: React.FC<DefineConversationProps> = (props) => {
                         dropdownItem: { height: '100px' },
                         dropdownItemSelected: { height: '100px' },
                       }}
-                      onChange={(_e, option) => updateField('runtimeType', option?.key.toString())}
-                      onRenderLabel={(props) => (
-                        <Stack horizontal styles={{ root: { alignItems: 'center' } }}>
-                          <Label required>{props?.label}</Label>
-                          <TooltipHost
-                            content={formatMessage(
-                              'Azure offers a number of ways to host your application code. The runtime type refers to the hosting model for the computing resources that your application runs on.'
-                            )}
-                          >
-                            <Icon
-                              iconName="Unknown"
-                              styles={{
-                                root: {
-                                  color: NeutralColors.gray160,
-                                  userSelect: 'none',
-                                },
-                              }}
-                            />
-                          </TooltipHost>
-                        </Stack>
+                      tooltip={formatMessage(
+                        'Azure offers a number of ways to host your application code. The runtime type refers to the hosting model for the computing resources that your application runs on.'
                       )}
+                      onChange={(_e, option) => updateField('runtimeType', option?.key.toString())}
                       onRenderOption={renderRuntimeDropdownOption}
                     />
                   </StackItem>
                   {inBotMigration && (
                     <StackItem grow={0}>
-                      <Dropdown
+                      <DropdownField
                         data-testid="NewDialogRuntimeLanguage"
                         label={formatMessage('Runtime Language')}
                         options={getRuntimeLanguageOptions()}

--- a/Composer/packages/client/src/components/FieldWithCustomButton.tsx
+++ b/Composer/packages/client/src/components/FieldWithCustomButton.tsx
@@ -4,7 +4,7 @@
 /** @jsx jsx */
 import { jsx, css } from '@emotion/core';
 import React, { useState, useRef, Fragment, useEffect } from 'react';
-import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
+import { IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
 import { FluentTheme, SharedColors } from '@uifabric/fluent-theme';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import { ActionButton } from 'office-ui-fabric-react/lib/Button';

--- a/Composer/packages/client/src/components/FieldWithCustomButton.tsx
+++ b/Composer/packages/client/src/components/FieldWithCustomButton.tsx
@@ -4,16 +4,17 @@
 /** @jsx jsx */
 import { jsx, css } from '@emotion/core';
 import React, { useState, useRef, Fragment, useEffect } from 'react';
-import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
 import { SharedColors } from '@uifabric/fluent-theme';
-import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import { ActionButton } from 'office-ui-fabric-react/lib/Button';
-import { FontSizes, FontWeights } from 'office-ui-fabric-react/lib/Styling';
+import { FontWeights, mergeStyleSets } from 'office-ui-fabric-react/lib/Styling';
 import { NeutralColors } from '@uifabric/fluent-theme';
+import { TextField, DropdownField } from '@bfc/ui-shared';
 
-const disabledTextFieldStyle = {
+import { customFieldLabel } from '../styles';
+
+const disabledTextFieldStyle = mergeStyleSets(customFieldLabel, {
   root: {
     selectors: {
       '.ms-TextField-field': {
@@ -27,7 +28,7 @@ const disabledTextFieldStyle = {
       },
     },
   },
-};
+});
 
 const actionButtonStyle = {
   root: {
@@ -62,30 +63,6 @@ const errorTextStyle = css`
   margin-bottom: 5px;
 `;
 
-const labelContainer = css`
-  display: flex;
-  flex-direction: row;
-`;
-
-const customerLabel = css`
-  font-size: ${FontSizes.small};
-  margin-right: 5px;
-`;
-
-const unknownIconStyle = (required) => {
-  return {
-    root: {
-      selectors: {
-        '&::before': {
-          content: required ? " '*'" : '',
-          color: SharedColors.red10,
-          paddingRight: 3,
-        },
-      },
-    },
-  };
-};
-
 type Props = {
   label: string;
   ariaLabel: string;
@@ -110,17 +87,6 @@ const errorElement = (errorText: string) => {
       <Icon iconName="ErrorBadge" styles={errorIcon} />
       <span css={errorTextStyle}>{errorText}</span>
     </span>
-  );
-};
-
-const onRenderLabel = (props) => {
-  return (
-    <div css={labelContainer}>
-      <div css={customerLabel}> {props.label} </div>
-      <TooltipHost content={props.label}>
-        <Icon iconName="Unknown" styles={unknownIconStyle(props.required)} />
-      </TooltipHost>
-    </div>
   );
 };
 
@@ -161,13 +127,13 @@ export const FieldWithCustomButton: React.FC<Props> = (props) => {
     label,
     required,
     ariaLabel,
+    styles: customFieldLabel,
   };
   const commonDisabledProps = {
     disabled: true,
     componentRef: fieldComponentRef,
     placeholder: placeholderOnDisable,
     styles: disabledTextFieldStyle,
-    onRenderLabel,
   };
   const commonEnabledProps = {
     disabled: false,
@@ -189,7 +155,7 @@ export const FieldWithCustomButton: React.FC<Props> = (props) => {
         errorMessage={required ? errorElement(errorMessage) : ''}
       />
     ) : (
-      <Dropdown
+      <DropdownField
         {...commonProps}
         {...commonDisabledProps}
         data-testid={fieldDataTestId}
@@ -211,7 +177,7 @@ export const FieldWithCustomButton: React.FC<Props> = (props) => {
         }}
       />
     ) : (
-      <Dropdown
+      <DropdownField
         {...commonProps}
         {...commonEnabledProps}
         data-testid={fieldDataTestId}

--- a/Composer/packages/client/src/components/FieldWithCustomButton.tsx
+++ b/Composer/packages/client/src/components/FieldWithCustomButton.tsx
@@ -5,7 +5,7 @@
 import { jsx, css } from '@emotion/core';
 import React, { useState, useRef, Fragment, useEffect } from 'react';
 import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
-import { SharedColors } from '@uifabric/fluent-theme';
+import { FluentTheme, SharedColors } from '@uifabric/fluent-theme';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import { ActionButton } from 'office-ui-fabric-react/lib/Button';
 import { FontWeights, mergeStyleSets } from 'office-ui-fabric-react/lib/Styling';
@@ -25,6 +25,13 @@ const disabledTextFieldStyle = mergeStyleSets(customFieldLabel, {
       },
       'p > span': {
         width: '100%',
+      },
+    },
+  },
+  subComponentStyles: {
+    label: {
+      root: {
+        color: FluentTheme.palette.neutralPrimary,
       },
     },
   },
@@ -65,7 +72,7 @@ const errorTextStyle = css`
 
 type Props = {
   label: string;
-  ariaLabel: string;
+  ariaLabel?: string;
   buttonText: string;
   errorMessage?;
   placeholder: string;
@@ -78,6 +85,7 @@ type Props = {
   options?: IDropdownOption[];
   fieldDataTestId?: string;
   buttonDataTestId?: string;
+  tooltip?: string;
 };
 
 const errorElement = (errorText: string) => {
@@ -106,6 +114,7 @@ export const FieldWithCustomButton: React.FC<Props> = (props) => {
     options,
     fieldDataTestId = '',
     buttonDataTestId = '',
+    tooltip,
   } = props;
   const [isDisabled, setDisabled] = useState<boolean>(!value);
   const fieldComponentRef = useRef<any>(null);
@@ -127,6 +136,7 @@ export const FieldWithCustomButton: React.FC<Props> = (props) => {
     label,
     required,
     ariaLabel,
+    tooltip,
     styles: customFieldLabel,
   };
   const commonDisabledProps = {

--- a/Composer/packages/client/src/pages/botProject/AppIdAndPassword.tsx
+++ b/Composer/packages/client/src/pages/botProject/AppIdAndPassword.tsx
@@ -5,14 +5,10 @@
 import React, { useState, useEffect, useCallback, Fragment } from 'react';
 import { jsx, css } from '@emotion/core';
 import { useRecoilValue } from 'recoil';
-import { TextField } from 'office-ui-fabric-react/lib/TextField';
-import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
-import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import formatMessage from 'format-message';
-import { FontSizes } from 'office-ui-fabric-react/lib/Styling';
-import { SharedColors } from '@uifabric/fluent-theme';
 import { Link } from 'office-ui-fabric-react/lib/Link';
 import { PrimaryButton } from 'office-ui-fabric-react/lib/Button';
+import { TextField } from '@bfc/ui-shared';
 
 import { dispatcherState, settingsState } from '../../recoilModel';
 import { mergePropertiesManagedByRootBot } from '../../recoilModel/dispatchers/utils/project';
@@ -23,30 +19,6 @@ import { SettingTitle } from './shared/SettingTitle';
 import { GetAppInfoFromPublishProfileDialog } from './GetAppInfoFromPublishProfileDialog';
 // -------------------- Styles -------------------- //
 
-const labelContainer = css`
-  display: flex;
-  flex-direction: row;
-`;
-
-const customerLabel = css`
-  font-size: ${FontSizes.small};
-  margin-right: 5px;
-`;
-
-const unknownIconStyle = (required) => {
-  return {
-    root: {
-      selectors: {
-        '&::before': {
-          content: required ? " '*'" : '',
-          color: SharedColors.red10,
-          paddingRight: 3,
-        },
-      },
-    },
-  };
-};
-
 const appIdAndPasswordStyle = css`
   display: flex;
   flex-direction: column;
@@ -56,17 +28,6 @@ const appIdAndPasswordStyle = css`
 
 type AppIdAndPasswordProps = {
   projectId: string;
-};
-
-const onRenderLabel = (props) => {
-  return (
-    <div css={labelContainer}>
-      <div css={customerLabel}> {props.label} </div>
-      <TooltipHost content={props.label}>
-        <Icon iconName="Unknown" styles={unknownIconStyle(props.required)} />
-      </TooltipHost>
-    </div>
-  );
 };
 
 export const AppIdAndPassword: React.FC<AppIdAndPasswordProps> = (props) => {
@@ -134,26 +95,24 @@ export const AppIdAndPassword: React.FC<AppIdAndPasswordProps> = (props) => {
       </div>
       <div css={appIdAndPasswordStyle}>
         <TextField
-          ariaLabel={formatMessage('Microsoft App Id')}
           data-testid={'MicrosoftAppId'}
           label={formatMessage('Microsoft App Id')}
           placeholder={formatMessage('Type App Id')}
           styles={inputFieldStyles}
+          tooltip={formatMessage('Microsoft App Id')}
           value={localMicrosoftAppId}
           onBlur={handleAppIdOnBlur}
           onChange={handleAppIdOnChange}
-          onRenderLabel={onRenderLabel}
         />
         <TextField
-          ariaLabel={formatMessage('Microsoft App Password')}
           data-testid={'MicrosoftPassword'}
           label={formatMessage('Microsoft App Password')}
           placeholder={formatMessage('Type App Password')}
           styles={inputFieldStyles}
+          tooltip={formatMessage('Microsoft App Password')}
           value={localMicrosoftAppPassword}
           onBlur={handleAppPasswordOnBlur}
           onChange={handleAppPasswordOnChange}
-          onRenderLabel={onRenderLabel}
         />
         <PrimaryButton
           styles={{ root: { width: '230px', marginTop: '15px' } }}

--- a/Composer/packages/client/src/pages/botProject/RootBotExternalService.tsx
+++ b/Composer/packages/client/src/pages/botProject/RootBotExternalService.tsx
@@ -6,18 +6,17 @@ import React, { useState, useEffect, useRef, Fragment } from 'react';
 import { jsx, keyframes } from '@emotion/core';
 import { BotIndexer } from '@bfc/indexers';
 import { useRecoilValue } from 'recoil';
-import { TextField } from 'office-ui-fabric-react/lib/TextField';
-import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
-import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
+import { IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import formatMessage from 'format-message';
 import get from 'lodash/get';
 import { css } from '@emotion/core';
 import { FontSizes } from 'office-ui-fabric-react/lib/Styling';
-import { NeutralColors, SharedColors } from '@uifabric/fluent-theme';
+import { NeutralColors } from '@uifabric/fluent-theme';
 import { PrimaryButton } from 'office-ui-fabric-react/lib/Button';
 import { Link } from 'office-ui-fabric-react/lib/Link';
 import { MessageBar, MessageBarType } from 'office-ui-fabric-react/lib/MessageBar';
+import { TextField, DropdownField } from '@bfc/ui-shared';
 
 import {
   dispatcherState,
@@ -36,32 +35,7 @@ import { ManageQNA } from '../../components/ManageQNA/ManageQNA';
 
 import { inputFieldStyles, subtext } from './styles';
 import { SettingTitle } from './shared/SettingTitle';
-
 // -------------------- Styles -------------------- //
-
-const labelContainer = css`
-  display: flex;
-  flex-direction: row;
-`;
-
-const customerLabel = css`
-  font-size: ${FontSizes.small};
-  margin-right: 5px;
-`;
-
-const unknownIconStyle = (required) => {
-  return {
-    root: {
-      selectors: {
-        '&::before': {
-          content: required ? " '*'" : '',
-          color: SharedColors.red10,
-          paddingRight: 3,
-        },
-      },
-    },
-  };
-};
 
 const externalServiceContainerStyle = css`
   display: flex;
@@ -119,17 +93,6 @@ const luisRegionErrorTextStyle = css`
 type RootBotExternalServiceProps = {
   projectId: string;
   scrollToSectionId?: string;
-};
-
-const onRenderLabel = (props) => {
-  return (
-    <div css={labelContainer}>
-      <div css={customerLabel}> {props.label} </div>
-      <TooltipHost content={props.label}>
-        <Icon iconName="Unknown" styles={unknownIconStyle(props.required)} />
-      </TooltipHost>
-    </div>
-  );
 };
 
 const errorElement = (errorText: string) => {
@@ -361,20 +324,18 @@ export const RootBotExternalService: React.FC<RootBotExternalServiceProps> = (pr
       </div>
       <div css={externalServiceContainerStyle}>
         <TextField
-          ariaLabel={formatMessage('Application name')}
           data-testid={'rootLUISApplicationName'}
           id={'luisName'}
           label={formatMessage('Application name')}
           placeholder={formatMessage('Type application name')}
           styles={inputFieldStyles}
+          tooltip={formatMessage('Application name')}
           value={localRootLuisName}
           onBlur={handleRootLUISNameOnBlur}
           onChange={handleRootLUISNameOnChange}
-          onRenderLabel={onRenderLabel}
         />
         <div ref={luisKeyFieldRef}>
           <TextField
-            ariaLabel={formatMessage('Language Understanding authoring key')}
             data-testid={'rootLUISAuthoringKey'}
             errorMessage={isLUISKeyNeeded ? errorElement(luisKeyErrorMsg) : ''}
             id={'luisAuthoringKey'}
@@ -382,14 +343,14 @@ export const RootBotExternalService: React.FC<RootBotExternalServiceProps> = (pr
             placeholder={formatMessage('Type Language Understanding authoring key')}
             required={isLUISKeyNeeded}
             styles={inputFieldStyles}
+            tooltip={formatMessage('Language Understanding authoring key')}
             value={localRootLuisKey}
             onBlur={handleRootLuisAuthoringKeyOnBlur}
             onChange={handleRootLUISKeyOnChange}
-            onRenderLabel={onRenderLabel}
           />
         </div>
         <div ref={luisRegionFieldRef}>
-          <Dropdown
+          <DropdownField
             ariaLabel={formatMessage('Language Understanding region')}
             data-testid={'rootLUISRegion'}
             id={'luisRegion'}
@@ -399,9 +360,9 @@ export const RootBotExternalService: React.FC<RootBotExternalServiceProps> = (pr
             required={isLUISKeyNeeded}
             selectedKey={localRootLuisRegion}
             styles={inputFieldStyles}
+            tooltip={formatMessage('Language Understanding region')}
             onBlur={handleRootLuisRegionOnBlur}
             onChange={handleRootLuisRegionOnChange}
-            onRenderLabel={onRenderLabel}
           />
           {luisRegionErrorMsg && (
             <div css={luisRegionErrorContainerStyle}>
@@ -465,7 +426,6 @@ export const RootBotExternalService: React.FC<RootBotExternalServiceProps> = (pr
         </div>
         <div ref={qnaKeyFieldRef}>
           <TextField
-            ariaLabel={formatMessage('QnA Maker Subscription key')}
             data-testid={'QnASubscriptionKey'}
             errorMessage={isQnAKeyNeeded ? errorElement(qnaKeyErrorMsg) : ''}
             id={'qnaKey'}
@@ -473,10 +433,10 @@ export const RootBotExternalService: React.FC<RootBotExternalServiceProps> = (pr
             placeholder={formatMessage('Type subscription key')}
             required={isQnAKeyNeeded}
             styles={inputFieldStyles}
+            tooltip={formatMessage('QnA Maker Subscription key')}
             value={localRootQnAKey}
             onBlur={handleRootQnAKeyOnBlur}
             onChange={handleRootQnAKeyOnChange}
-            onRenderLabel={onRenderLabel}
           />
         </div>
         <PrimaryButton

--- a/Composer/packages/client/src/pages/botProject/SkillBotExternalService.tsx
+++ b/Composer/packages/client/src/pages/botProject/SkillBotExternalService.tsx
@@ -9,8 +9,9 @@ import { useRecoilValue } from 'recoil';
 import formatMessage from 'format-message';
 import get from 'lodash/get';
 import { css } from '@emotion/core';
-import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import { Link } from 'office-ui-fabric-react/lib/Link';
+import { mergeStyleSets } from 'office-ui-fabric-react/lib/Styling';
+import { TextField } from '@bfc/ui-shared';
 
 import {
   dispatcherState,
@@ -25,6 +26,7 @@ import { rootBotProjectIdSelector } from '../../recoilModel/selectors/project';
 import { FieldWithCustomButton } from '../../components/FieldWithCustomButton';
 import { mergePropertiesManagedByRootBot } from '../../recoilModel/dispatchers/utils/project';
 import { LUIS_REGIONS } from '../../constants';
+import { customFieldLabel } from '../../styles';
 
 import { subtext } from './styles';
 import { SettingTitle } from './shared/SettingTitle';
@@ -161,19 +163,17 @@ export const SkillBotExternalService: React.FC<SkillBotExternalServiceProps> = (
       </div>
       <div css={externalServiceContainerStyle}>
         <TextField
-          ariaLabel={formatMessage('Application name')}
           data-testid={'skillLUISApplicationName'}
           id={'luisName'}
           label={formatMessage('Application name')}
           placeholder={formatMessage('Type application name')}
-          styles={{ root: { marginBottom: 10 } }}
+          styles={mergeStyleSets(customFieldLabel, { root: { marginBottom: 10 } })}
           value={localSkillLuisName}
           onBlur={handleSkillLUISNameOnBlur}
           onChange={handleSkillLUISNameOnChange}
         />
         <div ref={luisKeyFieldRef}>
           <FieldWithCustomButton
-            ariaLabel={formatMessage('Language Understanding authoring key')}
             buttonDataTestId="skillLUISAuthoringKeyBtn"
             buttonText={formatMessage('Use custom LUIS authoring key')}
             errorMessage={!rootLuisKey ? formatMessage('Root Bot LUIS authoring key is empty') : ''}
@@ -183,13 +183,13 @@ export const SkillBotExternalService: React.FC<SkillBotExternalServiceProps> = (
             placeholder={formatMessage('Type Language Understanding authoring key')}
             placeholderOnDisable={rootLuisKey}
             required={isLUISKeyNeeded}
+            tooltip={formatMessage('Language Understanding authoring key')}
             value={skillLuisKey}
             onBlur={handleLUISKeyOnBlur}
           />
         </div>
         <div ref={luisRegionFieldRef}>
           <FieldWithCustomButton
-            ariaLabel={formatMessage('Language Understanding region')}
             buttonDataTestId="skillLUISAuthoringRegionBtn"
             buttonText={formatMessage('Use custom LUIS region')}
             errorMessage={!rootLuisRegion ? formatMessage('Root Bot LUIS region is empty') : ''}
@@ -199,6 +199,7 @@ export const SkillBotExternalService: React.FC<SkillBotExternalServiceProps> = (
             placeholder={formatMessage('Select region')}
             placeholderOnDisable={rootLuisRegion}
             required={isLUISKeyNeeded}
+            tooltip={formatMessage('Language Understanding region')}
             value={skillLuisRegion}
             onBlur={handleLUISRegionOnBlur}
           />
@@ -227,7 +228,6 @@ export const SkillBotExternalService: React.FC<SkillBotExternalServiceProps> = (
         </div>
         <div ref={qnaKeyFieldRef}>
           <FieldWithCustomButton
-            ariaLabel={formatMessage('QnA Maker Subscription key')}
             buttonDataTestId="skillQnaAuthoringBtn"
             buttonText={formatMessage('Use custom QnA Maker Subscription key')}
             errorMessage={!rootQnAKey ? formatMessage('Root Bot QnA Maker Subscription key is empty') : ''}
@@ -237,6 +237,7 @@ export const SkillBotExternalService: React.FC<SkillBotExternalServiceProps> = (
             placeholder={formatMessage('Enter QnA Maker Subscription key')}
             placeholderOnDisable={rootQnAKey}
             required={isQnAKeyNeeded}
+            tooltip={formatMessage('QnA Maker Subscription key')}
             value={skillQnAKey}
             onBlur={handleSkillQnAKeyOnBlur}
           />

--- a/Composer/packages/client/src/pages/botProject/SkillHostEndPoint.tsx
+++ b/Composer/packages/client/src/pages/botProject/SkillHostEndPoint.tsx
@@ -3,64 +3,24 @@
 
 /** @jsx jsx */
 import React, { Fragment, useState } from 'react';
-import { jsx, css } from '@emotion/core';
+import { jsx } from '@emotion/core';
 import { useRecoilValue } from 'recoil';
-import { TextField } from 'office-ui-fabric-react/lib/TextField';
-import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
-import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import formatMessage from 'format-message';
-import { FontSizes } from 'office-ui-fabric-react/lib/Styling';
-import { SharedColors } from '@uifabric/fluent-theme';
 import { Link } from 'office-ui-fabric-react/lib/components/Link';
+import { TextField } from '@bfc/ui-shared';
 
 import { dispatcherState, settingsState } from '../../recoilModel';
 import { rootBotProjectIdSelector } from '../../recoilModel/selectors/project';
 import { mergePropertiesManagedByRootBot } from '../../recoilModel/dispatchers/utils/project';
+import { customFieldLabel } from '../../styles';
 
 import { subtext } from './styles';
 import { SettingTitle } from './shared/SettingTitle';
-
-// -------------------- Styles -------------------- //
-
-const labelContainer = css`
-  display: flex;
-  flex-direction: row;
-`;
-
-const customerLabel = css`
-  font-size: ${FontSizes.small};
-  margin-right: 5px;
-`;
-
-const unknownIconStyle = (required) => {
-  return {
-    root: {
-      selectors: {
-        '&::before': {
-          content: required ? " '*'" : '',
-          color: SharedColors.red10,
-          paddingRight: 3,
-        },
-      },
-    },
-  };
-};
 
 // -------------------- SkillHostEndPoint -------------------- //
 
 type SkillHostEndPointProps = {
   projectId: string;
-};
-
-const onRenderLabel = (props) => {
-  return (
-    <div css={labelContainer}>
-      <div css={customerLabel}> {props.label} </div>
-      <TooltipHost content={props.label}>
-        <Icon iconName="Unknown" styles={unknownIconStyle(props.required)} />
-      </TooltipHost>
-    </div>
-  );
 };
 
 export const SkillHostEndPoint: React.FC<SkillHostEndPointProps> = (props) => {
@@ -99,14 +59,14 @@ export const SkillHostEndPoint: React.FC<SkillHostEndPointProps> = (props) => {
         )}
       </div>
       <TextField
-        ariaLabel={formatMessage('Skill host endpoint url')}
         data-testid={'SkillHostEndPointTextField'}
         label={formatMessage('Skill host endpoint URL')}
         placeholder={formatMessage('Enter Skill host endpoint URL')}
+        styles={customFieldLabel}
+        tooltip={formatMessage('Skill host endpoint URL')}
         value={endpointUrl}
         onBlur={handleBlur}
         onChange={handleChange}
-        onRenderLabel={onRenderLabel}
       />
     </Fragment>
   );

--- a/Composer/packages/client/src/pages/botProject/create-publish-profile/ProfileFormDialog.tsx
+++ b/Composer/packages/client/src/pages/botProject/create-publish-profile/ProfileFormDialog.tsx
@@ -2,18 +2,20 @@
 // Licensed under the MIT License.
 
 /** @jsx jsx */
-import { jsx, css } from '@emotion/core';
+import { jsx } from '@emotion/core';
 import formatMessage from 'format-message';
 import { DialogFooter } from 'office-ui-fabric-react/lib/Dialog';
 import { useState, useMemo, useCallback, Fragment } from 'react';
 import { PrimaryButton, DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { Separator } from 'office-ui-fabric-react/lib/Separator';
-import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
-import { TextField } from 'office-ui-fabric-react/lib/TextField';
+import { IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
 import { PublishTarget } from '@bfc/shared';
+import { DropdownField, TextField } from '@bfc/ui-shared';
+import { mergeStyleSets } from 'office-ui-fabric-react/lib/Styling';
 
 import { separator } from '../../publish/styles';
 import { PublishType } from '../../../recoilModel/types';
+import { customFieldLabel } from '../../../styles';
 
 type ProfileFormDialogProps = {
   onDismiss: () => void;
@@ -26,25 +28,6 @@ type ProfileFormDialogProps = {
   setName: (value: string) => void;
   setTargetType: (value: string) => void;
   current?: { index: number; item: PublishTarget } | null;
-};
-const labelContainer = css`
-  display: flex;
-  flex-direction: row;
-  margin-bottom: 5px;
-`;
-
-const customerLabel = css`
-  margin-right: 5px;
-  font-weight: 600;
-  font-size: 14px;
-`;
-
-const onRenderLabel = (props) => {
-  return (
-    <div css={labelContainer}>
-      <div css={customerLabel}> {props.label} </div>
-    </div>
-  );
 };
 
 //const hiddenProfileTypes = ['pva-publish-composer'];
@@ -113,19 +96,18 @@ export const ProfileFormDialog: React.FC<ProfileFormDialogProps> = (props) => {
               errorMessage={errorMessage}
               label={formatMessage('Name')}
               placeholder={formatMessage('e.g. AzureBot')}
-              styles={{ root: { paddingBottom: '8px' } }}
+              styles={mergeStyleSets(customFieldLabel, { root: { paddingBottom: '8px' } })}
               onChange={updateName}
-              onRenderLabel={onRenderLabel}
             />
-            <Dropdown
+            <DropdownField
               required
               ariaLabel={formatMessage('The target where you publish your bot')}
               defaultSelectedKey={targetType}
               label={formatMessage('Publishing target')}
               options={targetTypes}
               placeholder={formatMessage('Select one')}
+              styles={customFieldLabel}
               onChange={updateType}
-              onRenderLabel={onRenderLabel}
             />
           </form>
         </div>

--- a/Composer/packages/client/src/pages/botProject/styles.ts
+++ b/Composer/packages/client/src/pages/botProject/styles.ts
@@ -5,6 +5,8 @@ import { css } from '@emotion/core';
 import { NeutralColors, SharedColors } from '@uifabric/fluent-theme';
 import { FontSizes, FontWeights, mergeStyleSets } from 'office-ui-fabric-react/lib/Styling';
 
+import { customFieldLabel } from '../../styles';
+
 export const tabContentContainer = css`
   margin-left: 10px;
   max-width: 580px;
@@ -121,21 +123,6 @@ export const errorIcon = {
   },
 };
 
-export const unknownIconStyle = (required: boolean) => {
-  return {
-    root: {
-      selectors: {
-        '&::before': {
-          content: required ? " '*'" : '',
-          color: SharedColors.red10,
-          paddingRight: 10,
-        },
-      },
-      fontSize: FontSizes.medium,
-    },
-  };
-};
-
 export const columnSizes = ['300px', '150px', '150px'];
 export const extendedColumnSizes = ['220px', '80px', '250px'];
 export const publishProfileButtonColumnSize = '50px';
@@ -151,7 +138,7 @@ export const actionButton = {
   },
 };
 
-export const inputFieldStyles = mergeStyleSets({ root: { marginTop: 10 } }, customError);
+export const inputFieldStyles = mergeStyleSets({ root: { marginTop: 10 } }, customError, customFieldLabel);
 
 export const teamsCallOutStyles = mergeStyleSets({
   callout: {

--- a/Composer/packages/client/src/pages/design/exportSkillModal/content/SelectProfile.tsx
+++ b/Composer/packages/client/src/pages/design/exportSkillModal/content/SelectProfile.tsx
@@ -9,7 +9,7 @@ import React, { Fragment, useEffect, useMemo, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
-import { NeutralColors } from '@uifabric/fluent-theme';
+import { FluentTheme, NeutralColors } from '@uifabric/fluent-theme';
 import { MessageBar, MessageBarType } from 'office-ui-fabric-react/lib/MessageBar';
 import { Link } from 'office-ui-fabric-react/lib/Link';
 import { TextField } from '@bfc/ui-shared';
@@ -24,6 +24,17 @@ const styles = {
     height: 350px;
     overflow: auto;
   `,
+};
+
+const inputStyles = {
+  root: { paddingBottom: '8px' },
+  subComponentStyles: {
+    label: {
+      root: {
+        color: FluentTheme.palette.neutralPrimary,
+      },
+    },
+  },
 };
 
 const onRenderInvalidProfileWarning = (hasValidProfile, handleShowPublishProfileWrapperDialog) => {
@@ -183,7 +194,7 @@ export const SelectProfile: React.FC<ContentProps> = ({
             options={publishingOptions}
             placeholder={formatMessage('Select one')}
             selectedKey={selectedKey}
-            styles={{ root: { paddingBottom: '8px' } }}
+            styles={inputStyles}
             onChange={handleCurrentProfileChange}
             onRenderTitle={onRenderTitle}
           />
@@ -196,8 +207,9 @@ export const SelectProfile: React.FC<ContentProps> = ({
                 required
                 label={formatMessage('Endpoint Url')}
                 placeholder={formatMessage('The endpoint url of your web app resource')}
-                styles={{ root: { paddingBottom: '8px' } }}
+                styles={inputStyles}
                 tooltip={formatMessage('The endpoint url')}
+                tooltipIconName="Info"
                 value={endpointUrl}
               />
               <TextField
@@ -205,8 +217,9 @@ export const SelectProfile: React.FC<ContentProps> = ({
                 required
                 label={formatMessage('Microsoft App ID')}
                 placeholder={formatMessage('The App ID')}
-                styles={{ root: { paddingBottom: '8px' } }}
+                styles={inputStyles}
                 tooltip={formatMessage('The app id of your application registration')}
+                tooltipIconName="Info"
                 value={appId}
               />
             </Fragment>

--- a/Composer/packages/client/src/pages/design/exportSkillModal/content/SelectProfile.tsx
+++ b/Composer/packages/client/src/pages/design/exportSkillModal/content/SelectProfile.tsx
@@ -7,17 +7,15 @@ import { PublishTarget } from '@bfc/shared';
 import formatMessage from 'format-message';
 import React, { Fragment, useEffect, useMemo, useState } from 'react';
 import { useRecoilValue } from 'recoil';
-import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
-import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import { NeutralColors } from '@uifabric/fluent-theme';
 import { MessageBar, MessageBarType } from 'office-ui-fabric-react/lib/MessageBar';
 import { Link } from 'office-ui-fabric-react/lib/Link';
+import { TextField } from '@bfc/ui-shared';
 
 import { botDisplayNameState, dispatcherState, settingsState } from '../../../../recoilModel';
 import { CreatePublishProfileDialog } from '../../../botProject/CreatePublishProfileDialog';
-import { iconStyle } from '../../../botProject/runtime-settings/style';
 import { ContentProps } from '../constants';
 import { PublishProfileWrapperDialog } from '../../../botProject/PublishProfieWrapperDialog';
 
@@ -26,37 +24,6 @@ const styles = {
     height: 350px;
     overflow: auto;
   `,
-};
-
-const onRenderLabel = (props) => {
-  return (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'row',
-        marginBottom: '5px',
-      }}
-    >
-      <div
-        style={{
-          marginRight: '5px',
-          fontWeight: 600,
-          fontSize: '14px',
-        }}
-      >
-        <div
-          style={{
-            padding: '0 5px',
-          }}
-        >
-          {props.label}
-        </div>
-      </div>
-      <TooltipHost content={props.ariaLabel}>
-        <Icon iconName="Info" styles={iconStyle(props.required)} />
-      </TooltipHost>
-    </div>
-  );
 };
 
 const onRenderInvalidProfileWarning = (hasValidProfile, handleShowPublishProfileWrapperDialog) => {
@@ -227,22 +194,20 @@ export const SelectProfile: React.FC<ContentProps> = ({
               <TextField
                 disabled
                 required
-                ariaLabel={formatMessage('The endpoint url')}
                 label={formatMessage('Endpoint Url')}
                 placeholder={formatMessage('The endpoint url of your web app resource')}
                 styles={{ root: { paddingBottom: '8px' } }}
+                tooltip={formatMessage('The endpoint url')}
                 value={endpointUrl}
-                onRenderLabel={onRenderLabel}
               />
               <TextField
                 disabled
                 required
-                ariaLabel={formatMessage('The app id of your application registration')}
                 label={formatMessage('Microsoft App ID')}
                 placeholder={formatMessage('The App ID')}
                 styles={{ root: { paddingBottom: '8px' } }}
+                tooltip={formatMessage('The app id of your application registration')}
                 value={appId}
-                onRenderLabel={onRenderLabel}
               />
             </Fragment>
           )}

--- a/Composer/packages/client/src/pages/design/exportSkillModal/content/SelectProfile.tsx
+++ b/Composer/packages/client/src/pages/design/exportSkillModal/content/SelectProfile.tsx
@@ -209,7 +209,7 @@ export const SelectProfile: React.FC<ContentProps> = ({
                 placeholder={formatMessage('The endpoint url of your web app resource')}
                 styles={inputStyles}
                 tooltip={formatMessage('The endpoint url')}
-                tooltipIconName="Info"
+                tooltipIconProps={{ iconName: 'Info' }}
                 value={endpointUrl}
               />
               <TextField
@@ -219,7 +219,7 @@ export const SelectProfile: React.FC<ContentProps> = ({
                 placeholder={formatMessage('The App ID')}
                 styles={inputStyles}
                 tooltip={formatMessage('The app id of your application registration')}
-                tooltipIconName="Info"
+                tooltipIconProps={{ iconName: 'Info' }}
                 value={appId}
               />
             </Fragment>

--- a/Composer/packages/client/src/pages/setting/app-settings/SettingDropdown.tsx
+++ b/Composer/packages/client/src/pages/setting/app-settings/SettingDropdown.tsx
@@ -6,7 +6,7 @@ import { DropdownField } from '@bfc/ui-shared';
 import { jsx } from '@emotion/core';
 import { useId } from '@uifabric/react-hooks';
 import kebabCase from 'lodash/kebabCase';
-import { mergeStyleSets } from 'office-ui-fabric-react/lib/Styling';
+import { FontSizes, mergeStyleSets } from 'office-ui-fabric-react/lib/Styling';
 import { IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
 import React from 'react';
 
@@ -29,6 +29,16 @@ type Props = {
   onChange: (key: string) => void;
 };
 
+const tooltipStyles = {
+  subComponentStyles: {
+    helpTooltip: {
+      helpIcon: {
+        fontSize: FontSizes.small,
+      },
+    },
+  },
+};
+
 export const SettingDropdown: React.FC<Props> = ({
   id,
   label,
@@ -49,7 +59,7 @@ export const SettingDropdown: React.FC<Props> = ({
         label={label}
         options={options}
         selectedKey={selected}
-        styles={mergeStyleSets(customFieldLabel, { root: { width } })}
+        styles={mergeStyleSets(customFieldLabel, tooltipStyles, { root: { width } })}
         tooltip={tooltip ?? label}
         onChange={(_e, option) => onChange(option?.key?.toString() ?? '')}
       />

--- a/Composer/packages/client/src/pages/setting/app-settings/SettingDropdown.tsx
+++ b/Composer/packages/client/src/pages/setting/app-settings/SettingDropdown.tsx
@@ -2,13 +2,15 @@
 // Licensed under the MIT License.
 
 /** @jsx jsx */
+import { DropdownField } from '@bfc/ui-shared';
 import { jsx } from '@emotion/core';
 import { useId } from '@uifabric/react-hooks';
 import kebabCase from 'lodash/kebabCase';
-import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
-import { Icon } from 'office-ui-fabric-react/lib/Icon';
-import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
+import { mergeStyleSets } from 'office-ui-fabric-react/lib/Styling';
+import { IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
 import React from 'react';
+
+import { customFieldLabel } from '../../../styles';
 
 import * as styles from './styles';
 
@@ -19,7 +21,7 @@ const defaultDropdownWidth = 300;
 type Props = {
   label: string;
   options: IDropdownOption[];
-  tooltip?: React.ReactNode;
+  tooltip?: string;
   id?: string;
   selected?: string;
   width?: number;
@@ -39,28 +41,17 @@ export const SettingDropdown: React.FC<Props> = ({
 }) => {
   const uniqueId = useId(kebabCase(label));
 
-  const renderLabel = React.useCallback(({ label: dropdownLabel }) => {
-    return (
-      <div css={styles.labelContainer}>
-        <div css={styles.customerLabel}>{dropdownLabel}</div>
-        <TooltipHost content={tooltip ?? dropdownLabel}>
-          <Icon iconName="Unknown" styles={styles.icon} />
-        </TooltipHost>
-      </div>
-    );
-  }, []);
-
   return (
     <div css={styles.settingsContainer}>
-      <Dropdown
+      <DropdownField
         calloutProps={{ calloutMaxHeight: defaultItemHeight * itemCountBeforeScroll }}
         id={id || uniqueId}
         label={label}
         options={options}
         selectedKey={selected}
-        styles={{ root: { width } }}
+        styles={mergeStyleSets(customFieldLabel, { root: { width } })}
+        tooltip={tooltip ?? label}
         onChange={(_e, option) => onChange(option?.key?.toString() ?? '')}
-        onRenderLabel={renderLabel}
       />
     </div>
   );

--- a/Composer/packages/client/src/pages/setting/app-settings/TemplateFeedForm.tsx
+++ b/Composer/packages/client/src/pages/setting/app-settings/TemplateFeedForm.tsx
@@ -14,8 +14,7 @@ import { Text } from 'office-ui-fabric-react/lib/Text';
 
 import { dispatcherState, templateFeedUrlState, templateProjectsState } from '../../../recoilModel/atoms/appState';
 import TelemetryClient from '../../../telemetry/TelemetryClient';
-
-import * as styles from './styles';
+import { customFieldLabel } from '../../../styles';
 
 const settingsContainer = css`
   border-top: 1px solid ${NeutralColors.gray20};
@@ -46,14 +45,6 @@ export const TemplateFeedForm = () => {
       setTemplateFeedUrl(urlValue);
     }
   };
-
-  const renderLabel = useCallback(({ label: dropdownLabel }) => {
-    return (
-      <div css={styles.labelContainer}>
-        <div css={styles.customerLabel}>{dropdownLabel}</div>
-      </div>
-    );
-  }, []);
 
   useEffect(() => {
     setFieldDisabled(true);
@@ -86,6 +77,7 @@ export const TemplateFeedForm = () => {
         disabled={fieldDisabled}
         errorMessage={errorMessage}
         label={formatMessage('Template Feed Url')}
+        styles={customFieldLabel}
         value={urlValue}
         onBlur={(ev) => {
           savePendingEdits();
@@ -97,7 +89,6 @@ export const TemplateFeedForm = () => {
             setUrlValue('');
           }
         }}
-        onRenderLabel={renderLabel}
       />
       <Link
         data-testid={'default-feed-link'}

--- a/Composer/packages/client/src/pages/setting/app-settings/TemplateFeedForm.tsx
+++ b/Composer/packages/client/src/pages/setting/app-settings/TemplateFeedForm.tsx
@@ -3,7 +3,7 @@
 
 /** @jsx jsx */
 import { css, jsx } from '@emotion/core';
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState } from 'react';
 import formatMessage from 'format-message';
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import { firstPartyTemplateFeed } from '@bfc/shared';

--- a/Composer/packages/client/src/pages/setting/app-settings/styles.ts
+++ b/Composer/packages/client/src/pages/setting/app-settings/styles.ts
@@ -60,22 +60,6 @@ export const image = css`
   width: 86px;
 `;
 
-export const labelContainer = css`
-  display: flex;
-  flex-direction: row;
-`;
-
-export const customerLabel = css`
-  font-size: ${FontSizes.size12};
-  margin-right: 5px;
-`;
-
-export const icon = {
-  root: {
-    fontSize: FontSizes.size12,
-  },
-};
-
 export const featureFlagGroupContainer = css`
   margin-left: 166px;
   font-size: ${FontSizes.size12};

--- a/Composer/packages/client/src/styles.ts
+++ b/Composer/packages/client/src/styles.ts
@@ -2,6 +2,18 @@
 // Licensed under the MIT License.
 
 import { css } from '@emotion/core';
+import { FontSizes, FontWeights } from 'office-ui-fabric-react/lib/Styling';
+
+export const customFieldLabel = {
+  subComponentStyles: {
+    label: {
+      root: {
+        fontWeight: FontWeights.regular,
+        fontSize: FontSizes.small,
+      },
+    },
+  },
+};
 
 export const showDesign = (show) => css`
   display: ${show ? 'block' : 'none'} !important;

--- a/Composer/packages/form-dialogs/src/components/common/HelpTooltip.tsx
+++ b/Composer/packages/form-dialogs/src/components/common/HelpTooltip.tsx
@@ -4,13 +4,13 @@
 import { FluentTheme } from '@uifabric/fluent-theme';
 import * as React from 'react';
 import { HelpTooltip as SharedHelpTooltip } from '@bfc/ui-shared';
+import { FontSizes } from 'office-ui-fabric-react/lib/Styling';
 
 const iconStyles = {
   helpIcon: {
     color: FluentTheme.palette.neutralSecondary,
-    fontSize: 12,
-    lineHeight: '12px',
-    cursor: 'default',
+    fontSize: FontSizes.small,
+    lineHeight: '1',
   },
 };
 

--- a/Composer/packages/form-dialogs/src/components/common/HelpTooltip.tsx
+++ b/Composer/packages/form-dialogs/src/components/common/HelpTooltip.tsx
@@ -2,19 +2,17 @@
 // Licensed under the MIT License.
 
 import { FluentTheme } from '@uifabric/fluent-theme';
-import { Icon, IIconProps, IIconStyles } from 'office-ui-fabric-react/lib/Icon';
-import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
-import { classNamesFunction } from 'office-ui-fabric-react/lib/Utilities';
 import * as React from 'react';
+import { HelpTooltip as SharedHelpTooltip } from '@bfc/ui-shared';
 
-const iconStyles = classNamesFunction<IIconProps, IIconStyles>()({
-  root: {
+const iconStyles = {
+  helpIcon: {
     color: FluentTheme.palette.neutralSecondary,
     fontSize: 12,
     lineHeight: '12px',
     cursor: 'default',
   },
-});
+};
 
 type Props = {
   tooltipId: string;
@@ -23,8 +21,11 @@ type Props = {
 
 export const HelpTooltip = React.memo((props: Props) => {
   return (
-    <TooltipHost content={props.helpMessage} id={props.tooltipId}>
-      <Icon aria-label={props.helpMessage} iconName={'Unknown'} styles={iconStyles} />
-    </TooltipHost>
+    <SharedHelpTooltip
+      aria-label={props.helpMessage}
+      content={props.helpMessage}
+      id={props.tooltipId}
+      styles={iconStyles}
+    />
   );
 });

--- a/Composer/packages/lib/code-editor/src/components/HelpIconTooltip.tsx
+++ b/Composer/packages/lib/code-editor/src/components/HelpIconTooltip.tsx
@@ -1,18 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { HelpTooltip, HelpTooltipProps } from '@bfc/ui-shared';
 import { FluentTheme, NeutralColors } from '@uifabric/fluent-theme';
-import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import * as React from 'react';
 
-import { withTooltip, WithTooltipProps } from '../utils/withTooltip';
-
-const iconStyles = {
+const tooltipStyles = {
   root: {
-    cursor: 'default',
-    lineHeight: '12px',
+    padding: 0,
+  },
+  helpIcon: {
     fontSize: FluentTheme.fonts.small.fontSize,
     color: NeutralColors.gray130,
+    lineHeight: '14px',
   },
 };
 
@@ -24,9 +24,16 @@ export const HelpIconTooltip = React.memo(
   }: {
     tooltipId: string;
     helpMessage: string | JSX.Element | JSX.Element[];
-    tooltipProps?: WithTooltipProps;
+    tooltipProps?: Partial<HelpTooltipProps>;
   }) => {
-    const TooltipIcon = withTooltip({ ...tooltipProps, content: helpMessage, id: tooltipId }, Icon);
-    return <TooltipIcon data-testid="helpIcon" iconName={'Unknown'} styles={iconStyles} />;
+    return (
+      <HelpTooltip
+        {...tooltipProps}
+        content={helpMessage}
+        data-testid="helpIcon"
+        id={tooltipId}
+        styles={tooltipStyles}
+      />
+    );
   }
 );

--- a/Composer/packages/lib/code-editor/src/components/HelpIconTooltip.tsx
+++ b/Composer/packages/lib/code-editor/src/components/HelpIconTooltip.tsx
@@ -30,7 +30,7 @@ export const HelpIconTooltip = React.memo(
       <HelpTooltip
         {...tooltipProps}
         content={helpMessage}
-        data-testid="helpIcon"
+        iconProps={{ 'data-testid': 'helpIcon' }}
         id={tooltipId}
         styles={tooltipStyles}
       />

--- a/Composer/packages/lib/code-editor/src/components/ItemWithTooltip.tsx
+++ b/Composer/packages/lib/code-editor/src/components/ItemWithTooltip.tsx
@@ -4,8 +4,7 @@
 import * as React from 'react';
 import { Text } from 'office-ui-fabric-react/lib/Text';
 import { Stack } from 'office-ui-fabric-react/lib/Stack';
-
-import { WithTooltipProps } from '../utils/withTooltip';
+import { HelpTooltipProps } from '@bfc/ui-shared';
 
 import { HelpIconTooltip } from './HelpIconTooltip';
 
@@ -15,7 +14,7 @@ type Props = {
   tooltipId: string;
   itemText: string | JSX.Element | JSX.Element[] | React.ReactNode;
   tooltipText: string | JSX.Element | JSX.Element[];
-  tooltipProps?: WithTooltipProps;
+  tooltipProps?: Partial<HelpTooltipProps>;
 };
 
 const defaultRender = (text: string) => <Text variant="small">{text}</Text>;

--- a/Composer/packages/lib/ui-shared/src/components/Field.tsx
+++ b/Composer/packages/lib/ui-shared/src/components/Field.tsx
@@ -12,11 +12,11 @@ import { getTheme, mergeStyleSets, ITheme } from 'office-ui-fabric-react/lib/Sty
 
 import { HelpTooltip } from './HelpTooltip';
 
-import { HelpTooltipStyles } from '.';
+import { HelpTooltipProps, HelpTooltipStyles } from '.';
 
 type LabelWithTooltipProps<Props, Styles> = Omit<Props, 'styles'> & {
   tooltip?: string;
-  tooltipIconName?: string;
+  tooltipIconProps?: HelpTooltipProps['iconProps'];
   styles?: IStyleFunctionOrObject<
     never,
     // @ts-expect-error: subComponentStyles won't match the exact component's interface
@@ -67,13 +67,13 @@ const useOnRenderLabelWithHelpTooltip = <Props, Styles>(props: LabelWithTooltipP
           <HelpTooltip
             aria-label={props.tooltip}
             content={props.tooltip}
-            iconName={props.tooltipIconName}
+            iconProps={props.tooltipIconProps}
             styles={classNames.subComponentStyles.helpTooltip}
           />
         )}
       </Stack>
     ),
-    [classNames, props.tooltip, props.tooltipIconName]
+    [classNames, props.tooltip, props.tooltipIconProps]
   );
 };
 

--- a/Composer/packages/lib/ui-shared/src/components/Field.tsx
+++ b/Composer/packages/lib/ui-shared/src/components/Field.tsx
@@ -39,6 +39,7 @@ const getClassNames = (
   mergeStyleSets(
     {
       subComponentStyles: {
+        helpTooltip: {},
         label: {
           root: {
             selectors: {
@@ -55,18 +56,26 @@ const getClassNames = (
 
 const useClassNames = <Styles,>(styles: Styles) => useMemo(() => getClassNames(getTheme(), { styles }), [styles]);
 
-const useOnRenderLabelWithHelpTooltip = <Props, Styles>(props: LabelWithTooltipProps<Props, Styles>) =>
-  useCallback<IRenderFunction<Props>>(
+const useOnRenderLabelWithHelpTooltip = <Props, Styles>(props: LabelWithTooltipProps<Props, Styles>) => {
+  const classNames = useClassNames(props.styles);
+
+  return useCallback<IRenderFunction<Props>>(
     (componentProps, defaultRender) => (
       <Stack horizontal verticalAlign="center">
         {componentProps && defaultRender && defaultRender(componentProps)}
         {props.tooltip && (
-          <HelpTooltip aria-label={props.tooltip} content={props.tooltip} iconName={props.tooltipIconName} />
+          <HelpTooltip
+            aria-label={props.tooltip}
+            content={props.tooltip}
+            iconName={props.tooltipIconName}
+            styles={classNames.subComponentStyles.helpTooltip}
+          />
         )}
       </Stack>
     ),
-    [props.tooltip, props.tooltipIconName]
+    [classNames, props.tooltip, props.tooltipIconName]
   );
+};
 
 export type DropdownFieldProps = LabelWithTooltipProps<IDropdownProps, IDropdownStyles>;
 

--- a/Composer/packages/lib/ui-shared/src/components/Field.tsx
+++ b/Composer/packages/lib/ui-shared/src/components/Field.tsx
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/** @jsx jsx */
+import { jsx } from '@emotion/core';
+import { Dropdown, IDropdownProps, IDropdownStyles } from 'office-ui-fabric-react/lib/Dropdown';
+import React, { useCallback, useMemo } from 'react';
+import { TextField as FluentTextField, ITextFieldProps, ITextFieldStyles } from 'office-ui-fabric-react/lib/TextField';
+import { Stack } from 'office-ui-fabric-react/lib/Stack';
+import { IStyleFunctionOrObject, IRenderFunction } from 'office-ui-fabric-react/lib/Utilities';
+import { getTheme, mergeStyleSets, ITheme } from 'office-ui-fabric-react/lib/Styling';
+
+import { HelpTooltip } from './HelpTooltip';
+
+import { HelpTooltipStyles } from '.';
+
+type LabelWithTooltipProps<Props, Styles> = Omit<Props, 'styles'> & {
+  tooltip?: string;
+  tooltipIconName?: string;
+  styles?: IStyleFunctionOrObject<
+    never,
+    // @ts-expect-error: subComponentStyles won't match the exact component's interface
+    // but the resulting type is still valid
+    Styles & {
+      subComponentStyles: {
+        /** Styling for HelpTooltip child component */
+        helpTooltip: HelpTooltipStyles;
+      };
+    }
+  >;
+};
+
+const getClassNames = (
+  theme: ITheme,
+  props: {
+    styles?: IStyleFunctionOrObject<unknown, {}>;
+  }
+) =>
+  mergeStyleSets(
+    {
+      subComponentStyles: {
+        label: {
+          root: {
+            selectors: {
+              '::after': {
+                paddingRight: '0',
+              },
+            },
+          },
+        },
+      },
+    },
+    props.styles
+  );
+
+const useClassNames = <Styles,>(styles: Styles) => useMemo(() => getClassNames(getTheme(), { styles }), [styles]);
+
+const useOnRenderLabelWithHelpTooltip = <Props, Styles>(props: LabelWithTooltipProps<Props, Styles>) =>
+  useCallback<IRenderFunction<Props>>(
+    (componentProps, defaultRender) => (
+      <Stack horizontal verticalAlign="center">
+        {componentProps && defaultRender && defaultRender(componentProps)}
+        {props.tooltip && (
+          <HelpTooltip aria-label={props.tooltip} content={props.tooltip} iconName={props.tooltipIconName} />
+        )}
+      </Stack>
+    ),
+    [props.tooltip, props.tooltipIconName]
+  );
+
+export type DropdownFieldProps = LabelWithTooltipProps<IDropdownProps, IDropdownStyles>;
+
+export const DropdownField: React.FC<DropdownFieldProps> = (props) => {
+  const onRenderLabel: IRenderFunction<IDropdownProps> = useOnRenderLabelWithHelpTooltip(props);
+  const classNames = useClassNames(props.styles);
+  return <Dropdown {...props} styles={classNames} onRenderLabel={onRenderLabel} />;
+};
+
+DropdownField.displayName = 'DropdownField';
+
+export type TextFieldProps = LabelWithTooltipProps<ITextFieldProps, ITextFieldStyles>;
+
+export const TextField: React.FC<TextFieldProps> = (props) => {
+  const onRenderLabel: IRenderFunction<ITextFieldProps> = useOnRenderLabelWithHelpTooltip(props);
+  const classNames = useClassNames(props.styles);
+  return <FluentTextField {...props} styles={classNames} onRenderLabel={onRenderLabel} />;
+};
+
+TextField.displayName = 'TextField';

--- a/Composer/packages/lib/ui-shared/src/components/HelpTooltip.tsx
+++ b/Composer/packages/lib/ui-shared/src/components/HelpTooltip.tsx
@@ -21,6 +21,7 @@ const getClassNames = (theme: ITheme, props: Pick<HelpTooltipProps, 'styles'>) =
       root: {
         display: 'flex',
         padding: '5px',
+        cursor: 'default',
       },
       helpIcon: [
         {

--- a/Composer/packages/lib/ui-shared/src/components/HelpTooltip.tsx
+++ b/Composer/packages/lib/ui-shared/src/components/HelpTooltip.tsx
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/** @jsx jsx */
+import { jsx } from '@emotion/core';
+import { FluentTheme } from '@uifabric/fluent-theme';
+import { Icon } from 'office-ui-fabric-react/lib/Icon';
+import {
+  TooltipHost,
+  ITooltipHostProps,
+  ITooltipHostStyles,
+  ITooltipHostStyleProps,
+} from 'office-ui-fabric-react/lib/Tooltip';
+import React, { useMemo } from 'react';
+import { mergeStyleSets, getFocusStyle, getTheme, ITheme, IStyle } from 'office-ui-fabric-react/lib/Styling';
+import { IStyleFunctionOrObject } from 'office-ui-fabric-react/lib/Utilities';
+
+const getClassNames = (theme: ITheme, props: Pick<HelpTooltipProps, 'styles'>) =>
+  mergeStyleSets(
+    {
+      root: {
+        display: 'flex',
+        padding: '5px',
+      },
+      helpIcon: [
+        {
+          color: FluentTheme.palette.neutralPrimary,
+          userSelect: 'none',
+          height: '1em',
+        },
+        getFocusStyle(theme, {
+          inset: -3,
+        }),
+      ],
+    },
+    props.styles
+  );
+
+export type HelpTooltipStyles = IStyleFunctionOrObject<
+  Partial<ITooltipHostStyleProps>,
+  ITooltipHostStyles & {
+    helpIcon?: IStyle;
+  }
+>;
+
+export type HelpTooltipProps = Omit<ITooltipHostProps, 'styles'> & {
+  iconName?: string;
+  styles?: HelpTooltipStyles;
+};
+
+const useClassNames = <Styles,>(styles: Styles) => useMemo(() => getClassNames(getTheme(), { styles }), [styles]);
+
+export const HelpTooltip: React.FC<HelpTooltipProps> = ({ iconName = 'Unknown', ...props }) => {
+  const classNames = useClassNames(props.styles);
+  return (
+    <TooltipHost {...props} styles={classNames}>
+      <Icon aria-label={props['aria-label']} className={classNames.helpIcon} iconName={iconName} tabIndex={0} />
+    </TooltipHost>
+  );
+};
+
+HelpTooltip.displayName = 'HelpTooltip';

--- a/Composer/packages/lib/ui-shared/src/components/HelpTooltip.tsx
+++ b/Composer/packages/lib/ui-shared/src/components/HelpTooltip.tsx
@@ -14,6 +14,7 @@ import {
 import React, { useMemo } from 'react';
 import { mergeStyleSets, getFocusStyle, getTheme, ITheme, IStyle } from 'office-ui-fabric-react/lib/Styling';
 import { IStyleFunctionOrObject } from 'office-ui-fabric-react/lib/Utilities';
+import { IIconProps } from 'office-ui-fabric-react/lib/Icon';
 
 const getClassNames = (theme: ITheme, props: Pick<HelpTooltipProps, 'styles'>) =>
   mergeStyleSets(
@@ -45,17 +46,23 @@ export type HelpTooltipStyles = IStyleFunctionOrObject<
 >;
 
 export type HelpTooltipProps = Omit<ITooltipHostProps, 'styles'> & {
-  iconName?: string;
+  iconProps?: IIconProps & { 'data-testid'?: string };
   styles?: HelpTooltipStyles;
 };
 
 const useClassNames = <Styles,>(styles: Styles) => useMemo(() => getClassNames(getTheme(), { styles }), [styles]);
 
-export const HelpTooltip: React.FC<HelpTooltipProps> = ({ iconName = 'Unknown', ...props }) => {
+export const HelpTooltip: React.FC<HelpTooltipProps> = ({ iconProps, ...props }) => {
   const classNames = useClassNames(props.styles);
   return (
     <TooltipHost {...props} styles={classNames}>
-      <Icon aria-label={props['aria-label']} className={classNames.helpIcon} iconName={iconName} tabIndex={0} />
+      <Icon
+        aria-label={props['aria-label']}
+        className={classNames.helpIcon}
+        iconName="Unknown"
+        tabIndex={0}
+        {...iconProps}
+      />
     </TooltipHost>
   );
 };

--- a/Composer/packages/lib/ui-shared/src/components/SectionTitle.tsx
+++ b/Composer/packages/lib/ui-shared/src/components/SectionTitle.tsx
@@ -21,3 +21,5 @@ export const SectionTitle: React.FC<SectionTitleProps> = ({ level, ...props }) =
     {...props}
   />
 );
+
+SectionTitle.displayName = 'SectionTitle';

--- a/Composer/packages/lib/ui-shared/src/components/__tests__/Field.test.tsx
+++ b/Composer/packages/lib/ui-shared/src/components/__tests__/Field.test.tsx
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import React from 'react';
+import { render } from '@botframework-composer/test-utils';
+
+import { TextField, DropdownField } from '../Field';
+
+describe.each([
+  ['TextField', TextField],
+  ['DropdownField', DropdownField],
+])('<%s/>', (fieldName, Field) => {
+  const defaultProps = { options: [] };
+
+  it('Should render an input with the given label', () => {
+    const labelText = `${fieldName} Test Label`;
+    const { container } = render(<Field {...defaultProps} label={labelText} />);
+    expect(container).toHaveTextContent(labelText);
+  });
+
+  it('Should render tooltip with the given text', async () => {
+    const tooltipText = `${fieldName} Test Tooltip`;
+    const tooltipIconTestId = 'tooltip-icon';
+    const { findByTestId } = render(
+      <Field
+        {...defaultProps}
+        tooltip={tooltipText}
+        tooltipIconProps={{
+          'data-testid': tooltipIconTestId,
+        }}
+      />
+    );
+    const icon = await findByTestId(tooltipIconTestId);
+    expect(icon.getAttribute('aria-label')).toEqual(tooltipText);
+    expect(icon.tabIndex).toEqual(0);
+  });
+
+  it('Should render a tooltip only when the tooltip property is specified', () => {
+    const tooltipIconTestId = 'tooltip-icon';
+    const { queryByTestId } = render(
+      <Field
+        {...defaultProps}
+        tooltipIconProps={{
+          'data-testid': tooltipIconTestId,
+        }}
+      />
+    );
+    const icon = queryByTestId(tooltipIconTestId);
+    expect(icon).toBeNull();
+  });
+});

--- a/Composer/packages/lib/ui-shared/src/components/index.ts
+++ b/Composer/packages/lib/ui-shared/src/components/index.ts
@@ -13,3 +13,5 @@ export * from './tags/TagInput';
 export * from './IconMenu';
 export * from './CopyableText';
 export * from './SectionTitle';
+export * from './HelpTooltip';
+export * from './Field';


### PR DESCRIPTION
## Description

This PR contains changes to achieve the following goals:
- Make labels to be linked with inputs in a way FluentUi does it
- Make help tooltips to be accessible via keyboard and able to be read via screen-readers
- Make field components usage more consistent across the code base

To achieve these goals the following changes were made:
- Added own `TextField` and `DropdownField` shared components extending FluentUi corresponding components: mainly adding a help tooltip properties
- Implemented `useLabelWithTooltip` hook to be utilized in extended components 
- Added `HelpTolltip` shared component to be used in place of current tooltip with icon use and the new components as well
- Refactored codebase to utilize introduced components

## Task Item

- [VSTS 70112](https://fuselabs.visualstudio.com/Composer/_workitems/edit/70112)
- [VSTS 70450](https://fuselabs.visualstudio.com/Composer/_workitems/edit/70450)
- [VSTS 70454](https://fuselabs.visualstudio.com/Composer/_workitems/edit/70454)
- [VSTS 70465](https://fuselabs.visualstudio.com/Composer/_workitems/edit/70465)
- [VSTS 70104](https://fuselabs.visualstudio.com/Composer/_workitems/edit/70104)
- [VSTS 70430](https://fuselabs.visualstudio.com/Composer/_workitems/edit/70430)
- [VSTS 70431](https://fuselabs.visualstudio.com/Composer/_workitems/edit/70431)

## Screenshots
#### adaptive-form FieldLabel
![adaptive-form-FieldLabel-1](https://user-images.githubusercontent.com/2841858/147577039-0655e3d5-3dbd-4f1b-818d-4b6fdb0f390c.png)
![adaptive-form__FieldLabel](https://user-images.githubusercontent.com/2841858/147577080-4d37230d-4987-4190-893d-9609b192de64.png)

#### DefineConversation
![client__DefineConversation](https://user-images.githubusercontent.com/2841858/147577103-a2783f41-e3ce-4e42-9917-2acde72a04ce.png)

#### ExportSkillModal
![client__ExportSkillModal](https://user-images.githubusercontent.com/2841858/147577400-2181a279-7ef2-4e3b-87c7-1a78182119d0.png)

#### ProfileFormDialog
![client__ProfileFormDialog](https://user-images.githubusercontent.com/2841858/147577158-092deecb-d4e6-4bc9-baf7-40ee862a277e.png)

#### RootBotExternalService
![client__RootBotExternalService](https://user-images.githubusercontent.com/2841858/147577183-b2e5902f-c4a7-4752-815d-f42ef34106c5.png)

#### RuntimeSettings
![client__RuntimeSettings](https://user-images.githubusercontent.com/2841858/147577204-e4034169-78ff-416c-a6b2-f770bd866eb5.png)

#### SelectProfile
![client__SelectProfile](https://user-images.githubusercontent.com/2841858/147577231-79f47c5f-0323-4b62-ab32-6993ce73ef90.png)

#### SettingsDropdown

![client__SettingsDropdown](https://user-images.githubusercontent.com/2841858/147577270-b069a040-3b60-4f64-8413-40a0d183f0a8.png)

#### SkillBotExternalService
![client_SkillBotExternalService-1](https://user-images.githubusercontent.com/2841858/147577330-87865695-4547-4ebe-b35d-34b8f105ec14.png)

![client__SkillBotExternalService](https://user-images.githubusercontent.com/2841858/147577321-73464bb4-e64b-40ce-8fbe-15ba10f526c6.png)

#### SkillHostEndPoint
![client__SkillHostEndPoint](https://user-images.githubusercontent.com/2841858/147577431-6497f1c3-d303-467a-8518-36f1eee6a504.png)


#minor