### PR TITLE
a11y: improve contextual menus and filtering

### DIFF
--- a/Composer/packages/client/src/components/ProjectTree/ProjectTreeHeader.tsx
+++ b/Composer/packages/client/src/components/ProjectTree/ProjectTreeHeader.tsx
@@ -6,10 +6,11 @@ import { jsx, css } from '@emotion/core';
 import { useEffect, useRef, useState } from 'react';
 import { FontSizes, NeutralColors } from '@uifabric/fluent-theme';
 import formatMessage from 'format-message';
-import { CommandButton } from 'office-ui-fabric-react/lib/Button';
+import { CommandButton, IButton } from 'office-ui-fabric-react/lib/Button';
 import { IOverflowSetItemProps } from 'office-ui-fabric-react/lib/OverflowSet';
 import { ISearchBox, ISearchBoxStyles, SearchBox } from 'office-ui-fabric-react/lib/SearchBox';
 import { useRecoilValue } from 'recoil';
+import { usePrevious } from '@uifabric/react-hooks';
 
 import { DisableFeatureToolTip } from '../DisableFeatureToolTip';
 import { usePVACheck } from '../../hooks/usePVACheck';
@@ -97,6 +98,17 @@ export const ProjectTreeHeader: React.FC<ProjectTreeHeaderProps> = ({
     setShowFilter(false);
   };
 
+  // Move focus back to the filter button after the filter search box gets closed
+  const filterButtonRef = useRef<IButton>(null);
+  const prevShowFilter = usePrevious(showFilter);
+  useEffect(() => {
+    if (prevShowFilter && prevShowFilter !== showFilter) {
+      setTimeout(() => {
+        if (filterButtonRef.current) filterButtonRef.current.focus();
+      });
+    }
+  }, [prevShowFilter, showFilter]);
+
   const addCommandBtn = (
     <CommandButton
       data-is-focusable
@@ -129,6 +141,11 @@ export const ProjectTreeHeader: React.FC<ProjectTreeHeaderProps> = ({
           styles={searchBox}
           onBlur={handleSearchBoxBlur}
           onChange={(_e, value) => onFilter(value)}
+          onClear={(ev) => {
+            if (!ev.target.value) {
+              handleSearchBoxBlur();
+            }
+          }}
         />
       ) : (
         <div css={commands}>
@@ -137,6 +154,7 @@ export const ProjectTreeHeader: React.FC<ProjectTreeHeaderProps> = ({
           ) : null}
           <CommandButton
             ariaLabel={formatMessage('Filter')}
+            componentRef={filterButtonRef}
             css={buttonStyle}
             iconProps={{ iconName: 'Filter' }}
             tabIndex={0}

--- a/Composer/packages/lib/code-editor/src/components/toolbar/ToolbarButtonMenu.tsx
+++ b/Composer/packages/lib/code-editor/src/components/toolbar/ToolbarButtonMenu.tsx
@@ -311,7 +311,7 @@ export const ToolbarButtonMenu = React.memo((props: ToolbarButtonMenuProps) => {
     []
   );
 
-  const { onRenderMenuList, query, setQuery } = useSearchableMenuListCallback(
+  const { onRenderMenuList, query, onReset } = useSearchableMenuListCallback(
     uiStrings.searchPlaceholder,
     menuHeaderRenderer
   );
@@ -339,8 +339,8 @@ export const ToolbarButtonMenu = React.memo((props: ToolbarButtonMenuProps) => {
     }
   }, [menuItems, flatPropertyListItems, flatFunctionListItems, noSearchResultMenuItem, query, payload.kind]);
 
-  const onDismiss = React.useCallback(() => {
-    setQuery('');
+  const onMenuDismissed = React.useCallback(() => {
+    onReset();
     setPropertyTreeExpanded({});
   }, []);
 
@@ -348,7 +348,7 @@ export const ToolbarButtonMenu = React.memo((props: ToolbarButtonMenuProps) => {
     switch (payload.kind) {
       case 'template': {
         return {
-          onDismiss,
+          onMenuDismissed,
           items,
           calloutProps,
           onRenderMenuList,
@@ -359,7 +359,7 @@ export const ToolbarButtonMenu = React.memo((props: ToolbarButtonMenuProps) => {
       }
       case 'function': {
         return {
-          onDismiss,
+          onMenuDismissed,
           items,
           calloutProps,
           onRenderMenuList,
@@ -377,7 +377,7 @@ export const ToolbarButtonMenu = React.memo((props: ToolbarButtonMenuProps) => {
       }
       case 'property': {
         return {
-          onDismiss,
+          onMenuDismissed,
           items,
           calloutProps,
           onRenderMenuList,
@@ -431,7 +431,7 @@ export const ToolbarButtonMenu = React.memo((props: ToolbarButtonMenuProps) => {
         } as IContextualMenuProps;
       }
     }
-  }, [items, calloutProps, onRenderMenuList, onDismiss, propertyTreeExpanded, query]);
+  }, [items, calloutProps, onRenderMenuList, onMenuDismissed, propertyTreeExpanded, query]);
 
   const renderIcon = React.useCallback(() => getIcon(payload.kind), [payload.kind]);
 

--- a/Composer/packages/lib/code-editor/src/hooks/useSearchableMenuListCallback.tsx
+++ b/Composer/packages/lib/code-editor/src/hooks/useSearchableMenuListCallback.tsx
@@ -15,7 +15,6 @@ const fontSizeStyle = {
   fontSize: FluentTheme.fonts.small.fontSize,
 };
 
-const itemsContainerStyles = { root: { overflowY: 'auto', maxHeight: 216, width: 200, overflowX: 'hidden' } };
 const searchFieldStyles = { root: { borderRadius: 0, ...fontSizeStyle }, iconContainer: { display: 'none' } };
 
 /**
@@ -26,6 +25,11 @@ export const useSearchableMenuListCallback = (
   headerRenderer?: () => React.ReactNode
 ) => {
   const { onSearchAbort, onSearchQueryChange, query, setQuery } = useDebouncedSearchCallbacks();
+
+  const onReset = React.useCallback(() => {
+    setQuery('');
+  }, [setQuery]);
+
   const callback = React.useCallback(
     (menuListProps?: IContextualMenuListProps, defaultRender?: IRenderFunction<IContextualMenuListProps>) => {
       return (
@@ -38,12 +42,12 @@ export const useSearchableMenuListCallback = (
             onAbort={onSearchAbort}
             onChange={onSearchQueryChange}
           />
-          <Stack styles={itemsContainerStyles}>{defaultRender?.(menuListProps)}</Stack>
+          {defaultRender?.(menuListProps)}
         </Stack>
       );
     },
-    [searchFiledPlaceHolder, headerRenderer, onSearchAbort, onSearchQueryChange]
+    [searchFiledPlaceHolder, headerRenderer, onReset, onSearchQueryChange]
   );
 
-  return { onRenderMenuList: callback, query, setQuery };
+  return { onRenderMenuList: callback, query, onReset };
 };

--- a/Composer/packages/lib/code-editor/src/lu/DefineEntityButton.tsx
+++ b/Composer/packages/lib/code-editor/src/lu/DefineEntityButton.tsx
@@ -68,9 +68,7 @@ export const DefineEntityButton = React.memo((props: Props) => {
 
   const [showListEntityCreationDialog, setShowListEntityCreationDialog] = React.useState(false);
   const { iconName, text } = React.useMemo(() => getLuToolbarItemTextAndIcon('defineEntity'), []);
-  const { onRenderMenuList, query, setQuery } = useSearchableMenuListCallback(
-    formatMessage('Search prebuilt entities')
-  );
+  const { onRenderMenuList, query, onReset } = useSearchableMenuListCallback(formatMessage('Search prebuilt entities'));
 
   const noSearchResultsMenuItem = useNoSearchResultMenuItem(formatMessage('no prebuilt entities found'));
 
@@ -110,18 +108,14 @@ export const DefineEntityButton = React.memo((props: Props) => {
     }));
   }, [onDefineEntity, noSearchResultsMenuItem, query]);
 
-  const onDismiss = React.useCallback(() => {
-    setQuery('');
-  }, []);
-
   const prebuiltSubMenuProps = React.useMemo<IContextualMenuProps>(
     () => ({
       calloutProps: { calloutMaxHeight: 216 },
       items: filteredPrebuiltEntities,
       onRenderMenuList,
-      onDismiss,
+      onMenuDismissed: onReset,
     }),
-    [filteredPrebuiltEntities, onDismiss, onRenderMenuList]
+    [filteredPrebuiltEntities, onReset, onRenderMenuList]
   );
 
   const renderMenuItemHeader = React.useCallback(

--- a/Composer/packages/lib/code-editor/src/lu/hooks/useLabelingMenuItems.tsx
+++ b/Composer/packages/lib/code-editor/src/lu/hooks/useLabelingMenuItems.tsx
@@ -71,7 +71,7 @@ export const useLabelingMenuProps = (
     [menuHeaderText]
   );
 
-  const { onRenderMenuList, query, setQuery } = useSearchableMenuListCallback(
+  const { onRenderMenuList, query, onReset } = useSearchableMenuListCallback(
     formatMessage('Search entities'),
     searchHeaderRenderer
   );
@@ -109,12 +109,8 @@ export const useLabelingMenuProps = (
     );
   }, []);
 
-  const onDismiss = React.useCallback(() => {
-    setQuery('');
-  }, []);
-
   return {
     noEntities: !entities.length,
-    menuProps: { items, onRenderMenuList, contextualMenuItemAs, onDismiss },
+    menuProps: { items, onRenderMenuList, contextualMenuItemAs, onMenuDismissed: onReset },
   };
 };


### PR DESCRIPTION
## Description

This improvements UX when navigating via keyboard through contextual menus and search/filter fields in the following ways:
- Search/filter is cleared on the first Escape key press, and gets closed on the second one
- When contextual menu is used with filter or search field, it respects arrows keys in addition to Escape key for toggling the menu.

These improvements resulted in the following changes:
- Swapped `onDismiss` for contextual menu items with `onMenuDismissed` since the later doesn't block the menu from being dismissed in contrast to the former.
- Added the logic to return focus back on filter blur action
- Refactored contextual menus hooks to avoid repeating code

## Task Item

- [VSTS 70101](https://fuselabs.visualstudio.com/Composer/_workitems/edit/70101)


## Screenshots

![Desktop Recording 4 webm](https://user-images.githubusercontent.com/2841858/150889744-3b5f2fc0-9168-49ad-8293-bf88b05dfa56.gif)
![Desktop Recording 6 webm](https://user-images.githubusercontent.com/2841858/150889745-d8ecb91a-fb73-4214-a41b-73d4292c9179.gif)

#minor
