### PR TITLE
chore: Fix Component Governance Security Alerts

### DIFF
--- a/Composer/packages/extension/package.json
+++ b/Composer/packages/extension/package.json
@@ -18,7 +18,7 @@
     "@types/fs-extra": "^9.0.1",
     "@types/path-to-regexp": "^1.7.0",
     "@types/tar": "^4.0.3",
-    "json-schema": "^0.2.5",
+    "json-schema": "0.4.0",
     "rimraf": "3.0.2",
     "typescript": "^3.8.3"
   },

--- a/Composer/packages/lib/shared/package.json
+++ b/Composer/packages/lib/shared/package.json
@@ -39,7 +39,7 @@
     "@botframework-composer/types": "*",
     "format-message": "6.2.4",
     "https-proxy-agent": "^5.0.0",
-    "json-schema": "^0.2.5",
+    "json-schema": "0.4.0",
     "multimatch": "^5.0.0",
     "nanoid": "^3.1.3",
     "nanoid-dictionary": "^3.0.0",

--- a/Composer/packages/server/package.json
+++ b/Composer/packages/server/package.json
@@ -94,7 +94,7 @@
     "debug": "^4.1.1",
     "dotenv": "^8.1.0",
     "download-npm-package": "^3.1.12",
-    "ejs": "^3.1.6",
+    "ejs": "3.1.8",
     "express": "4.16.1",
     "express-serve-static-core": "0.1.1",
     "express-session": "^1.17.0",

--- a/Composer/packages/types/package.json
+++ b/Composer/packages/types/package.json
@@ -20,7 +20,7 @@
     "axios": "^0.21.1",
     "botframework-schema": "^4.11.1",
     "express-serve-static-core": "0.1.1",
