### PR TITLE
chore: fix e2e-ci calling npx instead of yarn

### DIFF
--- a/Composer/packages/integration-tests/package.json
+++ b/Composer/packages/integration-tests/package.json
@@ -8,7 +8,8 @@
     "open": "cypress open",
     "clean": "node scripts/clean-e2e.js",
     "clean-all": "node scripts/clean-e2e.js --all",
-    "lint": "eslint --quiet cypress"
+    "lint": "eslint --quiet cypress",
+    "cypress": "cypress run"
   },
   "keywords": [],
   "author": "",

--- a/Composer/packages/integration-tests/scripts/e2e-ci.sh
+++ b/Composer/packages/integration-tests/scripts/e2e-ci.sh
@@ -10,7 +10,7 @@ yarn start >> e2e.log 2>&1 &
 SERVER_PID=$!
 
 cd packages/integration-tests
-npx cypress run "$@"
+yarn run cypress -- "$@"
 EXIT_CODE=$?
 
 # kill server process


### PR DESCRIPTION
## Description

Found out the cause of Cypress@10 usage. The `npx` command which was used to run cypress cant find Cypress binary installed by yarn@3.

Fixed the issue by adding a script to run Cypress to the `package.json` and running the command via yarn.

![image](https://user-images.githubusercontent.com/2841858/176229704-a473efa2-d7df-4011-8423-b8a35f8a481c.png)

#minor