### PR TITLE
a11y: make Select Dialog a listbox with options

### DIFF
--- a/Composer/packages/ui-plugins/select-dialog/src/SelectDialogMenu.tsx
+++ b/Composer/packages/ui-plugins/select-dialog/src/SelectDialogMenu.tsx
@@ -121,6 +121,7 @@ export const SelectDialogMenu: React.FC<SelectDialogMenuProps> = (props) => {
       text: d.displayName,
       isSelected: value === d.displayName,
       data: d,
+      role: 'option',
       iconProps: {
         iconName: getIconName(d),
         styles: {
@@ -141,6 +142,7 @@ export const SelectDialogMenu: React.FC<SelectDialogMenuProps> = (props) => {
         sectionProps: {
           items: dialogItems,
         },
+        role: 'option',
       },
       {
         key: 'actions',
@@ -154,6 +156,7 @@ export const SelectDialogMenu: React.FC<SelectDialogMenuProps> = (props) => {
               iconProps: {
                 iconName: Icons.EXPRESSION,
               },
+              role: 'option',
             },
             {
               key: ADD_DIALOG,
@@ -161,6 +164,7 @@ export const SelectDialogMenu: React.FC<SelectDialogMenuProps> = (props) => {
               iconProps: {
                 iconName: 'Add',
               },
+              role: 'option',
             },
           ],
         },
@@ -266,6 +270,7 @@ export const SelectDialogMenu: React.FC<SelectDialogMenuProps> = (props) => {
                 }
               `,
             }}
+            role="listbox"
             styles={buttonStyles}
             text={selectedLabel || ' '}
             onBlur={() => onBlur?.(id, value)}


### PR DESCRIPTION


## Description

The PR improves the button role by making the control to appear as a listbox with options which is closer to the control functionality.

## Task Item

- [VSTS 70436](https://fuselabs.visualstudio.com/Composer/_workitems/edit/70436)

## Screenshots

#minor