### PR TITLE
fix: reset to default or const when field value is undefined

### DIFF
--- a/Composer/packages/adaptive-form/src/components/SchemaField.tsx
+++ b/Composer/packages/adaptive-form/src/components/SchemaField.tsx
@@ -63,7 +63,7 @@ export const SchemaField: React.FC<FieldProps> = (props) => {
         handleChange(schema.default);
       }
     }
-  }, []);
+  }, [value]);
 
   if (name.startsWith('$') || hidden) {
     return null;


### PR DESCRIPTION
Fixes #8809 
