### PR TITLE
a11y: Add aria-required attribute to Form Editor required fields

### DIFF
--- a/Composer/packages/adaptive-form/src/components/fields/BooleanField.tsx
+++ b/Composer/packages/adaptive-form/src/components/fields/BooleanField.tsx
@@ -72,6 +72,7 @@ const BooleanField: React.FC<FieldProps> = function CheckboxWidget(props) {
         required={required}
       />
       <Dropdown
+        aria-required={required}
         ariaLabel={label || formatMessage('boolean field')}
         id={id}
         options={options}

--- a/Composer/packages/adaptive-form/src/components/fields/OpenObjectField/ObjectItem.tsx
+++ b/Composer/packages/adaptive-form/src/components/fields/OpenObjectField/ObjectItem.tsx
@@ -34,6 +34,7 @@ const ObjectItem: React.FC<ObjectItemProps> = ({
   onChange,
   onNameChange,
   onDelete,
+  required,
   ...rest
 }) => {
   const initialName = useMemo(() => originalName, []);
@@ -76,7 +77,7 @@ const ObjectItem: React.FC<ObjectItemProps> = ({
           label={formatMessage('Key')}
           name="key"
           placeholder={initialName || formatMessage('Add a new key')}
-          required={rest.required}
+          required={required}
           schema={{ type: 'string' }}
           uiOptions={{}}
           value={name}
@@ -90,6 +91,7 @@ const ObjectItem: React.FC<ObjectItemProps> = ({
           label={formatMessage('Value')}
           name="value"
           placeholder={placeholder}
+          required={required}
           schema={schema}
           value={value}
           onChange={onChange}

--- a/Composer/packages/adaptive-form/src/components/fields/OpenObjectField/ObjectItem.tsx
+++ b/Composer/packages/adaptive-form/src/components/fields/OpenObjectField/ObjectItem.tsx
@@ -76,6 +76,7 @@ const ObjectItem: React.FC<ObjectItemProps> = ({
           label={formatMessage('Key')}
           name="key"
           placeholder={initialName || formatMessage('Add a new key')}
+          required={rest.required}
           schema={{ type: 'string' }}
           uiOptions={{}}
           value={name}

--- a/Composer/packages/adaptive-form/src/components/fields/OpenObjectField/OpenObjectField.tsx
+++ b/Composer/packages/adaptive-form/src/components/fields/OpenObjectField/OpenObjectField.tsx
@@ -43,6 +43,7 @@ const OpenObjectField: React.FC<FieldProps<{
             formData={value}
             id={`${id}.value`}
             name={propertyName}
+            required={props.required}
             schema={typeof additionalProperties === 'object' ? additionalProperties : {}}
             uiOptions={uiOptions.properties?.additionalProperties || {}}
             value={propertyValue}

--- a/Composer/packages/adaptive-form/src/components/fields/OpenObjectField/OpenObjectField.tsx
+++ b/Composer/packages/adaptive-form/src/components/fields/OpenObjectField/OpenObjectField.tsx
@@ -43,7 +43,7 @@ const OpenObjectField: React.FC<FieldProps<{
             formData={value}
             id={`${id}.value`}
             name={propertyName}
-            required={props.required}
+            required={required}
             schema={typeof additionalProperties === 'object' ? additionalProperties : {}}
             uiOptions={uiOptions.properties?.additionalProperties || {}}
             value={propertyValue}

--- a/Composer/packages/adaptive-form/src/components/fields/SelectField.tsx
+++ b/Composer/packages/adaptive-form/src/components/fields/SelectField.tsx
@@ -62,6 +62,7 @@ export const SelectField: React.FC<FieldProps<string | number>> = function Selec
     <>
       <FieldLabel description={description} helpLink={uiOptions?.helpLink} id={id} label={label} required={required} />
       <Dropdown
+        aria-required={required}
         ariaLabel={label || formatMessage('selection field')}
         data-testid="SelectFieldDropdown"
         errorMessage={error as string}

--- a/Composer/packages/adaptive-form/src/components/fields/StringField.tsx
+++ b/Composer/packages/adaptive-form/src/components/fields/StringField.tsx
@@ -64,6 +64,7 @@ export const StringField: React.FC<FieldProps<string>> = function StringField(pr
     <>
       <FieldLabel description={description} helpLink={uiOptions?.helpLink} id={id} label={label} required={required} />
       <TextField
+        aria-required={required}
         ariaLabel={label || formatMessage('string field')}
         autoAdjustHeight={!!uiOptions?.multiline}
         autoComplete="off"


### PR DESCRIPTION
## Description
These fields are visually indicated as required. so add `aria-required` attribute for screenreaders.

Alternative approach is might be in using a `required` property. It has more things to fix though:
- Need to remove double asterisk indication
- When placed in a native field, native tooltip pops-up which can't be customized

## Task Item

- [VSTS 70102](https://fuselabs.visualstudio.com/Composer/_workitems/edit/70102)


## Screenshots
![image](https://user-images.githubusercontent.com/2841858/160493120-f80f02b2-cfc3-4695-ae2b-445240469792.png)
![image](https://user-images.githubusercontent.com/2841858/160493249-e67b6a73-f106-4677-bcee-d4efa3501b80.png)


#minor