### PR TITLE
fix: yaml dump usage

### DIFF
--- a/Composer/packages/electron-server/scripts/common.js
+++ b/Composer/packages/electron-server/scripts/common.js
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license.
-
 /** Hashes a file asynchronously */
 const path = require('path');
 const fs = require('fs');

--- a/Composer/packages/electron-server/scripts/common.js
+++ b/Composer/packages/electron-server/scripts/common.js
@@ -1,12 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.
 
 /** Hashes a file asynchronously */
 const path = require('path');
-const fsp = require('fs-extra');
-const yaml = require('js-yaml');
 const fs = require('fs');
 const crypto = require('crypto');
+
+const fsp = require('fs-extra');
+const yaml = require('js-yaml');
+
 const packageJson = require('../package.json');
 
 async function writeToDist(err, files, fileName) {
@@ -26,7 +31,7 @@ async function writeToDist(err, files, fileName) {
     path: releaseFileName,
     sha512,
   };
-  const ymlStr = yaml.safeDump(ymlInfo);
+  const ymlStr = yaml.dump(ymlInfo);
   const ymlPath = path.join(__dirname, `../dist/${fileName}`);
   fsp.writeFileSync(ymlPath, ymlStr);
 }


### PR DESCRIPTION
## Description

This fixes `js-yaml` package replaced `safeDump` in v4 with `dump`

#minor