### PR TITLE
a11y: fix table-forms keyboard navigation

### DIFF
--- a/Composer/packages/client/src/components/CellFocusZone.tsx
+++ b/Composer/packages/client/src/components/CellFocusZone.tsx
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+/** @jsx jsx */
+import { jsx, css } from '@emotion/core';
+import React, { useCallback } from 'react';
+import { FocusZone, FocusZoneTabbableElements, IFocusZoneProps } from 'office-ui-fabric-react/lib/FocusZone';
+import { getFocusStyle, getTheme, mergeStyles } from 'office-ui-fabric-react/lib/Styling';
+
+export const formCell = css`
+  outline: none;
+  white-space: pre-wrap;
+  font-size: 14px;
+  line-height: 28px;
+`;
+
+export const formCellFocus = mergeStyles(
+  getFocusStyle(getTheme(), {
+    inset: -3,
+  })
+);
+
+/**
+ * CellFocusZone component props.
+ * Props are intently omitted as they're required for component to function correctly.
+ * Please manually test the component using keyboard in places it is used in case any changes made.
+ */
+type CellFocusZoneProps = Omit<
+  React.HTMLAttributes<unknown> & IFocusZoneProps,
+  | 'allowFocusRoot'
+  | 'data-is-focusable'
+  | 'isCircularNavigation'
+  | 'className'
+  | 'handleTabKey'
+  | 'shouldFocusInnerElementWhenReceivedFocus'
+  | 'tabIndex'
+  | 'onBlur'
+  | 'onKeyDown'
+>;
+
+const CellFocusZone: React.FC<CellFocusZoneProps> = (props) => {
+  const focusCurrentZoneAfterRender = useCallback((focusZoneEl: any) => {
+    const focusZoneId = focusZoneEl?.dataset?.focuszoneId;
+    if (!focusZoneId) {
+      return;
+    }
+    // wait for render to happen before placing focus back to the focus zone
+    setTimeout(() => {
+      const focusZone: HTMLElement | null = document.querySelector(`[data-focuszone-id=${focusZoneId}]`);
+      focusZone?.focus();
+    }, 100);
+  }, []);
+
+  const onCellKeyDown = useCallback((ev) => {
+    // ignore any of events coming from input fields
+    if (ev.target.localName === 'input' || ev.target.localName === 'textarea') {
+      ev.stopPropagation();
+      return;
+    }
+
+    // enter inside cell using Enter key
+    if (ev.target.dataset.focuszoneId && ev.key === 'Enter') {
+      const input: HTMLElement | null = (ev?.target as HTMLElement)?.querySelector('a, button, input, textarea');
+      input?.focus();
+      return;
+    }
+
+    // handle uncaught escape key events to allow returning back to navigation between cells
+    if (ev.key === 'Escape') {
+      ev.stopPropagation();
+      focusCurrentZoneAfterRender(ev.currentTarget);
+    }
+  }, []);
+
+  const onCellInnerBlur = useCallback((ev) => {
+    // this means we dont have an element to focus so we place focus back to the cell
+    if (!ev.relatedTarget) {
+      focusCurrentZoneAfterRender(ev.currentTarget);
+    }
+  }, []);
+
+  return (
+    <FocusZone
+      css={formCell}
+      {...props}
+      allowFocusRoot
+      data-is-focusable
+      isCircularNavigation
+      className={formCellFocus}
+      handleTabKey={FocusZoneTabbableElements.all}
+      shouldFocusInnerElementWhenReceivedFocus={false}
+      tabIndex={0}
+      onBlur={onCellInnerBlur}
+      onKeyDown={onCellKeyDown}
+    >
+      {props.children}
+    </FocusZone>
+  );
+};
+
+export { CellFocusZone };

--- a/Composer/packages/client/src/components/CellFocusZone.tsx
+++ b/Composer/packages/client/src/components/CellFocusZone.tsx
@@ -6,6 +6,8 @@ import React, { useCallback } from 'react';
 import { FocusZone, FocusZoneTabbableElements, IFocusZoneProps } from 'office-ui-fabric-react/lib/FocusZone';
 import { getFocusStyle, getTheme, mergeStyles } from 'office-ui-fabric-react/lib/Styling';
 
