### PR TITLE
a11y: fix August pass issues

### DIFF
--- a/Composer/packages/adaptive-form/src/components/AddButton.tsx
+++ b/Composer/packages/adaptive-form/src/components/AddButton.tsx
@@ -24,13 +24,20 @@ export const actionButtonStyles: IButtonStyles = {
 
 type Props = {
   disabled?: boolean;
+  ariaLabel?: string;
   onClick: React.MouseEventHandler<unknown>;
 };
 
-export const AddButton = ({ children, onClick, disabled }: React.PropsWithChildren<Props>) => {
+export const AddButton = ({ ariaLabel, children, onClick, disabled }: React.PropsWithChildren<Props>) => {
   return (
     <ButtonContainer>
-      <ActionButton data-testid="add-button" disabled={disabled} styles={actionButtonStyles} onClick={onClick}>
+      <ActionButton
+        ariaLabel={ariaLabel}
+        data-testid="add-button"
+        disabled={disabled}
+        styles={actionButtonStyles}
+        onClick={onClick}
+      >
         {children ?? formatMessage('Add new')}
       </ActionButton>
     </ButtonContainer>

--- a/Composer/packages/adaptive-form/src/components/FieldLabel.tsx
+++ b/Composer/packages/adaptive-form/src/components/FieldLabel.tsx
@@ -121,6 +121,7 @@ const FieldLabel: React.FC<FieldLabelProps> = (props) => {
     >
       <Label
         htmlFor={id}
+        id={`${id}-field-label`}
         required={required}
         styles={{
           root: {

--- a/Composer/packages/adaptive-form/src/components/fields/OpenObjectField/OpenObjectField.tsx
+++ b/Composer/packages/adaptive-form/src/components/fields/OpenObjectField/OpenObjectField.tsx
@@ -4,6 +4,7 @@
 import { jsx } from '@emotion/react';
 import React from 'react';
 import { FieldProps } from '@bfc/extension-client';
+import formatMessage from 'format-message';
 
 import { FieldLabel } from '../../FieldLabel';
 import { getPropertyItemProps, useObjectItems } from '../../../utils/objectUtils';
@@ -51,7 +52,12 @@ const OpenObjectField: React.FC<FieldProps<{
           />
         );
       })}
-      {additionalProperties && <AddButton onClick={onClick} />}
+      {additionalProperties && (
+        <AddButton
+          ariaLabel={label ? formatMessage('Add new value to the {label} field', { label }) : undefined}
+          onClick={onClick}
+        />
+      )}
     </div>
   );
 };

--- a/Composer/packages/client/src/components/CreationFlow/FileSelector.tsx
+++ b/Composer/packages/client/src/components/CreationFlow/FileSelector.tsx
@@ -253,7 +253,7 @@ export const FileSelector: React.FC<FileSelectorProps> = (props) => {
   const renderNameColumn = (file: File, index: number | undefined) => {
     const iconName = getFileIconName(file);
     return (
-      <div data-is-focusable css={tableCell}>
+      <div css={tableCell}>
         {index == selectedIndex && editMode !== EditMode.NONE ? (
           <TextField
             autoFocus
@@ -366,8 +366,8 @@ export const FileSelector: React.FC<FileSelectorProps> = (props) => {
           !focusedStorageFolder.writable ||
           item.type !== FileTypes.FOLDER ||
           index !== selectedIndex ? null : (
-          <div data-is-focusable css={tableCell}>
-            <div css={content} tabIndex={-1}>
+          <div css={tableCell}>
+            <div css={content}>
               <IconButton
                 ariaLabel={formatMessage('Edit')}
                 iconProps={{ iconName: 'Edit' }}

--- a/Composer/packages/client/src/components/MultiLanguage/AddLanguageModal.tsx
+++ b/Composer/packages/client/src/components/MultiLanguage/AddLanguageModal.tsx
@@ -18,6 +18,7 @@ import { DialogWrapper, DialogTypes } from '@bfc/ui-shared';
 import { hiddenContentStyle, mergeStyles } from '@fluentui/react/lib/Styling';
 import { Announced } from '@fluentui/react/lib/Announced';
 import { useId } from '@fluentui/react-hooks';
+import { FocusZoneDirection, FocusZone } from '@fluentui/react/lib/FocusZone';
 
 import { MultiLanguagesDialog } from '../../constants';
 
@@ -166,7 +167,7 @@ const AddLanguageModal: React.FC<IAddLanguageModalProps> = (props) => {
               onChange={onDefaultLanguageChange}
             />
           </StackItem>
-          <StackItem aria-labelledBy={translationsLabelId} grow={0}>
+          <StackItem aria-labelledby={translationsLabelId} grow={0}>
             <div id={translationsLabelId}>
               <div className={screenReaderOnly}>{formatMessage('Bot language translations')}</div>
               <Announced
@@ -196,21 +197,26 @@ const AddLanguageModal: React.FC<IAddLanguageModalProps> = (props) => {
                   { languagesCount: formData.languages.length }
                 )}
               />
+              <div className={screenReaderOnly}>
+                {formatMessage('Press tab then up and down arrow keys to navigate the search results')}
+              </div>
             </div>
             <Label htmlFor={searchBoxId} id={searchBoxLabelId}>
               {MultiLanguagesDialog.ADD_DIALOG.selectionTitle}
             </Label>
             <SearchBox
               disableAnimation
-              aria-labelledBy={searchBoxLabelId}
+              aria-labelledby={searchBoxLabelId}
               id={searchBoxId}
               placeholder={MultiLanguagesDialog.ADD_DIALOG.searchPlaceHolder}
               styles={{ root: { width: 300 } }}
               onChange={onSearch}
             />
-            <ScrollablePane styles={scrollablePaneStyles}>
-              <div role="list">{languageCheckBoxList}</div>
-            </ScrollablePane>
+            <FocusZone direction={FocusZoneDirection.vertical}>
+              <ScrollablePane styles={scrollablePaneStyles}>
+                <div role="list">{languageCheckBoxList}</div>
+              </ScrollablePane>
+            </FocusZone>
           </StackItem>
           <StackItem>
             <Checkbox

--- a/Composer/packages/client/src/components/ProjectTree/ProjectTreeHeader.tsx
+++ b/Composer/packages/client/src/components/ProjectTree/ProjectTreeHeader.tsx
@@ -116,7 +116,7 @@ export const ProjectTreeHeader: React.FC<ProjectTreeHeaderProps> = ({
   const addCommandBtn = (
     <CommandButton
       data-is-focusable
-      ariaLabel={formatMessage('Actions')}
+      ariaLabel={formatMessage('Add actions')}
       className="project-tree-header-more-btn"
       css={buttonStyle}
       data-testid="projectTreeHeaderMoreButton"

--- a/Composer/packages/client/src/components/QnA/CreateQnAFromUrl.tsx
+++ b/Composer/packages/client/src/components/QnA/CreateQnAFromUrl.tsx
@@ -111,11 +111,11 @@ export const CreateQnAFromUrl: React.FC<CreateQnAFromFormProps> = (props) => {
         </p>
       </Stack>
       <Stack maxHeight={400} styles={urlStackStyle}>
-        <Text styles={knowledgeBaseStyle}>{formatMessage('Source URL')}</Text>
         <div key={`add${formData.locales[0]}InCreateQnAFromUrlModal`} css={urlPairStyle}>
           <TextField
             data-testid={`add${formData.locales[0]}InCreateQnAFromUrlModal`}
             errorMessage={formDataErrors.urls[0]}
+            label={formatMessage('Source URL')}
             placeholder={formatMessage('Enter a URL')}
             styles={textFieldUrl}
             value={formData.urls[0]}

--- a/Composer/packages/client/src/components/QnA/EditQnAFromScratchModal.tsx
+++ b/Composer/packages/client/src/components/QnA/EditQnAFromScratchModal.tsx
@@ -73,6 +73,7 @@ export const EditQnAFromScratchModal: React.FC<EditQnAFromScratchModalProps> = (
       <div css={dialogWindow}>
         <Stack>
           <TextField
+            required
             data-testid={`knowledgeLocationTextField-name`}
             errorMessage={formErrors.name}
             label={formatMessage('Knowledge base name')}

--- a/Composer/packages/client/src/components/QnA/EditQnAFromUrlModal.tsx
+++ b/Composer/packages/client/src/components/QnA/EditQnAFromUrlModal.tsx
@@ -84,6 +84,7 @@ export const EditQnAFromUrlModal: React.FC<EditQnAFromUrlModalProps> = (props) =
       <div css={dialogWindow}>
         <Stack>
           <TextField
+            required
             data-testid={`knowledgeLocationTextField-name`}
             errorMessage={formErrors.name}
             label={formatMessage('Knowledge base name')}

--- a/Composer/packages/client/src/components/TriggerCreationModal/TriggerCreationModal.tsx
+++ b/Composer/packages/client/src/components/TriggerCreationModal/TriggerCreationModal.tsx
@@ -9,7 +9,7 @@ import { Dialog, DialogType, DialogFooter } from '@fluentui/react/lib/Dialog';
 import { PrimaryButton, DefaultButton } from '@fluentui/react/lib/Button';
 import { SDKKinds, RegexRecognizer } from '@bfc/shared';
 import { useRecoilValue } from 'recoil';
-import { useTriggerConfig, TriggerUISchema } from '@bfc/extension-client';
+import { useTriggerConfig, TriggerUISchema, useShellApi } from '@bfc/extension-client';
 
 import { TriggerFormData, TriggerFormDataErrors } from '../../utils/dialogUtil';
 import { userSettingsState } from '../../recoilModel/atoms';
@@ -49,6 +49,9 @@ interface TriggerCreationModalProps {
 }
 
 export const TriggerCreationModal: React.FC<TriggerCreationModalProps> = (props) => {
+  const {
+    shellApi: { announce },
+  } = useShellApi();
   const { isOpen, onDismiss, onSubmit, dialogId, projectId } = props;
   const dialogs = useRecoilValue(dialogsSelectorFamily(projectId));
   const triggerUISchema = useTriggerConfig();
@@ -78,6 +81,7 @@ export const TriggerCreationModal: React.FC<TriggerCreationModalProps> = (props)
     }
     onDismiss();
     onSubmit(dialogId, { ...formData, $kind: selectedType, label: resolveSchemaLabel(selectedType, triggerUISchema) });
+    announce(formatMessage(`The trigger {triggerName} has been created`, { triggerName: formData.intent }));
     TelemetryClient.track('AddNewTriggerCompleted', { kind: formData.$kind });
   };
 

--- a/Composer/packages/client/src/pages/botProject/GetAppInfoFromPublishProfileDialog.tsx
+++ b/Composer/packages/client/src/pages/botProject/GetAppInfoFromPublishProfileDialog.tsx
@@ -93,6 +93,7 @@ export const GetAppInfoFromPublishProfileDialog: React.FC<Props> = (props) => {
     >
       <div css={{ height: '100px' }}>
         <Dropdown
+          ariaLabel={formatMessage('Publishing profile')}
           data-testid={'publishProfileDropdown'}
           errorMessage={publishTargetsErrorMessage}
           options={publishTargetOptions}

--- a/Composer/packages/client/src/pages/home/CardWidget.tsx
+++ b/Composer/packages/client/src/pages/home/CardWidget.tsx
@@ -68,7 +68,7 @@ export const CardWidget: React.FC<CardWidgetProps> = ({
   return (
     <div ref={forwardedRef} css={home.cardWrapper} {...rest}>
       <a
-        aria-labelledBy={labelId}
+        aria-labelledby={labelId}
         css={[itemContainerWrapper(disabled), styles.container]}
         href={href}
         target={target}
@@ -93,7 +93,7 @@ export const CardWidget: React.FC<CardWidgetProps> = ({
           <div css={styles.content}>{content}</div>
         </div>
         {moreLinkText && (
-          <Link aria-labelledBy={labelId} css={styles.moreLink} role="link">
+          <Link aria-labelledby={labelId} css={styles.moreLink} role="link">
             {moreLinkText}
           </Link>
         )}

--- a/Composer/packages/lib/code-editor/src/hooks/useEditorToolbarPopExpandItem.tsx
+++ b/Composer/packages/lib/code-editor/src/hooks/useEditorToolbarPopExpandItem.tsx
@@ -47,6 +47,7 @@ export const useEditorToolbarPopExpandItem = (
             key: 'popExpandButton',
             buttonStyles: itemButtonStyles,
             className: options?.customClassName,
+            ariaLabel: formatMessage('Pop out editor: open editor'),
             onRenderIcon: () => {
               let PopExpandIcon = createSvgIcon({ svg: () => popExpandSvgIcon, displayName: 'PopExpandIcon' });
               PopExpandIcon = withTooltip({ content: formatMessage('Pop out editor') }, PopExpandIcon);

--- a/Composer/packages/lib/code-editor/src/hooks/useNoSearchResultMenuItem.tsx
+++ b/Composer/packages/lib/code-editor/src/hooks/useNoSearchResultMenuItem.tsx
@@ -6,6 +6,7 @@ import { IContextualMenuItem } from '@fluentui/react/lib/ContextualMenu';
 import { Icon } from '@fluentui/react/lib/Icon';
 import { Stack } from '@fluentui/react/lib/Stack';
 import { Text } from '@fluentui/react/lib/Text';
+import { Announced } from '@fluentui/react/lib/Announced';
 import * as React from 'react';
 
 const searchEmptyMessageStyles = { root: { height: 32 } };
@@ -29,6 +30,7 @@ export const useNoSearchResultMenuItem = (message?: string): IContextualMenuItem
           verticalAlign="center"
         >
           <Icon iconName="SearchIssue" title={message} />
+          <Announced message={message} role="alert" />
           <Text variant="small">{message}</Text>
         </Stack>
       ),

--- a/Composer/packages/lib/ui-shared/src/components/ProvisionHandoff/ProvisionHandoff.tsx
+++ b/Composer/packages/lib/ui-shared/src/components/ProvisionHandoff/ProvisionHandoff.tsx
@@ -7,6 +7,8 @@ import { DialogFooter } from '@fluentui/react/lib/Dialog';
 import { PrimaryButton } from '@fluentui/react/lib/Button';
 import formatMessage from 'format-message';
 import { Text } from '@fluentui/react/lib/Text';
+import { Label } from '@fluentui/react/lib/Label';
+import { useId } from '@fluentui/react-hooks';
 import { DefaultButton, IconButton } from '@fluentui/react/lib/components/Button';
 import { FontSizes, NeutralColors } from '@fluentui/theme';
 import { useRef } from 'react';
@@ -41,6 +43,8 @@ export const ProvisionHandoff = (props: ProvisionHandoffProps) => {
     }
   };
 
+  const textFieldId = useId('instructions-field-');
+
   return (
     <DialogWrapper
       dialogType={DialogTypes.ProvisionFlow}
@@ -59,7 +63,9 @@ export const ProvisionHandoff = (props: ProvisionHandoffProps) => {
         </div>
       )}
       <div>
-        <Text style={{ fontSize: FontSizes.size14, fontWeight: 600 }}>{formatMessage('Instructions')}</Text>
+        <Label htmlFor={textFieldId} style={{ fontSize: FontSizes.size14, fontWeight: 600 }}>
+          {formatMessage('Instructions')}
+        </Label>
         <IconButton
           ariaLabel={formatMessage('Copy Icon')}
           menuIconProps={{ iconName: 'Copy' }}
@@ -86,6 +92,7 @@ export const ProvisionHandoff = (props: ProvisionHandoffProps) => {
       <TextField
         multiline
         componentRef={textFieldRef}
+        id={textFieldId}
         styles={{
           root: { marginTop: '10px' },
           fieldGroup: { height: '200px', backgroundColor: '#f3f2f1' },

--- a/Composer/packages/server/src/locales/en-US.json
+++ b/Composer/packages/server/src/locales/en-US.json
@@ -179,6 +179,9 @@
   "add_a_skill_host_endpoint_so_your_skills_can_relia_950a7614": {
     "message": "Add a skill host endpoint so your skills can reliably connect to your root bot. <a>Learn more</a>."
   },
+  "add_actions_6c84c880": {
+    "message": "Add actions"
+  },
   "add_allowed_callers_7188d3d4": {
     "message": "Add allowed callers"
   },
@@ -238,6 +241,9 @@
   },
   "add_new_validation_rule_here_eb675ccf": {
     "message": "Add new validation rule here"
+  },
+  "add_new_value_to_the_label_field_6d8cc425": {
+    "message": "Add new value to the { label } field"
   },
   "add_packages_3ab0558c": {
     "message": "Add packages"
@@ -2153,6 +2159,9 @@
   "label_row_index_e1b09205": {
     "message": "{ label }: row { index }"
   },
+  "language_6b3e2c7c": {
+    "message": "Language"
+  },
   "language_generation_1876f6d6": {
     "message": "Language Generation"
   },
@@ -2317,6 +2326,9 @@
   },
   "list_of_attachments_with_their_type_used_by_channe_7ecf0086": {
     "message": "List of attachments with their type. Used by channels to render as UI cards or other generic file attachment types."
+  },
+  "list_of_languages_that_bot_will_be_able_to_underst_6868beff": {
+    "message": "List of languages that bot will be able to understand and respond to"
   },
   "list_of_languages_that_bot_will_be_able_to_underst_c6f62837": {
     "message": "List of languages that bot will be able to understand (User input) and respond to (Bot responses). To make this bot available in other languages, click ‘Manage languages’ to create a copy of the default language, and translate the content into the new language."
@@ -2885,6 +2897,9 @@
   "pop_out_editor_5528a187": {
     "message": "Pop out editor"
   },
+  "pop_out_editor_open_editor_c29c5820": {
+    "message": "Pop out editor: open editor"
+  },
   "power_virtual_agents_bots_cannot_be_run_at_the_mom_a866be28": {
     "message": "Power Virtual Agents bots cannot be run at the moment. Publish the bot to Power Virtual Agents and test it there."
   },
@@ -2902,6 +2917,9 @@
   },
   "press_shift_enter_to_insert_a_new_line_2a5a970f": {
     "message": "Press Shift+Enter to insert a new line"
+  },
+  "press_tab_then_up_and_down_arrow_keys_to_navigate__f09033c0": {
+    "message": "Press tab then up and down arrow keys to navigate the search results"
   },
   "preview_features_e279bac5": {
     "message": "Preview features"
@@ -3955,6 +3973,9 @@
   },
   "the_skill_you_tried_to_remove_from_the_project_is__2c0bd965": {
     "message": "The skill you tried to remove from the project is currently used in the below bot(s). Removing this skill won’t delete the files, but it will cause your Bot to malfunction without additional action."
+  },
+  "the_trigger_triggername_has_been_created_eed0c973": {
+    "message": "The trigger { triggerName } has been created"
   },
   "the_user_input_page_is_where_the_language_understa_c9262f3f": {
     "message": "The User Input page is where the Language Understanding editor locates. From here users can view all the Language Understanding templates and edit them."

--- a/extensions/azurePublish/yarn-berry.lock
+++ b/extensions/azurePublish/yarn-berry.lock
@@ -1879,7 +1879,7 @@ __metadata:
 
 "@bfc/code-editor@file:../../Composer/packages/lib/code-editor::locator=azurePublish%40workspace%3A.":
   version: 0.0.0
-  resolution: "@bfc/code-editor@file:../../Composer/packages/lib/code-editor#../../Composer/packages/lib/code-editor::hash=14c2ca&locator=azurePublish%40workspace%3A."
+  resolution: "@bfc/code-editor@file:../../Composer/packages/lib/code-editor#../../Composer/packages/lib/code-editor::hash=96fbdb&locator=azurePublish%40workspace%3A."
   dependencies:
     "@emotion/react": ^11.1.3
     "@emotion/styled": ^11.1.3
@@ -1902,7 +1902,7 @@ __metadata:
     "@bfc/ui-shared": "*"
     react: 16.13.1
     react-dom: 16.13.1
-  checksum: b81b6db7a4d65ab86ba4ef1b08854672c13310f6b5292b8c361b162f438a8b2aa0a0e5dfde903ef90e223ab89970c2141cc57f7fae1e02dc2d5e17fcbf0e7dd1
+  checksum: cae0fcb331c2a391dc48da25f945a9d9ab3e65ed1151621d3b431c003b9b6f585ab90331c63e82ee06f5f43da7d747d99ebaa071e4bb337d6acdaa49526b600a
   languageName: node
   linkType: hard
 
@@ -1957,7 +1957,7 @@ __metadata:
 
 "@bfc/ui-shared@file:../../Composer/packages/lib/ui-shared::locator=azurePublish%40workspace%3A.":
   version: 0.0.0
-  resolution: "@bfc/ui-shared@file:../../Composer/packages/lib/ui-shared#../../Composer/packages/lib/ui-shared::hash=e5b454&locator=azurePublish%40workspace%3A."
+  resolution: "@bfc/ui-shared@file:../../Composer/packages/lib/ui-shared#../../Composer/packages/lib/ui-shared::hash=ffa00b&locator=azurePublish%40workspace%3A."
   dependencies:
     "@emotion/react": ^11.1.3
     "@emotion/styled": ^11.1.3
@@ -1969,7 +1969,7 @@ __metadata:
     format-message: ^6.2.3
     react: 16.13.1
     react-dom: 16.13.1
-  checksum: 611483129dd4e2958981a63534253aa763125515551f2ee179615dbe1f53091a5afb8547e5b48e5fc31b7a54ce52d022e519b62dfa1eafe2005180c8162bacd2
+  checksum: 349364ab9b42c8f96771b6e2ffcb9c7a3debbbef285bfa86979c1ae1ff33be96a23d77387840f2b3624b440584244f72a6012c4aade9dd8ce91f92b0d56ec98b
   languageName: node
   linkType: hard
 

--- a/extensions/azurePublishNew/yarn-berry.lock
+++ b/extensions/azurePublishNew/yarn-berry.lock
@@ -1952,7 +1952,7 @@ __metadata:
 
 "@bfc/ui-shared@file:../../Composer/packages/lib/ui-shared::locator=azure-publish-new%40workspace%3A.":
   version: 0.0.0
-  resolution: "@bfc/ui-shared@file:../../Composer/packages/lib/ui-shared#../../Composer/packages/lib/ui-shared::hash=e5b454&locator=azure-publish-new%40workspace%3A."
+  resolution: "@bfc/ui-shared@file:../../Composer/packages/lib/ui-shared#../../Composer/packages/lib/ui-shared::hash=ffa00b&locator=azure-publish-new%40workspace%3A."
   dependencies:
     "@emotion/react": ^11.1.3
     "@emotion/styled": ^11.1.3
@@ -1964,7 +1964,7 @@ __metadata:
     format-message: ^6.2.3
     react: 16.13.1
     react-dom: 16.13.1
-  checksum: 611483129dd4e2958981a63534253aa763125515551f2ee179615dbe1f53091a5afb8547e5b48e5fc31b7a54ce52d022e519b62dfa1eafe2005180c8162bacd2
+  checksum: 349364ab9b42c8f96771b6e2ffcb9c7a3debbbef285bfa86979c1ae1ff33be96a23d77387840f2b3624b440584244f72a6012c4aade9dd8ce91f92b0d56ec98b
   languageName: node
   linkType: hard
 

--- a/extensions/packageManager/yarn-berry.lock
+++ b/extensions/packageManager/yarn-berry.lock
@@ -136,7 +136,7 @@ __metadata:
 
 "@bfc/ui-shared@file:../../Composer/packages/lib/ui-shared::locator=package-manager%40workspace%3A.":
   version: 0.0.0
-  resolution: "@bfc/ui-shared@file:../../Composer/packages/lib/ui-shared#../../Composer/packages/lib/ui-shared::hash=e5b454&locator=package-manager%40workspace%3A."
+  resolution: "@bfc/ui-shared@file:../../Composer/packages/lib/ui-shared#../../Composer/packages/lib/ui-shared::hash=ffa00b&locator=package-manager%40workspace%3A."
   dependencies:
     "@emotion/react": ^11.1.3
     "@emotion/styled": ^11.1.3
@@ -148,7 +148,7 @@ __metadata:
     format-message: ^6.2.3
     react: 16.13.1
     react-dom: 16.13.1
-  checksum: 611483129dd4e2958981a63534253aa763125515551f2ee179615dbe1f53091a5afb8547e5b48e5fc31b7a54ce52d022e519b62dfa1eafe2005180c8162bacd2
+  checksum: 349364ab9b42c8f96771b6e2ffcb9c7a3debbbef285bfa86979c1ae1ff33be96a23d77387840f2b3624b440584244f72a6012c4aade9dd8ce91f92b0d56ec98b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

### a11y: add label for Provision modal Instructions field 

Fixes [75910](https://fuselabs.visualstudio.com/Composer/_queries/edit/75910)
 
<details>
<summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/2841858/192022467-7a6e4ead-96f2-4f8b-b2c3-128074c352d2.png)

</details>

### a11y: fix Source URLfield label aria for CreateQnAForm 

Fixes [75891](https://fuselabs.visualstudio.com/Composer/_queries/edit/75891)
 
<details>
<summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/2841858/192024047-5a86ac1d-026d-48fc-8d7e-c311634e4835.png)

</details>

### a11y: mark Knowledge base name required in EditQnAFormModal 

Fixes [75867](https://fuselabs.visualstudio.com/Composer/_queries/edit/75867)

 <details>
<summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/2841858/192043198-5350abd0-5ca1-44a9-b9d5-af7f4a0db2d6.png)

</details>

### a11y: Make bot languages accessible 

Fixes [75868](https://fuselabs.visualstudio.com/Composer/_queries/edit/75868)

List of changes:
- Add list and list-item roles for the Bot Languages list
- Add aria-labels for the list
- Add keyboard navigation support for the list
- Add focus state indication for list-items
- Show list-item action buttons on list item focus

 <details>
<summary>Screenshot</summary>

![529bb1a0-085a-42b9-944e-4c2bcd454c6e](https://user-images.githubusercontent.com/2841858/192027262-ebbf5580-a68f-478d-bb36-ac15ab845ddd.gif)

</details>
 
### a11y: announce trigger creation on TriggerCreationModal submit action 

Fixes [75735](https://fuselabs.visualstudio.com/Composer/_queries/edit/75735)

 <details>
<summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/2841858/192027866-8778dc7d-2b6f-4923-a394-443510d231c6.png)

</details>
 
### a11y: align Add ProjectTreeHeader menu button announcement with visible content

Fixes [75711](https://fuselabs.visualstudio.com/Composer/_queries/edit/75711)

Make title to start with visible content, so the button is announced as `"Add actions menu button, collapsed"`

 <details>
<summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/2841858/192028723-498cc678-3f98-4bcd-abdd-73119a2b50a4.png)

</details>
 
### a11y: remove redundant nested focusable elements from FileSelector table 

Fixes [75696](https://fuselabs.visualstudio.com/Composer/_queries/edit/75696)

Removed hacks were previously needed in Fluent v7 to make the cell contents accessible via keyboard.
 
 <details>
<summary>Screenshot</summary>

![d1cd2850-622d-4aac-abfa-bbc1e79857f7](https://user-images.githubusercontent.com/2841858/192029512-b617a0a0-6ace-4d0e-93c2-955ce9e75990.gif)

</details>

### a11y: add missing aria-label for GetAppInfoFromPublishProfileDialog profile field

Fixes [75812](https://fuselabs.visualstudio.com/Composer/_queries/edit/75812)

 <details>
<summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/2841858/192030263-1c46c958-0cbd-4c67-bb30-ac669aeafe55.png)

</details>

### a11y: rework keyboard navigation for AddLanguageModal 

Fixes [75813](https://fuselabs.visualstudio.com/Composer/_queries/edit/75813)

In addition fixes `aria-labelledby` usage

 <details>
<summary>Screenshot</summary>

![bf93f0ee-6c63-46c5-a73b-6e3f50377c20](https://user-images.githubusercontent.com/2841858/192031219-a38c4436-6f9d-4c7b-bbb5-fe3efb1a6599.gif)

</details>

### a11y: add aria-label for codeeditor open in popup button 

Fixes [75783](https://fuselabs.visualstudio.com/Composer/_queries/edit/75783)

 <details>
<summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/2841858/192031843-34821ebf-7998-43a9-94a1-fd0f94a539bf.png)

</details>

### a11y: announce empty search results in code editor toolbar menus 

Fixes [75831](https://fuselabs.visualstudio.com/Composer/_queries/edit/75831)

 <details>
<summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/2841858/192042245-d20cd274-1aeb-4e74-9e0a-2c3f626ee3a0.png)

</details>

### a11y: make dialog schema labels more descriptive 

Fixes [75846](https://fuselabs.visualstudio.com/Composer/_queries/edit/75846)

 <details>
<summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/2841858/192033027-36e91dec-92a7-452e-b02b-3b645a6e28c5.png)

</details>

### a11y: link intellisense input with label 

Fixes [75853](https://fuselabs.visualstudio.com/Composer/_queries/edit/75853)

 <details>
<summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/2841858/192041838-1cbd4766-8198-40df-bf43-a6a6c82dadfa.png)

</details>

#minor