### PR TITLE
fix: yarn hashes for local pacakges dont match

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -326,6 +326,7 @@ logs
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+**/.swc
 
 # Runtime data
 pids

--- a/Composer/packages/adaptive-flow/package.json
+++ b/Composer/packages/adaptive-flow/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "yarn clean && yarn build:ts",
     "build:ts": "tsc --build tsconfig.build.json",
-    "clean": "rimraf lib demo/dist",
+    "clean": "rimraf lib demo/dist .swc",
     "prepublishOnly": "npm run build",
     "start": "webpack-dev-server --config demo/webpack.config.demo.js --port 3002",
     "test": "jest --no-cache",

--- a/Composer/packages/adaptive-form/package.json
+++ b/Composer/packages/adaptive-form/package.json
@@ -11,7 +11,7 @@
     "start": "tsc --watch --preserveWatchOutput",
     "build": "yarn clean && yarn build:ts",
     "build:ts": "tsc --build ./tsconfig.build.json",
-    "clean": "rimraf lib demo/dist",
+    "clean": "rimraf lib demo/dist .swc",
     "lint": "eslint --quiet src",
     "lint:fix": "yarn lint --fix",
     "prepare": "yarn build"

--- a/Composer/packages/client/package.json
+++ b/Composer/packages/client/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start": "node --max_old_space_size=6114 --max-http-header-size=16000 scripts/start.js",
     "build": "node --max_old_space_size=6114 scripts/build.js",
-    "clean": "rimraf build",
+    "clean": "rimraf build .swc",
     "test": "jest",
     "lint": "eslint --quiet --ext .js,.jsx,.ts,.tsx ./src ./__tests__",
     "lint:fix": "yarn lint --fix",

--- a/Composer/packages/electron-server/package.json
+++ b/Composer/packages/electron-server/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "build": "tsc -b tsconfig.build.json && ncp src/preload.js build/preload.js",
-    "clean": "rimraf build && rimraf dist && rimraf l10ntemp",
+    "clean": "rimraf build dist l10ntemp .swc",
     "copy-artifacts": "node scripts/copy-artifacts.js",
     "dist": "node scripts/electronBuilderDist.js",
     "dist:full": "yarn clean && yarn build && yarn run pack && yarn copy-artifacts && yarn dist",

--- a/Composer/packages/extension-client/package.json
+++ b/Composer/packages/extension-client/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "yarn clean && yarn build:ts",
     "build:ts": "tsc --build tsconfig.build.json",
-    "clean": "rimraf lib"
+    "clean": "rimraf lib .swc"
   },
   "peerDependencies": {
     "@botframework-composer/types": "*",

--- a/Composer/packages/form-dialogs/package.json
+++ b/Composer/packages/form-dialogs/package.json
@@ -11,7 +11,7 @@
     "lib/FormDialogSchemaEditor.d.ts"
   ],
   "scripts": {
-    "clean": "rimraf lib dist",
+    "clean": "rimraf lib dist .swc",
     "start": "node tools/devServer.js",
     "build": "yarn clean && yarn build:ts",
     "build:ts": "tsc --build ./tsconfig.lib.json",

--- a/Composer/packages/intellisense/package.json
+++ b/Composer/packages/intellisense/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "yarn clean && yarn build:ts",
     "build:ts": "tsc --build ./tsconfig.build.json",
-    "clean": "rimraf lib demo/dist"
+    "clean": "rimraf lib demo/dist .swc"
   },
   "peerDependencies": {
     "@fluentui/react": "^8.83.1",

--- a/Composer/packages/lib/code-editor/package.json
+++ b/Composer/packages/lib/code-editor/package.json
@@ -13,7 +13,7 @@
     "build": "yarn clean && yarn build:css && yarn build:ts",
     "build:ts": "tsc --build tsconfig.build.json",
     "build:css": "copyfiles --up 1 \"src/**/*.css\" \"src/**/*.scss\" lib",
-    "clean": "rimraf lib demo/dist",
+    "clean": "rimraf lib demo/dist .swc",
     "prepublishOnly": "npm run build",
     "start": "webpack-dev-server --config demo/webpack.config.demo.js",
     "build:demo": "webpack --config demo/webpack.config.demo.js",

--- a/Composer/packages/lib/indexers/package.json
+++ b/Composer/packages/lib/indexers/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "yarn clean && yarn build:ts",
     "build:ts": "tsc --build tsconfig.build.json",
-    "clean": "rimraf lib",
+    "clean": "rimraf lib .swc",
     "prepublishOnly": "npm run build",
     "test": "jest",
     "lint": "eslint --quiet ./src",

--- a/Composer/packages/lib/shared/package.json
+++ b/Composer/packages/lib/shared/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "yarn clean && yarn build:ts",
     "build:ts": "tsc --build tsconfig.build.json",
-    "clean": "rimraf lib demo/dist",
+    "clean": "rimraf lib demo/dist .swc",
     "prepublishOnly": "npm run build",
     "test": "jest",
     "lint": "eslint --quiet ./src ./__tests__",

--- a/Composer/packages/server-workers/package.json
+++ b/Composer/packages/server-workers/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "build": "yarn clean && tsc",
-    "clean": "rimraf lib",
+    "clean": "rimraf lib .swc",
     "lint": "eslint --quiet src",
     "prepublishOnly": "npm run lint && npm run build"
   },