+import { useAfterRender } from '../hooks/useAfterRender';
+
 export const formCell = css`
   outline: none;
   white-space: pre-wrap;
@@ -38,16 +40,17 @@ type CellFocusZoneProps = Omit<
 >;
 
 const CellFocusZone: React.FC<CellFocusZoneProps> = (props) => {
+  const onAfterRender = useAfterRender();
   const focusCurrentZoneAfterRender = useCallback((focusZoneEl: any) => {
     const focusZoneId = focusZoneEl?.dataset?.focuszoneId;
     if (!focusZoneId) {
       return;
     }
     // wait for render to happen before placing focus back to the focus zone
-    setTimeout(() => {
+    onAfterRender(() => {
       const focusZone: HTMLElement | null = document.querySelector(`[data-focuszone-id=${focusZoneId}]`);
       focusZone?.focus();
-    }, 100);
+    });
   }, []);
 
   const onCellKeyDown = useCallback((ev) => {

--- a/Composer/packages/client/src/components/EditableField.tsx
+++ b/Composer/packages/client/src/components/EditableField.tsx
@@ -11,6 +11,7 @@ import { IIconProps } from 'office-ui-fabric-react/lib/Icon';
 import { Announced } from 'office-ui-fabric-react/lib/Announced';
 
 import { FieldConfig, useForm } from '../hooks/useForm';
+import { useAfterRender } from '../hooks/useAfterRender';
 
 const allowedNavigationKeys = ['ArrowDown', 'ArrowUp', 'ArrowLeft', 'ArrowRight', 'PageDown', 'PageUp', 'Home', 'End'];
 
@@ -119,6 +120,7 @@ const EditableField: React.FC<EditableFieldProps> = (props) => {
   const [hasFocus, setHasFocus] = useState<boolean>(false);
   const [hasBeenEdited, setHasBeenEdited] = useState<boolean>(false);
   const [multiline, setMultiline] = useState<boolean>(true);
+  const onAfterRender = useAfterRender();
 
   const formConfig: FieldConfig<{ value: string }> = {
     value: {
@@ -206,13 +208,13 @@ const EditableField: React.FC<EditableFieldProps> = (props) => {
       setMultiline(true);
       updateField('value', e.target.value + '\n');
       // wait for the textarea to be rendered and then restore focus and selection
-      setTimeout(() => {
+      onAfterRender(() => {
         const len = fieldRef.current?.value?.length;
         fieldRef.current?.focus();
         if (len) {
           fieldRef.current?.setSelectionRange(len, len);
         }
-      }, 100);
+      });
     }
     if (enterOnField && !e.shiftKey) {
       // blur triggers commit, so call blur to avoid multiple commits

--- a/Composer/packages/client/src/hooks/useAfterRender.ts
+++ b/Composer/packages/client/src/hooks/useAfterRender.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { useCallback, useLayoutEffect, useRef } from 'react';
+
+/**
+ * Run a callback function not earlier than immediate re-renders happen
+ * @returns onAfterRender
+ */
+export const useAfterRender = () => {
+  const timeout = useRef<NodeJS.Timeout>();
+  const callback = useRef<(() => void) | null>(null);
+
+  useLayoutEffect(() => {
+    callback.current?.();
+  });
+
+  return useCallback((fn: () => unknown) => {
+    callback.current = () => {
+      if (timeout.current) clearTimeout(timeout.current);
+      timeout.current = setTimeout(() => {
+        callback.current = null;
+        fn();
+      }, 0);
+    };
+
+    callback.current?.();
+  }, []);
+};

--- a/Composer/packages/client/src/pages/knowledge-base/styles.ts
+++ b/Composer/packages/client/src/pages/knowledge-base/styles.ts
@@ -94,7 +94,7 @@ export const rowDetails = {
       '.ms-GroupHeader-expand': {
         fontSize: 8,
       },
-      '&:hover': {
+      '&:hover, &:focus-within': {
         background: NeutralColors.gray30,
         selectors: {
           '.ms-TextField-fieldGroup': {

--- a/Composer/packages/client/src/pages/knowledge-base/table-view.tsx
+++ b/Composer/packages/client/src/pages/knowledge-base/table-view.tsx
@@ -15,7 +15,6 @@ import {
   IDetailsGroupRenderProps,
   IGroup,
   IDetailsList,
-  IColumn,
 } from 'office-ui-fabric-react/lib/DetailsList';
 import { GroupHeader, CollapseAllVisibility } from 'office-ui-fabric-react/lib/GroupedList';
 import { IOverflowSetItemProps, OverflowSet } from 'office-ui-fabric-react/lib/OverflowSet';
@@ -525,7 +524,7 @@ const TableView: React.FC<TableViewProps> = (props) => {
   );
 
   const getTableColums = () => {
-    const tableColums: IColumn[] = [
+    const tableColums = [
       {
         key: 'ToggleShowAll',
         name: '',

--- a/Composer/packages/client/src/pages/knowledge-base/table-view.tsx
+++ b/Composer/packages/client/src/pages/knowledge-base/table-view.tsx
@@ -15,6 +15,7 @@ import {
   IDetailsGroupRenderProps,
   IGroup,
   IDetailsList,
+  IColumn,
 } from 'office-ui-fabric-react/lib/DetailsList';
 import { GroupHeader, CollapseAllVisibility } from 'office-ui-fabric-react/lib/GroupedList';
 import { IOverflowSetItemProps, OverflowSet } from 'office-ui-fabric-react/lib/OverflowSet';
@@ -43,6 +44,7 @@ import { EditQnAModal } from '../../components/QnA/EditQnAFrom';
 import { ReplaceQnAFromModal } from '../../components/QnA/ReplaceQnAFromModal';
 import { getQnAFileUrlOption } from '../../utils/qnaUtil';
 import TelemetryClient from '../../telemetry/TelemetryClient';
+import { CellFocusZone } from '../../components/CellFocusZone';
 
 import {
   formCell,
@@ -523,7 +525,7 @@ const TableView: React.FC<TableViewProps> = (props) => {
   );
 
   const getTableColums = () => {
-    const tableColums = [
+    const tableColums: IColumn[] = [
       {
         key: 'ToggleShowAll',
         name: '',
@@ -566,7 +568,8 @@ const TableView: React.FC<TableViewProps> = (props) => {
           const addQuestionButton = (
             <ActionButton
               styles={addAlternative}
-              onClick={() => {
+              onClick={(ev) => {
+                ev.stopPropagation();
                 setCreatingQuestionInKthSection(item.sectionId);
                 TelemetryClient.track('AlternateQnAPhraseAdded');
               }}
@@ -576,7 +579,7 @@ const TableView: React.FC<TableViewProps> = (props) => {
           );
 
           return (
-            <div data-is-focusable css={formCell}>
+            <CellFocusZone>
               {questions.map((question, qIndex: number) => {
                 const isQuestionEmpty = question.content === '';
                 const isOnlyQuestion = questions.length === 1 && qIndex === 0;
@@ -627,6 +630,9 @@ const TableView: React.FC<TableViewProps> = (props) => {
                       }}
                       onChange={() => {}}
                       onFocus={() => setExpandedIndex(index)}
+                      onNewLine={() => {
+                        setCreatingQuestionInKthSection(item.sectionId);
+                      }}
                     />
                   </div>
                 );
@@ -674,11 +680,12 @@ const TableView: React.FC<TableViewProps> = (props) => {
                   }}
                   onChange={() => {}}
                   onFocus={() => setExpandedIndex(index)}
+                  onNewLine={() => {}}
                 />
               ) : (
                 addQuestionButton
               )}
-            </div>
+            </CellFocusZone>
           );
         },
       },
@@ -698,7 +705,7 @@ const TableView: React.FC<TableViewProps> = (props) => {
             item.fileId === createQnAPairSettings.groupKey && index === createQnAPairSettings.sectionIndex;
 
           return (
-            <div data-is-focusable css={formCell}>
+            <CellFocusZone>
               <EditableField
                 required
                 ariaLabel={formatMessage(`Answer is {content}`, { content: item.Answer })}
@@ -741,7 +748,7 @@ const TableView: React.FC<TableViewProps> = (props) => {
                 onChange={() => {}}
                 onFocus={() => setExpandedIndex(index)}
               />
-            </div>
+            </CellFocusZone>
           );
         },
       },
@@ -755,7 +762,7 @@ const TableView: React.FC<TableViewProps> = (props) => {
         data: 'string',
         onRender: (item) => {
           return (
-            <div data-is-focusable css={formCell} style={{ marginTop: 10, marginLeft: 13 }}>
+            <div css={formCell} style={{ marginTop: 10, marginLeft: 13 }}>
               {item.usedIn.map(({ id, displayName }) => {
                 return (
                   <Link
@@ -928,6 +935,7 @@ const TableView: React.FC<TableViewProps> = (props) => {
           checkboxVisibility={CheckboxVisibility.hidden}
           columns={getTableColums()}
           componentRef={detailListRef}
+          getKey={(item, index) => `row-${index}`}
           groupProps={{
             onRenderHeader: onRenderGroupHeader,
             collapseAllVisibility: CollapseAllVisibility.hidden,

--- a/Composer/packages/client/src/pages/language-generation/table-view.tsx
+++ b/Composer/packages/client/src/pages/language-generation/table-view.tsx
@@ -22,11 +22,12 @@ import { LgFile } from '@botframework-composer/types/src';
 
 import { EditableField } from '../../components/EditableField';
 import { navigateTo } from '../../utils/navigation';
-import { actionButton, formCell, editableFieldContainer } from '../language-understanding/styles';
+import { actionButton, editableFieldContainer } from '../language-understanding/styles';
 import { dispatcherState, localeState, settingsState, dialogsSelectorFamily } from '../../recoilModel';
 import { languageListTemplates } from '../../components/MultiLanguage';
 import TelemetryClient from '../../telemetry/TelemetryClient';
 import { lgFilesSelectorFamily } from '../../recoilModel/selectors/lg';
+import { CellFocusZone } from '../../components/CellFocusZone';
 
 interface TableViewProps extends RouteComponentProps<{ dialogId: string; skillId: string; projectId: string }> {
   projectId: string;
@@ -59,8 +60,6 @@ const TableView: React.FC<TableViewProps> = (props) => {
   const listRef = useRef(null);
 
   const activeDialog = dialogs.find(({ id }) => id === dialogId);
-
-  //const [focusedIndex, setFocusedIndex] = useState(0);
 
   useEffect(() => {
     if (!file || isEmpty(file)) return;
@@ -207,7 +206,7 @@ const TableView: React.FC<TableViewProps> = (props) => {
         onRender: (item) => {
           const displayName = `#${item.name}`;
           return (
-            <div data-is-focusable css={formCell}>
+            <CellFocusZone>
               <EditableField
                 ariaLabel={formatMessage(`Name is {name}`, { name: displayName })}
                 containerStyles={editableFieldContainer}
@@ -224,7 +223,7 @@ const TableView: React.FC<TableViewProps> = (props) => {
                 }}
                 onChange={() => {}}
               />
