### PR TITLE
fix: Packages stuck at "Installing package..." screen on network failure

### DIFF
--- a/extensions/packageManager/src/pages/Library.tsx
+++ b/extensions/packageManager/src/pages/Library.tsx
@@ -432,8 +432,8 @@ const Library: React.FC = () => {
 
       console.error(err);
       setApplicationLevelError({
-        status: err.response.status,
-        message: err.response && err.response.data.message ? err.response.data.message : err,
+        status: err?.response?.status,
+        message: err?.response?.data?.message || err,
         summary: strings.importError,
       });
     }


### PR DESCRIPTION

## Description

When installing a package, in case of a network failure, the error passed to the `importComponent` catch block doesn't contain `err.response.status` field, so it throws a new error preventing the modal from being closed.

The PR adds an optional chaining operator for `error` to prevent the issue.

## Task Item

The PR should fix the following a11y bug as well. Can't check this as narrator started to crash in this place after the fix (looks like a narrator bug)

- [VSTS 70520](https://fuselabs.visualstudio.com/Composer/_workitems/edit/70520)

## Screenshots

![package-install-failure-error webm](https://user-images.githubusercontent.com/2841858/154580757-326293fd-2481-42df-9d83-8636d3d6ac51.gif)

#minor