--- a/Composer/packages/server/package.json
+++ b/Composer/packages/server/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "analyze": "source-map-explorer 'build/public/static/js/*.js'",
     "build": "tsc -p tsconfig.build.json && node scripts/build.js",
-    "clean": "rimraf build",
+    "clean": "rimraf build .swc",
     "prep:dist:electron": "yarn build --outDir ../electron-server/dist && node scripts/copyAssets.js",
     "start": "node --max-http-header-size=16000 build/init.js",
     "start:dev": "nodemon",

--- a/Composer/packages/tools/language-servers/language-generation/package.json
+++ b/Composer/packages/tools/language-servers/language-generation/package.json
@@ -7,7 +7,7 @@
     "build": "tsc --build tsconfig.build.json",
     "build:demo": "cd demo && tsc --build tsconfig.json",
     "prepublishOnly": "npm run build",
-    "clean": "rimraf lib demo/dist",
+    "clean": "rimraf lib demo/dist .swc",
     "start": "cd demo && cross-env NODE_ENV=test ts-node ./src/server.ts",
     "test": "jest",
     "lint": "eslint --quiet ./src ./__tests__",

--- a/Composer/packages/tools/language-servers/language-understanding/package.json
+++ b/Composer/packages/tools/language-servers/language-understanding/package.json
@@ -7,7 +7,7 @@
     "build": "tsc --build tsconfig.build.json",
     "build:demo": "cd demo && tsc --build tsconfig.json",
     "prepublishOnly": "npm run build",
-    "clean": "rimraf lib demo/dist",
+    "clean": "rimraf lib demo/dist .swc",
     "start": "cd demo && ts-node ./src/server.ts",
     "test": "jest",
     "lint": "eslint --quiet ./src ./__tests__",

--- a/Composer/packages/types/package.json
+++ b/Composer/packages/types/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "build": "yarn clean && tsc",
-    "clean": "rimraf lib",
+    "clean": "rimraf lib .swc",
     "lint": "eslint --quiet src",
     "prepublishOnly": "npm run lint && npm run build"
   },

--- a/extensions/azurePublish/yarn-berry.lock
+++ b/extensions/azurePublish/yarn-berry.lock
@@ -1852,7 +1852,7 @@ __metadata:
 
 "@bfc/code-editor@file:../../Composer/packages/lib/code-editor::locator=azurePublish%40workspace%3A.":
   version: 0.0.0
