### PR TITLE
build: Fix Component Governance in Composer DevOps pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,6 +71,8 @@ jobs:
       - powershell: |
           $find = 'npm:';
           $replace = '';
+          $find2 = 'resolution:';
+          $replace2 = 'resolved:';
 
           Get-ChildItem -Recurse -Path '**\yarn-berry.lock' | % {
             $source = $_.FullName;
@@ -80,8 +82,8 @@ jobs:
             Copy-Item -Path $source -Destination $dest -Force
 
             $content = Get-Content -Raw $dest;
+            $content -Replace "$find", "$replace" -Replace "$find2", "$replace2" | Set-Content $dest;
 
-            $content -Replace "$find", "$replace" | Set-Content $dest;
             '--------------------'; get-content $dest; '====================';
           }
         displayName: Generate "yarn.lock" files for CG Detection

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,6 +16,13 @@ jobs:
         displayName: Copy yarn-berry.lock to yarn.lock
         continueOnError: true
 
+      - powershell: |
+          cd ..
+          ls -R
+        displayName: Dir workspace
+        continueOnError: true
+        condition: succeededOrFailed()
+
       - task: UseDotNet@2
         inputs:
           packageType: "runtime"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,8 +71,6 @@ jobs:
       - powershell: |
           $find = 'npm:';
           $replace = '';
-          $find2 = 'resolution:';
-          $replace2 = 'resolved:';
 
           Get-ChildItem -Recurse -Path '**\yarn-berry.lock' | % {
             $source = $_.FullName;
@@ -82,7 +80,7 @@ jobs:
             Copy-Item -Path $source -Destination $dest -Force
 
             $content = Get-Content -Raw $dest;
-            $content -Replace "$find", "$replace" -Replace "$find2", "$replace2" | Set-Content $dest;
+            $content -Replace "$find", "$replace" | Set-Content $dest;
 
             '--------------------'; get-content $dest; '====================';
           }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,11 @@ jobs:
       vmImage: ubuntu-latest
 
     steps:
+      - powershell: |
+          Copy-Item -Path "$(Build.SourcesDirectory)\Composer\yarn-berry.lock" -Destination "$(Build.SourcesDirectory)\Composer\yarn.lock" -Force
+        displayName: Copy yarn-berry.lock to yarn.lock
+        continueOnError: true
+
       - task: UseDotNet@2
         inputs:
           packageType: "runtime"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,21 +63,28 @@ jobs:
         condition: always()
         continueOnError: true
         workingDirectory: Composer
-      - powershell: |
-          cd ..
-          ls -R
-        displayName: Dir workspace
-        continueOnError: true
-        condition: succeededOrFailed()
   - job: security
     displayName: Security Analysis
     pool:
       vmImage: ubuntu-latest
     steps:
       - powershell: |
-          Copy-Item -Path "$(Build.SourcesDirectory)\Composer\yarn-berry.lock" -Destination "$(Build.SourcesDirectory)\Composer\yarn.lock" -Force
-        displayName: Copy yarn-berry.lock to yarn.lock
+          Get-ChildItem -Recurse -Path '**\yarn-berry.lock' | % {
+            $source = $_.FullName;
+            $dest = $_.DirectoryName + "\yarn.lock"
+            Write-Host $source;
+            Write-Host $dest;
+            Copy-Item -Path $source -Destination $dest -Force
+          }
+        displayName: Copy yarn-berry.lock files to yarn.lock
         continueOnError: true
+
+      - powershell: |
+          cd ..
+          ls -R
+        displayName: Dir workspace
+        continueOnError: true
+        condition: succeededOrFailed()
 
       - task: ComponentGovernanceComponentDetection@0
         displayName: Component Detection
@@ -86,3 +93,4 @@ jobs:
           verbosity: "Verbose"
           alertWarningLevel: "High"
           failOnAlert: true
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,7 +69,7 @@ jobs:
       vmImage: ubuntu-latest
     steps:
       - powershell: |