-            </div>
+            </CellFocusZone>
           );
         },
       },
@@ -238,7 +237,7 @@ const TableView: React.FC<TableViewProps> = (props) => {
         onRender: (item) => {
           const text = item.body;
           return (
-            <div data-is-focusable css={formCell}>
+            <CellFocusZone>
               <EditableField
                 multiline
                 ariaLabel={formatMessage(`Response is {response}`, { response: text })}
@@ -259,7 +258,7 @@ const TableView: React.FC<TableViewProps> = (props) => {
                 }}
                 onChange={() => {}}
               />
-            </div>
+            </CellFocusZone>
           );
         },
       },
@@ -274,7 +273,7 @@ const TableView: React.FC<TableViewProps> = (props) => {
         onRender: (item) => {
           const text = item.body;
           return (
-            <div data-is-focusable css={formCell}>
+            <CellFocusZone>
               <EditableField
                 multiline
                 ariaLabel={formatMessage(`Response is {response}`, { response: text })}
@@ -295,7 +294,7 @@ const TableView: React.FC<TableViewProps> = (props) => {
                 }}
                 onChange={() => {}}
               />
-            </div>
+            </CellFocusZone>
           );
         },
       },
@@ -309,7 +308,7 @@ const TableView: React.FC<TableViewProps> = (props) => {
         onRender: (item) => {
           const text = item[`body-${defaultLanguage}`];
           return (
-            <div data-is-focusable css={formCell}>
+            <CellFocusZone>
               <EditableField
                 multiline
                 ariaLabel={formatMessage(`Response is {response}`, { response: text })}
@@ -330,7 +329,7 @@ const TableView: React.FC<TableViewProps> = (props) => {
                 }}
                 onChange={() => {}}
               />
-            </div>
+            </CellFocusZone>
           );
         },
       },