-  resolution: "@bfc/code-editor@file:../../Composer/packages/lib/code-editor#../../Composer/packages/lib/code-editor::hash=9daeab&locator=azurePublish%40workspace%3A."
+  resolution: "@bfc/code-editor@file:../../Composer/packages/lib/code-editor#../../Composer/packages/lib/code-editor::hash=85aa6e&locator=azurePublish%40workspace%3A."
   dependencies:
     "@emotion/react": ^11.1.3
     "@emotion/styled": ^11.1.3
@@ -1875,13 +1875,13 @@ __metadata:
     "@bfc/ui-shared": "*"
     react: 16.13.1
     react-dom: 16.13.1
-  checksum: a0df5aa27ed60aa635a93c64c60feaaa3e7709ad306bc923a291616fb639898c2fd35909ee51858637295ee349001cb697ea92bbe86c34b1a7ec2d6038be7cc6
+  checksum: 29f5412bdf1777648742441cb612fd4809132e7a1fe595e18f9f7911e167a66e53022254ababf281168d0b48d27d6c1ec7209e29d280633fe80189538aec9606
   languageName: node
   linkType: hard
 
 "@bfc/extension-client@file:../../Composer/packages/extension-client::locator=azurePublish%40workspace%3A.":
   version: 1.0.0
-  resolution: "@bfc/extension-client@file:../../Composer/packages/extension-client#../../Composer/packages/extension-client::hash=8dd52b&locator=azurePublish%40workspace%3A."
+  resolution: "@bfc/extension-client@file:../../Composer/packages/extension-client#../../Composer/packages/extension-client::hash=dd3090&locator=azurePublish%40workspace%3A."
   dependencies:
     debug: ^4.1.1
     lodash: ^4.17.19
@@ -1890,13 +1890,13 @@ __metadata:
     "@botframework-composer/types": "*"
     react: 16.13.1
     react-dom: 16.13.1
-  checksum: e915e895f8bddee9e70e18f12ba5ab4668bc6883ab3c9dd00833f3d7fb9be0e8cb0dbc35f686f4baf5baf31390f8e6bd037274219c68cea718b0d3f72d9ecc8a
+  checksum: fc7d4f2873f20135f09faebfaa750f3b795ccc741f4c39a42249e730a4ef79b4dda7f872587936c215001681d5b99368109d328a26191785940785eee419488e
   languageName: node
   linkType: hard
 
 "@bfc/indexers@file:../../Composer/packages/lib/indexers::locator=azurePublish%40workspace%3A.":
   version: 0.0.0
-  resolution: "@bfc/indexers@file:../../Composer/packages/lib/indexers#../../Composer/packages/lib/indexers::hash=8e5fca&locator=azurePublish%40workspace%3A."
+  resolution: "@bfc/indexers@file:../../Composer/packages/lib/indexers#../../Composer/packages/lib/indexers::hash=8231f8&locator=azurePublish%40workspace%3A."
   dependencies:
     "@microsoft/bf-lu": 4.15.0-dev.20210702.cbf708d
     adaptive-expressions: ^4.18.0
@@ -1905,13 +1905,13 @@ __metadata:
     tslib: 2.4.0
   peerDependencies:
     "@bfc/shared": "*"
-  checksum: 31d8a809464f7fa700f4baef1ace105d62f8586d249ad56f6b02edeb4cb5be4a97d4109e589fa8e331378f6e8616c7c976dba70b29c71fa7bc32138a73dda91b
+  checksum: d8e8eed98d9e41a430b97ea800332ce8b5a8be4a5e6055911a0f1eb4ee17aebc8bc3039b2338d1ed1346bfaaea6c587818edfcc7fa596ed2a99c2fe66068ad0e
   languageName: node
   linkType: hard
 
 "@bfc/shared@file:../../Composer/packages/lib/shared::locator=azurePublish%40workspace%3A.":
   version: 0.0.0
-  resolution: "@bfc/shared@file:../../Composer/packages/lib/shared#../../Composer/packages/lib/shared::hash=8bb646&locator=azurePublish%40workspace%3A."
+  resolution: "@bfc/shared@file:../../Composer/packages/lib/shared#../../Composer/packages/lib/shared::hash=823a6f&locator=azurePublish%40workspace%3A."
   dependencies:
     "@botframework-composer/types": "*"
     format-message: 6.2.4
