### PR TITLE
2.1.3 release

### DIFF
--- a/Composer/packages/electron-server/package.json
+++ b/Composer/packages/electron-server/package.json
@@ -2,7 +2,7 @@
   "name": "@bfc/electron-server",
   "license": "MIT",
   "author": "Microsoft Corporation",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Electron wrapper around Composer that launches Composer as a desktop application.",
   "main": "./build/main.js",
   "engines": {

--- a/releases/2.1.3.md
+++ b/releases/2.1.3.md
@@ -1,0 +1,69 @@
+### 08-15-2023
+
+#### Added
+
+- feat: allow to disable OneAuth Eugene Olonov
+- feat: reflow improvements ([#9454](https://github.com/microsoft/BotFramework-Composer/pull/9454)) Eugene
+- feat: extend CSRF token protection to all api routes ([#9422](https://github.com/microsoft/BotFramework-Composer/pull/9422)) Eugene
+
+#### Fixed
+
+- fix: Optimize memory usage when parsing LgFiles ([#9614](https://github.com/microsoft/BotFramework-Composer/pull/9614)) Joel Mut
+- fix: [#9528] Unable to add two PVA bot skills through bot framework composer with the option connect to a skill ([#9549](https://github.com/microsoft/BotFramework-Composer/pull/9549)) Cecilia Avila
+- fix: rework app exit to account for running bots ([#9532](https://github.com/microsoft/BotFramework-Composer/pull/9532)) Eugene
+- fix: yarn hashes for local pacakges dont match ([#9559](https://github.com/microsoft/BotFramework-Composer/pull/9559)) Eugene
+- fix: extensions typescript errors ([#9524](https://github.com/microsoft/BotFramework-Composer/pull/9524)) Eugene
+- fix: package manager readme display in sidebar and modal Eugene Olonov
+- fix: [#9364] Missing InputHint support for IgnoringSpeechInput and IgnoringNonSpeechInput ([#9456](https://github.com/microsoft/BotFramework-Composer/pull/9456)) Cecilia Avila
+- fix: package manager visual regressions ([#9504](https://github.com/microsoft/BotFramework-Composer/pull/9504)) Eugene
+- fix: revert azure publising dep upgrades ([#9497](https://github.com/microsoft/BotFramework-Composer/pull/9497)) Eugene
+- fix: [#9346] Fix memory leak issues in VisualPanel components ([#9468](https://github.com/microsoft/BotFramework-Composer/pull/9468)) Cecilia Avila
+- fix: ensure CSRF token is passed through cy.request Eugene Olonov
+- fix: bind composer server to localhost ([#9467](https://github.com/microsoft/BotFramework-Composer/pull/9467)) Eugene
+- fix: update preload script to properly expose globals after Electron upgrade Eugene Olonov
+- a11y: fix remaining issues ([#9408](https://github.com/microsoft/BotFramework-Composer/pull/9408)) Eugene
+- a11y: fix minor issues ([#9404](https://github.com/microsoft/BotFramework-Composer/pull/9404)) Eugene
+- a11y: reflow and zoom support for Composer ([#9398](https://github.com/microsoft/BotFramework-Composer/pull/9398)) Eugene
+- a11y: more fixes for the last pass ([#9396](https://github.com/microsoft/BotFramework-Composer/pull/9396)) Eugene
+- a11y: add italy compliance link ([#9394](https://github.com/microsoft/BotFramework-Composer/pull/9394)) Eugene
+- a11y: fix August pass issues ([#9388](https://github.com/microsoft/BotFramework-Composer/pull/9388)) Eugene
+- fix: dev mode commit version display ([#9385](https://github.com/microsoft/BotFramework-Composer/pull/9385)) Eugene
+- fix: improve portfinder usage ([#9366](https://github.com/microsoft/BotFramework-Composer/pull/9366)) Eugene
+- fix: get started content is not visible ([#9219](https://github.com/microsoft/BotFramework-Composer/pull/9219)) Eugene
+- a11y: add labels for editor toolbar ([#9210](https://github.com/microsoft/BotFramework-Composer/pull/9210)) Eugene
+- fix: failing cypress tests ([#9153](https://github.com/microsoft/BotFramework-Composer/pull/9153)) Eugene
+- a11y: address accessibility insights issues ([#9148](https://github.com/microsoft/BotFramework-Composer/pull/9148)) Eugene
+- a11y: add support for intellisense ([#9091](https://github.com/microsoft/BotFramework-Composer/pull/9091)) Eugene
+- a11y: fix project tre roles and aria ([#9093](https://github.com/microsoft/BotFramework-Composer/pull/9093)) Eugene
+- a11y: fix aria-label content ([#9092](https://github.com/microsoft/BotFramework-Composer/pull/9092)) Eugene
+- a11y: Add aria-required attribute to Form Editor required fields ([#9079](https://github.com/microsoft/BotFramework-Composer/pull/9079)) Eugene
+- a11y: ensure there is only one main landmark ([#9074](https://github.com/microsoft/BotFramework-Composer/pull/9074)) Eugene
+- a11y: show one modal at once for bot creation flow ([#9047](https://github.com/microsoft/BotFramework-Composer/pull/9047)) Eugene
+- a11y: fix table-forms keyboard navigation ([#9020](https://github.com/microsoft/BotFramework-Composer/pull/9020)) Eugene
+- a11y: improve bot controller keyboard handling ([#9014](https://github.com/microsoft/BotFramework-Composer/pull/9014)) Eugene
+- fix: Packages stuck at "Installing package..." screen after network failure ([#9002](https://github.com/microsoft/BotFramework-Composer/pull/9002)) Eugene
+- a11y: handle keyboard navigation in array fields ([#8998](https://github.com/microsoft/BotFramework-Composer/pull/8998)) Eugene
+- fix: Fix incorrect port getting passed to DLServerContext.getInstance ([#8989](https://github.com/microsoft/BotFramework-Composer/pull/8989)) ([@tdurnford](https://github.com/tdurnford))
+- a11y: fix reamining setting controls empty labels ([#8990](https://github.com/microsoft/BotFramework-Composer/pull/8990)) Eugene
+- a11y: make learn more links more descriptive ([#8985](https://github.com/microsoft/BotFramework-Composer/pull/8985)) Eugene
+- a11y: organize home page links into lists ([#8959](https://github.com/microsoft/BotFramework-Composer/pull/8959)) Eugene
+- a11y: make Select Dialog to be a listbox with options ([#8976](https://github.com/microsoft/BotFramework-Composer/pull/8976)) Eugene
+- a11y: Improve Copy content for trnaslation modal ([#8973](https://github.com/microsoft/BotFramework-Composer/pull/8973)) Eugene
+- a11y: improve tree filtering keyboard navigation and announcement ([#8968](https://github.com/microsoft/BotFramework-Composer/pull/8968)) Eugene
+
+#### Other
+
+- nit: spelling Eugene Olonov
+- build: add typechecking to extension build script ([#9494](https://github.com/microsoft/BotFramework-Composer/pull/9494)) ([@a-b-r-o-w-n](https://github.com/a-b-r-o-w-n))
+- chore: update webchat to 4.15.3 ([#9344](https://github.com/microsoft/BotFramework-Composer/pull/9344)) Eugene
+- chore: update fluent to v 8.83 ([#9319](https://github.com/microsoft/BotFramework-Composer/pull/9319)) Eugene
+- chore: Fix Component Governance Security Alerts ([#9306](https://github.com/microsoft/BotFramework-Composer/pull/9306)) BruceHaley
+- chore: Update dependencies for Composer and extensions ([#9298](https://github.com/microsoft/BotFramework-Composer/pull/9298)) BruceHaley
+- doc: Specify correct version of Azure CLI ([#9225](https://github.com/microsoft/BotFramework-Composer/pull/9225)) BruceHaley
+- build: Fix Component Governance in Composer DevOps pipeline ([#9257](https://github.com/microsoft/BotFramework-Composer/pull/9257)) BruceHaley
+- chore: use yarn 3 for development ([#9201](https://github.com/microsoft/BotFramework-Composer/pull/9201)) Eugene
+- chore: upgrade webchat and emotion ([#9150](https://github.com/microsoft/BotFramework-Composer/pull/9150)) Eugene
+- chore: update electron to currently supported version ([#9053](https://github.com/microsoft/BotFramework-Composer/pull/9053)) Eugene
+- chore: update url-parse ([#9048](https://github.com/microsoft/BotFramework-Composer/pull/9048)) Eugene
+- chore: update FluentUI to v8 ([#9025](https://github.com/microsoft/BotFramework-Composer/pull/9025)) Eugene
+- chore: Merge 2.1.2 release branch into main ([#8965](https://github.com/microsoft/BotFramework-Composer/pull/8965)) ([@tonyanziano](https://github.com/tonyanziano))


### PR DESCRIPTION
### 08-15-2023

#### Added

- feat: allow to disable OneAuth Eugene Olonov
- feat: reflow improvements ([#9454](https://github.com/microsoft/BotFramework-Composer/pull/9454)) Eugene
- feat: extend CSRF token protection to all api routes ([#9422](https://github.com/microsoft/BotFramework-Composer/pull/9422)) Eugene

#### Fixed

- fix: Optimize memory usage when parsing LgFiles ([#9614](https://github.com/microsoft/BotFramework-Composer/pull/9614)) Joel Mut
- fix: [#9528] Unable to add two PVA bot skills through bot framework composer with the option connect to a skill ([#9549](https://github.com/microsoft/BotFramework-Composer/pull/9549)) Cecilia Avila
- fix: rework app exit to account for running bots ([#9532](https://github.com/microsoft/BotFramework-Composer/pull/9532)) Eugene
- fix: yarn hashes for local pacakges dont match ([#9559](https://github.com/microsoft/BotFramework-Composer/pull/9559)) Eugene
- fix: extensions typescript errors ([#9524](https://github.com/microsoft/BotFramework-Composer/pull/9524)) Eugene
- fix: package manager readme display in sidebar and modal Eugene Olonov
- fix: [#9364] Missing InputHint support for IgnoringSpeechInput and IgnoringNonSpeechInput ([#9456](https://github.com/microsoft/BotFramework-Composer/pull/9456)) Cecilia Avila
- fix: package manager visual regressions ([#9504](https://github.com/microsoft/BotFramework-Composer/pull/9504)) Eugene
- fix: revert azure publising dep upgrades ([#9497](https://github.com/microsoft/BotFramework-Composer/pull/9497)) Eugene
- fix: [#9346] Fix memory leak issues in VisualPanel components ([#9468](https://github.com/microsoft/BotFramework-Composer/pull/9468)) Cecilia Avila
- fix: ensure CSRF token is passed through cy.request Eugene Olonov
- fix: bind composer server to localhost ([#9467](https://github.com/microsoft/BotFramework-Composer/pull/9467)) Eugene
- fix: update preload script to properly expose globals after Electron upgrade Eugene Olonov
- a11y: fix remaining issues ([#9408](https://github.com/microsoft/BotFramework-Composer/pull/9408)) Eugene
- a11y: fix minor issues ([#9404](https://github.com/microsoft/BotFramework-Composer/pull/9404)) Eugene
- a11y: reflow and zoom support for Composer ([#9398](https://github.com/microsoft/BotFramework-Composer/pull/9398)) Eugene
- a11y: more fixes for the last pass ([#9396](https://github.com/microsoft/BotFramework-Composer/pull/9396)) Eugene
- a11y: add italy compliance link ([#9394](https://github.com/microsoft/BotFramework-Composer/pull/9394)) Eugene
- a11y: fix August pass issues ([#9388](https://github.com/microsoft/BotFramework-Composer/pull/9388)) Eugene
- fix: dev mode commit version display ([#9385](https://github.com/microsoft/BotFramework-Composer/pull/9385)) Eugene
- fix: improve portfinder usage ([#9366](https://github.com/microsoft/BotFramework-Composer/pull/9366)) Eugene
- fix: get started content is not visible ([#9219](https://github.com/microsoft/BotFramework-Composer/pull/9219)) Eugene
- a11y: add labels for editor toolbar ([#9210](https://github.com/microsoft/BotFramework-Composer/pull/9210)) Eugene
- fix: failing cypress tests ([#9153](https://github.com/microsoft/BotFramework-Composer/pull/9153)) Eugene
- a11y: address accessibility insights issues ([#9148](https://github.com/microsoft/BotFramework-Composer/pull/9148)) Eugene
- a11y: add support for intellisense ([#9091](https://github.com/microsoft/BotFramework-Composer/pull/9091)) Eugene
- a11y: fix project tre roles and aria ([#9093](https://github.com/microsoft/BotFramework-Composer/pull/9093)) Eugene
- a11y: fix aria-label content ([#9092](https://github.com/microsoft/BotFramework-Composer/pull/9092)) Eugene
- a11y: Add aria-required attribute to Form Editor required fields ([#9079](https://github.com/microsoft/BotFramework-Composer/pull/9079)) Eugene
- a11y: ensure there is only one main landmark ([#9074](https://github.com/microsoft/BotFramework-Composer/pull/9074)) Eugene
- a11y: show one modal at once for bot creation flow ([#9047](https://github.com/microsoft/BotFramework-Composer/pull/9047)) Eugene
- a11y: fix table-forms keyboard navigation ([#9020](https://github.com/microsoft/BotFramework-Composer/pull/9020)) Eugene
- a11y: improve bot controller keyboard handling ([#9014](https://github.com/microsoft/BotFramework-Composer/pull/9014)) Eugene
- fix: Packages stuck at "Installing package..." screen after network failure ([#9002](https://github.com/microsoft/BotFramework-Composer/pull/9002)) Eugene
- a11y: handle keyboard navigation in array fields ([#8998](https://github.com/microsoft/BotFramework-Composer/pull/8998)) Eugene
- fix: Fix incorrect port getting passed to DLServerContext.getInstance ([#8989](https://github.com/microsoft/BotFramework-Composer/pull/8989)) ([@tdurnford](https://github.com/tdurnford))
- a11y: fix reamining setting controls empty labels ([#8990](https://github.com/microsoft/BotFramework-Composer/pull/8990)) Eugene
- a11y: make learn more links more descriptive ([#8985](https://github.com/microsoft/BotFramework-Composer/pull/8985)) Eugene
- a11y: organize home page links into lists ([#8959](https://github.com/microsoft/BotFramework-Composer/pull/8959)) Eugene
- a11y: make Select Dialog to be a listbox with options ([#8976](https://github.com/microsoft/BotFramework-Composer/pull/8976)) Eugene
- a11y: Improve Copy content for trnaslation modal ([#8973](https://github.com/microsoft/BotFramework-Composer/pull/8973)) Eugene
- a11y: improve tree filtering keyboard navigation and announcement ([#8968](https://github.com/microsoft/BotFramework-Composer/pull/8968)) Eugene

#### Other

- nit: spelling Eugene Olonov
- build: add typechecking to extension build script ([#9494](https://github.com/microsoft/BotFramework-Composer/pull/9494)) ([@a-b-r-o-w-n](https://github.com/a-b-r-o-w-n))
- chore: update webchat to 4.15.3 ([#9344](https://github.com/microsoft/BotFramework-Composer/pull/9344)) Eugene
- chore: update fluent to v 8.83 ([#9319](https://github.com/microsoft/BotFramework-Composer/pull/9319)) Eugene
- chore: Fix Component Governance Security Alerts ([#9306](https://github.com/microsoft/BotFramework-Composer/pull/9306)) BruceHaley
- chore: Update dependencies for Composer and extensions ([#9298](https://github.com/microsoft/BotFramework-Composer/pull/9298)) BruceHaley
- doc: Specify correct version of Azure CLI ([#9225](https://github.com/microsoft/BotFramework-Composer/pull/9225)) BruceHaley
- build: Fix Component Governance in Composer DevOps pipeline ([#9257](https://github.com/microsoft/BotFramework-Composer/pull/9257)) BruceHaley
- chore: use yarn 3 for development ([#9201](https://github.com/microsoft/BotFramework-Composer/pull/9201)) Eugene
- chore: upgrade webchat and emotion ([#9150](https://github.com/microsoft/BotFramework-Composer/pull/9150)) Eugene
- chore: update electron to currently supported version ([#9053](https://github.com/microsoft/BotFramework-Composer/pull/9053)) Eugene
- chore: update url-parse ([#9048](https://github.com/microsoft/BotFramework-Composer/pull/9048)) Eugene
- chore: update FluentUI to v8 ([#9025](https://github.com/microsoft/BotFramework-Composer/pull/9025)) Eugene
- chore: Merge 2.1.2 release branch into main ([#8965](https://github.com/microsoft/BotFramework-Composer/pull/8965)) ([@tonyanziano](https://github.com/tonyanziano))
