### PR TITLE
a11y: show one modal at once for bot creation flow

### DIFF
--- a/Composer/packages/client/src/components/CreationFlow/CreateOptions.tsx
+++ b/Composer/packages/client/src/components/CreationFlow/CreateOptions.tsx
@@ -86,7 +86,7 @@ export function CreateOptions(props: CreateOptionsProps) {
   return (
     <Fragment>
       <AzureBotDialog
-        isOpen={isOpenOptionsModal}
+        isOpen={!isOpenCreateModal && isOpenOptionsModal}
         onDismiss={onDismiss}
         onJumpToOpenModal={onJumpToOpenModal}
         onToggleCreateModal={setIsOpenCreateModal}


### PR DESCRIPTION
## Description
Opening multiple modals simultaneously confuses screen readers. This fixes the issue by allowing only one modal to be showed at the same time.

## Task Item

- [VSTS 70108](https://fuselabs.visualstudio.com/Composer/_workitems/edit/70108)

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/2841858/157747275-dc0300aa-cb17-4c49-92b6-aeaa3705619a.png)
The `AzureBotDialog` is placed beneath "Select the template" dialog (notice double dark overlay)

### After
![image](https://user-images.githubusercontent.com/2841858/157747384-0e11215c-f690-4ca0-b7d8-62526b4f1542.png)


#minor