### PR TITLE
fix: rework app exit to account for running bots

### DIFF
--- a/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
@@ -103,7 +103,7 @@ import { getPublishProfileFromPayload } from '../../../utils/electronUtil';
 import { crossTrainConfigState, projectIndexingState } from './../../atoms/botState';
 import { recognizersSelectorFamily } from './../../selectors/recognizers';
 
-export const resetBotStates = async ({ reset }: CallbackInterface, projectId: string) => {
+export const resetBotStates = ({ reset }: CallbackInterface, projectId: string) => {
   const botStates = Object.keys(botstates);
   botStates.forEach((state) => {
     const currentRecoilAtom: any = botstates[state];
@@ -137,13 +137,13 @@ export const flushExistingTasks = async (callbackHelpers: CallbackInterface) => 
   reset(botProjectSpaceLoadedState);
   reset(botProjectIdsState);
 
-  for (const projectId of projectIds) {
-    botRuntimeOperations?.stopBot(projectId);
+  const result = projectIds.map(async (projectId) => {
+    await botRuntimeOperations?.stopBot(projectId);
     resetBotStates(callbackHelpers, projectId);
-  }
+  });
 
   const workers = [lgWorker, luWorker, qnaWorker];
-  return Promise.all([workers.map((w) => w.flush())]);
+  return Promise.all([result, workers.map((w) => w.flush())]);
 };
 
 // merge sensitive values in localStorage

--- a/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
@@ -142,8 +142,10 @@ export const flushExistingTasks = async (callbackHelpers: CallbackInterface) => 
     resetBotStates(callbackHelpers, projectId);
   });
 
-  const workers = [lgWorker, luWorker, qnaWorker];
-  return Promise.all([result, workers.map((w) => w.flush())]);
+  const workers = [lgWorker, luWorker, qnaWorker].map(async (worker) => {
+    await worker.flush();
+  });
+  await Promise.all([...result, ...workers]);
 };
 
 // merge sensitive values in localStorage

