### PR TITLE
Fix Microsoft Nuget Security Analysis violations in Composer bots

### DIFF
--- a/Composer/packages/server/src/utility/project.ts
+++ b/Composer/packages/server/src/utility/project.ts
@@ -64,19 +64,6 @@ export async function ejectAndMerge(currentProject: BotProject, jobId: string) {
     const runtime = ExtensionContext.getRuntimeByProject(currentProject);
     const runtimePath = currentProject.getRuntimePath();
     if (runtimePath) {
-      // TO-DO: Remove this once the SDK packages are public on Nuget instad of Myget
-      // Inject a Nuget.config file into the project so that pre-release packages can be resolved.
-      // fs.writeFileSync(
-      //   Path.join(runtimePath, 'Nuget.config'),
-      //   `<?xml version="1.0" encoding="utf-8"?>
-      // <configuration>
-      //   <packageSources>
-      //     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-      //     <add key="BotBuilder.myget.org" value="https://botbuilder.myget.org/F/botbuilder-v4-dotnet-daily/api/v3/index.json" protocolVersion="3" />
-      //   </packageSources>
-      // </configuration>`
-      // );
-
       // install all dependencies and build the app
       BackgroundProcessManager.updateProcess(jobId, 202, formatMessage('Building runtime'));
       await runtime.build(runtimePath, currentProject);

--- a/Composer/packages/server/src/utility/project.ts
+++ b/Composer/packages/server/src/utility/project.ts
@@ -66,16 +66,16 @@ export async function ejectAndMerge(currentProject: BotProject, jobId: string) {
     if (runtimePath) {
       // TO-DO: Remove this once the SDK packages are public on Nuget instad of Myget
       // Inject a Nuget.config file into the project so that pre-release packages can be resolved.
-      fs.writeFileSync(
-        Path.join(runtimePath, 'Nuget.config'),
-        `<?xml version="1.0" encoding="utf-8"?>
-      <configuration>
-        <packageSources>
-          <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-          <add key="BotBuilder.myget.org" value="https://botbuilder.myget.org/F/botbuilder-v4-dotnet-daily/api/v3/index.json" protocolVersion="3" />
-        </packageSources>
-      </configuration>`
-      );
+      // fs.writeFileSync(
+      //   Path.join(runtimePath, 'Nuget.config'),
+      //   `<?xml version="1.0" encoding="utf-8"?>
+      // <configuration>
+      //   <packageSources>
+      //     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+      //     <add key="BotBuilder.myget.org" value="https://botbuilder.myget.org/F/botbuilder-v4-dotnet-daily/api/v3/index.json" protocolVersion="3" />
+      //   </packageSources>
+      // </configuration>`
+      // );
 
       // install all dependencies and build the app
       BackgroundProcessManager.updateProcess(jobId, 202, formatMessage('Building runtime'));


### PR DESCRIPTION
Addresses Issue #9082
## Description
Composer injects a nuget.config file into every new new bot project. This appears to be no longer needed. This causes Microsoft Nuget Security Analysis violations in ADO pipelines, as described in Issue #9082.

## The fix
Remove the call to `fs.writeFileSync()` in Composer/packages/server/src/utility/project.ts.

I have not built and tested Composer with this fix. If invited to be a collaborator in [this repo](https://github.com/microsoft/BotFramework-Composer), I would immediately run that test. (I could then move this fix from my fork to a branch in this repo, permitting the running of a package build.)