### PR TITLE
a11y: add support for intellisense

### DIFF
--- a/Composer/packages/adaptive-form/src/components/fields/IntellisenseFields.tsx
+++ b/Composer/packages/adaptive-form/src/components/fields/IntellisenseFields.tsx
@@ -47,9 +47,11 @@ export const IntellisenseTextField: React.FC<FieldProps<string>> = (props) => {
         onKeyDownTextField,
         onKeyUpTextField,
         onClickTextField,
+        aria,
       }) => (
         <StringField
           {...props}
+          aria={aria}
           cursorPosition={cursorPosition}
           focused={focused}
           id={id}
@@ -109,10 +111,12 @@ export const IntellisenseExpressionField: React.FC<FieldProps<string>> = (props)
         onKeyDownTextField,
         onKeyUpTextField,
         onClickTextField,
+        aria,
       }) => (
         <div ref={setContainerElm}>
           <StringField
             {...props}
+            aria={aria}
             cursorPosition={cursorPosition}
             focused={focused}
             id={id}
@@ -161,9 +165,10 @@ export const IntellisenseNumberField: React.FC<FieldProps<string>> = (props) => 
       onBlur={props.onBlur}
       onChange={onChange}
     >
-      {({ textFieldValue, focused, onValueChanged, onKeyDownTextField, onKeyUpTextField, onClickTextField }) => (
+      {({ textFieldValue, focused, onValueChanged, onKeyDownTextField, onKeyUpTextField, onClickTextField, aria }) => (
         <NumberField
           {...props}
+          aria={aria}
           focused={focused}
           id={id}
           value={textFieldValue}

--- a/Composer/packages/adaptive-form/src/components/fields/StringField.tsx
+++ b/Composer/packages/adaptive-form/src/components/fields/StringField.tsx
@@ -26,6 +26,7 @@ export const StringField: React.FC<FieldProps<string>> = function StringField(pr
     focused,
     cursorPosition,
     hasIcon,
+    aria,
   } = props;
 
   const textFieldRef = React.createRef<ITextField>();
@@ -64,6 +65,7 @@ export const StringField: React.FC<FieldProps<string>> = function StringField(pr
     <>
       <FieldLabel description={description} helpLink={uiOptions?.helpLink} id={id} label={label} required={required} />
       <TextField
+        {...aria}
         aria-required={required}
         ariaLabel={label || formatMessage('string field')}
         autoAdjustHeight={!!uiOptions?.multiline}

--- a/Composer/packages/extension-client/src/types/form.ts
+++ b/Composer/packages/extension-client/src/types/form.ts
@@ -13,6 +13,7 @@ export type ChangeHandler<T = any> = (newValue?: T) => void;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface FieldProps<T = any> {
+  aria?: Record<string, unknown>;
   className?: string;
   definitions: SchemaDefinitions | undefined;
   description?: string;

--- a/Composer/packages/intellisense/src/components/CompletionElement.tsx
+++ b/Composer/packages/intellisense/src/components/CompletionElement.tsx
@@ -6,7 +6,7 @@ import { css, jsx } from '@emotion/core';
 import { CompletionItemKind } from 'monaco-languageclient';
 import { FontIcon } from '@fluentui/react/lib/Icon';
 import { TooltipHost } from '@fluentui/react/lib/Tooltip';
-import React from 'react';
+import React, { useLayoutEffect, useRef } from 'react';
 import { CompletionItem, MarkupContent } from 'vscode-languageserver-types';
 import { DirectionalHint } from '@fluentui/react/lib/common/DirectionalHint';
 
@@ -78,17 +78,31 @@ const renderDocumentation = (documentation: string | MarkupContent | undefined) 
 };
 
 export const CompletionElement = (props: {
+  id: string;
   completionItem: CompletionItem;
   isSelected: boolean;
   onClickCompletionItem: () => void;
 }) => {
-  const { completionItem, isSelected, onClickCompletionItem } = props;
-
+  const { completionItem, isSelected, onClickCompletionItem, id } = props;
+  const rootRef = useRef<HTMLDivElement>(null);
   const additionalStyles = isSelected ? styles.selectedElement : {};
+
+  useLayoutEffect(() => {
+    if (isSelected && rootRef.current) {
+      rootRef.current.scrollIntoView();
+    }
+  }, [isSelected]);
 
   const renderItem = () => {
     return (
-      <div css={[styles.completionElement, additionalStyles]} onClick={onClickCompletionItem}>
+      <div
+        id={id}
+        ref={rootRef}
+        aria-selected={isSelected}
+        css={[styles.completionElement, additionalStyles]}
+        onClick={onClickCompletionItem}
+        role="option"
+      >
         <FontIcon iconName={getIconName(completionItem.kind)} css={styles.icon} />
         <div css={styles.text}>
           {completionItem.data?.matches

--- a/Composer/packages/intellisense/src/components/CompletionElement.tsx
+++ b/Composer/packages/intellisense/src/components/CompletionElement.tsx
@@ -88,8 +88,8 @@ export const CompletionElement = (props: {
   const additionalStyles = isSelected ? styles.selectedElement : {};
 
   useLayoutEffect(() => {
-    if (isSelected && rootRef.current) {
-      rootRef.current.scrollIntoView?.();
+    if (isSelected) {
+      rootRef.current?.scrollIntoView?.();
     }
   }, [isSelected]);
 

--- a/Composer/packages/intellisense/src/components/CompletionElement.tsx
+++ b/Composer/packages/intellisense/src/components/CompletionElement.tsx
@@ -89,7 +89,7 @@ export const CompletionElement = (props: {
 
   useLayoutEffect(() => {
     if (isSelected && rootRef.current) {
-      rootRef.current.scrollIntoView();
+      rootRef.current.scrollIntoView?.();
     }
   }, [isSelected]);
 

--- a/Composer/packages/intellisense/src/components/CompletionList.tsx
+++ b/Composer/packages/intellisense/src/components/CompletionList.tsx
@@ -27,18 +27,22 @@ export const CompletionList = React.forwardRef<
   HTMLDivElement,
   {
     completionItems: CompletionItem[];
+    getItemId: (index: number) => string;
     selectedItem: number;
     completionListOverride?: JSX.Element | null;
     onClickCompletionItem: (index: number) => void;
+    'aria-label': string;
+    id: string;
   }
 >((props, ref) => {
-  const { completionItems, selectedItem, completionListOverride, onClickCompletionItem } = props;
+  const { completionItems, selectedItem, completionListOverride, onClickCompletionItem, getItemId, ...rest } = props;
 
   return (
-    <div ref={ref} css={styles.completionList}>
+    <div {...rest} ref={ref} css={styles.completionList} role={completionListOverride ? 'none' : 'listbox'}>
       {completionListOverride ??
         completionItems.map((completionItem, index) => (
           <CompletionElement
+            id={getItemId(index)}
             key={index}
             completionItem={completionItem}
             isSelected={selectedItem === index}

--- a/Composer/packages/intellisense/src/components/Intellisense.tsx
+++ b/Composer/packages/intellisense/src/components/Intellisense.tsx
@@ -234,11 +234,11 @@ export const Intellisense = React.memo(
     const resultsMessage = showCompletionList
       ? formatMessage(
           `{
-        suggestionsCount, plural,
-          =1 {One suggestion found}
-          =0 {No suggestions found}
-          other {# suggestions found}
-      }`,
+            suggestionsCount, plural,
+              =1 {One suggestion found}
+              =0 {No suggestions found}
+              other {# suggestions found}
+          }`,
           { suggestionsCount: completionListOverride ? 0 : completionItems.length }
         )
       : '';


### PR DESCRIPTION
## Description

The PR adds accessibility properties for the intellisense component, wires them with input components and fixes some observations.

List of changes:
- Added `aria` attributes set into `Intellisense` component, so it to be passed down to any input rendered
- Updated fields. where it makes sense. to include a11y parameters passed by Intellisense
- Added scrollIntoView for CompletionElement to ensure the selected element is in the view
- Refactored CompletionList a11y properties. Now list has a listbox role when showing suggestions

## Task Item

- [VSTS 70456](https://fuselabs.visualstudio.com/Composer/_workitems/edit/70456)

## Screenshots

![image](https://user-images.githubusercontent.com/2841858/161598661-b80bae2a-1840-4a79-b97d-ce33ce52bfc5.png)

![image](https://user-images.githubusercontent.com/2841858/161598074-b108b9e2-862a-43dc-b7b9-583b6ada29b2.png)

![Suggestions-infocus webm](https://user-images.githubusercontent.com/2841858/161600415-9bda3c37-3796-476b-8d9c-9b3db2318a3a.gif)

#minor
