### PR TITLE
build: add typechecking to extension build script

### DIFF
--- a/extensions/package.json
+++ b/extensions/package.json
@@ -39,5 +39,8 @@
     "prettier": "2.0.5",
     "typescript": "^4.0.5",
     "validate-npm-package-name": "4.0.0"
+  },
+  "devDependencies": {
+    "cross-env": "7.0.3"
   }
 }

--- a/extensions/scripts/build.js
+++ b/extensions/scripts/build.js
@@ -22,7 +22,7 @@ function typecheck(extPath) {
       // eslint-disable-next-line security/detect-non-literal-fs-filename
       const configFile = ts.readJsonConfigFile(tsConfigPath, ts.sys.readFile);
 
-      const { fileNames, options } = ts.parseJsonSourceFileConfigFileContent(configFile, ts.sys, './');
+      const { fileNames, options } = ts.parseJsonSourceFileConfigFileContent(configFile, ts.sys, extPath);
 
       const program = ts.createProgram(fileNames, { ...options, noEmit: true });
       const emitResult = program.emit();

--- a/extensions/scripts/build.js
+++ b/extensions/scripts/build.js
@@ -18,7 +18,6 @@ function typecheck(extPath) {
   const tsConfigPath = ts.findConfigFile(extPath, ts.sys.fileExists, 'tsconfig.json');
 
   if (tsConfigPath) {
-    console.log('found config:', tsConfigPath);
     // eslint-disable-next-line security/detect-non-literal-fs-filename
     const configFile = ts.readJsonConfigFile(tsConfigPath, ts.sys.readFile);
 

--- a/extensions/yarn-berry.lock
+++ b/extensions/yarn-berry.lock
@@ -534,6 +534,7 @@ __metadata:
     "@types/fs-extra": 9.0.13
     "@typescript-eslint/eslint-plugin": 2.34.0
     "@typescript-eslint/parser": 2.34.0
+    cross-env: 7.0.3
     esbuild: ^0.8.44
     esbuild-plugin-globals: 0.1.1
     eslint: 7.0.0
@@ -580,7 +581,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.2":
+"cross-env@npm:7.0.3":
+  version: 7.0.3
+  resolution: "cross-env@npm:7.0.3"
+  dependencies:
+    cross-spawn: ^7.0.1
+  bin:
+    cross-env: src/bin/cross-env.js
+    cross-env-shell: src/bin/cross-env-shell.js
+  checksum: 26f2f3ea2ab32617f57effb70d329c2070d2f5630adc800985d8b30b56e8bf7f5f439dd3a0358b79cee6f930afc23cf8e23515f17ccfb30092c6b62c6b630a79
+  languageName: node
+  linkType: hard
+
+"cross-spawn@npm:^7.0.1, cross-spawn@npm:^7.0.2":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
   dependencies:


### PR DESCRIPTION
## Description

Adds a typechecking step when building extensions to guard against type changes during package upgrades, etc.

## Task Item

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->
#minor

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