--- a/Composer/packages/client/src/pages/language-understanding/styles.ts
+++ b/Composer/packages/client/src/pages/language-understanding/styles.ts
@@ -23,16 +23,6 @@ export const codeEditorContainer = css`
   width: 100%;
 `;
 
-export const formCell = css`
-  outline: none;
-  :focus {
-    outline: rgb(102, 102, 102) solid 1px;
-  }
-  white-space: pre-wrap;
-  font-size: 14px;
-  line-height: 28px;
-`;
-
 export const luPhraseCell = css`
   outline: none;
   :focus {

--- a/Composer/packages/client/src/pages/language-understanding/table-view.tsx
+++ b/Composer/packages/client/src/pages/language-understanding/table-view.tsx
@@ -31,8 +31,10 @@ import {
   dialogsSelectorFamily,
   luFilesSelectorFamily,
 } from '../../recoilModel';
+import { CellFocusZone } from '../../components/CellFocusZone';
 
-import { formCell, luPhraseCell, tableCell, editableFieldContainer } from './styles';
+import { luPhraseCell, tableCell, editableFieldContainer } from './styles';
+
 interface TableViewProps extends RouteComponentProps<{ dialogId: string; skillId: string; projectId: string }> {
   projectId: string;
   skillId?: string;
@@ -199,7 +201,7 @@ const TableView: React.FC<TableViewProps> = (props) => {
         onRender: (item: Intent) => {
           const displayName = `#${item.name}`;
           return (
-            <div data-is-focusable css={formCell}>
+            <CellFocusZone>
               <EditableField
                 multiline
                 ariaLabel={formatMessage(`Name is {name}`, { name: displayName })}
@@ -217,7 +219,7 @@ const TableView: React.FC<TableViewProps> = (props) => {
                 }}
                 onChange={() => {}}
               />