@@ -1925,7 +1925,7 @@ __metadata:
     react: 16.13.1
     react-dom: 16.13.1
     tslib: 2.4.0
-  checksum: ed6af3f1b57b302c951d934f2686f139541e99eb23765906e96f3d4b024b059f0e17f1af869939a6bf8170b366b3d0034a8fa4855395ad545f430a76e377b545
+  checksum: 0151f655c015639587f6687101f0bc056a07611770ee08d2dc60dc8b61f81e7d6d21e86b4439135ec4270368eff57518c9a4e1bce48eba4099e9a998f35b9500
   languageName: node
   linkType: hard
 
@@ -1970,7 +1970,7 @@ __metadata:
 
 "@botframework-composer/types@file:../../Composer/packages/types::locator=azurePublish%40workspace%3A.":
   version: 0.0.2
-  resolution: "@botframework-composer/types@file:../../Composer/packages/types#../../Composer/packages/types::hash=a03b13&locator=azurePublish%40workspace%3A."
+  resolution: "@botframework-composer/types@file:../../Composer/packages/types#../../Composer/packages/types::hash=d657f3&locator=azurePublish%40workspace%3A."
   dependencies:
     "@types/express": 4.16.1
     "@types/passport": ^1.0.4
@@ -1979,7 +1979,7 @@ __metadata:
     express-serve-static-core: 0.1.1
     json-schema: 0.4.0
     tslib: 2.4.0
-  checksum: 042462523dc3e89a15817f431da9df2cfd64b5adcbc29b0fb7dfcebe2989dd7e76445890540be2919c7c230912826a5b83bd1bd90398ef3be4c7e35be78ed41d
+  checksum: b085f9dddc37d8e77c723814f40c0551dd68f9a45e40ef64cbe51ed956f7ff64a266ea4fcc35144e352cadf6a657ac9fa6d0f74b90ea362d39104a26cf88c643
   languageName: node
   linkType: hard
 

--- a/extensions/azurePublishNew/yarn-berry.lock
+++ b/extensions/azurePublishNew/yarn-berry.lock
@@ -1921,7 +1921,7 @@ __metadata:
 
 "@bfc/extension-client@file:../../Composer/packages/extension-client::locator=azure-publish-new%40workspace%3A.":
   version: 1.0.0
-  resolution: "@bfc/extension-client@file:../../Composer/packages/extension-client#../../Composer/packages/extension-client::hash=8dd52b&locator=azure-publish-new%40workspace%3A."
+  resolution: "@bfc/extension-client@file:../../Composer/packages/extension-client#../../Composer/packages/extension-client::hash=dd3090&locator=azure-publish-new%40workspace%3A."
   dependencies:
     debug: ^4.1.1
     lodash: ^4.17.19
@@ -1930,13 +1930,13 @@ __metadata:
     "@botframework-composer/types": "*"
     react: 16.13.1
     react-dom: 16.13.1
-  checksum: e915e895f8bddee9e70e18f12ba5ab4668bc6883ab3c9dd00833f3d7fb9be0e8cb0dbc35f686f4baf5baf31390f8e6bd037274219c68cea718b0d3f72d9ecc8a
+  checksum: fc7d4f2873f20135f09faebfaa750f3b795ccc741f4c39a42249e730a4ef79b4dda7f872587936c215001681d5b99368109d328a26191785940785eee419488e
   languageName: node
   linkType: hard
 
 "@bfc/indexers@file:../../Composer/packages/lib/indexers::locator=azure-publish-new%40workspace%3A.":
   version: 0.0.0
-  resolution: "@bfc/indexers@file:../../Composer/packages/lib/indexers#../../Composer/packages/lib/indexers::hash=8e5fca&locator=azure-publish-new%40workspace%3A."
+  resolution: "@bfc/indexers@file:../../Composer/packages/lib/indexers#../../Composer/packages/lib/indexers::hash=8231f8&locator=azure-publish-new%40workspace%3A."
   dependencies:
     "@microsoft/bf-lu": 4.15.0-dev.20210702.cbf708d
     adaptive-expressions: ^4.18.0
