### PR TITLE
a11y: fix project tree roles and aria

### DIFF
--- a/Composer/packages/client/src/components/ProjectTree/ExpandableNode.tsx
+++ b/Composer/packages/client/src/components/ProjectTree/ExpandableNode.tsx
@@ -76,7 +76,7 @@ export const ExpandableNode = ({
       onKeyDown={handleKey}
     >
       {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/no-noninteractive-tabindex */}
-      <li css={listItemStyle(isActive, isExpanded, children != null)} data-testid={'summaryTag'}>
+      <li css={listItemStyle(isActive, isExpanded, children != null)} data-testid={'summaryTag'} role="treeitem">
         {summary}
       </li>
       {children != null && isExpanded && <div role="group">{children}</div>}

--- a/Composer/packages/client/src/components/ProjectTree/treeItem.tsx
+++ b/Composer/packages/client/src/components/ProjectTree/treeItem.tsx
@@ -427,7 +427,7 @@ export const TreeItem: React.FC<ITreeItemProps> = ({
 }) => {
   const [thisItemSelected, setThisItemSelected] = useState<boolean>(false);
 
-  const ariaLabel = `${objectNames[itemType]()} ${link.displayName}`;
+  const ariaLabel = `${link.displayName} ${objectNames[itemType]()}`;
   const dataTestId = `${dialogName ?? '$Root'}_${link.displayName}`;
   const isExternal = Boolean(link.href);
 
@@ -470,8 +470,18 @@ export const TreeItem: React.FC<ITreeItemProps> = ({
             tabIndex={0}
             onBlur={item.onBlur}
             onFocus={item.onFocus}
+            onKeyDown={
+              onSelect
+                ? (e) => {
+                    if (e.key === 'Enter') {
+                      onSelect(link);
+                      e.stopPropagation();
+                    }
+                  }
+                : undefined
+            }
           >
-            <div css={projectTreeItem} role="presentation" tabIndex={-1}>
+            <div css={projectTreeItem} role="presentation">
               {item.itemType != null && TreeIcons[item.itemType] != null && (
                 <Icon
                   iconName={TreeIcons[item.itemType]}
@@ -482,7 +492,6 @@ export const TreeItem: React.FC<ITreeItemProps> = ({
                       outline: 'none',
                     },
                   }}
-                  tabIndex={-1}
                 />
               )}
               <span className={'treeItem-text'} css={itemName(maxTextWidth)}>
@@ -564,25 +573,12 @@ export const TreeItem: React.FC<ITreeItemProps> = ({
 
   return (
     <div
-      aria-label={ariaLabel}
       css={navContainer(isMenuOpen, isActive, thisItemSelected, textWidth - overflowIconWidthOnHover, isBroken)}
       data-testid={dataTestId}
-      role={role}
-      tabIndex={0}
       onClick={
         onSelect
           ? () => {
               onSelect(link);
-            }
-          : undefined
-      }
-      onKeyDown={
-        onSelect
-          ? (e) => {
-              if (e.key === 'Enter') {
-                onSelect(link);
-                e.stopPropagation();
-              }
             }
           : undefined
       }


### PR DESCRIPTION
## Description

This improves aria for the Project Tree control.

Includes the following changes:
- Remove redundant aria-label causing two elements in the chain to have the same name
- Remove redundant tabIndex and move keyboard handler to the place where the keyboard event happens
- Make aria-labels to follow the rule: visible content goes first in the label

## Task Item

- [VSTS 70524](https://fuselabs.visualstudio.com/Composer/_workitems/edit/70524)

## Screenshots
![image](https://user-images.githubusercontent.com/2841858/161603493-2376c01b-a052-4806-ac1c-f38d50a13931.png)
![image](https://user-images.githubusercontent.com/2841858/161604557-7bf58acf-359f-46d6-8cae-da2269afef3e.png)

#minor