-            </div>
+            </CellFocusZone>
           );
         },
       },
@@ -231,7 +233,7 @@ const TableView: React.FC<TableViewProps> = (props) => {
         onRender: (item) => {
           const text = item.phrases;
           return (
-            <div data-is-focusable css={luPhraseCell}>
+            <CellFocusZone>
               <EditableField
                 multiline
                 ariaLabel={formatMessage(`Sample Phrases are {phrases}`, { phrases: text })}
@@ -250,7 +252,7 @@ const TableView: React.FC<TableViewProps> = (props) => {
                 }}
                 onChange={() => {}}
               />
-            </div>
+            </CellFocusZone>
           );
         },
       },
@@ -265,7 +267,7 @@ const TableView: React.FC<TableViewProps> = (props) => {
         onRender: (item) => {
           const text = item.phrases;
           return (
-            <div data-is-focusable css={luPhraseCell}>
+            <CellFocusZone css={luPhraseCell}>
               <EditableField
                 multiline
                 ariaLabel={formatMessage(`Sample Phrases are {phrases}`, { phrases: text })}
@@ -284,7 +286,7 @@ const TableView: React.FC<TableViewProps> = (props) => {
                 }}
                 onChange={() => {}}
               />
-            </div>
+            </CellFocusZone>
           );
         },
       },
