### PR TITLE
a11y: organize home page links into lists

### DIFF
--- a/Composer/packages/client/__tests__/components/home.test.tsx
+++ b/Composer/packages/client/__tests__/components/home.test.tsx
@@ -105,7 +105,6 @@ describe('<Home/>', () => {
     };
     const { container } = renderWithRecoil(
       <CardWidget
-        ariaLabel="test"
         cardType={'video'}
         content={videoItem.description}
         href={videoItem.url}

--- a/Composer/packages/client/src/pages/home/CardWidget.tsx
+++ b/Composer/packages/client/src/pages/home/CardWidget.tsx
@@ -3,9 +3,10 @@
 
 /** @jsx jsx */
 import { jsx, SerializedStyles } from '@emotion/core';
-import React, { useState, useRef } from 'react';
+import React, { useState } from 'react';
 import { Image, ImageFit, ImageLoadState } from 'office-ui-fabric-react/lib/Image';
 import { Link } from 'office-ui-fabric-react/lib/Link';
+import { useId } from '@uifabric/react-hooks';
 
 import defaultArticleCardCover from '../../images/defaultArticleCardCover.svg';
 import defaultVideoCardCover from '../../images/defaultVideoCardCover.svg';
@@ -20,7 +21,6 @@ export interface CardWidgetProps {
   href?: string;
   target?: string;
   title: string | JSX.Element;
-  subContent?: string;
   content: string;
   styles?: {
     container?: SerializedStyles;
@@ -31,9 +31,8 @@ export interface CardWidgetProps {
   };
   disabled?: boolean;
   forwardedRef?: (project: any) => void | Promise<void>;
-  openExternal?: boolean;
   moreLinkText?: string;
-  ariaLabel: string;
+  role?: string;
 }
 
 export const CardWidget: React.FC<CardWidgetProps> = ({
@@ -42,11 +41,8 @@ export const CardWidget: React.FC<CardWidgetProps> = ({
   target = '_blank',
   title,
   content,
-  subContent,
   disabled,
   forwardedRef,
-  openExternal,
-  ariaLabel,
   imageCover,
   cardType,
   moreLinkText,
@@ -54,7 +50,6 @@ export const CardWidget: React.FC<CardWidgetProps> = ({
 }) => {
   const defaultImageCover = cardType === 'video' ? defaultVideoCardCover : defaultArticleCardCover;
   const [appliedImageCover, setAppliedImageCover] = useState<string>(imageCover ?? defaultImageCover);
-  const imageContainerEl = useRef<HTMLDivElement>(null);
   const styles =
     rest.styles || cardType === 'resource'
       ? home.cardItem
@@ -68,32 +63,41 @@ export const CardWidget: React.FC<CardWidgetProps> = ({
     }
   };
 
+  const labelId = useId('link-label');
+
   return (
-    <a
-      css={[itemContainerWrapper(disabled), styles.container]}
-      href={href}
-      target={target}
-      onClick={async (e) => {
-        if (onClick != null) {
-          e.preventDefault();
-          await onClick();
-        }
-      }}
-      {...rest}
-    >
-      <div ref={forwardedRef} aria-label={ariaLabel}>
-        <div ref={imageContainerEl} css={styles.imageCover}>
+    <div ref={forwardedRef} css={home.cardWrapper} {...rest}>
+      <a
+        aria-labelledBy={labelId}
+        css={[itemContainerWrapper(disabled), styles.container]}
+        href={href}
+        target={target}
+        onClick={async (e) => {
+          if (onClick != null) {
+            e.preventDefault();
+            await onClick();
+          }
+        }}
+      >
+        <div css={styles.imageCover}>
           <Image
             className={'image-cover-img'}
             imageFit={ImageFit.contain}
+            role="presentation"
             src={appliedImageCover}
             onLoadingStateChange={onImageLoading}
           />
         </div>
-        <div css={styles.title}>{title}</div>
-        <div css={styles.content}>{content}</div>
-        {moreLinkText && <Link css={styles.moreLink}> {moreLinkText} </Link>}
-      </div>
-    </a>
+        <div id={labelId}>
+          <div css={styles.title}>{title}</div>
+          <div css={styles.content}>{content}</div>
+        </div>
+        {moreLinkText && (
+          <Link aria-labelledBy={labelId} css={styles.moreLink} role="link">
+            {moreLinkText}
+          </Link>
+        )}
+      </a>
+    </div>
   );
 };

--- a/Composer/packages/client/src/pages/home/Home.tsx
+++ b/Composer/packages/client/src/pages/home/Home.tsx
@@ -208,16 +208,16 @@ const Home: React.FC<RouteComponentProps> = () => {
           </div>
           <div css={home.resourcesContainer}>
             <h2 css={home.subtitle}>{formatMessage('Resources')}&nbsp;</h2>
-            <div css={home.rowContainer}>
+            <div css={home.rowContainer} role="list">
               {resources.map((item, index) => (
                 <CardWidget
                   key={index}
-                  ariaLabel={item.title}
                   cardType={'resource'}
                   content={item.description}
                   href={item.url}
                   imageCover={item.imageCover}
                   moreLinkText={item.moreText}
+                  role="listitem"
                   target="_blank"
                   title={item.title}
                 />
@@ -234,15 +234,15 @@ const Home: React.FC<RouteComponentProps> = () => {
                         {tab.viewAllLinkText} <Icon iconName={'OpenInNewWindow'}></Icon>{' '}
                       </Link>
                     )}
-                    <div css={home.tabRowContainer}>
+                    <div css={home.tabRowContainer} role="list">
                       {tab.cards.map((card, index) => (
                         <CardWidget
                           key={index}
-                          ariaLabel={card.title}
                           cardType={tab.title === 'Videos' ? 'video' : 'article'}
                           content={card.description}
                           href={card.url}
                           imageCover={card.image}
+                          role="listitem"
                           target="_blank"
                           title={card.title}
                         />

--- a/Composer/packages/client/src/pages/home/WhatsNewsList.tsx
+++ b/Composer/packages/client/src/pages/home/WhatsNewsList.tsx
@@ -5,7 +5,6 @@
 import { jsx } from '@emotion/core';
 import { Link } from 'office-ui-fabric-react/lib/Link';
 import formatMessage from 'format-message';
-import { Fragment } from 'react';
 
 import * as home from './styles';
 
@@ -17,18 +16,18 @@ export function WhatsNewsList({ newsList }: WhatsNewsListProps): JSX.Element {
   return (
     <div aria-label={formatMessage("What's new list")} css={home.whatsNewsContainer} role="region">
       <h3 css={home.subtitle}>{formatMessage("What's new")}</h3>
-      <div css={home.whatsNewsList}>
+      <ol css={home.whatsNewsList}>
         {newsList.map(({ title, description, url }, index) => {
           return (
-            <Fragment key={index}>
-              <Link css={home.bluetitle} href={url} target={'_blank'}>
+            <li key={index} css={home.whatsNewsListItem}>
+              <Link css={home.blueTitle} href={url} target={'_blank'}>
                 {title}
               </Link>
               <p css={home.newsDescription}>{description}</p>
-            </Fragment>
+            </li>
           );
         })}
-      </div>
+      </ol>
     </div>
   );
 }

--- a/Composer/packages/client/src/pages/home/styles.ts
+++ b/Composer/packages/client/src/pages/home/styles.ts
@@ -106,6 +106,11 @@ export const tabRowViewMore = css`
   }
 `;
 
+export const cardWrapper = css`
+  display: flex;
+  margin-right: 12px;
+`;
+
 export const itemContainerWrapper = (disabled?: boolean) => css`
   border-radius: 2px;
   border-width: 0;
@@ -113,13 +118,17 @@ export const itemContainerWrapper = (disabled?: boolean) => css`
   display: block;
   height: auto;
   text-decoration-line: none;
-  margin-right: 12px;
   padding: 0;
 `;
 
 export const itemContainer = css`
   outline: none;
   height: 50%;
+`;
+
+export const fullCardLink = css`
+  inset: 0;
+  position: absolute;
 `;
 
 export const subtitle = css`
@@ -130,12 +139,11 @@ export const subtitle = css`
   margin: 0;
 `;
 
-export const bluetitle = css`
+export const blueTitle = css`
   line-height: 20px;
   font-size: ${fonts.medium.fontSize};
   display: inline-block;
   color: #0078d4;
-  margin: 16px 0 0 0;
 `;
 
 export const toolbar = css`
@@ -199,7 +207,8 @@ export const cardItem = {
     box-shadow: ${Depths.depth4};
     transition: box-shadow ${MotionDurations.duration2} ${MotionTimings.standard};
     &:hover,
-    &:focus {
+    &:focus,
+    &:focus-within {
       box-shadow: ${Depths.depth16};
     }
 
@@ -333,6 +342,14 @@ export const whatsNewsContainer = css`
 
 export const whatsNewsList = css`
   flex: 1;
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+`;
+
+export const whatsNewsListItem = css`
+  display: block;
+  margin: 16px 0 0 0;
 `;
 
 export const loading = css`


### PR DESCRIPTION

## Description

This improves accessibility of home page cards and links:
- Organize links into lists so screen readers can utilize list nav
- Provide more detailed description for card links
- Added focus within a card indication
- Remove redundant card props
- Hide image from card to prevent scan mode issues

## Task Item

- [VSTS 70100](https://fuselabs.visualstudio.com/Composer/_workitems/edit/70100)
- [VSTS 70099](https://fuselabs.visualstudio.com/Composer/_workitems/edit/70099)
- [VSTS 70093](https://fuselabs.visualstudio.com/Composer/_workitems/edit/70093)

## Screenshots