@@ -1945,13 +1945,13 @@ __metadata:
     tslib: 2.4.0
   peerDependencies:
     "@bfc/shared": "*"
-  checksum: 31d8a809464f7fa700f4baef1ace105d62f8586d249ad56f6b02edeb4cb5be4a97d4109e589fa8e331378f6e8616c7c976dba70b29c71fa7bc32138a73dda91b
+  checksum: d8e8eed98d9e41a430b97ea800332ce8b5a8be4a5e6055911a0f1eb4ee17aebc8bc3039b2338d1ed1346bfaaea6c587818edfcc7fa596ed2a99c2fe66068ad0e
   languageName: node
   linkType: hard
 
 "@bfc/shared@file:../../Composer/packages/lib/shared::locator=azure-publish-new%40workspace%3A.":
   version: 0.0.0
-  resolution: "@bfc/shared@file:../../Composer/packages/lib/shared#../../Composer/packages/lib/shared::hash=8bb646&locator=azure-publish-new%40workspace%3A."
+  resolution: "@bfc/shared@file:../../Composer/packages/lib/shared#../../Composer/packages/lib/shared::hash=823a6f&locator=azure-publish-new%40workspace%3A."
   dependencies:
     "@botframework-composer/types": "*"
     format-message: 6.2.4
@@ -1965,7 +1965,7 @@ __metadata:
     react: 16.13.1
     react-dom: 16.13.1
     tslib: 2.4.0
-  checksum: ed6af3f1b57b302c951d934f2686f139541e99eb23765906e96f3d4b024b059f0e17f1af869939a6bf8170b366b3d0034a8fa4855395ad545f430a76e377b545
+  checksum: 0151f655c015639587f6687101f0bc056a07611770ee08d2dc60dc8b61f81e7d6d21e86b4439135ec4270368eff57518c9a4e1bce48eba4099e9a998f35b9500
   languageName: node
   linkType: hard
 
@@ -2010,7 +2010,7 @@ __metadata:
 
 "@botframework-composer/types@file:../../Composer/packages/types::locator=azure-publish-new%40workspace%3A.":
   version: 0.0.2
-  resolution: "@botframework-composer/types@file:../../Composer/packages/types#../../Composer/packages/types::hash=a03b13&locator=azure-publish-new%40workspace%3A."
+  resolution: "@botframework-composer/types@file:../../Composer/packages/types#../../Composer/packages/types::hash=d657f3&locator=azure-publish-new%40workspace%3A."
   dependencies:
     "@types/express": 4.16.1
     "@types/passport": ^1.0.4
@@ -2019,7 +2019,7 @@ __metadata:
     express-serve-static-core: 0.1.1
     json-schema: 0.4.0
     tslib: 2.4.0
-  checksum: 042462523dc3e89a15817f431da9df2cfd64b5adcbc29b0fb7dfcebe2989dd7e76445890540be2919c7c230912826a5b83bd1bd90398ef3be4c7e35be78ed41d
+  checksum: b085f9dddc37d8e77c723814f40c0551dd68f9a45e40ef64cbe51ed956f7ff64a266ea4fcc35144e352cadf6a657ac9fa6d0f74b90ea362d39104a26cf88c643
   languageName: node
   linkType: hard
 

--- a/extensions/localPublish/yarn-berry.lock
+++ b/extensions/localPublish/yarn-berry.lock
@@ -7,7 +7,7 @@ __metadata:
 
 "@botframework-composer/types@file:../../Composer/packages/types::locator=localpublish%40workspace%3A.":
   version: 0.0.2
-  resolution: "@botframework-composer/types@file:../../Composer/packages/types#../../Composer/packages/types::hash=a03b13&locator=localpublish%40workspace%3A."
+  resolution: "@botframework-composer/types@file:../../Composer/packages/types#../../Composer/packages/types::hash=d657f3&locator=localpublish%40workspace%3A."
   dependencies:
     "@types/express": 4.16.1
     "@types/passport": ^1.0.4
