### PR TITLE
fix: [#9716] correct page title and manifest

### DIFF
--- a/Composer/packages/client/public/index.html
+++ b/Composer/packages/client/public/index.html
@@ -22,7 +22,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>BotFramework Composer</title>
+    <title>Bot Framework Composer</title>
 
     <% if (process.env.NODE_ENV === 'production') { %>
       <? if (__nonce__) { ?>

--- a/Composer/packages/client/public/manifest.json
+++ b/Composer/packages/client/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "short_name": "Composer",
-  "name": "BotFramework Composer",
+  "name": "Bot Framework Composer",
   "icons": [
     {
       "src": "composerfavicon.ico",


### PR DESCRIPTION
## Description

The HTML Page `<title>` did not match the spelling of the product.

I have simply updated the `Title` and the `Manifest` file so that publicly it will show `"Bot Framework Composer"` rather than previously (incorrectly) showing as `"BotFramework Composer"`

Closes #9716 
