### PR TITLE
fix: [#9543] Composer does not recognize valid bearer token

### DIFF
--- a/Composer/packages/server/src/directline/middleware/__tests__/createBotFrameworkAuthentication.test.ts
+++ b/Composer/packages/server/src/directline/middleware/__tests__/createBotFrameworkAuthentication.test.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import * as jwt from 'jsonwebtoken';
+import { decode } from 'jsonwebtoken';
 
 import {
   usGovernmentAuthentication,
@@ -36,9 +37,9 @@ describe('botFrameworkAuthenticationMiddleware', () => {
     mockNext.mockClear();
     mockEnd.mockClear();
     mockStatus.mockClear();
-    (jwt.decode as jest.Mock).mockClear();
+    (decode as jest.Mock).mockClear();
     (jwt.verify as jest.Mock).mockClear();
-    (jwt.decode as jest.Mock).mockImplementation(() => ({
+    (decode as jest.Mock).mockImplementation(() => ({
       header: {
         kid: 'someKeyId',
       },

--- a/Composer/packages/server/src/directline/middleware/createBotFrameworkAuthentication.ts
+++ b/Composer/packages/server/src/directline/middleware/createBotFrameworkAuthentication.ts
@@ -3,6 +3,7 @@
 
 import * as jwt from 'jsonwebtoken';
 import * as express from 'express';
+import { decode } from 'jsonwebtoken';
 import { StatusCodes } from 'http-status-codes';
 
 import { authentication, usGovernmentAuthentication, v31Authentication, v32Authentication } from '../utils/constants';
@@ -21,7 +22,7 @@ export const createBotFrameworkAuthenticationMiddleware = () => {
     }
 
     const [authMethod, token] = authorization.trim().split(' ');
-    const decoded: any = /^bearer$/i.test(authMethod) && token && jwt.decode(token, { complete: true });
+    const decoded: any = /^bearer$/i.test(authMethod) && token && decode(token, { complete: true });
 
     if (!decoded) {
       res.status(StatusCodes.UNAUTHORIZED).end();


### PR DESCRIPTION
## Description

This PR fixes the `jwt.decode is not a function` error thrown after upgrading [jsonwebtoken](https://www.npmjs.com/package/jsonwebtoken) dependency to version 9.
The reason for the failure was that, in version 9 of jsonwebtoken the decode method is enumerable and the import used in Composer only worked for non-enumerable properties.
We added an individual import for the _decode_ property and that solved the issue.

## Task Item
Fixes #9543

## Screenshots
Here we can see a composer bot working in WebChat after the changes.
![image](https://user-images.githubusercontent.com/44245136/228288105-45e7d6dc-e0b2-42e6-8471-69a7224e1d1e.png)
