### PR TITLE
fix: package manager visual regressions

### DIFF
--- a/extensions/packageManager/src/components/LibraryList.tsx
+++ b/extensions/packageManager/src/components/LibraryList.tsx
@@ -166,6 +166,7 @@ export const LibraryList: React.FC<ILibraryListProps> = (props) => {
           selection={selection}
           selectionMode={SelectionMode.single}
           setKey="none"
+          onShouldVirtualize={() => false}
         />
       </div>
     </div>

--- a/extensions/packageManager/src/components/styles.ts
+++ b/extensions/packageManager/src/components/styles.ts
@@ -8,7 +8,13 @@ export const packageScrollContainerStyle = {
   root: { borderTop: '1px solid #CCC', height: 'calc(100% - 150px)' },
 };
 
-export const tabAndSearchBarStyles = { root: { paddingLeft: '12px', paddingRight: '20px', height: '48px' } };
+export const tabAndSearchBarStyles = {
+  root: {
+    paddingLeft: '12px',
+    paddingRight: '20px',
+    height: '48px',
+  },
+};
 
 export const ContentHeaderStyle = css`
   padding: 5px 20px;

--- a/extensions/packageManager/src/pages/Library.tsx
+++ b/extensions/packageManager/src/pages/Library.tsx
@@ -80,8 +80,11 @@ const InstallButtonVersion = styled.span`
 `;
 
 const tabsStackStyle = css`
-  min-width: 512px;
-  overflow: auto;
+  overflow: hidden auto;
+  max-height: 100%;
+  flex: auto;
+  display: flex;
+  flex-flow: column nowrap;
 `;
 
 const fieldStyles = {
@@ -655,7 +658,7 @@ const Library: React.FC = () => {
             />
           </Stack.Item>
         )}
-        <Stack.Item align="stretch" styles={{ root: { flexGrow: 1, overflowX: 'hidden', maxHeight: '100%' } }}>
+        <Stack.Item align="stretch" css={tabsStackStyle}>
           {!ejectedRuntime && (
             <MessageBar
               actions={
@@ -681,8 +684,8 @@ const Library: React.FC = () => {
                 <PivotItem headerText={strings.installHeader} itemKey={TABS.INSTALL} />
               </Pivot>
             </Stack.Item>
-            <Stack.Item align="end" grow={1}>
-              <Stack horizontal css={tabsStackStyle} horizontalAlign="center" tokens={{ childrenGap: 10 }}>
+            <Stack.Item align="center" grow={1}>
+              <Stack horizontal grow={1} horizontalAlign="end" tokens={{ childrenGap: 10 }} verticalAlign="center">
                 <Stack.Item>
                   <Dropdown
                     ariaLabel={formatMessage('Feeds')}


### PR DESCRIPTION
## Description

Found a couple of regressions while testing Composer in package manager:
- The search item wasn't placed properly in command bar
- Virtual scrolling broke for packages list

## Screenshots
![Screenshot from 2023-02-03 13-29-41](https://user-images.githubusercontent.com/2841858/216715060-2ff8538f-fd83-460a-a2db-c55ad5a5584f.png)

![Screenshot from 2023-02-03 13-30-36](https://user-images.githubusercontent.com/2841858/216715047-b97cd239-16cf-452e-aae3-b3c8a5a3bab9.png)

#minor