--- a/Composer/packages/electron-server/src/main.ts
+++ b/Composer/packages/electron-server/src/main.ts
@@ -334,6 +334,23 @@ async function run() {
     if (process.env.COMPOSER_DEV_TOOLS) {
       mainWindow?.webContents.openDevTools();
     }
+
+    let mainWindowClosed = false;
+    mainWindow?.on('close', (event) => {
+      if (mainWindowClosed) {
+        return;
+      }
+
+      event.preventDefault();
+
+      ipcMain.on('closed', () => {
+        mainWindowClosed = true;
+        mainWindow.close();
+      });
+
+      mainWindow.webContents.send('session-update', 'session-ended');
+      mainWindow.webContents.send('closing');
+    });
   });
 
   app.on('activate', () => {

--- a/Composer/packages/electron-server/src/main.ts
+++ b/Composer/packages/electron-server/src/main.ts
@@ -310,11 +310,13 @@ async function run() {
       }
 
     mainWindow.on('close', (event) => {
-      event.preventDefault();
+      // when the window is not visible, it means that window.close
+      // has been called by the handler, so it is time to proceed
       if (!mainWindow?.isVisible) {
         return;
       }
 
+      event.preventDefault();
       mainWindow.hide();
 
       // Give 30 seconds to close app gracefully, then proceed

--- a/Composer/packages/electron-server/src/main.ts
+++ b/Composer/packages/electron-server/src/main.ts
@@ -374,11 +374,11 @@ async function run() {
     await initApp();
   });
 
-  app.on('activate', () => {
+  app.on('activate', async () => {
     // On OS X it's common to re-create a window in the app when the
     // dock icon is clicked and there are no other windows open.
     if (!ElectronWindow.isBrowserWindowCreated) {
-      main(true);
+      await main(true);
       initApp();
     }
   });

--- a/Composer/packages/electron-server/src/main.ts
+++ b/Composer/packages/electron-server/src/main.ts
@@ -294,14 +294,22 @@ async function run() {
     }
 
     let mainWindowClosed = false;
+    let mainWindowClosing = false;
     mainWindow?.on('close', (event) => {
+      // hide window on the second attempt to close to not bother user with teardown screen
+      if (mainWindowClosing) {
+        mainWindow.hide();
+        return;
+      }
       if (mainWindowClosed) {
         return;
       }
 
       event.preventDefault();
+      mainWindowClosing = true;
 
       ipcMain.once('closed', () => {
+        mainWindowClosing = false;
         mainWindowClosed = true;
         mainWindow.close();
         quitApp();

--- a/Composer/packages/electron-server/src/main.ts
+++ b/Composer/packages/electron-server/src/main.ts
@@ -295,6 +295,7 @@ async function run() {
       ]).then(() => {
         mainWindow?.close();
         mainWindow = undefined;
+        ElectronWindow.destroy();
 
         // preserve app icon in the dock on MacOS
         if (isMac()) return;

--- a/Composer/packages/lib/code-editor/src/components/toolbar/__tests__/ToolbarButtonMenu.test.tsx
+++ b/Composer/packages/lib/code-editor/src/components/toolbar/__tests__/ToolbarButtonMenu.test.tsx
@@ -117,7 +117,7 @@ describe('<ToolbarButtonMenu />', () => {
       jest.runAllTimers();
     });
 
-    expect((await screen.findAllByText(/this/)).length).toBe(3);
+    expect((await screen.findAllByText(/this\.\w/)).length).toBe(2);
   });
 
   it('property: Should expand property in the menu on click if not leaf', async () => {

--- a/extensions/azurePublish/yarn-berry.lock
+++ b/extensions/azurePublish/yarn-berry.lock
@@ -1852,7 +1852,7 @@ __metadata:
 
 "@bfc/code-editor@file:../../Composer/packages/lib/code-editor::locator=azurePublish%40workspace%3A.":
   version: 0.0.0
-  resolution: "@bfc/code-editor@file:../../Composer/packages/lib/code-editor#../../Composer/packages/lib/code-editor::hash=85aa6e&locator=azurePublish%40workspace%3A."
+  resolution: "@bfc/code-editor@file:../../Composer/packages/lib/code-editor#../../Composer/packages/lib/code-editor::hash=370616&locator=azurePublish%40workspace%3A."
   dependencies:
     "@emotion/react": ^11.1.3
     "@emotion/styled": ^11.1.3
@@ -1875,7 +1875,7 @@ __metadata:
     "@bfc/ui-shared": "*"
     react: 16.13.1
     react-dom: 16.13.1
-  checksum: 29f5412bdf1777648742441cb612fd4809132e7a1fe595e18f9f7911e167a66e53022254ababf281168d0b48d27d6c1ec7209e29d280633fe80189538aec9606
+  checksum: 0641044374678271252eb2b5e6707068cae2a8ed9359ebf03d28a0075ff146c80321018c9725f17cdd3d16caed6cb890fede89cc98aa54a9fadd8bf6e4ccff11
   languageName: node
   linkType: hard
 

--- a/extensions/localPublish/src/index.ts
+++ b/extensions/localPublish/src/index.ts
@@ -459,7 +459,7 @@ class LocalPublisher implements PublishPlugin<PublishConfig> {
       // Kill the bot process AND all child processes
       try {
         if (isWin) {
-          spawn(`taskkill /pid ${bot.process.pid} /T /F`);
+          spawn(`taskkill /pid ${bot.process.pid} /T /F`, { shell: true });
         } else {
           process.kill(-bot.process.pid);
         }

--- a/extensions/localPublish/src/index.ts
+++ b/extensions/localPublish/src/index.ts
@@ -458,7 +458,11 @@ class LocalPublisher implements PublishPlugin<PublishConfig> {
       const bot = LocalPublisher.runningBots[botId];
       // Kill the bot process AND all child processes
       try {
-        process.kill(isWin ? bot.process.pid : -bot.process.pid);
+        if (isWin) {
+          spawn(`taskkill /pid ${bot.process.pid} /T /F`);
+        } else {
+          process.kill(-bot.process.pid);
+        }
       } catch (err) {
         // swallow this error which happens if the child process is already gone
       }

--- a/extensions/localPublish/src/index.ts
+++ b/extensions/localPublish/src/index.ts
@@ -486,3 +486,5 @@ const cleanup = () => {
 (['SIGINT', 'SIGTERM', 'SIGQUIT'] as NodeJS.Signals[]).forEach((signal: NodeJS.Signals) => {
   process.on(signal, cleanup.bind(null, signal));
 });
+
+process.on('beforeExit', cleanup);


### PR DESCRIPTION
## Description

This reworks exit flow:
- Added exit indication and fixed client exit cycle (by @sw-joelmut)
- Reworked server exit functionality to account for platform specifics and enforce proper exit (by @OEvgeny)

## Task Item

fixes #9059 

## Screenshot
![](https://user-images.githubusercontent.com/62260472/225022460-38ef265d-ae58-43d6-92fe-8c7ef42db768.png)