### PR TITLE
fix: version hash display in development builds

### DIFF
--- a/Composer/packages/client/config/env.js
+++ b/Composer/packages/client/config/env.js
@@ -42,7 +42,7 @@ dotenvFiles.forEach((dotenvFile) => {
 
 function getGitSha() {
   try {
-    const sha = execSync('git rev-parse --short', { stdio: ['ignore', 'ignore', 'ignore'] });
+    const sha = execSync('git rev-parse --short HEAD').toString().replace(/\n/, '');
     return sha;
   } catch (e) {
     return 'test';


### PR DESCRIPTION
## Description

The current revision is missing in development environment. The command provided gives the following error on my machine:
```
fatal: Needed a single revision
```
In addition the output is null when `stdio` is set to `"ignore"`.

Accessibility testers now use Composer built from sources for testing on the web. This fix will help them reporting current revision correctly.

## Screenshots
![image](https://user-images.githubusercontent.com/2841858/191378020-5cc11dd9-8f18-416f-a0a2-fc32703d208d.png)

#minor