### PR TITLE
fix: [#9492] Fix WebChat createGetAttachmentHandler image file serving

### DIFF
--- a/Composer/packages/server/src/directline/middleware/__tests__/attachmentHandler.test.ts
+++ b/Composer/packages/server/src/directline/middleware/__tests__/attachmentHandler.test.ts
@@ -20,9 +20,14 @@ const mockSend = jest.fn(() => ({
   end: mockEnd,
 }));
 
+const mockType = jest.fn(() => ({
+  send: mockSend,
+}));
+
 const mockStatus = jest.fn(() => ({
   json: mockJsonResponse,
   send: mockSend,
+  type: mockType,
 }));
 
 describe('getAttachment handler', () => {
@@ -54,12 +59,15 @@ describe('getAttachment handler', () => {
       end: jest.fn(),
       send: jest.fn(),
       type: jest.fn(),
+      status: mockStatus,
       json: mockJsonResponse,
     };
 
     getAttachmentHandler(req, res);
 
-    expect(res.send).toHaveBeenCalledWith(StatusCodes.OK, Buffer.from(mockAttachmentData));
+    expect(res.status).toHaveBeenCalledWith(StatusCodes.OK);
+    expect(res.status().type).toHaveBeenCalledWith('text/plain');
+    expect(res.status().type().send).toHaveBeenCalledWith(Buffer.from(mockAttachmentData));
   });
 
   it('should return the attachment content uploaded via the bot', () => {
@@ -80,12 +88,14 @@ describe('getAttachment handler', () => {
       end: jest.fn(),
       type: jest.fn(),
       send: jest.fn(),
-      status: jest.fn(),
+      status: mockStatus,
     };
 
     getAttachmentHandler(req, res);
 
-    expect(res.send).toHaveBeenCalledWith(StatusCodes.OK, Buffer.from(mockAttachmentData.toString(), 'base64'));
+    expect(res.status).toHaveBeenCalledWith(StatusCodes.OK);
+    expect(res.status().type).toHaveBeenCalledWith('text/plain');
+    expect(res.status().type().send).toHaveBeenCalledWith(Buffer.from(mockAttachmentData.toString(), 'base64'));
   });
 
   it('should send an error message if the original view is requested, but missing', () => {

--- a/Composer/packages/server/src/directline/middleware/attachmentHandler.ts
+++ b/Composer/packages/server/src/directline/middleware/attachmentHandler.ts
@@ -76,8 +76,7 @@ export function createGetAttachmentHandler(state: DLServerState) {
               buffer = Buffer.from(attachmentBase64.toString(), 'base64');
             }
 
-            res.type(attachment.type);
-            res.send(StatusCodes.OK, buffer);
+            res.status(StatusCodes.OK).type(attachment.type).send(buffer);
           } else {
             handleDirectLineErrors(req, res, {
               status: StatusCodes.NOT_FOUND,

--- a/Composer/packages/server/src/middleware/logNetworkTraffic.ts
+++ b/Composer/packages/server/src/middleware/logNetworkTraffic.ts
@@ -18,9 +18,11 @@ export function logNetworkTraffic(req: Request, res: Response, next?: NextFuncti
   // when the request finishes, log the payload and status code to the client
   res.once('finish', () => {
     let data: ConversationNetworkErrorItem | ConversationNetworkTrafficItem | undefined;
+    let payload = (res as any).sentData;
+    payload = typeof payload === 'string' ? JSON.parse(payload || '{}') : payload;
     if (res.statusCode >= 400) {
       // an error was sent to the client
-      const { error = {} } = JSON.parse((res as any).sentData || '{}');
+      const { error = {} } = payload;
       data = {
         error: {
           details: error.details,
@@ -29,7 +31,7 @@ export function logNetworkTraffic(req: Request, res: Response, next?: NextFuncti
         id: uuid(),
         request: { method: req.method, payload: req.body, route: req.originalUrl },
         response: {
-          payload: JSON.parse((res as any).sentData || '{}'),
+          payload,
           statusCode: res.statusCode,
         },
         timestamp: Date.now(),
@@ -41,7 +43,7 @@ export function logNetworkTraffic(req: Request, res: Response, next?: NextFuncti
         id: uuid(),
         request: { method: req.method, payload: req.body, route: req.originalUrl },
         response: {
-          payload: JSON.parse((res as any).sentData || '{}'),
+          payload,
           statusCode: res.statusCode,
         },
         timestamp: Date.now(),


### PR DESCRIPTION
## Description

This PR fixes an issue when uploading an image file from Composer's WebChat and then accessing it through the `/v3/attachments/<attachment id>/views/original` endpoint failed on displaying it (saying `it cannot be displayed because it contains errors`).

**Detailed changes**
- Send only one value through the `Response.send` function.
- Support other data types than just JSON strings in the `logNetworkTraffic` file.

## Task Item

Fixes #9492

## Screenshots
The following image shows both Emulator and WebChat working as expected.
![image](https://user-images.githubusercontent.com/62260472/215194733-8301cca6-87ca-4224-8b95-b920abfe53ea.png)