### PR TITLE
a11y: fix aria-label content

### DIFF
--- a/Composer/packages/client/src/pages/botProject/create-publish-profile/ProfileFormDialog.tsx
+++ b/Composer/packages/client/src/pages/botProject/create-publish-profile/ProfileFormDialog.tsx
@@ -101,7 +101,7 @@ export const ProfileFormDialog: React.FC<ProfileFormDialogProps> = (props) => {
             />
             <DropdownField
               required
-              ariaLabel={formatMessage('The target where you publish your bot')}
+              ariaLabel={formatMessage('Publishing target: the target where you publish your bot')}
               defaultSelectedKey={targetType}
               label={formatMessage('Publishing target')}
               options={targetTypes}


### PR DESCRIPTION
## Description

Aria label should start from visible content. This PR fixes the occurrence pointed out in the linked bug.

## Task Item

- [VSTS 70094](https://fuselabs.visualstudio.com/Composer/_workitems/edit/70094)

## Screenshots

![image](https://user-images.githubusercontent.com/2841858/161602234-70ab3d54-c9b6-42b8-ac67-0e94292eefa2.png)


#minor
