### PR TITLE
fix: bind composer server to localhost

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Health check
         run: |
           containerId=$(docker run -d -p "5000:5000" botframework-composer)
-          sleep 30
+          sleep 10
           docker logs $containerId
           curl -Is http://localhost:5000 | grep -q "200 OK"
         shell: bash

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Health check
         run: |
           containerId=$(docker run -d -p "5000:5000" botframework-composer)
-          sleep 10
+          sleep 30
           docker logs $containerId
           curl -Is http://localhost:5000 | grep -q "200 OK"
         shell: bash

--- a/Composer/packages/client/src/components/WebChat/WebChatPanel.tsx
+++ b/Composer/packages/client/src/components/WebChat/WebChatPanel.tsx
@@ -22,7 +22,7 @@ import { WebChatHeader } from './WebChatHeader';
 import { WebChatComposer } from './WebChatComposer';
 import { BotSecret, ChatData, RestartOption } from './types';
 
-const BASEPATH = process.env.PUBLIC_URL || 'http://localhost:3000/';
+const BASEPATH = process.env.PUBLIC_URL || `http://${location.hostname}:3000/`;
 // TODO: Refactor to include Webchat header component as a part of WebchatComposer to avoid this variable.
 const webChatHeaderHeight = '85px';
 
@@ -67,7 +67,7 @@ export const WebChatPanel: React.FC<WebChatPanelProps> = ({
       const conversationServerPort = await conversationService.setUpConversationServer();
       try {
         // set up Web Chat traffic listener
-        webChatTrafficChannel.current = new WebSocket(`ws://localhost:${conversationServerPort}/ws/traffic`);
+        webChatTrafficChannel.current = new WebSocket(`ws://${location.hostname}:${conversationServerPort}/ws/traffic`);
         if (webChatTrafficChannel.current) {
           webChatTrafficChannel.current.onmessage = (event) => {
             const data:

--- a/Composer/packages/client/src/components/WebChat/utils/conversationService.ts
+++ b/Composer/packages/client/src/components/WebChat/utils/conversationService.ts
@@ -80,7 +80,7 @@ export class ConversationService {
       secret,
       domain: `${this.directlineHostUrl}/v3/directline`,
       webSocket: true,
-      streamUrl: `ws://localhost:${this.restServerForWSPort}/ws/conversation/${conversationId}`,
+      streamUrl: `ws://${location.hostname}:${this.restServerForWSPort}/ws/conversation/${conversationId}`,
     });
     return directLine;
   }

--- a/Composer/packages/client/src/constants.tsx
+++ b/Composer/packages/client/src/constants.tsx
@@ -527,7 +527,7 @@ export const defaultTeamsManifest: TeamsManifest = {
 };
 
 export const defaultBotPort = 3979;
-export const defaultBotEndpoint = `http://localhost:${defaultBotPort}/api/messages`;
+export const defaultBotEndpoint = `http://${location.hostname}:${defaultBotPort}/api/messages`;
 
 const DAYS_IN_MS = 1000 * 60 * 60 * 24;
 export const SURVEY_PARAMETERS = {

--- a/Composer/packages/electron-server/src/main.ts
+++ b/Composer/packages/electron-server/src/main.ts
@@ -41,13 +41,14 @@ const waitForMainWindowToShow = new Promise((resolve) => {
 
 // webpack dev server runs on :3000
 const getBaseUrl = () => {
+  const host = process.env.COMPOSER_HOSTNAME ?? 'localhost';
   if (isDevelopment) {
-    return 'http://localhost:3000/';
+    return `http://${host}:3000/`;
   }
   if (!serverPort) {
     throw new Error('getBaseUrl() called before serverPort is defined.');
   }
-  return `http://localhost:${serverPort}/`;
+  return `http://${host}:${serverPort}/`;
 };
 
 // set production flag

--- a/Composer/packages/electron-server/src/main.ts
+++ b/Composer/packages/electron-server/src/main.ts
@@ -41,7 +41,7 @@ const waitForMainWindowToShow = new Promise((resolve) => {
 
 // webpack dev server runs on :3000
 const getBaseUrl = () => {
-  const host = process.env.COMPOSER_HOSTNAME ?? 'localhost';
+  const host = process.env.COMPOSER_HOST ?? 'localhost';
   if (isDevelopment) {
     return `http://${host}:3000/`;
   }

--- a/Composer/packages/server/src/controllers/publisher.ts
+++ b/Composer/packages/server/src/controllers/publisher.ts
@@ -15,6 +15,7 @@ import AssetService from '../services/asset';
 import logger from '../logger';
 import { LocationRef } from '../models/bot/interface';
 import { TelemetryService } from '../services/telemetry';
+import { serverHostname } from '../settings/env';
 
 const log = logger.extend('publisher-controller');
 
@@ -318,7 +319,7 @@ export const PublishController = {
       const pluginMethod = ExtensionContext.extensions.publish[extensionName].methods.setupRuntimeLogServer;
       if (typeof pluginMethod === 'function') {
         try {
-          const runtimeLogUrl = await pluginMethod.call(null, projectId);
+          const runtimeLogUrl = await pluginMethod.call(null, projectId, serverHostname);
           return res.status(200).send(runtimeLogUrl);
         } catch (ex) {
           res.status(400).json({

--- a/Composer/packages/server/src/controllers/publisher.ts
+++ b/Composer/packages/server/src/controllers/publisher.ts
@@ -15,7 +15,7 @@ import AssetService from '../services/asset';
 import logger from '../logger';
 import { LocationRef } from '../models/bot/interface';
 import { TelemetryService } from '../services/telemetry';
-import { serverHostname } from '../settings/env';
+import { serverListenHost, serverHostname } from '../settings/env';
 
 const log = logger.extend('publisher-controller');
 
@@ -319,7 +319,7 @@ export const PublishController = {
       const pluginMethod = ExtensionContext.extensions.publish[extensionName].methods.setupRuntimeLogServer;
       if (typeof pluginMethod === 'function') {
         try {
-          const runtimeLogUrl = await pluginMethod.call(null, projectId, serverHostname);
+          const runtimeLogUrl = await pluginMethod.call(null, projectId, serverHostname, serverListenHost);
           return res.status(200).send(runtimeLogUrl);
         } catch (ex) {
           res.status(400).json({

--- a/Composer/packages/server/src/directline/store/dlServerState.ts
+++ b/Composer/packages/server/src/directline/store/dlServerState.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { serverHostname } from '../../settings/env';
+
 import { BotEndpoint } from './entities/botEndpoint';
 import { Attachments } from './entities/attachments';
 import { ConversationSet } from './entities/conversationSet';
@@ -27,7 +29,7 @@ class DLServerContext {
       conversations: new ConversationSet(),
       endpoints: new EndpointSet(),
       attachments: new Attachments(),
-      serviceUrl: serverPort ? `http://localhost:${serverPort}` : '',
+      serviceUrl: serverPort ? `http://${serverHostname}:${serverPort}` : '',
       dispatchers: {
         getDefaultEndpoint: this.getDefaultEndpoint,
         updateConversation: this.updateConversation,

--- a/Composer/packages/server/src/directline/utils/webSocketServer.ts
+++ b/Composer/packages/server/src/directline/utils/webSocketServer.ts
@@ -13,7 +13,7 @@ import {
   ConversationNetworkTrafficItem,
 } from '@botframework-composer/types';
 
-import { serverHostname } from '../../settings/env';
+import { serverListenHost } from '../../settings/env';
 
 import log from './logger';
 
@@ -89,7 +89,7 @@ export class WebSocketServer {
       });
       this.port = port;
       log(`Using ${port} port for directline`);
-      this.restServer.listen(port, serverHostname);
+      this.restServer.listen(port, serverListenHost);
 
       app.use('/ws/conversation/:conversationId', (req: express.Request, res: express.Response) => {
         if (!(req as any).claimUpgrade) {

--- a/Composer/packages/server/src/directline/utils/webSocketServer.ts
+++ b/Composer/packages/server/src/directline/utils/webSocketServer.ts
@@ -13,6 +13,8 @@ import {
   ConversationNetworkTrafficItem,
 } from '@botframework-composer/types';
 
+import { serverHostname } from '../../settings/env';
+
 import log from './logger';
 
 const socketTrafficChannelKey = 'DL_TRAFFIC_SOCKET';
@@ -87,7 +89,7 @@ export class WebSocketServer {
       });
       this.port = port;
       log(`Using ${port} port for directline`);
-      this.restServer.listen(port);
+      this.restServer.listen(port, serverHostname);
 
       app.use('/ws/conversation/:conversationId', (req: express.Request, res: express.Response) => {
         if (!(req as any).claimUpgrade) {

--- a/Composer/packages/server/src/server.ts
+++ b/Composer/packages/server/src/server.ts
@@ -36,6 +36,7 @@ import { mountDirectLineRoutes } from './directline/mountDirectlineRoutes';
 import { mountAttachmentRoutes } from './directline/mountAttachmentRoutes';
 import { cleanHostedBots } from './utility/cleanHostedBots';
 import { getVersion } from './utility/getVersion';
+import { serverHostname } from './settings/env';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const session = require('express-session');
@@ -183,12 +184,14 @@ export async function start(electronContext?: ElectronContext): Promise<number |
   });
 
   let server;
-  await new Promise((resolve) => {
-    server = app.listen(port, () => {
+  await new Promise<void>((resolve) => {
+    server = app.listen(port, serverHostname, () => {
       if (process.env.NODE_ENV === 'production') {
         // We don't use the debug logger here because we always want it to be shown.
         // eslint-disable-next-line no-console
-        console.log(`\n\n${chalk.green('Composer now running at:')}\n\n${chalk.blue(`http://localhost:${port}`)}\n`);
+        console.log(
+          `\n\n${chalk.green('Composer now running at:')}\n\n${chalk.blue(`http://${serverHostname}:${port}`)}\n`
+        );
       }
       resolve();
     });

--- a/Composer/packages/server/src/server.ts
+++ b/Composer/packages/server/src/server.ts
@@ -36,7 +36,7 @@ import { mountDirectLineRoutes } from './directline/mountDirectlineRoutes';
 import { mountAttachmentRoutes } from './directline/mountAttachmentRoutes';
 import { cleanHostedBots } from './utility/cleanHostedBots';
 import { getVersion } from './utility/getVersion';
-import { serverHostname } from './settings/env';
+import { serverListenHost, serverHostname } from './settings/env';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const session = require('express-session');
@@ -185,7 +185,7 @@ export async function start(electronContext?: ElectronContext): Promise<number |
 
   let server;
   await new Promise<void>((resolve) => {
-    server = app.listen(port, serverHostname, () => {
+    server = app.listen(port, serverListenHost, () => {
       if (process.env.NODE_ENV === 'production') {
         // We don't use the debug logger here because we always want it to be shown.
         // eslint-disable-next-line no-console

--- a/Composer/packages/server/src/settings/env.ts
+++ b/Composer/packages/server/src/settings/env.ts
@@ -5,10 +5,12 @@ import childProcess from 'child_process';
 
 import { Path } from '../utility/path';
 
+export const serverHostname = process.env.COMPOSER_HOSTNAME || 'localhost';
+
 export const absHosted = process.env.COMPOSER_AUTH_PROVIDER === 'abs-h';
 export const absHostRoot = process.env.WEBSITE_HOSTNAME
   ? `https://${process.env.WEBSITE_HOSTNAME}`
-  : 'http://localhost:3978';
+  : `http://${serverHostname}:3978`;
 
 let folder = process.env.COMPOSER_BOTS_FOLDER;
 if (folder?.endsWith(':')) {

--- a/Composer/packages/server/src/settings/env.ts
+++ b/Composer/packages/server/src/settings/env.ts
@@ -5,7 +5,8 @@ import childProcess from 'child_process';
 
 import { Path } from '../utility/path';
 
-export const serverHostname = process.env.COMPOSER_HOSTNAME || 'localhost';
+export const serverListenHost = process.env.COMPOSER_HOST || 'localhost';
+export const serverHostname = serverListenHost === '0.0.0.0' || !serverListenHost ? 'localhost' : serverListenHost;
 
 export const absHosted = process.env.COMPOSER_AUTH_PROVIDER === 'abs-h';
 export const absHostRoot = process.env.WEBSITE_HOSTNAME

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN yarn build:prod $YARN_ARGS
 ENV COMPOSER_REMOTE_EXTENSIONS_DIR "/src/remote-extensions"
 ENV COMPOSER_REMOTE_EXTENSION_DATA_DIR "/src/extension-data"
 ENV COMPOSER_EXTENSION_MANIFEST "/src/extensions.json"
+ENV COMPOSER_HOST="0.0.0.0"
 CMD ["yarn","start:server"]
 
 FROM base as composerbasic

--- a/extensions/localPublish/src/index.ts
+++ b/extensions/localPublish/src/index.ts
@@ -243,10 +243,11 @@ class LocalPublisher implements PublishPlugin<PublishConfig> {
     }
   };
 
-  setupRuntimeLogServer = async (projectId: string, serverHostname?: string) => {
+  setupRuntimeLogServer = async (projectId: string, serverHostname?: string, serverListenHost?: string) => {
     await RuntimeLogServer.init({
       log: this.composer.log,
       hostname: serverHostname,
+      boundHost: serverListenHost,
     });
     return RuntimeLogServer.getRuntimeLogStreamingUrl(projectId);
   };

--- a/extensions/localPublish/src/index.ts
+++ b/extensions/localPublish/src/index.ts
@@ -243,9 +243,10 @@ class LocalPublisher implements PublishPlugin<PublishConfig> {
     }
   };
 
-  setupRuntimeLogServer = async (projectId: string) => {
+  setupRuntimeLogServer = async (projectId: string, serverHostname?: string) => {
     await RuntimeLogServer.init({
       log: this.composer.log,
+      hostname: serverHostname,
     });
     return RuntimeLogServer.getRuntimeLogStreamingUrl(projectId);
   };

--- a/extensions/localPublish/src/runtimeLogServer.ts
+++ b/extensions/localPublish/src/runtimeLogServer.ts
@@ -26,9 +26,11 @@ export class RuntimeLogServer {
 
   public static async init({
     log,
+    boundHost = 'localhost',
     hostname = 'localhost',
   }: {
     log: Debugger;
+    boundHost?: string;
     hostname?: string;
   }): Promise<number | void> {
     if (!this.restServer) {
@@ -49,7 +51,7 @@ export class RuntimeLogServer {
         return preferredPort;
       });
       log(`Using ${port} port for runtime-log`);
-      this.restServer.listen(port, hostname);
+      this.restServer.listen(port, boundHost);
 
       app.use('/ws/runtimeLog/:projectId', (req: Request, res: Response) => {
         if (!(req as any).claimUpgrade) {

--- a/extensions/localPublish/src/runtimeLogServer.ts
+++ b/extensions/localPublish/src/runtimeLogServer.ts
@@ -18,12 +18,19 @@ export class RuntimeLogServer {
   private static servers: WSServer = {};
   private static sockets: Record<string, WebSocket> = {};
   private static port: number;
+  private static hostname: string;
 
   public static getRuntimeLogStreamingUrl(projectId: string): string {
-    return `ws://localhost:${this.port}/ws/runtimeLog/${projectId}`;
+    return `ws://${this.hostname}:${this.port}/ws/runtimeLog/${projectId}`;
   }
 
-  public static async init({ log }: { log: Debugger }): Promise<number | void> {
+  public static async init({
+    log,
+    hostname = 'localhost',
+  }: {
+    log: Debugger;
+    hostname?: string;
+  }): Promise<number | void> {
     if (!this.restServer) {
       const app = express();
       this.restServer = http.createServer(app);
@@ -42,7 +49,7 @@ export class RuntimeLogServer {
         return preferredPort;
       });
       log(`Using ${port} port for runtime-log`);
-      this.restServer.listen(port);
+      this.restServer.listen(port, hostname);
 
       app.use('/ws/runtimeLog/:projectId', (req: Request, res: Response) => {
         if (!(req as any).claimUpgrade) {
@@ -74,6 +81,7 @@ export class RuntimeLogServer {
         }
       });
       this.port = port;
+      this.hostname = hostname;
       return this.port;
     }
   }


### PR DESCRIPTION
## Description

Bind composer server to localhost unless the host is specified by `COMPOSER_HOST` environment variable. The variable can be set to `0.0.0.0` to restore previous behavior for server builds only, (isn't supported in Electron currently).

#minor