@@ -16,7 +16,7 @@ __metadata:
     express-serve-static-core: 0.1.1
     json-schema: 0.4.0
     tslib: 2.4.0
-  checksum: 042462523dc3e89a15817f431da9df2cfd64b5adcbc29b0fb7dfcebe2989dd7e76445890540be2919c7c230912826a5b83bd1bd90398ef3be4c7e35be78ed41d
+  checksum: b085f9dddc37d8e77c723814f40c0551dd68f9a45e40ef64cbe51ed956f7ff64a266ea4fcc35144e352cadf6a657ac9fa6d0f74b90ea362d39104a26cf88c643
   languageName: node
   linkType: hard
 

--- a/extensions/mockRemotePublish/yarn-berry.lock
+++ b/extensions/mockRemotePublish/yarn-berry.lock
@@ -7,7 +7,7 @@ __metadata:
 
 "@botframework-composer/types@file:../../Composer/packages/types::locator=mockRemotePublish%40workspace%3A.":
   version: 0.0.2
-  resolution: "@botframework-composer/types@file:../../Composer/packages/types#../../Composer/packages/types::hash=a03b13&locator=mockRemotePublish%40workspace%3A."
+  resolution: "@botframework-composer/types@file:../../Composer/packages/types#../../Composer/packages/types::hash=d657f3&locator=mockRemotePublish%40workspace%3A."
   dependencies:
     "@types/express": 4.16.1
     "@types/passport": ^1.0.4
@@ -16,7 +16,7 @@ __metadata:
     express-serve-static-core: 0.1.1
     json-schema: 0.4.0
     tslib: 2.4.0
-  checksum: 042462523dc3e89a15817f431da9df2cfd64b5adcbc29b0fb7dfcebe2989dd7e76445890540be2919c7c230912826a5b83bd1bd90398ef3be4c7e35be78ed41d
+  checksum: b085f9dddc37d8e77c723814f40c0551dd68f9a45e40ef64cbe51ed956f7ff64a266ea4fcc35144e352cadf6a657ac9fa6d0f74b90ea362d39104a26cf88c643
   languageName: node
   linkType: hard
 

--- a/extensions/packageManager/yarn-berry.lock
+++ b/extensions/packageManager/yarn-berry.lock
@@ -101,7 +101,7 @@ __metadata:
 
 "@bfc/extension-client@file:../../Composer/packages/extension-client::locator=package-manager%40workspace%3A.":
   version: 1.0.0
-  resolution: "@bfc/extension-client@file:../../Composer/packages/extension-client#../../Composer/packages/extension-client::hash=8dd52b&locator=package-manager%40workspace%3A."
+  resolution: "@bfc/extension-client@file:../../Composer/packages/extension-client#../../Composer/packages/extension-client::hash=dd3090&locator=package-manager%40workspace%3A."
   dependencies:
     debug: ^4.1.1
     lodash: ^4.17.19
@@ -110,7 +110,7 @@ __metadata:
     "@botframework-composer/types": "*"
     react: 16.13.1
     react-dom: 16.13.1
-  checksum: e915e895f8bddee9e70e18f12ba5ab4668bc6883ab3c9dd00833f3d7fb9be0e8cb0dbc35f686f4baf5baf31390f8e6bd037274219c68cea718b0d3f72d9ecc8a
+  checksum: fc7d4f2873f20135f09faebfaa750f3b795ccc741f4c39a42249e730a4ef79b4dda7f872587936c215001681d5b99368109d328a26191785940785eee419488e
   languageName: node
   linkType: hard
 
@@ -154,7 +154,7 @@ __metadata:
 
 "@botframework-composer/types@file:../../Composer/packages/types::locator=package-manager%40workspace%3A.":
   version: 0.0.2
