### PR TITLE
fix: [#9059] Bot remains as a background process after closing Composer

### DIFF
--- a/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/utils/project.ts
@@ -103,7 +103,7 @@ import { getPublishProfileFromPayload } from '../../../utils/electronUtil';
 import { crossTrainConfigState, projectIndexingState } from './../../atoms/botState';
 import { recognizersSelectorFamily } from './../../selectors/recognizers';
 
-export const resetBotStates = async ({ reset }: CallbackInterface, projectId: string) => {
+export const resetBotStates = ({ reset }: CallbackInterface, projectId: string) => {
   const botStates = Object.keys(botstates);
   botStates.forEach((state) => {
     const currentRecoilAtom: any = botstates[state];
@@ -137,13 +137,13 @@ export const flushExistingTasks = async (callbackHelpers: CallbackInterface) => 
   reset(botProjectSpaceLoadedState);
   reset(botProjectIdsState);
 
-  for (const projectId of projectIds) {
-    botRuntimeOperations?.stopBot(projectId);
+  const result = projectIds.map(async (projectId) => {
+    await botRuntimeOperations?.stopBot(projectId);
     resetBotStates(callbackHelpers, projectId);
-  }
+  });
 
   const workers = [lgWorker, luWorker, qnaWorker];
-  return Promise.all([workers.map((w) => w.flush())]);
+  return Promise.all([result, workers.map((w) => w.flush())]);
 };
 
 // merge sensitive values in localStorage


### PR DESCRIPTION
## Description
This PR fixes an issue where Composer didn't terminate bots' processes properly, leaving them running in the background after closing Composer.

## Task Item

Fixes #9059

## Screenshots
The following image shows the bot running and the new message shown when cleaning up the processes.
![image](https://user-images.githubusercontent.com/62260472/225022460-38ef265d-ae58-43d6-92fe-8c7ef42db768.png)