-    "json-schema": "^0.2.5",
+    "json-schema": "0.4.0",
     "tslib": "2.4.0"
   },
   "devDependencies": {

--- a/Composer/yarn-berry.lock
+++ b/Composer/yarn-berry.lock
@@ -3895,7 +3895,7 @@ __metadata:
     express-serve-static-core: 0.1.1
     fs-extra: ^9.0.1
     globby: ^11.0.0
-    json-schema: ^0.2.5
+    json-schema: 0.4.0
     node-fetch: ^2.6.1
     passport: ^0.4.1
     path-to-regexp: ^6.1.0
@@ -4177,7 +4177,7 @@ __metadata:
     debug: ^4.1.1
     dotenv: ^8.1.0
     download-npm-package: ^3.1.12
-    ejs: ^3.1.6
+    ejs: 3.1.8
     eslint: 7.0.0
     express: 4.16.1
     express-serve-static-core: 0.1.1
@@ -4237,7 +4237,7 @@ __metadata:
     copyfiles: ^2.1.0
     format-message: 6.2.4
     https-proxy-agent: ^5.0.0
-    json-schema: ^0.2.5
+    json-schema: 0.4.0
     multimatch: ^5.0.0
     nanoid: ^3.1.3
     nanoid-dictionary: ^3.0.0
@@ -4535,7 +4535,7 @@ __metadata:
     botframework-schema: ^4.11.1
     eslint: 7.0.0
     express-serve-static-core: 0.1.1
-    json-schema: ^0.2.5
+    json-schema: 0.4.0
     rimraf: 3.0.2
     tslib: 2.4.0
     typescript: ^3.8.3
@@ -14813,10 +14813,10 @@ __metadata:
 
 "eventsource@npm:^1.0.7":
   version: 1.1.0
-  resolution: "eventsource@npm:1.1.0"
+  resolution: "eventsource@npm:1.1.2"
   dependencies:
     original: ^1.0.0
-  checksum: 78338b7e75ec471cb793efb3319e0c4d2bf00fb638a2e3f888ad6d98cd1e3d4492a29f554c0921c7b2ac5130c3a732a1a0056739f6e2f548d714aec685e5da7e
+  checksum: fe8f2ac3c70b1b63ee3cef5c0a28680cb00b5747bfda1d9835695fab3ed602be41c5c799b1fc997b34b02633573fead25b12b036bdf5212f23a6aa9f59212e9b
   languageName: node
   linkType: hard
 
@@ -19398,13 +19398,6 @@ __metadata:
   version: 0.4.0
   resolution: "json-schema@npm:0.4.0"
   checksum: 66389434c3469e698da0df2e7ac5a3281bcff75e797a5c127db7c5b56270e01ae13d9afa3c03344f76e32e81678337a8c912bdbb75101c62e487dc3778461d72
-  languageName: node
-  linkType: hard
-
-"json-schema@npm:^0.2.5":
-  version: 0.2.5
-  resolution: "json-schema@npm:0.2.5"
-  checksum: 54871525a19997c824d98916fbbef3cb190638c62e5945412785f3c6d90faae7bfff5a1935355a51b979497a7e059a2013eab4a6de144097b9fa80a5be920fb3
   languageName: node
   linkType: hard
 

--- a/Composer/yarn-berry.lock
+++ b/Composer/yarn-berry.lock
@@ -21018,14 +21018,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.2.0, minimist@npm:^1.2.5":
-  version: 1.2.5
-  resolution: "minimist@npm:1.2.5"
-  checksum: 86706ce5b36c16bfc35c5fe3dbb01d5acdc9a22f2b6cc810b6680656a1d2c0e44a0159c9a3ba51fb072bb5c203e49e10b51dcd0eec39c481f4c42086719bae52
-  languageName: node
-  linkType: hard
-
-"minimist@npm:^1.2.6":
+"minimist@npm:^1.2.0, minimist@npm:^1.2.5, minimist@npm:^1.2.6":
   version: 1.2.6
   resolution: "minimist@npm:1.2.6"
   checksum: d15428cd1e11eb14e1233bcfb88ae07ed7a147de251441d61158619dfb32c4d7e9061d09cab4825fdee18ecd6fce323228c8c47b5ba7cd20af378ca4048fb3fb

--- a/extensions/azurePublish/yarn-berry.lock
+++ b/extensions/azurePublish/yarn-berry.lock
@@ -2019,7 +2019,7 @@ __metadata:
     "@botframework-composer/types": "*"
     format-message: 6.2.4
     https-proxy-agent: ^5.0.0
-    json-schema: ^0.2.5
+    json-schema: 0.4.0
     multimatch: ^5.0.0
     nanoid: ^3.1.3
     nanoid-dictionary: ^3.0.0
@@ -2077,7 +2077,7 @@ __metadata:
     axios: ^0.21.1
     botframework-schema: ^4.11.1
     express-serve-static-core: 0.1.1
-    json-schema: ^0.2.5
+    json-schema: 0.4.0
     tslib: 2.4.0
   languageName: node
   linkType: hard
@@ -8070,13 +8070,6 @@ __metadata:
   version: 0.4.0
   resolution: "json-schema@npm:0.4.0"
   checksum: 66389434c3469e698da0df2e7ac5a3281bcff75e797a5c127db7c5b56270e01ae13d9afa3c03344f76e32e81678337a8c912bdbb75101c62e487dc3778461d72
-  languageName: node
-  linkType: hard
-
-"json-schema@npm:^0.2.5":
-  version: 0.2.5
-  resolution: "json-schema@npm:0.2.5"
-  checksum: 54871525a19997c824d98916fbbef3cb190638c62e5945412785f3c6d90faae7bfff5a1935355a51b979497a7e059a2013eab4a6de144097b9fa80a5be920fb3
   languageName: node
   linkType: hard
 

--- a/extensions/azurePublishNew/yarn-berry.lock
+++ b/extensions/azurePublishNew/yarn-berry.lock
@@ -1936,7 +1936,7 @@ __metadata:
     "@botframework-composer/types": "*"
     format-message: 6.2.4
     https-proxy-agent: ^5.0.0
-    json-schema: ^0.2.5
+    json-schema: 0.4.0
     multimatch: ^5.0.0
     nanoid: ^3.1.3
     nanoid-dictionary: ^3.0.0
@@ -1994,7 +1994,7 @@ __metadata:
     axios: ^0.21.1
     botframework-schema: ^4.11.1
     express-serve-static-core: 0.1.1
-    json-schema: ^0.2.5
+    json-schema: 0.4.0
     tslib: 2.4.0
   languageName: node
   linkType: hard
@@ -7897,13 +7897,6 @@ __metadata:
   version: 0.4.0
   resolution: "json-schema@npm:0.4.0"
   checksum: 66389434c3469e698da0df2e7ac5a3281bcff75e797a5c127db7c5b56270e01ae13d9afa3c03344f76e32e81678337a8c912bdbb75101c62e487dc3778461d72
-  languageName: node
-  linkType: hard
-
-"json-schema@npm:^0.2.5":
-  version: 0.2.5
-  resolution: "json-schema@npm:0.2.5"
-  checksum: 54871525a19997c824d98916fbbef3cb190638c62e5945412785f3c6d90faae7bfff5a1935355a51b979497a7e059a2013eab4a6de144097b9fa80a5be920fb3
   languageName: node
   linkType: hard
 

--- a/extensions/localPublish/yarn-berry.lock
+++ b/extensions/localPublish/yarn-berry.lock
@@ -14,7 +14,7 @@ __metadata:
     axios: ^0.21.1
     botframework-schema: ^4.11.1
     express-serve-static-core: 0.1.1
-    json-schema: ^0.2.5
+    json-schema: 0.4.0
     tslib: 2.4.0
   languageName: node
   linkType: hard
@@ -552,10 +552,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-schema@npm:^0.2.5":
-  version: 0.2.5
-  resolution: "json-schema@npm:0.2.5"
-  checksum: 54871525a19997c824d98916fbbef3cb190638c62e5945412785f3c6d90faae7bfff5a1935355a51b979497a7e059a2013eab4a6de144097b9fa80a5be920fb3
+"json-schema@npm:0.4.0":
+  version: 0.4.0
+  resolution: "json-schema@npm:0.4.0"
+  checksum: 66389434c3469e698da0df2e7ac5a3281bcff75e797a5c127db7c5b56270e01ae13d9afa3c03344f76e32e81678337a8c912bdbb75101c62e487dc3778461d72
   languageName: node
   linkType: hard
 

--- a/extensions/mockRemotePublish/yarn-berry.lock
+++ b/extensions/mockRemotePublish/yarn-berry.lock
@@ -14,7 +14,7 @@ __metadata:
     axios: ^0.21.1
     botframework-schema: ^4.11.1
     express-serve-static-core: 0.1.1
-    json-schema: ^0.2.5
+    json-schema: 0.4.0
     tslib: 2.4.0
   languageName: node
   linkType: hard
@@ -169,10 +169,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-schema@npm:^0.2.5":
-  version: 0.2.5
-  resolution: "json-schema@npm:0.2.5"
-  checksum: 54871525a19997c824d98916fbbef3cb190638c62e5945412785f3c6d90faae7bfff5a1935355a51b979497a7e059a2013eab4a6de144097b9fa80a5be920fb3
+"json-schema@npm:0.4.0":
+  version: 0.4.0
+  resolution: "json-schema@npm:0.4.0"
+  checksum: 66389434c3469e698da0df2e7ac5a3281bcff75e797a5c127db7c5b56270e01ae13d9afa3c03344f76e32e81678337a8c912bdbb75101c62e487dc3778461d72
   languageName: node
   linkType: hard
 

--- a/extensions/packageManager/yarn-berry.lock
+++ b/extensions/packageManager/yarn-berry.lock
@@ -158,7 +158,7 @@ __metadata:
     axios: ^0.21.1
     botframework-schema: ^4.11.1
     express-serve-static-core: 0.1.1
-    json-schema: ^0.2.5
+    json-schema: 0.4.0
     tslib: 2.4.0
   languageName: node
   linkType: hard
@@ -3176,10 +3176,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-schema@npm:^0.2.5":
-  version: 0.2.5
-  resolution: "json-schema@npm:0.2.5"
-  checksum: 54871525a19997c824d98916fbbef3cb190638c62e5945412785f3c6d90faae7bfff5a1935355a51b979497a7e059a2013eab4a6de144097b9fa80a5be920fb3
+"json-schema@npm:0.4.0":
+  version: 0.4.0
+  resolution: "json-schema@npm:0.4.0"
+  checksum: 66389434c3469e698da0df2e7ac5a3281bcff75e797a5c127db7c5b56270e01ae13d9afa3c03344f76e32e81678337a8c912bdbb75101c62e487dc3778461d72
   languageName: node
   linkType: hard
 

--- a/extensions/pvaPublish/yarn-berry.lock
+++ b/extensions/pvaPublish/yarn-berry.lock
@@ -1649,7 +1649,7 @@ __metadata:
     axios: ^0.21.1
     botframework-schema: ^4.11.1
     express-serve-static-core: 0.1.1
-    json-schema: ^0.2.5
+    json-schema: 0.4.0
     tslib: 2.4.0
   languageName: node
   linkType: hard
@@ -5305,10 +5305,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-schema@npm:^0.2.5":
-  version: 0.2.5
-  resolution: "json-schema@npm:0.2.5"
-  checksum: 54871525a19997c824d98916fbbef3cb190638c62e5945412785f3c6d90faae7bfff5a1935355a51b979497a7e059a2013eab4a6de144097b9fa80a5be920fb3
+"json-schema@npm:0.4.0":
+  version: 0.4.0
+  resolution: "json-schema@npm:0.4.0"
+  checksum: 66389434c3469e698da0df2e7ac5a3281bcff75e797a5c127db7c5b56270e01ae13d9afa3c03344f76e32e81678337a8c912bdbb75101c62e487dc3778461d72
   languageName: node
   linkType: hard
 

--- a/extensions/runtimes/yarn-berry.lock
+++ b/extensions/runtimes/yarn-berry.lock
@@ -14,7 +14,7 @@ __metadata:
     axios: ^0.21.1
     botframework-schema: ^4.11.1
     express-serve-static-core: 0.1.1
-    json-schema: ^0.2.5
+    json-schema: 0.4.0
     tslib: 2.4.0
   languageName: node
   linkType: hard
@@ -899,10 +899,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-schema@npm:^0.2.5":
-  version: 0.2.5
-  resolution: "json-schema@npm:0.2.5"
-  checksum: 54871525a19997c824d98916fbbef3cb190638c62e5945412785f3c6d90faae7bfff5a1935355a51b979497a7e059a2013eab4a6de144097b9fa80a5be920fb3
+"json-schema@npm:0.4.0":
+  version: 0.4.0
+  resolution: "json-schema@npm:0.4.0"
+  checksum: 66389434c3469e698da0df2e7ac5a3281bcff75e797a5c127db7c5b56270e01ae13d9afa3c03344f76e32e81678337a8c912bdbb75101c62e487dc3778461d72
   languageName: node
   linkType: hard
 

--- a/extensions/sample-ui-plugin/yarn-berry.lock
+++ b/extensions/sample-ui-plugin/yarn-berry.lock
@@ -110,7 +110,7 @@ __metadata:
     axios: ^0.21.1
     botframework-schema: ^4.11.1
     express-serve-static-core: 0.1.1
-    json-schema: ^0.2.5
+    json-schema: 0.4.0
     tslib: 2.4.0
   languageName: node
   linkType: hard
@@ -1542,10 +1542,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-schema@npm:^0.2.5":
-  version: 0.2.5
-  resolution: "json-schema@npm:0.2.5"
-  checksum: 54871525a19997c824d98916fbbef3cb190638c62e5945412785f3c6d90faae7bfff5a1935355a51b979497a7e059a2013eab4a6de144097b9fa80a5be920fb3
+"json-schema@npm:0.4.0":
+  version: 0.4.0
+  resolution: "json-schema@npm:0.4.0"
+  checksum: 66389434c3469e698da0df2e7ac5a3281bcff75e797a5c127db7c5b56270e01ae13d9afa3c03344f76e32e81678337a8c912bdbb75101c62e487dc3778461d72
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #minor

## Description

This compares file changes against branch bruce/yarnuptest7-6e, the branch for PR [chore: Update dependencies for Composer and extensions #9298](https://github.com/microsoft/BotFramework-Composer/pull/9298). This PR assumes #9298 will be merged first, then this PR can be revised to merge to main.

This fixes the 17 security alerts listed in the security analysis component detection log for [this build](https://dev.azure.com/FuseLabs/Composer/_build/results?buildId=312203&view=logs&j=4b2e88cf-7f41-52d9-bc09-6abcb4f006a6&t=4df4959e-2e5c-519a-4a2a-a05a39029822).

[This build shows the alerts fixed](https://dev.azure.com/FuseLabs/Composer/_build/results?buildId=312272&view=results).
