### PR TITLE
a11y: fix node menu focus styles

### DIFF
--- a/Composer/packages/adaptive-flow/src/adaptive-flow-editor/renderers/NodeMenu.tsx
+++ b/Composer/packages/adaptive-flow/src/adaptive-flow-editor/renderers/NodeMenu.tsx
@@ -7,6 +7,8 @@ import { useContext } from 'react';
 import formatMessage from 'format-message';
 import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
 import { IconMenu } from '@bfc/ui-shared';
+import { getFocusStyle, getTheme } from 'office-ui-fabric-react/lib/Styling';
+import { FluentTheme } from '@uifabric/fluent-theme';
 
 import { NodeEventTypes, EditorEventHandler } from '../../adaptive-flow-renderer/constants/NodeEventTypes';
 import { MenuTypes } from '../constants/MenuTypes';
@@ -26,6 +28,11 @@ interface NodeMenuProps {
   onEvent: EditorEventHandler;
   colors: ElementColor;
 }
+
+const focusStyles = getFocusStyle(getTheme(), {
+  borderColor: FluentTheme.palette.themePrimary,
+});
+
 export const NodeMenu: React.FC<NodeMenuProps> = ({ colors = { color: 'black' }, id, onEvent }) => {
   const menuItems = [
     {
@@ -57,20 +64,10 @@ export const NodeMenu: React.FC<NodeMenuProps> = ({ colors = { color: 'black' },
           iconSize={12}
           iconStyles={{
             color: `${colors.color}`,
-            selectors: {
-              ':focus': {
-                outline: 'none',
-                selectors: {
-                  '::after': {
-                    outline: '1px solid #0078d4 !important',
-                  },
-                },
-              },
-            },
+            ...focusStyles,
           }}
           label={moreLabel}
           menuItems={menuItems}
-          menuWidth={100}
         />
       </TooltipHost>
     </div>

--- a/Composer/packages/lib/ui-shared/src/components/IconMenu.tsx
+++ b/Composer/packages/lib/ui-shared/src/components/IconMenu.tsx
@@ -8,6 +8,7 @@ import { IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
 import { OverflowSet } from 'office-ui-fabric-react/lib/OverflowSet';
 import { IRenderFunction } from 'office-ui-fabric-react/lib/Utilities';
 import { ICalloutProps } from 'office-ui-fabric-react/lib/Callout';
+import { getFocusStyle, getTheme } from 'office-ui-fabric-react/lib/Styling';
 
 interface IconMenuProps {
   autoFocus?: boolean;
@@ -26,6 +27,15 @@ interface IconMenuProps {
   handleMenuShow?: (menuShowed: boolean) => void;
 }
 
+const menuItemStyles = {
+  root: [
+    { marginRight: 10 },
+    getFocusStyle(getTheme(), {
+      inset: 2,
+    }),
+  ],
+};
+
 export const IconMenu: React.FC<IconMenuProps> = ({
   autoFocus,
   iconName,
@@ -40,7 +50,7 @@ export const IconMenu: React.FC<IconMenuProps> = ({
 }): JSX.Element => {
   const onRenderItem = (item): React.ReactNode => {
     return (
-      <Link styles={{ root: { marginRight: 10 } }} onClick={item.onClick}>
+      <Link styles={menuItemStyles} onClick={item.onClick}>
         {item.name}
       </Link>
     );


### PR DESCRIPTION
## Description

A minor refactor to improve node menu focus styles.

## Task Item

- [VSTS 70423](https://fuselabs.visualstudio.com/Composer/_workitems/edit/70423)

## Screenshots

### Before
![MAS2 4 7-Keyboard focus is not cropped on the right on the delete button in node menu](https://user-images.githubusercontent.com/2841858/151259183-91de1ec0-7476-41d6-aa9a-ffb2edf72cac.jpg)


### After

![image](https://user-images.githubusercontent.com/2841858/151255643-46a0c2df-eec8-4f6f-9964-26014618cf9a.png)

![image](https://user-images.githubusercontent.com/2841858/151255725-1521eb1a-f5f6-42d3-a934-929c5caa2df1.png)

#minor