@@ -298,7 +300,7 @@ const TableView: React.FC<TableViewProps> = (props) => {
         onRender: (item) => {
           const text = item[`body-${defaultLanguage}`];
           return (
-            <div data-is-focusable css={luPhraseCell}>
+            <CellFocusZone css={luPhraseCell}>
               <EditableField
                 multiline
                 ariaLabel={formatMessage(`Sample Phrases are {phrases}`, { phrases: text })}
@@ -320,7 +322,7 @@ const TableView: React.FC<TableViewProps> = (props) => {
                 }}
                 onChange={() => {}}
               />
-            </div>
+            </CellFocusZone>
           );
         },
       },
@@ -338,7 +340,6 @@ const TableView: React.FC<TableViewProps> = (props) => {
           return (
             <div
               key={id}
-              data-is-focusable
               aria-label={formatMessage(`link to where this LUIS intent is defined`)}
               onClick={() => navigateTo(`${baseURL}dialogs/${id}`)}
             >
@@ -399,7 +400,7 @@ const TableView: React.FC<TableViewProps> = (props) => {
         data: 'string',
         onRender: (item) => {
           return (
-            <div data-is-focusable css={tableCell}>
+            <div css={tableCell}>
               <div aria-label={formatMessage(`State is {state}`, { state: item.state })} tabIndex={-1}>
                 {item.state}
               </div>


### PR DESCRIPTION
## Description

The PR aims to address the following issues found on pages with lists containing nested forms, including: "Bot Responses", "Knowledge (QnA)" and "Knowledge Base" pages.

Here is the list of issues addressed:
- Unable to navigate to fields nested in DetailsList cells using keyboard
- Some buttons are hidden while navigating via keyboard ("Clear field" button, "Add new" item button)
- Save via keyboard Enter key doesn't work under several circumstances
- Shift+Enter should persist caret position and the field in focus while adding a new line
- Visual focus indication for focused fields works unstable
- No error announcement
- No way to blur selected fields when the focus is on the DetailsList cell field

Highlights on changes made:
- Implement a CellFocusZone component to handle focus in DetailsLists' cells having form elements
- Move all related logic to the component, so it can: focus form elements, handle Escape and Enter key and handle focus loss cases
- Update EditField to play well with the new component
- Add a callback to be called on EditField when a new line gets added
- Handle Shift+Enter properly: from now it adds a new row to input and resets focus back to the input after it got switched to the textarea element
- Update CSS rules to handle focus for tables-view and EditableField components
- Refactor styles: move shared styles to the CellFocusZone
- Refactor table-views: introduce CellFocusZone and improve keyboard handling
- Knowledge Base: change the way alternative questions added (see the last gif: from now Shift+Enter equals clicking "Add new" button)
- Fix EditField styles to handle field height correctly
- Add announcements for EdtiField errors

## Task Item
- [VSTS 70470](https://fuselabs.visualstudio.com/Composer/_workitems/edit/70470)
- [VSTS 70527](https://fuselabs.visualstudio.com/Composer/_workitems/edit/70527)


## Screenshots
![br-keyboard webm](https://user-images.githubusercontent.com/2841858/156234350-1e90a5b1-52d8-47aa-96b0-6ba87eb58885.gif)
![ui-keyboard webm](https://user-images.githubusercontent.com/2841858/156234368-cd664372-22f7-4b7d-837e-29d2a6d4f0da.gif)
![kb-keyboard webm](https://user-images.githubusercontent.com/2841858/156235095-6e07a751-c2e0-41e7-b5e9-4b8531014dfc.gif)


#minor