### PR TITLE
WIP: avoid cross-geo calls

### DIFF
--- a/Composer/packages/electron-server/src/main.ts
+++ b/Composer/packages/electron-server/src/main.ts
@@ -343,6 +343,11 @@ async function run() {
       };
     });
 
+    ipcMain.handle('deeplink', async (evt, url: string) => {
+      const deeplink = parseDeepLinkUrl(url);
+      await getMainWindow()?.webContents.loadURL(getBaseUrl() + deeplink);
+    });
+
     await main();
     setTimeout(() => startApp(signalThatMainWindowIsShowing), 500);
     await initApp();

--- a/extensions/pvaPublish/src/node/publish.ts
+++ b/extensions/pvaPublish/src/node/publish.ts
@@ -41,7 +41,10 @@ export const publish = async (
   try {
     logger.log('Starting publish to Power Virtual Agents.');
     // authenticate with PVA
-    const base = baseUrl || getBaseUrl();
+    const base = baseUrl;
+    if (!base) {
+      throw new Error('Base URL is not supplied in published target');
+    }
     const creds = getAuthCredentials(base, tenantId);
     const accessToken = await getAccessToken(creds);
 
@@ -161,7 +164,10 @@ export const getStatus = async (
 
   try {
     // authenticate with PVA
-    const base = baseUrl || getBaseUrl();
+    const base = baseUrl;
+    if (!base) {
+      throw new Error('Base URL is not supplied in published target');
+    }
     const creds = getAuthCredentials(base, tenantId);
     const accessToken = await getAccessToken(creds);
 


### PR DESCRIPTION
## Description

For now this does the following:
- ensure we don't use predefined endpoints and rely only on the endpoint given by PVA

Note that PVA deeplink generation should also be updated to pass in the proper endpoint instead of hardcoded one.