-          $find = '@npm';
+          $find = 'npm:';
           $replace = '';
 
           Get-ChildItem -Recurse -Path '**\yarn-berry.lock' | % {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,12 +69,15 @@ jobs:
       vmImage: ubuntu-latest
     steps:
       - powershell: |
+          # Gin up imitation v1 yarn.lock files to aid Component Governance Detection analysis. The method:
+          # Find v3 yarn-berry.lock files. From each, generate a yarn.lock file, deleting all occurrences of 'npm:'.
+          # This allows CG to work with yarn v3.
           $find = 'npm:';
           $replace = '';
 
-          Get-ChildItem -Recurse -Path '**\yarn-berry.lock' | % {
+          Get-ChildItem -Recurse -Path '**/yarn-berry.lock' | % {
             $source = $_.FullName;
-            $dest = $_.DirectoryName + "\yarn.lock"
+            $dest = $_.DirectoryName + "/yarn.lock"
             Write-Host $source;
             Write-Host $dest;
             Copy-Item -Path $source -Destination $dest -Force
@@ -86,13 +89,6 @@ jobs:
           }
         displayName: Generate "yarn.lock" files for CG Detection
         continueOnError: true
-
-      - powershell: |
-          cd ..
-          ls -R
-        displayName: Dir workspace
-        continueOnError: true
-        condition: succeededOrFailed()
 
       - task: ComponentGovernanceComponentDetection@0
         displayName: Component Detection

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,18 +11,6 @@ jobs:
       vmImage: ubuntu-latest
 
     steps:
-      - powershell: |
-          Copy-Item -Path "$(Build.SourcesDirectory)\Composer\yarn-berry.lock" -Destination "$(Build.SourcesDirectory)\Composer\yarn.lock" -Force
-        displayName: Copy yarn-berry.lock to yarn.lock
-        continueOnError: true
-
-      - powershell: |
-          cd ..
-          ls -R
-        displayName: Dir workspace
-        continueOnError: true
-        condition: succeededOrFailed()
-
       - task: UseDotNet@2
         inputs:
           packageType: "runtime"
@@ -75,11 +63,22 @@ jobs:
         condition: always()
         continueOnError: true
         workingDirectory: Composer
+      - powershell: |
+          cd ..
+          ls -R
+        displayName: Dir workspace
+        continueOnError: true
+        condition: succeededOrFailed()
   - job: security
     displayName: Security Analysis
     pool:
       vmImage: ubuntu-latest
     steps:
+      - powershell: |
+          Copy-Item -Path "$(Build.SourcesDirectory)\Composer\yarn-berry.lock" -Destination "$(Build.SourcesDirectory)\Composer\yarn.lock" -Force
+        displayName: Copy yarn-berry.lock to yarn.lock
+        continueOnError: true
+
       - task: ComponentGovernanceComponentDetection@0
         displayName: Component Detection
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,14 +69,22 @@ jobs:
       vmImage: ubuntu-latest
     steps:
       - powershell: |
+          $find = '@npm';
+          $replace = '';
+
           Get-ChildItem -Recurse -Path '**\yarn-berry.lock' | % {
             $source = $_.FullName;
             $dest = $_.DirectoryName + "\yarn.lock"
             Write-Host $source;
             Write-Host $dest;
             Copy-Item -Path $source -Destination $dest -Force
+
+            $content = Get-Content -Raw $dest;
+
+            $content -Replace "$find", "$replace" | Set-Content $dest;
+            '--------------------'; get-content $dest; '====================';
           }
-        displayName: Copy yarn-berry.lock files to yarn.lock
+        displayName: Generate "yarn.lock" files for CG Detection
         continueOnError: true
 
       - powershell: |


### PR DESCRIPTION
Fixes #minor

## Description
Implementation of yarn v3 resulted in Component Governance analysis failing to find security vulnerabilities: CG does not handle the new v3 yarn-berry.lock files.

## Changes
Add a script to generate imitation yarn v1 yarn.lock files just before CG analysis runs.