-  resolution: "@botframework-composer/types@file:../../Composer/packages/types#../../Composer/packages/types::hash=a03b13&locator=package-manager%40workspace%3A."
+  resolution: "@botframework-composer/types@file:../../Composer/packages/types#../../Composer/packages/types::hash=d657f3&locator=package-manager%40workspace%3A."
   dependencies:
     "@types/express": 4.16.1
     "@types/passport": ^1.0.4
@@ -163,7 +163,7 @@ __metadata:
     express-serve-static-core: 0.1.1
     json-schema: 0.4.0
     tslib: 2.4.0
-  checksum: 042462523dc3e89a15817f431da9df2cfd64b5adcbc29b0fb7dfcebe2989dd7e76445890540be2919c7c230912826a5b83bd1bd90398ef3be4c7e35be78ed41d
+  checksum: b085f9dddc37d8e77c723814f40c0551dd68f9a45e40ef64cbe51ed956f7ff64a266ea4fcc35144e352cadf6a657ac9fa6d0f74b90ea362d39104a26cf88c643
   languageName: node
   linkType: hard
 

--- a/extensions/pvaPublish/yarn-berry.lock
+++ b/extensions/pvaPublish/yarn-berry.lock
@@ -1607,7 +1607,7 @@ __metadata:
 
 "@bfc/extension-client@file:../../Composer/packages/extension-client::locator=pva-publish-composer%40workspace%3A.":
   version: 1.0.0
-  resolution: "@bfc/extension-client@file:../../Composer/packages/extension-client#../../Composer/packages/extension-client::hash=8dd52b&locator=pva-publish-composer%40workspace%3A."
+  resolution: "@bfc/extension-client@file:../../Composer/packages/extension-client#../../Composer/packages/extension-client::hash=dd3090&locator=pva-publish-composer%40workspace%3A."
   dependencies:
     debug: ^4.1.1
     lodash: ^4.17.19
@@ -1616,7 +1616,7 @@ __metadata:
     "@botframework-composer/types": "*"
     react: 16.13.1
     react-dom: 16.13.1
-  checksum: e915e895f8bddee9e70e18f12ba5ab4668bc6883ab3c9dd00833f3d7fb9be0e8cb0dbc35f686f4baf5baf31390f8e6bd037274219c68cea718b0d3f72d9ecc8a
+  checksum: fc7d4f2873f20135f09faebfaa750f3b795ccc741f4c39a42249e730a4ef79b4dda7f872587936c215001681d5b99368109d328a26191785940785eee419488e
   languageName: node
   linkType: hard
 
@@ -1643,7 +1643,7 @@ __metadata:
 
 "@botframework-composer/types@file:../../Composer/packages/types::locator=pva-publish-composer%40workspace%3A.":
   version: 0.0.2
-  resolution: "@botframework-composer/types@file:../../Composer/packages/types#../../Composer/packages/types::hash=a03b13&locator=pva-publish-composer%40workspace%3A."
+  resolution: "@botframework-composer/types@file:../../Composer/packages/types#../../Composer/packages/types::hash=d657f3&locator=pva-publish-composer%40workspace%3A."
   dependencies:
     "@types/express": 4.16.1
     "@types/passport": ^1.0.4
@@ -1652,7 +1652,7 @@ __metadata:
     express-serve-static-core: 0.1.1
     json-schema: 0.4.0
     tslib: 2.4.0
-  checksum: 042462523dc3e89a15817f431da9df2cfd64b5adcbc29b0fb7dfcebe2989dd7e76445890540be2919c7c230912826a5b83bd1bd90398ef3be4c7e35be78ed41d
+  checksum: b085f9dddc37d8e77c723814f40c0551dd68f9a45e40ef64cbe51ed956f7ff64a266ea4fcc35144e352cadf6a657ac9fa6d0f74b90ea362d39104a26cf88c643
   languageName: node
   linkType: hard
 

--- a/extensions/runtimes/yarn-berry.lock
+++ b/extensions/runtimes/yarn-berry.lock
@@ -7,7 +7,7 @@ __metadata:
 
 "@botframework-composer/types@file:../../Composer/packages/types::locator=plugin-runtimes%40workspace%3A.":
   version: 0.0.2
