### PR TITLE
[fix]: Update appRegistrationProvisionMethod to use accessToken

### DIFF
--- a/extensions/azurePublishNew/src/node/azureResources/appRegistration.ts
+++ b/extensions/azurePublishNew/src/node/azureResources/appRegistration.ts
@@ -61,10 +61,10 @@ const postRequestWithRetry = async (requestUri: string, requestOptions: AxiosReq
 };
 
 const appRegistrationProvisionMethod = (provisionConfig: ProvisionServiceConfig) => {
-  const { graphToken } = provisionConfig;
+  const { accessToken } = provisionConfig;
   const requestOptions: rp.RequestPromiseOptions = {
     json: true,
-    headers: { Authorization: `Bearer ${graphToken}` },
+    headers: { Authorization: `Bearer ${accessToken}` },
   } as rp.RequestPromiseOptions;
 
   const createApp = async (displayName: string) => {


### PR DESCRIPTION
## Description
The `appRegistrationProvisionMethod` was using the `graphToken` instead of the `accessToken` to create the app registration. This was causing the app registration to be created in the wrong tenant. 
## Task Item

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
