### PR TITLE
fix: [#8576] Field loses focus after keystroke

### DIFF
--- a/Composer/packages/adaptive-flow/src/adaptive-flow-editor/renderers/NodeWrapper.tsx
+++ b/Composer/packages/adaptive-flow/src/adaptive-flow-editor/renderers/NodeWrapper.tsx
@@ -67,8 +67,8 @@ export const ActionNodeWrapper = ({ id, tab, data, onEvent, hideComment, childre
   const { focusedId, focusedEvent, focusedTab } = useContext(NodeRendererContext);
   const { selectedIds, getNodeIndex } = useContext(SelectionContext);
   const nodeFocused = focusedId === id || focusedEvent === id;
-  const nodeDoubleSelected = tab && nodeFocused && tab === focusedTab;
   const nodeSelected = selectedIds.includes(id);
+  const nodeDoubleSelected = tab && nodeFocused && tab === focusedTab && nodeSelected;
   const nodeId = `action-${selectableId}`;
 
   const declareElementAttributes = (selectedId: string, id: string) => {


### PR DESCRIPTION
## Description

This PR fixes the issue with the lost focus on the Prompt action's text fields after the first keystroke.
The **_NodeWrapper_** component has a condition that evaluates the selected nodes, and tabs to decide if the _focus()_ function should be called. In the re-render of the component, this condition was evaluated as true when it shouldn't, causing an unnecessary re-focus.
We updated the flags used in this condition to call the _focus()_ function only when the tab and the node are selected.

## Task Item
Fixes #8576

## Screenshots
Here we can see the focus working as expected in the Prompt action after the changes.
![image](https://user-images.githubusercontent.com/44245136/218174898-5ca8a917-11e1-4078-9f47-78377080daa4.png)