-  resolution: "@botframework-composer/types@file:../../Composer/packages/types#../../Composer/packages/types::hash=a03b13&locator=plugin-runtimes%40workspace%3A."
+  resolution: "@botframework-composer/types@file:../../Composer/packages/types#../../Composer/packages/types::hash=d657f3&locator=plugin-runtimes%40workspace%3A."
   dependencies:
     "@types/express": 4.16.1
     "@types/passport": ^1.0.4
@@ -16,7 +16,7 @@ __metadata:
     express-serve-static-core: 0.1.1
     json-schema: 0.4.0
     tslib: 2.4.0
-  checksum: 042462523dc3e89a15817f431da9df2cfd64b5adcbc29b0fb7dfcebe2989dd7e76445890540be2919c7c230912826a5b83bd1bd90398ef3be4c7e35be78ed41d
+  checksum: b085f9dddc37d8e77c723814f40c0551dd68f9a45e40ef64cbe51ed956f7ff64a266ea4fcc35144e352cadf6a657ac9fa6d0f74b90ea362d39104a26cf88c643
   languageName: node
   linkType: hard
 

--- a/extensions/sample-ui-plugin/yarn-berry.lock
+++ b/extensions/sample-ui-plugin/yarn-berry.lock
@@ -89,7 +89,7 @@ __metadata:
 
 "@bfc/extension-client@file:../../Composer/packages/extension-client::locator=sample-ui-plugin%40workspace%3A.":
   version: 1.0.0
-  resolution: "@bfc/extension-client@file:../../Composer/packages/extension-client#../../Composer/packages/extension-client::hash=8dd52b&locator=sample-ui-plugin%40workspace%3A."
+  resolution: "@bfc/extension-client@file:../../Composer/packages/extension-client#../../Composer/packages/extension-client::hash=dd3090&locator=sample-ui-plugin%40workspace%3A."
   dependencies:
     debug: ^4.1.1
     lodash: ^4.17.19
@@ -98,13 +98,13 @@ __metadata:
     "@botframework-composer/types": "*"
     react: 16.13.1
     react-dom: 16.13.1
-  checksum: e915e895f8bddee9e70e18f12ba5ab4668bc6883ab3c9dd00833f3d7fb9be0e8cb0dbc35f686f4baf5baf31390f8e6bd037274219c68cea718b0d3f72d9ecc8a
+  checksum: fc7d4f2873f20135f09faebfaa750f3b795ccc741f4c39a42249e730a4ef79b4dda7f872587936c215001681d5b99368109d328a26191785940785eee419488e
   languageName: node
   linkType: hard
 
 "@botframework-composer/types@file:../../Composer/packages/types::locator=sample-ui-plugin%40workspace%3A.":
   version: 0.0.2
-  resolution: "@botframework-composer/types@file:../../Composer/packages/types#../../Composer/packages/types::hash=a03b13&locator=sample-ui-plugin%40workspace%3A."
+  resolution: "@botframework-composer/types@file:../../Composer/packages/types#../../Composer/packages/types::hash=d657f3&locator=sample-ui-plugin%40workspace%3A."
   dependencies:
     "@types/express": 4.16.1
     "@types/passport": ^1.0.4
@@ -113,7 +113,7 @@ __metadata:
     express-serve-static-core: 0.1.1
     json-schema: 0.4.0
     tslib: 2.4.0
-  checksum: 042462523dc3e89a15817f431da9df2cfd64b5adcbc29b0fb7dfcebe2989dd7e76445890540be2919c7c230912826a5b83bd1bd90398ef3be4c7e35be78ed41d
+  checksum: b085f9dddc37d8e77c723814f40c0551dd68f9a45e40ef64cbe51ed956f7ff64a266ea4fcc35144e352cadf6a657ac9fa6d0f74b90ea362d39104a26cf88c643
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Found one reason hashes don't match between my dev machine and CI: Jest uses swc under the hood and swc creates a cache directory which gets picked by yarn packaging command.

#minor