### PR TITLE
fix: ensure CSRF token is passed through cy.request

### DIFF
--- a/Composer/packages/integration-tests/cypress/integration/LuisDeploy.spec.ts
+++ b/Composer/packages/integration-tests/cypress/integration/LuisDeploy.spec.ts
@@ -36,7 +36,7 @@ context('Luis Deploy', () => {
       response: 'fixture:luPublish/success',
     });
     cy.findByTestId('startBotButton').click();
-    cy.findByText(/^Starting bot../);
+    cy.findAllByText(/^Starting bot../);
     cy.route('GET', '/api/publish/*/status/default', { endpointURL: 'anything', status: 200 });
     cy.route('PUT', '/api/projects/*/files/appsettings.json', { status: 200 });
   });

--- a/Composer/packages/integration-tests/cypress/support/commands.d.ts
+++ b/Composer/packages/integration-tests/cypress/support/commands.d.ts
@@ -6,6 +6,11 @@
 declare namespace Cypress {
   interface Chainable {
     /**
+     * Get CSRF token
+     * @example cy.getCSRFToken().then(token => ...)
+     */
+    getCSRFToken(): Chainable<string>;
+    /**
      * Creates a bot based on empty bot.
      * @example cy.createBot('EmptySample', ()=> {})
      */

--- a/Composer/packages/integration-tests/cypress/support/commands.ts
+++ b/Composer/packages/integration-tests/cypress/support/commands.ts
@@ -17,6 +17,7 @@ Cypress.Commands.add('getCSRFToken', () => {
     .its('__csrf__')
     .then((csrf) => {
       csrfToken = csrf;
+      return csrf;
     });
 });
 

--- a/Composer/packages/integration-tests/cypress/support/commands.ts
+++ b/Composer/packages/integration-tests/cypress/support/commands.ts
@@ -5,6 +5,48 @@ import '@testing-library/cypress/add-commands';
 
 let TemplateBotProjectId = '';
 
+let csrfToken: string;
+
+Cypress.Commands.add('getCSRFToken', () => {
+  if (csrfToken) {
+    return cy.wrap(csrfToken);
+  }
+  cy.visit('/');
+  return cy
+    .window()
+    .its('__csrf__')
+    .then((csrf) => {
+      csrfToken = csrf;
+    });
+});
+
+Cypress.Commands.overwrite('request', (originalFn, ...options) => {
+  return cy.getCSRFToken().then((csrf) => {
+    const headers = {
+      'X-CSRF-Token': csrf,
+    };
+
+    const optionsObject = options[0];
+
+    if (optionsObject === Object(optionsObject)) {
+      optionsObject.headers = {
+        ...headers,
+        ...optionsObject.headers,
+      };
+
+      return originalFn(optionsObject);
+    }
+
+    const [method, url, body] = options;
+    return originalFn({
+      method,
+      url,
+      body,
+      headers,
+    });
+  });
+});
+
 Cypress.Commands.add('createBot', (botName: string, callback?: (bot: any) => void) => {
   const params = {
     description: '',
@@ -60,6 +102,7 @@ Cypress.Commands.add('createTestBot', (botName: string, callback?: (bot: any) =>
     storageId: 'default',
   };
 
+  cy.wrap(TemplateBotProjectId).should('not.be.empty');
   cy.request('post', `/api/projects/${TemplateBotProjectId}/project/saveAs`, params).then((res) => {
     callback?.(res.body);
   });

--- a/Composer/packages/integration-tests/cypress/support/index.ts
+++ b/Composer/packages/integration-tests/cypress/support/index.ts
@@ -5,7 +5,8 @@ import './commands';
 
 before(() => {
   cy.exec('yarn clean-all');
-  cy.createTemplateBot('EmptySample');
+  cy.getCSRFToken();
+  cy.createTemplateBot('EmptySample2');
 });
 
 beforeEach(() => {

--- a/Composer/packages/integration-tests/cypress/support/index.ts
+++ b/Composer/packages/integration-tests/cypress/support/index.ts
@@ -6,7 +6,7 @@ import './commands';
 before(() => {
   cy.exec('yarn clean-all');
   cy.getCSRFToken();
-  cy.createTemplateBot('EmptySample2');
+  cy.createTemplateBot('EmptySample');
 });
 
 beforeEach(() => {


### PR DESCRIPTION
## Description

This fixes end-to-end tests for Composer and ensures `cy.request(...)` has CSRF token set.

#minor 
